### PR TITLE
Serve dafyomi.co.il study content on every daf (on-demand live fetch)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@chenglou/pretext": "^0.0.5",
     "daf-renderer": "^1.1.4",
     "hono": "^4.6.0",
+    "node-html-parser": "^7.1.0",
     "solid-js": "^1.9.0",
     "zod": "^4.4.3"
   },
@@ -35,7 +36,6 @@
     "@cloudflare/workers-types": "^4.20260511.1",
     "@solidjs/testing-library": "^0.8.10",
     "jsdom": "^29.1.1",
-    "node-html-parser": "^7.1.0",
     "typescript": "^5.7.0",
     "vite": "^6.0.0",
     "vite-plugin-solid": "^2.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       hono:
         specifier: ^4.6.0
         version: 4.12.14
+      node-html-parser:
+        specifier: ^7.1.0
+        version: 7.1.0
       solid-js:
         specifier: ^1.9.0
         version: 1.9.12
@@ -36,9 +39,6 @@ importers:
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
-      node-html-parser:
-        specifier: ^7.1.0
-        version: 7.1.0
       typescript:
         specifier: ^5.7.0
         version: 5.9.3

--- a/src/worker/context-providers.ts
+++ b/src/worker/context-providers.ts
@@ -35,6 +35,8 @@ import type { ContextItem } from '../lib/context/types';
 export interface ContextEnv {
   CACHE?: KVNamespace;
   ASSETS: Fetcher;
+  /** Set to "0" to disable on-demand live dafyomi.co.il fetching. */
+  DAFYOMI_LIVE?: string;
 }
 
 /**
@@ -49,8 +51,9 @@ export async function collectContext(
   assetOrigin?: string,
 ): Promise<ContextItem[]> {
   const cache = env.CACHE;
+  const allowLive = env.DAFYOMI_LIVE !== '0';
   const [dafyomi, sefariaPage, rishonim, halacha, mishna, topics] = await Promise.all([
-    getDafyomiContentCached(cache, env.ASSETS, tractate, page, { assetOrigin }).catch(() => null),
+    getDafyomiContentCached(cache, env.ASSETS, tractate, page, { assetOrigin, allowLive }).catch(() => null),
     getSefariaPageCached(cache, tractate, page).catch(() => null),
     getRishonimCached(cache, tractate, page).catch(() => ({})),
     getHalachaRefsCached(cache, tractate, page).catch(() => ({})),

--- a/src/worker/dafyomi-live.ts
+++ b/src/worker/dafyomi-live.ts
@@ -1,0 +1,84 @@
+/**
+ * @fileoverview On-demand dafyomi.co.il fetch + parse, for dapim not in the
+ * committed static corpus.
+ *
+ * Rather than rely on a hand-maintained dir/prefix table (which is easy to get
+ * wrong per masechet), this is HUB-DRIVEN: it reads the daf's hub page
+ * (`new_daflinks.php?gid=&daf=`), which lists the authoritative content URLs
+ * for that daf, then fetches + parses each with the SAME pure parsers. The
+ * caller (getDafyomiContentCached) memoizes the result in KV, so each daf is
+ * fetched once-ever then served from cache. Failures/absent pages are recorded,
+ * never fabricated.
+ */
+
+import { getDafyomiMasechet, type DafyomiContentType } from '../lib/sefref/dafyomi/masechtos';
+import { assembleDaf, type FetchedType } from '../lib/sefref/dafyomi/assemble';
+import type { DafyomiDaf } from '../lib/sefref/dafyomi/schema';
+
+const ORIGIN = 'https://www.dafyomi.co.il';
+const USER_AGENT = 'talmud-viewer/0.1 (+https://github.com/shaunregenbaum/talmud; study-context ingestion)';
+
+/** dafyomi.co.il folder name -> our content type. */
+const FOLDER_TO_TYPE: Record<string, DafyomiContentType> = {
+  insites: 'insights', backgrnd: 'background', halachah: 'halacha', tosfos: 'tosfos',
+  review: 'review', points: 'points', hebcharts: 'hebcharts', yerushalmi: 'yerushalmi',
+};
+
+async function fetchText(url: string, expectContent: boolean): Promise<string | null> {
+  // One retry: firing the hub + up to 8 content pages in parallel occasionally
+  // sees a transient failure, and since the result is cached we don't want a
+  // partial daf persisted. A genuine 404 (page has no #content) returns null
+  // without burning the retry on a real "absent".
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const res = await fetch(url, { headers: { 'User-Agent': USER_AGENT, accept: 'text/html' } });
+      if (res.ok) {
+        const body = await res.text();
+        // Real content pages always have the #content container; 404/landing
+        // pages don't. (The hub page itself is exempt.)
+        if (expectContent && !body.includes('id="content"')) return null;
+        return body;
+      }
+      if (res.status === 404) return null; // genuinely absent — no retry
+    } catch {
+      // network blip — fall through to retry
+    }
+    if (attempt === 0) await new Promise((r) => setTimeout(r, 400));
+  }
+  return null;
+}
+
+/** Parse the hub page's hrefs into one URL per content type present. */
+function urlsFromHub(hubHtml: string): Map<DafyomiContentType, string> {
+  const re = /href="([a-z0-9]+\/(insites|backgrnd|halachah|tosfos|review|points|hebcharts|yerushalmi)\/[a-z0-9]+-[a-z]{2}-\d+\.htm)"/gi;
+  const out = new Map<DafyomiContentType, string>();
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(hubHtml)) !== null) {
+    const rel = m[1];
+    const type = FOLDER_TO_TYPE[m[2].toLowerCase()];
+    if (type && !out.has(type)) out.set(type, `${ORIGIN}/${rel}${type === 'review' ? '?q=1' : ''}`);
+  }
+  return out;
+}
+
+export async function scrapeDafyomiLive(tractate: string, daf: number): Promise<DafyomiDaf | null> {
+  const m = getDafyomiMasechet(tractate);
+  if (!m || daf < 2 || daf > m.lastDaf) return null;
+
+  const hub = await fetchText(`${ORIGIN}/new_daflinks.php?gid=${m.gid}&daf=${daf}`, false);
+  if (!hub) return null;
+  const urls = urlsFromHub(hub);
+  if (urls.size === 0) return null;
+
+  // Fetch sequentially, not in a burst: hammering their Apache server with ~9
+  // simultaneous requests both trips transient failures (which would cache a
+  // partial daf) and is impolite. Sequential is ~3s for a cold daf, then cached.
+  const fetched: FetchedType[] = [];
+  for (const [type, url] of urls) {
+    fetched.push({ type, url, html: await fetchText(url, true) });
+  }
+
+  const { daf: dafObj } = assembleDaf(tractate, daf, fetched);
+  const present = Object.keys(dafObj.amudim.a ?? {}).length + Object.keys(dafObj.amudim.b ?? {}).length;
+  return present > 0 ? dafObj : null;
+}

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -4095,6 +4095,7 @@ app.get('/api/dafyomi/:tractate/:page', async (c) => {
   const data = await getDafyomiContentCached(c.env.CACHE, c.env.ASSETS, tractate, page, {
     assetOrigin: new URL(c.req.url).origin,
     refresh: c.req.query('refresh') === '1',
+    allowLive: (c.env as { DAFYOMI_LIVE?: string }).DAFYOMI_LIVE !== '0',
     track: { onCache: (s) => states.push(s) },
   });
   if (!data) return c.json({ error: `no dafyomi content for ${tractate} ${page}` }, 404);

--- a/src/worker/source-cache.ts
+++ b/src/worker/source-cache.ts
@@ -31,6 +31,7 @@ import {
 } from '../lib/sefref';
 import type { DafyomiDaf } from '../lib/sefref/dafyomi/schema';
 import { keyForDafyomi } from './cache-keys';
+import { scrapeDafyomiLive } from './dafyomi-live';
 
 const TTL_30_DAYS = 60 * 60 * 24 * 30;
 const TTL_NEGATIVE = 60 * 60;
@@ -261,6 +262,9 @@ export interface DafyomiFetchOpts {
   assetOrigin?: string;
   /** Skip the read-cache (incl. negative cache) and re-resolve from assets. */
   refresh?: boolean;
+  /** When the daf isn't in the committed static corpus, fetch + parse it live
+   *  from dafyomi.co.il (then memoize). Defaults off; callers opt in. */
+  allowLive?: boolean;
   track?: CacheTrack;
 }
 
@@ -271,7 +275,7 @@ export async function getDafyomiContentCached(
   page: string,
   opts: DafyomiFetchOpts = {},
 ): Promise<DafyomiDaf | null> {
-  const { assetOrigin, refresh, track } = opts;
+  const { assetOrigin, refresh, allowLive, track } = opts;
   const m = page.match(/^(\d+)/);
   if (!m) return null;
   const daf = m[1];
@@ -288,16 +292,25 @@ export async function getDafyomiContentCached(
   try {
     let res = await assets.fetch(new Request(`https://assets.local${path}`));
     if (!res.ok && assetOrigin) res = await fetch(`${assetOrigin}${path}`);
-    if (!res.ok) {
-      await writeCache(cache, key, { __failed: true } satisfies FailedMarker, TTL_NEGATIVE);
-      return null;
+    if (res.ok) {
+      const data = (await res.json()) as DafyomiDaf;
+      await writeCache(cache, key, data);
+      return data;
     }
-    const data = (await res.json()) as DafyomiDaf;
-    await writeCache(cache, key, data);
-    return data;
+    // Not in the committed corpus — fetch + parse live (then memoize) so every
+    // daf works, not just the pre-scraped ones.
+    if (allowLive) {
+      const live = await scrapeDafyomiLive(tractate, parseInt(daf, 10));
+      if (live) {
+        await writeCache(cache, key, live);
+        return live;
+      }
+    }
+    await writeCache(cache, key, { __failed: true } satisfies FailedMarker, TTL_NEGATIVE);
+    return null;
   } catch (err) {
     // eslint-disable-next-line no-console
-    console.warn(`[source-cache] dafyomi asset read failed for ${tractate} ${daf}:`, err);
+    console.warn(`[source-cache] dafyomi read failed for ${tractate} ${daf}:`, err);
     await writeCache(cache, key, { __failed: true } satisfies FailedMarker, TTL_NEGATIVE);
     return null;
   }


### PR DESCRIPTION
Previously the dafyomi.co.il study content only appeared on the one pre-scraped daf (Chullin 76); every other daf showed only the Sefaria-sourced context. This adds an on-demand fallback so it works everywhere.

- **`src/worker/dafyomi-live.ts`** — when a daf isn't in the committed corpus, fetch + parse it live, once, then cache in KV. Hub-driven: reads `new_daflinks.php?gid=&daf=` for the authoritative content URLs, so only each masechet's `gid` + `lastDaf` must be correct (the dir/prefix table rows, which were unreliable guesses, are unused by this path).
- **Sequential** fetch with one retry — gentle on their server and avoids transient burst failures caching a partial daf.
- `getDafyomiContentCached` gains an `allowLive` fallback; `/api/context` + `/api/dafyomi` opt in. Kill-switch env `DAFYOMI_LIVE=0`.
- `node-html-parser` moved to runtime dependencies (the worker now parses live).

Verified live (dev) on Chullin 76, Eruvin 102, Berakhot 2, Bava Metzia 2, Sukkah 2 — all return the full set of content types (~3-6s cold, then cached). Typecheck clean; full suite 1094 passing.