### PR TITLE
Align external content onto HebrewBooks daf at word granularity

### DIFF
--- a/src/client/AlignPage.tsx
+++ b/src/client/AlignPage.tsx
@@ -6,6 +6,7 @@ import { injectSegmentMarkers, type SegmentStats } from './injectSegmentMarkers'
 import { ContextSourcePanel } from './ContextSourcePanel';
 import type { ContextItem } from '../lib/context/types';
 import { applyMatches, type SegMatch } from '../lib/context/match';
+import { buildHbWords, locateInHb, type HbWords, type LocateQuery } from './hbAlign';
 
 interface AlignedDaf extends TalmudPageData {
   _source?: string;
@@ -39,9 +40,6 @@ function renderAlignedHtml(mainHtml: string, segmentsHe: string[]): { html: stri
 }
 
 // --- left-pane "base layer" views ---------------------------------------
-// All views emit `.daf-word[data-seg]` spans so the segment-coloring + the
-// hover-highlight <style> (and the onMouseOver handler) work identically.
-
 type LeftView = 'hb' | 'segments' | 'rashi' | 'tosafot';
 const LEFT_VIEWS: { id: LeftView; label: string }[] = [
   { id: 'hb', label: 'HebrewBooks' },
@@ -53,25 +51,18 @@ const LEFT_VIEWS: { id: LeftView; label: string }[] = [
 function escapeHtml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
-/** Sefaria text carries markup (<b>/<strong>/…); strip it, escape, collapse. */
 function clean(s: string): string {
   return escapeHtml(s.replace(/<[^>]+>/g, '')).replace(/\s+/g, ' ').trim();
 }
-/** Sefaria "S:P" pieceKey (1-based segment) -> 0-based segment index. */
 function segOfKey(key: string | undefined): number | null {
   if (!key) return null;
   const s = parseInt(String(key).split(':')[0], 10);
   return Number.isFinite(s) ? s - 1 : null;
 }
-
-/** Exact view: each Sefaria segment is its own colored span (no fuzzy match). */
 function buildSegmentsHtml(segs: string[]): string {
   if (!segs.length) return '<p style="color:#aaa">No Sefaria segments for this daf.</p>';
   return segs.map((s, i) => `<span class="daf-word" data-seg="${i}">${clean(s)} </span>`).join('');
 }
-
-/** Commentary view: each piece is a block, colored by the segment it anchors
- *  to (via its parallel pieceKey). Pieces without a key are left uncolored. */
 function buildCommentaryHtml(pieces?: string[], keys?: string[]): string {
   if (!pieces?.length) return '<p style="color:#aaa">No pieces for this commentary on this daf.</p>';
   return pieces.map((p, i) => {
@@ -82,26 +73,49 @@ function buildCommentaryHtml(pieces?: string[], keys?: string[]): string {
   }).join('');
 }
 
+/** First `n` whitespace words of a Hebrew string, or undefined. */
+function leadingWords(s: string | undefined, n: number): string | undefined {
+  if (!s) return undefined;
+  const w = s.trim().split(/\s+/).slice(0, n).join(' ');
+  return w || undefined;
+}
+
+/** What Hebrew to look for per source. AI quote (if any) wins; else the item's
+ *  natural Hebrew anchor — the dibur ha'maschil for Rashi/Tosafot, the term/DH
+ *  for dafyomi, leading Hebrew otherwise. `segs` always passed (bias + fallback). */
+function hbQueryFor(item: ContextItem, quotes: Map<string, string>): LocateQuery {
+  const segs = item.segs;
+  const aiQuote = quotes.get(item.key);
+  if (aiQuote) return { phrase: aiQuote, segs };
+  if (item.source === 'sefaria-rashi' || item.source === 'sefaria-tosafot') {
+    return { phrase: leadingWords(item.body?.he, 4), segs }; // dibur ha'maschil
+  }
+  return { phrase: leadingWords(item.title?.he, 6) ?? leadingWords(item.body?.he, 6), segs };
+}
+
+interface HL { segs: number[]; words: number[] }
+const EMPTY: HL = { segs: [], words: [] };
+
 export function AlignPage(): JSX.Element {
   const initialParams = new URLSearchParams(window.location.search);
   const [tractate, setTractate] = createSignal(initialParams.get('tractate') ?? 'Berakhot');
   const [page, setPage] = createSignal(initialParams.get('page') ?? '5a');
-  // Which base text fills the left "alignment canvas".
   const [leftView, setLeftView] = createSignal<LeftView>('hb');
-  // Two highlight layers: `pinned` from the selected source (persistent),
-  // `hover` from hovering a card/segment (transient). Hover wins when active.
-  const [pinnedSegs, setPinnedSegs] = createSignal<number[]>([]);
-  const [hoverSegs, setHoverSegs] = createSignal<number[]>([]);
-  const highlight = () => (hoverSegs().length ? hoverSegs() : pinnedSegs());
-  // AI matches applied on top of the server-assembled pool.
+  // Highlight has two layers (pinned from a selected source, hover transient)
+  // and two granularities: `words` = exact HB word indices, `segs` = segments.
+  const [pinned, setPinned] = createSignal<HL>(EMPTY);
+  const [hover, setHover] = createSignal<HL>(EMPTY);
+  const effective = () => (hover().segs.length || hover().words.length ? hover() : pinned());
+  // AI matches + the Hebrew quotes they emit (resolved to HB spans client-side).
   const [matches, setMatches] = createSignal<SegMatch[]>([]);
+  const [aiQuotes, setAiQuotes] = createSignal<Map<string, string>>(new Map());
   const [matchingSource, setMatchingSource] = createSignal<string | null>(null);
 
   const ref = createMemo(() => ({ tractate: tractate(), page: page() }));
   const [daf] = createResource(ref, fetchDaf);
   const [context] = createResource(ref, fetchContext);
-  // Reset client-side AI matches when the daf changes.
-  createMemo(() => { ref(); setMatches([]); setPinnedSegs([]); });
+  // Reset client-side state when the daf changes.
+  createMemo(() => { ref(); setMatches([]); setAiQuotes(new Map()); setPinned(EMPTY); });
 
   const rendered = createMemo(() => {
     const d = daf();
@@ -109,12 +123,16 @@ export function AlignPage(): JSX.Element {
     return renderAlignedHtml(d.mainText.hebrew, d.mainSegmentsHe ?? []);
   });
 
+  // Indexed HB word stream (for the locator). Derived from the HB render.
+  const hbWords = createMemo<HbWords | null>(() => {
+    const html = rendered()?.html;
+    return html ? buildHbWords(html) : null;
+  });
+
   const segmentCount = () => daf()?.mainSegmentsHe?.length ?? 0;
   const stats = () => rendered()?.stats;
-  const isHot = (i: number) => highlight().includes(i);
+  const isHot = (i: number) => effective().segs.includes(i);
 
-  // HTML for the left canvas, per the selected base-layer view. Every view
-  // emits `.daf-word[data-seg]` spans so coloring + highlighting are shared.
   const leftHtml = createMemo(() => {
     const d = daf();
     if (!d) return '';
@@ -126,13 +144,19 @@ export function AlignPage(): JSX.Element {
     }
   });
 
-  // The unified external-context pool, assembled server-side from dafyomi.co.il
-  // + Sefaria sources (commentary text, Mishnayot, Rishonim, halacha, topics),
-  // already anchored deterministically. Client-side AI-match promotions are
-  // layered on top (cloned so the resource stays pristine).
+  // The context pool + client-side HB placement: clone, apply AI segment
+  // matches, then locate each item's Hebrew on the HB word stream.
   const contextItems = createMemo<ContextItem[]>(() => {
     const items = (context() ?? []).map((i) => ({ ...i }));
     if (matches().length) applyMatches(items, matches());
+    const hb = hbWords();
+    if (hb && hb.norm.length) {
+      const quotes = aiQuotes();
+      for (const it of items) {
+        const loc = locateInHb(hb, hbQueryFor(it, quotes));
+        if (loc) { it.hbWords = loc.words; it.hbVia = loc.via; it.hbConfidence = loc.confidence; }
+      }
+    }
     return items;
   });
 
@@ -155,7 +179,13 @@ export function AlignPage(): JSX.Element {
       });
       if (!res.ok) return;
       const data = (await res.json()) as { matches?: SegMatch[] };
-      if (data.matches?.length) setMatches((prev) => [...prev, ...data.matches!]);
+      const got = data.matches ?? [];
+      if (got.length) {
+        const nextQuotes = new Map(aiQuotes());
+        for (const m of got) if (m.quote) nextQuotes.set(m.key, m.quote);
+        setAiQuotes(nextQuotes);
+        setMatches((prev) => [...prev, ...got]);
+      }
     } finally {
       setMatchingSource(null);
     }
@@ -212,7 +242,7 @@ export function AlignPage(): JSX.Element {
               <section>
                 <div style={{ display: 'flex', 'flex-wrap': 'wrap', 'align-items': 'center', gap: '0.4rem', 'margin-bottom': '0.4rem' }}>
                   <h2 style={{ 'font-size': '0.9rem', color: '#999', 'text-transform': 'uppercase', 'letter-spacing': '0.05em', margin: 0 }}>
-                    Alignment canvas — segments colored
+                    Alignment canvas
                   </h2>
                   <div style={{ display: 'flex', gap: '0.25rem', 'margin-left': 'auto' }}>
                     <For each={LEFT_VIEWS}>
@@ -248,18 +278,22 @@ export function AlignPage(): JSX.Element {
                   }}
                   innerHTML={leftHtml()}
                   onMouseOver={(e) => {
-                    const t = e.target as HTMLElement;
-                    const w = t.closest('.daf-word') as HTMLElement | null;
-                    const s = w?.getAttribute('data-seg');
-                    if (s !== null && s !== undefined) setHoverSegs([Number(s)]);
+                    const w = (e.target as HTMLElement).closest('.daf-word') as HTMLElement | null;
+                    if (!w) return;
+                    const s = w.getAttribute('data-seg');
+                    const wi = w.getAttribute('data-word-index');
+                    setHover({ segs: s != null ? [Number(s)] : [], words: wi != null ? [Number(wi)] : [] });
                   }}
-                  onMouseLeave={() => setHoverSegs([])}
+                  onMouseLeave={() => setHover(EMPTY)}
                 />
                 <style>{`
                   ${Array.from({ length: segmentCount() }).map((_, i) =>
                     `.daf-word[data-seg="${i}"] { background-color: ${segColor(i)}; border-radius: 2px; }`
                   ).join('\n')}
-                  ${highlight().map((i) => `.daf-word[data-seg="${i}"] { outline: 2px solid #8a2a2b; }`).join('\n')}
+                  ${(leftView() === 'hb' && effective().words.length
+                    ? effective().words.map((w) => `.daf-word[data-word-index="${w}"] { outline: 2px solid #8a2a2b; background-color: #fde68a; }`)
+                    : effective().segs.map((s) => `.daf-word[data-seg="${s}"] { outline: 2px solid #8a2a2b; }`)
+                  ).join('\n')}
                 `}</style>
               </section>
 
@@ -282,8 +316,8 @@ export function AlignPage(): JSX.Element {
                             background: isHot(i()) ? '#fef3c7' : segColor(i()),
                             opacity: aligned() ? 1 : 0.45,
                           }}
-                          onMouseEnter={() => setHoverSegs([i()])}
-                          onMouseLeave={() => setHoverSegs([])}
+                          onMouseEnter={() => setHover({ segs: [i()], words: [] })}
+                          onMouseLeave={() => setHover(EMPTY)}
                         >
                           <div style={{ display: 'flex', 'align-items': 'baseline', gap: '0.5rem', 'margin-bottom': '0.25rem' }}>
                             <span style={{ 'font-family': 'monospace', 'font-size': '0.72rem', color: '#555' }}>#{i()}</span>
@@ -319,9 +353,9 @@ export function AlignPage(): JSX.Element {
               </Show>
               <ContextSourcePanel
                 items={contextItems()}
-                onHover={(segs) => setHoverSegs(segs)}
-                onLeave={() => setHoverSegs([])}
-                onSelectSource={(_source, segs) => setPinnedSegs(segs)}
+                onHover={(h) => setHover(h)}
+                onLeave={() => setHover(EMPTY)}
+                onSelectSource={(_source, h) => setPinned(h)}
                 onMatch={runAiMatch}
                 matchingSource={matchingSource()}
               />

--- a/src/client/ContextSourcePanel.tsx
+++ b/src/client/ContextSourcePanel.tsx
@@ -1,18 +1,27 @@
 import { createSignal, createMemo, createEffect, For, Show, type JSX } from 'solid-js';
 import { type ContextItem, rangeLabel } from '../lib/context/types';
 
+/** Highlight payload: precise HB word indices + the segments they sit in. */
+interface Hl { segs: number[]; words: number[] }
+const EMPTY: Hl = { segs: [], words: [] };
+
+/** Precisely located on the HB text (a real phrase/AI hit, not a coarse
+ *  segment fallback). */
+function isPrecise(it: ContextItem): boolean {
+  return !!it.hbWords?.length && it.hbVia !== 'segment';
+}
+
 /**
  * The alignment workbench's external-context panel. Source tabs pick a
- * "match-up": selecting one pins a persistent highlight of that source's
- * segments onto the daf (via `onSelectSource`). Cards report their placement
- * (`segs`) + how it was matched. Sources still at whole-daf get a "Match to
- * text (AI)" button that runs the LLM segment-matcher.
+ * "match-up"; selecting one pins its placement onto the HB daf (`onSelectSource`).
+ * Cards report how each item landed on the text (via + confidence). Sources with
+ * items not yet precisely located get a "Match to text (AI)" button.
  */
 export function ContextSourcePanel(props: {
   items: ContextItem[];
-  onHover: (segs: number[]) => void;
+  onHover: (h: Hl) => void;
   onLeave: () => void;
-  onSelectSource?: (source: string, segs: number[]) => void;
+  onSelectSource?: (source: string, h: Hl) => void;
   onMatch?: (source: string, items: ContextItem[]) => void;
   matchingSource?: string | null;
 }): JSX.Element {
@@ -30,27 +39,32 @@ export function ContextSourcePanel(props: {
 
   const itemsOf = (source: string) =>
     source === 'all' ? props.items : props.items.filter((i) => i.source === source);
-  const segsOf = (source: string) => {
-    const set = new Set<number>();
-    for (const it of itemsOf(source)) for (const s of it.segs) set.add(s);
-    return Array.from(set).sort((a, b) => a - b);
+  const hlOf = (source: string): Hl => {
+    const segs = new Set<number>();
+    const words = new Set<number>();
+    for (const it of itemsOf(source)) {
+      for (const s of it.segs) segs.add(s);
+      for (const w of it.hbWords ?? []) words.add(w);
+    }
+    return { segs: [...segs].sort((a, b) => a - b), words: [...words].sort((a, b) => a - b) };
   };
 
   const visible = createMemo(() => itemsOf(selected()));
-  const placedCount = createMemo(() => props.items.filter((i) => i.segs.length > 0).length);
-  const unplacedInSelected = createMemo(() =>
-    selected() === 'all' ? [] : itemsOf(selected()).filter((i) => i.segs.length === 0),
+  const preciseCount = createMemo(() => props.items.filter(isPrecise).length);
+  // Items in the selected source not yet precisely located (candidates for AI).
+  const needAi = createMemo(() =>
+    selected() === 'all' ? [] : itemsOf(selected()).filter((i) => !isPrecise(i)),
   );
 
   const pick = (source: string) => {
     setSelected(source);
-    props.onSelectSource?.(source, source === 'all' ? [] : segsOf(source));
+    props.onSelectSource?.(source, source === 'all' ? EMPTY : hlOf(source));
   };
 
-  // Re-pin highlight when items change (e.g. after AI matching places segments).
+  // Re-pin when items change (e.g. after AI matching places words).
   createEffect(() => {
     props.items; // track
-    if (selected() !== 'all') props.onSelectSource?.(selected(), segsOf(selected()));
+    if (selected() !== 'all') props.onSelectSource?.(selected(), hlOf(selected()));
   });
 
   return (
@@ -58,7 +72,7 @@ export function ContextSourcePanel(props: {
       <h2 style={{ 'font-size': '0.9rem', color: '#999', 'text-transform': 'uppercase', 'letter-spacing': '0.05em', 'margin-bottom': '0.4rem' }}>
         External context
         <span style={{ 'text-transform': 'none', 'margin-left': '0.6rem', color: '#aaa', 'font-size': '0.8rem' }}>
-          {props.items.length} items · {placedCount()} placed on segments
+          {props.items.length} items · {preciseCount()} located on the text
         </span>
       </h2>
 
@@ -67,18 +81,18 @@ export function ContextSourcePanel(props: {
         <For each={sources()}>
           {(s) => <Tab active={selected() === s.source} label={s.label} n={s.n} onClick={() => pick(s.source)} />}
         </For>
-        <Show when={selected() !== 'all' && unplacedInSelected().length > 0 && props.onMatch}>
+        <Show when={selected() !== 'all' && needAi().length > 0 && props.onMatch}>
           <button
             type="button"
             disabled={props.matchingSource === selected()}
-            onClick={() => props.onMatch?.(selected(), unplacedInSelected())}
+            onClick={() => props.onMatch?.(selected(), needAi())}
             style={{
               'margin-left': '0.5rem', padding: '0.2rem 0.7rem', 'font-size': '0.78rem', 'border-radius': '6px',
               border: '1px solid #0369a1', background: props.matchingSource === selected() ? '#e0f2fe' : '#0369a1',
               color: props.matchingSource === selected() ? '#0369a1' : '#fff', cursor: 'pointer',
             }}
           >
-            {props.matchingSource === selected() ? 'matching…' : `Match ${unplacedInSelected().length} to text (AI)`}
+            {props.matchingSource === selected() ? 'matching…' : `Match ${needAi().length} to text (AI)`}
           </button>
         </Show>
       </div>
@@ -86,7 +100,7 @@ export function ContextSourcePanel(props: {
       <div style={{ display: 'flex', 'flex-direction': 'column', gap: '0.5rem' }}>
         <For each={visible()}>
           {(item) => (
-            <ContextCard item={item} onEnter={() => props.onHover(item.segs)} onLeave={props.onLeave} />
+            <ContextCard item={item} onEnter={() => props.onHover({ segs: item.segs, words: item.hbWords ?? [] })} onLeave={props.onLeave} />
           )}
         </For>
         <Show when={visible().length === 0}>
@@ -117,7 +131,10 @@ function Tab(props: { active: boolean; label: string; n: number; onClick: () => 
 function ContextCard(props: { item: ContextItem; onEnter: () => void; onLeave: () => void }): JSX.Element {
   const [open, setOpen] = createSignal(false);
   const it = props.item;
-  const placed = () => it.segs.length > 0;
+  const placed = () => isPrecise(it);
+  const via = () => it.hbVia ?? it.via;
+  const conf = () => it.hbConfidence ?? it.confidence;
+  const placeLabel = () => (it.hbWords?.length ? `${it.hbWords.length} word${it.hbWords.length === 1 ? '' : 's'}` : rangeLabel(it.segs, it.amud));
   const bodyEn = () => it.body?.en ?? '';
   const long = () => bodyEn().length > 280;
   const shown = () => (open() || !long() ? bodyEn() : bodyEn().slice(0, 280) + '…');
@@ -128,7 +145,7 @@ function ContextCard(props: { item: ContextItem; onEnter: () => void; onLeave: (
       onMouseLeave={props.onLeave}
       style={{
         border: '1px solid #eee', 'border-radius': '6px', padding: '0.55rem 0.7rem', background: '#fff',
-        'border-left': `3px solid ${placed() ? '#059669' : '#d1d5db'}`,
+        'border-left': `3px solid ${placed() ? '#059669' : it.hbWords?.length ? '#f59e0b' : '#d1d5db'}`,
       }}
     >
       <div style={{ display: 'flex', 'align-items': 'baseline', gap: '0.5rem', 'margin-bottom': '0.25rem', 'flex-wrap': 'wrap' }}>
@@ -136,11 +153,11 @@ function ContextCard(props: { item: ContextItem; onEnter: () => void; onLeave: (
           {it.sourceLabel}
         </span>
         <span style={{ 'font-size': '0.68rem', 'font-family': 'monospace', color: placed() ? '#059669' : '#999' }}>
-          {rangeLabel(it.segs, it.amud)}
+          {placeLabel()}
         </span>
-        <Show when={it.via}>
+        <Show when={via()}>
           <span style={{ 'font-size': '0.62rem', 'font-family': 'monospace', color: '#0369a1', background: '#e0f2fe', padding: '0 0.3rem', 'border-radius': '3px' }}>
-            {it.via}{it.confidence != null ? ` ${it.confidence.toFixed(2)}` : ''}
+            {via()}{conf() != null ? ` ${conf()!.toFixed(2)}` : ''}
           </span>
         </Show>
         <Show when={it.url}>

--- a/src/client/hbAlign.ts
+++ b/src/client/hbAlign.ts
@@ -1,0 +1,176 @@
+/**
+ * @fileoverview Locate external content on the HebrewBooks daf at word
+ * granularity — the core of "align dafyomi/Sefaria/Rashi/Tosafot to the HB text."
+ *
+ * The rendered HB daf is a stream of `<span class="daf-word" data-word-index>`
+ * (from tokenize.ts), each also tagged with `data-seg` (from
+ * injectSegmentMarkers.ts). `buildHbWords` parses that stream once;
+ * `locateInHb` places a query — a Hebrew phrase and/or Sefaria segments — onto
+ * the exact HB word indices it covers.
+ *
+ * Matching is two-tier: an EXACT normalized match first (precise), then a
+ * FUZZY match (reusing the alignment lib's `wordsMatchFuzzy`) but only WITHIN
+ * the item's segment window — because the HB text is full of abbreviations
+ * (א"ר, ס"ד) that never equal the spelled-out Sefaria/commentary Hebrew, and
+ * fuzzy matching is only safe when the search space is one segment.
+ */
+
+import { wordsMatchFuzzy } from '../lib/sefref/alignment';
+
+export interface HbWords {
+  /** Raw `.daf-word` text, in document order (for fuzzy matching). */
+  raw: string[];
+  /** Normalized text per word (for exact matching). */
+  norm: string[];
+  /** Parallel `data-word-index` per word (== array position in practice). */
+  wordIndex: number[];
+  /** Sefaria segment index per word (or null when unaligned). */
+  seg: (number | null)[];
+  /** segment index -> inclusive [first,last] positions in the arrays above. */
+  segRange: Map<number, { first: number; last: number }>;
+}
+
+export type LocateVia = 'phrase' | 'phrase-in-seg' | 'phrase-fuzzy' | 'segment' | 'ai';
+
+export interface Located {
+  /** Exact HB `data-word-index` values to highlight. */
+  words: number[];
+  via: LocateVia;
+  /** 0..1 — how confident the placement is. */
+  confidence: number;
+}
+
+/** Strip niqqud/cantillation, fold final letters, drop punctuation, collapse. */
+export function normHe(s: string): string {
+  return s
+    .replace(/[֑-ׇ]/g, '')
+    .replace(/[ךםןףץ]/g, (c) => ({ ך: 'כ', ם: 'מ', ן: 'נ', ף: 'פ', ץ: 'צ' } as Record<string, string>)[c] ?? c)
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/[.,:;?!"'״׳`()[\]{}־–—]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function buildHbWords(html: string): HbWords {
+  const out: HbWords = { raw: [], norm: [], wordIndex: [], seg: [], segRange: new Map() };
+  if (!html || typeof document === 'undefined') return out;
+  const doc = new DOMParser().parseFromString(`<body>${html}</body>`, 'text/html');
+  const spans = Array.from(doc.body.querySelectorAll<HTMLSpanElement>('.daf-word'));
+  spans.forEach((el, pos) => {
+    const text = el.textContent ?? '';
+    const wiRaw = el.getAttribute('data-word-index');
+    const wi = wiRaw != null && Number.isFinite(Number(wiRaw)) ? Number(wiRaw) : pos;
+    const segRaw = el.getAttribute('data-seg');
+    const seg = segRaw != null && Number.isFinite(Number(segRaw)) ? Number(segRaw) : null;
+    out.raw.push(text);
+    out.norm.push(normHe(text));
+    out.wordIndex.push(wi);
+    out.seg.push(seg);
+    if (seg != null) {
+      const e = out.segRange.get(seg);
+      if (e) e.last = pos;
+      else out.segRange.set(seg, { first: pos, last: pos });
+    }
+  });
+  return out;
+}
+
+/** Exact: norm equality, last needle token may be a prefix. Bounded to [start,end]. */
+function findExact(norm: string[], needle: string[], start: number, end: number): number {
+  const n = needle.length;
+  if (n === 0) return -1;
+  const hi = Math.min(end, norm.length - 1) - (n - 1);
+  outer: for (let i = Math.max(0, start); i <= hi; i++) {
+    for (let j = 0; j < n; j++) {
+      if (j === n - 1) { if (!norm[i + j].startsWith(needle[j])) continue outer; }
+      else if (norm[i + j] !== needle[j]) continue outer;
+    }
+    return i;
+  }
+  return -1;
+}
+
+/** Fuzzy: per-token `wordsMatchFuzzy`. Looser — only used inside a segment window. */
+function findFuzzy(raw: string[], needle: string[], start: number, end: number): number {
+  const n = needle.length;
+  if (n === 0) return -1;
+  const hi = Math.min(end, raw.length - 1) - (n - 1);
+  outer: for (let i = Math.max(0, start); i <= hi; i++) {
+    for (let j = 0; j < n; j++) {
+      if (!wordsMatchFuzzy(raw[i + j], needle[j])) continue outer;
+    }
+    return i;
+  }
+  return -1;
+}
+
+function segWindow(hb: HbWords, segs: number[]): { first: number; last: number } | null {
+  let first = Infinity;
+  let last = -Infinity;
+  for (const s of segs) {
+    const r = hb.segRange.get(s);
+    if (!r) continue;
+    if (r.first < first) first = r.first;
+    if (r.last > last) last = r.last;
+  }
+  return last >= first ? { first, last } : null;
+}
+
+export interface LocateQuery {
+  phrase?: string;
+  segs?: number[];
+}
+
+/**
+ * Place a query on the HB daf. Exact phrase first (in-window, then whole-daf for
+ * multi-word); then fuzzy within the segment window; then the whole segment
+ * range as a coarse fallback; else null (caller keeps it whole-daf).
+ */
+export function locateInHb(hb: HbWords, q: LocateQuery): Located | null {
+  if (hb.norm.length === 0) return null;
+  const win = q.segs && q.segs.length ? segWindow(hb, q.segs) : null;
+  const rawTokens = q.phrase ? q.phrase.replace(/<[^>]+>/g, ' ').trim().split(/\s+/).filter(Boolean) : [];
+  const normTokens = rawTokens.map(normHe).filter(Boolean);
+  const multi = normTokens.length >= 2;
+  const single = normTokens.length === 1;
+  const lastWord = hb.norm.length - 1;
+
+  if (multi || (single && win)) {
+    // 1. exact, inside the segment window.
+    if (win) {
+      const at = findExact(hb.norm, normTokens, win.first, win.last);
+      if (at >= 0) return mk(hb, at, normTokens.length, 'phrase-in-seg', conf(normTokens.length, true, false));
+    }
+    // 2. exact, anywhere (multi-word only — single words are too common).
+    if (multi) {
+      const at = findExact(hb.norm, normTokens, 0, lastWord);
+      if (at >= 0) return mk(hb, at, normTokens.length, 'phrase', conf(normTokens.length, false, false));
+    }
+    // 3. fuzzy, inside the window (abbreviation-tolerant; scoped to stay safe).
+    if (win) {
+      const at = findFuzzy(hb.raw, rawTokens, win.first, win.last);
+      if (at >= 0) return mk(hb, at, rawTokens.length, 'phrase-fuzzy', conf(normTokens.length, true, true));
+    }
+  }
+
+  // 4. coarse fallback: the whole segment range.
+  if (win) {
+    const words: number[] = [];
+    for (let p = win.first; p <= win.last; p++) words.push(hb.wordIndex[p]);
+    return { words, via: 'segment', confidence: 0.3 };
+  }
+  return null;
+}
+
+function mk(hb: HbWords, at: number, len: number, via: LocateVia, confidence: number): Located {
+  const words: number[] = [];
+  for (let p = at; p < at + len && p < hb.wordIndex.length; p++) words.push(hb.wordIndex[p]);
+  return { words, via, confidence };
+}
+
+function conf(nTokens: number, inWindow: boolean, fuzzy: boolean): number {
+  let c = nTokens === 1 ? 0.45 : Math.min(0.6 + 0.08 * nTokens, 0.92);
+  if (inWindow) c += 0.05;
+  if (fuzzy) c -= 0.2;
+  return Math.max(0.2, Math.min(0.97, c));
+}

--- a/src/client/tokenize.ts
+++ b/src/client/tokenize.ts
@@ -5,31 +5,37 @@
  * Preserves all existing element structure (gdropcap / shastitle7 / five / div
  * wrappers from HebrewBooks) — only text nodes are transformed, and each token
  * is wrapped individually so formatting from enclosing spans cascades naturally.
+ *
+ * Each word also gets a stable `data-word-index` (monotonic, in document order)
+ * so callers can address an exact HB word position — used by the alignment
+ * workbench to anchor external content onto specific words. Downstream passes
+ * (injectHadran, injectSegmentMarkers) only move/annotate these spans, never
+ * reorder or recreate them, so the index stays stable.
  */
 export function tokenizeHebrewHtml(html: string): string {
   if (!html || typeof document === 'undefined') return html;
 
   const doc = new DOMParser().parseFromString(`<body>${html}</body>`, 'text/html');
-  const body = doc.body;
-  walk(body);
-  return body.innerHTML;
+  const counter = { n: 0 };
+  walk(doc.body, counter);
+  return doc.body.innerHTML;
 }
 
 const WORD_RE = /(\S+)/g;
 
-function walk(node: Node): void {
+function walk(node: Node, counter: { n: number }): void {
   // Iterate over a snapshot since we'll mutate the children list.
   const children = Array.from(node.childNodes);
   for (const child of children) {
     if (child.nodeType === Node.TEXT_NODE) {
-      tokenizeTextNode(child as Text);
+      tokenizeTextNode(child as Text, counter);
     } else if (child.nodeType === Node.ELEMENT_NODE) {
-      walk(child);
+      walk(child, counter);
     }
   }
 }
 
-function tokenizeTextNode(text: Text): void {
+function tokenizeTextNode(text: Text, counter: { n: number }): void {
   const content = text.nodeValue ?? '';
   if (!content.trim()) return;
 
@@ -47,6 +53,7 @@ function tokenizeTextNode(text: Text): void {
     }
     const span = doc.createElement('span');
     span.className = 'daf-word';
+    span.setAttribute('data-word-index', String(counter.n++));
     span.textContent = match[1];
     frag.appendChild(span);
     lastIdx = match.index + match[1].length;

--- a/src/lib/context/anchor/ai-prompt.ts
+++ b/src/lib/context/anchor/ai-prompt.ts
@@ -29,7 +29,8 @@ Rules:
 - If it spans consecutive segments, set segStart..segEnd.
 - If an item is general to the whole daf / you cannot localize it, set segStart = null.
 - confidence is 0..1 (how sure you are of the localization).
-Reply with ONLY JSON: {"matches":[{"key":"<key>","segStart":<int|null>,"segEnd":<int|null>,"confidence":<number>}]}`;
+- "quote": copy 3-8 words of HEBREW VERBATIM from the segment(s) — the exact phrase the item is about — so it can be located precisely in the printed text. Copy the Hebrew exactly as shown; do not translate or paraphrase. Use "" if you can't pin a phrase.
+Reply with ONLY JSON: {"matches":[{"key":"<key>","segStart":<int|null>,"segEnd":<int|null>,"confidence":<number>,"quote":"<hebrew or empty>"}]}`;
 
 export function buildMatchPrompt(
   segmentsHe: string[],
@@ -52,7 +53,7 @@ export function buildMatchPrompt(
   return { system: SYS, user };
 }
 
-interface RawMatch { key?: unknown; segStart?: unknown; segEnd?: unknown; confidence?: unknown }
+interface RawMatch { key?: unknown; segStart?: unknown; segEnd?: unknown; confidence?: unknown; quote?: unknown }
 
 /** Parse the model's JSON into validated SegMatches. Drops unknown keys,
  *  out-of-range segments, and whole-daf (null) results. */
@@ -67,7 +68,8 @@ export function parseMatchResponse(content: string, validKeys: Set<string>, segC
     if (start == null) continue; // null / whole-daf / out of range
     const end = toSeg(m.segEnd, segCount);
     const confidence = typeof m.confidence === 'number' ? clamp01(m.confidence) : undefined;
-    out.push({ key: m.key, segs: segRange(start, end != null && end >= start ? end : start), via: 'ai', confidence });
+    const quote = typeof m.quote === 'string' && m.quote.trim() ? m.quote.trim() : undefined;
+    out.push({ key: m.key, segs: segRange(start, end != null && end >= start ? end : start), via: 'ai', confidence, quote });
   }
   return out;
 }

--- a/src/lib/context/match.ts
+++ b/src/lib/context/match.ts
@@ -18,6 +18,9 @@ export interface SegMatch {
   via: string;
   /** 0..1 confidence (AI matchers set this; deterministic ones may omit). */
   confidence?: number;
+  /** Optional verbatim Hebrew phrase the item is about (AI matcher emits this);
+   *  the client resolves it to exact HB word positions via the HB locator. */
+  quote?: string;
 }
 
 /** Write placements onto items in place. Returns the number changed. */

--- a/src/lib/context/types.ts
+++ b/src/lib/context/types.ts
@@ -45,6 +45,13 @@ export interface ContextItem {
   /** Tosfos-DH matcher input: niqqud-stripped DH opening words. Only set on
    *  dafyomi Tosfos items; lets the matcher place them via Sefaria pieceKeys. */
   dhNormalized?: string;
+
+  /** Client-side HB placement (computed in the alignment workbench, not from
+   *  the server pool): the exact HebrewBooks word indices this item maps to,
+   *  plus how it was located and a confidence. Drives word-level highlighting. */
+  hbWords?: number[];
+  hbVia?: string;
+  hbConfidence?: number;
 }
 
 /** A short human label for an item's segment placement (for card chips). */

--- a/tests/context-match.test.ts
+++ b/tests/context-match.test.ts
@@ -50,6 +50,12 @@ describe('AI match prompt + parse', () => {
     expect(user).toContain('segment zero');
   });
 
+  it('captures an optional Hebrew quote', () => {
+    const content = JSON.stringify({ matches: [{ key: 'ins:0', segStart: 1, segEnd: 1, confidence: 0.7, quote: 'מן הארכובה ולמטה' }] });
+    const m = parseMatchResponse(content, new Set(['ins:0']), 5);
+    expect(m[0].quote).toBe('מן הארכובה ולמטה');
+  });
+
   it('parses valid matches, dropping unknown keys / out-of-range / null', () => {
     const content = JSON.stringify({
       matches: [

--- a/tests/hb-align.test.ts
+++ b/tests/hb-align.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { buildHbWords, locateInHb, normHe, type HbWords } from '../src/client/hbAlign';
+
+describe('normHe', () => {
+  it('strips niqqud, folds final letters, drops punctuation', () => {
+    expect(normHe('בְּהֵמָה')).toBe('בהמה');
+    expect(normHe('רַגְלֶיהָ,')).toBe('רגליה');
+    expect(normHe('א"ר')).toBe('אר');
+    expect(normHe('שֶׁנֶּחְתְּכוּ ')).toBe('שנחתכו');
+    // final mem folded to medial
+    expect(normHe('הָאָדָם')).toBe(normHe('האדמ'));
+  });
+});
+
+describe('buildHbWords (jsdom)', () => {
+  const html =
+    '<span class="daf-word" data-word-index="0" data-seg="0">בְּהֵמָה</span> ' +
+    '<span class="daf-word" data-word-index="1" data-seg="0">שֶׁנֶּחְתְּכוּ</span> ' +
+    '<span class="daf-word" data-word-index="2" data-seg="1">רַגְלֶיהָ</span>';
+  const hb = buildHbWords(html);
+  it('indexes words, segs, and segment ranges', () => {
+    expect(hb.norm).toEqual(['בהמה', 'שנחתכו', 'רגליה']);
+    expect(hb.wordIndex).toEqual([0, 1, 2]);
+    expect(hb.seg).toEqual([0, 0, 1]);
+    expect(hb.segRange.get(0)).toEqual({ first: 0, last: 1 });
+    expect(hb.segRange.get(1)).toEqual({ first: 2, last: 2 });
+  });
+});
+
+// Hand-built word stream so locateInHb is tested without a DOM.
+function mkHb(words: string[], segs: number[]): HbWords {
+  const hb: HbWords = { raw: words, norm: words.map(normHe), wordIndex: words.map((_, i) => i), seg: segs, segRange: new Map() };
+  segs.forEach((s, pos) => {
+    const e = hb.segRange.get(s);
+    if (e) e.last = pos; else hb.segRange.set(s, { first: pos, last: pos });
+  });
+  return hb;
+}
+
+describe('locateInHb', () => {
+  const hb = mkHb(
+    ['בהמה', 'שנחתכו', 'רגליה', 'מן', 'הארכובה', 'ולמטה', 'כשרה'],
+    [0, 0, 0, 1, 1, 1, 1],
+  );
+
+  it('finds a multi-word phrase inside its segment window', () => {
+    const r = locateInHb(hb, { phrase: 'מן הארכובה', segs: [1] })!;
+    expect(r.words).toEqual([3, 4]);
+    expect(r.via).toBe('phrase-in-seg');
+    expect(r.confidence).toBeGreaterThan(0.7);
+  });
+
+  it('finds a multi-word phrase anywhere when no segment given', () => {
+    const r = locateInHb(hb, { phrase: 'רגליה מן' })!;
+    expect(r.words).toEqual([2, 3]);
+    expect(r.via).toBe('phrase');
+  });
+
+  it('locates a single word only within its segment window', () => {
+    const r = locateInHb(hb, { phrase: 'הארכובה', segs: [1] })!;
+    expect(r.words).toEqual([4]);
+    expect(r.via).toBe('phrase-in-seg');
+    // single-word is lower confidence
+    expect(r.confidence).toBeLessThan(0.6);
+    // …but not without a window (too common to place reliably)
+    expect(locateInHb(hb, { phrase: 'הארכובה' })).toBeNull();
+  });
+
+  it('falls back to the segment range when the phrase misses', () => {
+    const r = locateInHb(hb, { phrase: 'דבר אחר לגמרי', segs: [0] })!;
+    expect(r.words).toEqual([0, 1, 2]);
+    expect(r.via).toBe('segment');
+  });
+
+  it('returns null when nothing is locatable', () => {
+    expect(locateInHb(hb, { phrase: 'דבר אחר לגמרי' })).toBeNull();
+    expect(locateInHb(hb, {})).toBeNull();
+  });
+});


### PR DESCRIPTION
Tightens the alignment workbench from whole-segment to **exact HB words**.

- `hbAlign.ts` locates a source's Hebrew on the HB word stream: exact → exact-anywhere (multi-word) → fuzzy within the segment window (HB abbreviations tolerated via `wordsMatchFuzzy`) → coarse segment fallback → null. `tokenize.ts` adds a stable `data-word-index` per word.
- Per source: Rashi/Tosafot dibur-ha'maschil; dafyomi glossary term / Tosfos DH / Points Hebrew; all keep segments for windowing + fallback.
- Workbench highlights the exact words; cards show via (`phrase`/`phrase-in-seg`/`phrase-fuzzy`/`segment`) + confidence; header counts items located on the text.
- AI matcher additionally emits a verbatim Hebrew quote, resolved client-side through the same locator to exact words.

Exploration surface (not a finished accuracy number). Verified: typecheck clean; 1109 tests pass; measured live on Eruvin 102 / Chullin 76 (everything segment-anchored; a meaningful minority word-anchored deterministically; AI pass for the rest).