### PR TITLE
Align workbench: sticky source, dafyomi forever-cache, Tosafot-explanation label, AI-match nudge

### DIFF
--- a/src/client/AlignPage.tsx
+++ b/src/client/AlignPage.tsx
@@ -191,7 +191,7 @@ export function AlignPage(): JSX.Element {
       <Show when={daf()}>
         <>
           <div class="responsive-2col">
-              <section>
+              <section class="align-sticky-source">
                 <h2 style={{ 'font-size': '0.9rem', color: '#999', 'text-transform': 'uppercase', 'letter-spacing': '0.05em', margin: '0 0 0.4rem' }}>
                   Source text <span style={{ 'text-transform': 'none', color: '#bbb', 'font-weight': 400 }}>· HebrewBooks</span>
                 </h2>

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -104,6 +104,25 @@ main {
   }
 }
 
+/* Alignment workbench: keep the source text pinned in view while the taller
+   connections column scrolls past it. Desktop only — on phones the columns
+   stack, so a sticky/scrolling source would just cover the connections. */
+.align-sticky-source {
+  position: sticky;
+  top: 1rem;
+  align-self: start;
+  max-height: calc(100vh - 2rem);
+  overflow-y: auto;
+}
+
+@media (max-width: 767px) {
+  .align-sticky-source {
+    position: static;
+    max-height: none;
+    overflow: visible;
+  }
+}
+
 header {
   border-bottom: 1px solid var(--line);
   padding-bottom: 1rem;

--- a/src/lib/context/anchor/ai-prompt.ts
+++ b/src/lib/context/anchor/ai-prompt.ts
@@ -25,11 +25,12 @@ You are given the daf as a numbered list of Hebrew segments with English transla
 For EACH item, decide which segment (or contiguous range of segments) it most directly discusses or comments on.
 Rules:
 - Use the segment INDICES shown (0-based).
+- Most study-note items DO comment on a specific line — localize whenever you reasonably can. Prefer the single best segment over a wide range.
 - If an item maps to one segment, set segEnd = segStart.
 - If it spans consecutive segments, set segStart..segEnd.
-- If an item is general to the whole daf / you cannot localize it, set segStart = null.
+- Only set segStart = null when the item is genuinely about the whole daf (e.g. a general summary or methodology note) and no single segment fits.
 - confidence is 0..1 (how sure you are of the localization).
-- "quote": copy 3-8 words of HEBREW VERBATIM from the segment(s) — the exact phrase the item is about — so it can be located precisely in the printed text. Copy the Hebrew exactly as shown; do not translate or paraphrase. Use "" if you can't pin a phrase.
+- "quote": copy 3-8 CONSECUTIVE words of HEBREW exactly as they appear in the chosen segment — the precise phrase the item is about — so it can be located in the printed text. Do not translate, paraphrase, reorder, or merge non-adjacent words. Use "" only if no phrase fits.
 Reply with ONLY JSON: {"matches":[{"key":"<key>","segStart":<int|null>,"segEnd":<int|null>,"confidence":<number>,"quote":"<hebrew or empty>"}]}`;
 
 export function buildMatchPrompt(

--- a/src/lib/context/fromDafyomi.ts
+++ b/src/lib/context/fromDafyomi.ts
@@ -13,7 +13,9 @@ import type {
 import type { ContextItem } from './types.ts';
 
 const SOURCE_LABEL: Record<DafyomiContentType, string> = {
-  insights: 'Insights', background: 'Background', halacha: 'Halacha', tosfos: 'Tosfos',
+  // dafyomi "Tosfos" is the Kollel's explanation OF Tosafot, not Tosafot itself —
+  // label it so it reads as a companion to the Sefaria "Tosafot" source.
+  insights: 'Insights', background: 'Background', halacha: 'Halacha', tosfos: 'Tosafot explanation',
   review: 'Review', points: 'Points', hebcharts: 'Charts', yerushalmi: 'Yerushalmi',
 };
 

--- a/src/worker/source-cache.ts
+++ b/src/worker/source-cache.ts
@@ -297,15 +297,17 @@ export async function getDafyomiContentCached(
     let corpus = await readJsonAsset(assets.fetch(new Request(`https://assets.local${path}`)));
     if (!corpus && assetOrigin) corpus = await readJsonAsset(fetch(`${assetOrigin}${path}`));
     if (corpus) {
-      await writeCache(cache, key, corpus);
+      // dafyomi.co.il study content for a daf never changes — cache it forever,
+      // like the HebrewBooks daf HTML (ttl=null), not the 30-day Sefaria default.
+      await writeCache(cache, key, corpus, null);
       return corpus;
     }
     // Not in the committed corpus — fetch + parse live (then memoize) so every
-    // daf works, not just the pre-scraped ones.
+    // daf works, not just the pre-scraped ones. Same never-expire policy.
     if (allowLive) {
       const live = await scrapeDafyomiLive(tractate, parseInt(daf, 10));
       if (live) {
-        await writeCache(cache, key, live);
+        await writeCache(cache, key, live, null);
         return live;
       }
     }


### PR DESCRIPTION
Follow-ups from reviewing the workbench in production.

## Changes
- **Sticky source column** — the HebrewBooks source text now pins in view (its own scroll area) while the taller connections list scrolls past it; stacks back to static on phones.
- **dafyomi forever-cache** — dafyomi.co.il study content for a daf never changes, so a successful fetch is now cached with no TTL (like the HebrewBooks daf HTML) instead of the 30-day Sefaria default. Only the "absent/not-yet-scraped" negative marker still expires (1h) so new dapim get retried.
- **"Tosafot explanation" label** — the dafyomi "Tosfos" source is the Kollel's explanation *of* Tosafot, not Tosafot itself; relabeled so it reads as a companion to the Sefaria "Tosafot" source.
- **AI-match prompt nudge** — in testing the matcher defaulted to "whole daf" (null) too often, leaving items unplaced. It is now told to localize whenever reasonable, prefer the single best segment, and copy a *contiguous* verbatim Hebrew quote.

## Not changed (investigated)
- **Charts mojibake** — verified the charts render cleanly in the live DOM (0 replacement characters, valid Hebrew codepoints) and the data is clean end-to-end (API + static file). The garbling was a stale cached JS bundle; a hard refresh resolves it.

## Verification
`pnpm typecheck` + `pnpm test` (1102 passing) green.