### PR TITLE
Mobile: scroll selected section into view + wire drawer move highlights

### DIFF
--- a/src/client/DafViewer.tsx
+++ b/src/client/DafViewer.tsx
@@ -1118,6 +1118,12 @@ export default function DafViewer(): JSX.Element {
     })();
   });
 
+  // Tracks the selection identity (sidebar item + optional sub-move) we last
+  // auto-scrolled into view on mobile, so repaints from hover / resize / late
+  // font-load don't re-yank the scroll position. Reset to null when the
+  // selection clears so reopening the same item scrolls again.
+  let lastScrolledSelKey: string | null = null;
+
   // Apply all highlights (section / halacha range + per-rabbi accent) based
   // on the current sidebar + activeRabbi state. Range tints are drawn as
   // absolute-positioned overlay divs computed from Range.getClientRects() so
@@ -1510,6 +1516,37 @@ export default function DafViewer(): JSX.Element {
     if (place) {
       const sel = `.city-marker[data-city="${place.replace(/"/g, '\\"')}"]`;
       dafRootDiv.querySelectorAll(sel).forEach((el) => el.classList.add('city-highlighted'));
+    }
+
+    // Mobile: when the selection (a section / halacha / aggadata / pesuk, or a
+    // sub-move clicked in the shelf) changes, scroll the daf so the
+    // highlighted span sits near the top of the viewport — otherwise it
+    // routinely lands behind the fixed bottom shelf or off-screen and the
+    // user never sees the highlight they just triggered. Keyed on the
+    // selection identity so the many non-selection repaints (hover, resize,
+    // font-load) don't fight the user's own scrolling.
+    const moveKey = argumentMoveHighlight()?.key ?? '';
+    const selKey = s ? `${sidebarActiveKey() ?? ''}#${moveKey}` : null;
+    if (!selKey) {
+      lastScrolledSelKey = null;
+    } else if (isMobile() && selKey !== lastScrolledSelKey) {
+      lastScrolledSelKey = selKey;
+      // Scroll to the topmost *selection* band only (ignore the ambient
+      // commentary tint, which can sit higher up the daf).
+      const bands = overlay.querySelectorAll<HTMLElement>(
+        '.daf-range-highlight-section, .daf-range-highlight-halacha, .daf-range-highlight-aggadata, .daf-range-highlight-pesuk, .daf-range-highlight-move',
+      );
+      let topY = Infinity;
+      bands.forEach((el) => {
+        const r = el.getBoundingClientRect();
+        if (r.height > 0 && r.top < topY) topY = r.top;
+      });
+      if (topY !== Infinity) {
+        // Park the span ~12% down from the top of the viewport: clears the
+        // page header while keeping it well above the bottom shelf.
+        const desiredTop = window.innerHeight * 0.12;
+        window.scrollBy({ top: topY - desiredTop, behavior: 'smooth' });
+      }
     }
   };
 
@@ -2783,6 +2820,7 @@ export default function DafViewer(): JSX.Element {
           onCloseExpansion={() => {
             setSidebar(null);
             setActiveRabbi(null);
+            setArgumentMoveHighlight(null);
             if (activeCommentarySegIdx() === null) setLastInteractedCard(null);
           }}
           tractate={tractate()}
@@ -2794,6 +2832,7 @@ export default function DafViewer(): JSX.Element {
           onBack={popSidebar}
           dafRabbis={dafRabbis()}
           dafRabbiNames={dafRabbiNames()}
+          onHighlightRange={setArgumentMoveHighlight}
           onOpenRabbiSlug={openRabbiSlug}
           generationByName={generationByName()}
         />

--- a/src/client/MobileShelf.tsx
+++ b/src/client/MobileShelf.tsx
@@ -26,6 +26,9 @@ interface MobileShelfProps {
   dafRabbiNames: string[];
   onOpenRabbiSlug: (slug: string) => void;
   generationByName: Map<string, GenerationId>;
+  onHighlightRange?: (
+    range: { start: number; end: number; key: string; tokenStart?: number; tokenEnd?: number } | null,
+  ) => void;
 }
 
 // Fixed-bottom sheet on mobile. The interaction-mode bar (Read / Translate)
@@ -141,6 +144,7 @@ function ExpansionView(props: MobileShelfProps): JSX.Element {
           onBack={props.onBack}
           dafRabbis={props.dafRabbis}
           dafRabbiNames={props.dafRabbiNames}
+          onHighlightRange={props.onHighlightRange}
           onOpenRabbiSlug={props.onOpenRabbiSlug}
           generationByName={props.generationByName}
         />


### PR DESCRIPTION
## What
Two mobile fixes for daf section interaction:

1. **Sub-move highlights from the shelf were dead.** `MobileShelf` never forwarded `onHighlightRange` to `ArgumentSidebar`, so tapping a move card (question/answer/etc.) in the bottom drawer painted nothing on the daf. Now wired through to `setArgumentMoveHighlight`, and the move highlight is cleared when the shelf closes.

2. **Selected section was hidden behind the shelf / off-screen.** The highlight was painted but routinely sat below the fold or behind the fixed bottom shelf. `applyHighlights` now scrolls the topmost selection band (section/halacha/aggadata/pesuk/move) to ~12% down the viewport when the selection changes — clearing the header and keeping it above the shelf. Keyed on selection identity so hover/resize/font-load repaints don't fight the user's scrolling. Desktop is gated out (`isMobile()`).

## Verification
Driven in Chrome DevTools mobile emulation (390px, Berakhot 2a):
- Clicking an argument that sat at viewport y=655 (behind the shelf) scrolled the page so its highlight landed at y=90 — exactly the 12% target — fully visible above the shelf.
- Tapping a move card now paints the yellow move band (4 bands), section-wide tint correctly suppressed.
- `tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)