### PR TITLE
Add LLM spend budget guard + studio-secret hijack lockdown

### DIFF
--- a/src/client/MarkEnrichmentCards.tsx
+++ b/src/client/MarkEnrichmentCards.tsx
@@ -25,6 +25,7 @@ import { trackAI } from './aiActivity';
 import InstanceInspectorShelf from './InstanceInspectorShelf';
 import {
   RequestQueue, QUEUE_PRIORITY, runResultCache, runCacheKey, isAbort,
+  PAUSED_ERROR, isPausedBody,
   type RunResult,
 } from './enrichmentQueue';
 import { lang, t } from './i18n';
@@ -96,6 +97,7 @@ async function runEnrichmentImpl(
     signal,
   });
   const j = await r.json() as RunResponse | { error?: string };
+  if (isPausedBody(j)) throw new Error(PAUSED_ERROR);
   if (!r.ok && r.status !== 202) {
     throw new Error((j as { error?: string }).error ?? `HTTP ${r.status}`);
   }
@@ -165,6 +167,7 @@ async function pollJob(runId: string, cacheKey?: string, signal?: AbortSignal): 
     if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
     const r = await fetch(`/api/studio/run-status/${encodeURIComponent(runId)}${qs}`, { signal });
     const j = await r.json() as RunResponse | { status: 'pending' };
+    if (isPausedBody(j)) throw new Error(PAUSED_ERROR);
     if ('status' in j) {
       if (j.status === 'ok') return (j as { result: RunResult }).result;
       if (j.status === 'error') throw new Error((j as { error: string }).error);
@@ -472,9 +475,14 @@ export default function MarkEnrichmentCards(props: Props) {
       );
     }
     if (r.kind === 'error') {
+      const paused = r.error === PAUSED_ERROR;
       return (
-        <div style={{ color: '#c00', 'font-family': 'monospace', 'font-size': '0.78rem', padding: '0.4rem 0' }}>
-          {r.error}
+        <div style={{
+          color: paused ? '#a16207' : '#c00',
+          'font-family': paused ? 'inherit' : 'monospace',
+          'font-size': '0.78rem', padding: '0.4rem 0',
+        }}>
+          {paused ? t('qa.error.paused') : r.error}
         </div>
       );
     }

--- a/src/client/MarksRegistryPanel.tsx
+++ b/src/client/MarksRegistryPanel.tsx
@@ -180,10 +180,26 @@ type RunResponse =
 const POLL_INTERVAL_MS = 1500;
 const POLL_TIMEOUT_MS = 180_000;
 
+/** Studio secret for the privileged /api/studio/run knobs (bypass_cache here).
+ *  The owner sets it once via
+ *  `localStorage.setItem('talmud_studio_secret', '<secret>')` in the browser
+ *  console; it rides along as the x-studio-secret header so the server treats
+ *  these requests as trusted. Absent => the server simply downgrades
+ *  bypass_cache to a cache-respecting run (no error), so this panel still works
+ *  read-only for everyone else. */
+function studioHeaders(): Record<string, string> {
+  try {
+    const s = localStorage.getItem('talmud_studio_secret');
+    return s ? { 'x-studio-secret': s } : {};
+  } catch {
+    return {};
+  }
+}
+
 async function postAndAwait(body: unknown): Promise<RunResult> {
   const r = await fetch('/api/studio/run', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...studioHeaders() },
     body: JSON.stringify(body),
   });
   const j = await r.json() as RunResponse | { error?: string };

--- a/src/client/QAPanel.tsx
+++ b/src/client/QAPanel.tsx
@@ -32,6 +32,7 @@ import { Hebraized } from './Hebraized';
 import { hebraize } from './hebraize';
 import { trackAI } from './aiActivity';
 import { lang, t } from './i18n';
+import { PAUSED_ERROR, isPausedBody, isPausedError } from './enrichmentQueue';
 
 export interface QAPanelProps {
   /** Mark id — drives which `<mark>.suggested-questions` + `<mark>.qa`
@@ -87,6 +88,7 @@ async function runEnrichmentDirect(
     body: JSON.stringify(body),
   });
   const j = await r.json() as RunResponse | { error?: string };
+  if (isPausedBody(j)) throw new Error(PAUSED_ERROR);
   if (!r.ok && r.status !== 202) {
     throw new Error((j as { error?: string }).error ?? `HTTP ${r.status}`);
   }
@@ -105,6 +107,7 @@ async function pollJob(runId: string, cacheKey?: string): Promise<RunResultLike>
     await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
     const r = await fetch(`/api/studio/run-status/${encodeURIComponent(runId)}${qs}`);
     const j = await r.json() as RunResponse | { status: 'pending' };
+    if (isPausedBody(j)) throw new Error(PAUSED_ERROR);
     if ('status' in j) {
       if (j.status === 'ok') return (j as { result: RunResultLike }).result;
       if (j.status === 'error') throw new Error((j as { error: string }).error);
@@ -148,6 +151,7 @@ async function postAsk(mark: string, tractate: string, page: string, instanceId:
   qHash: string;
   alreadyAsked: boolean;
   rateLimited?: boolean;
+  paused?: boolean;
   error?: string;
 }> {
   const r = await fetch('/api/qa/ask', {
@@ -162,9 +166,14 @@ async function postAsk(mark: string, tractate: string, page: string, instanceId:
       lang: lang(),
     }),
   });
-  const j = await r.json() as { qHash?: string; alreadyAsked?: boolean; rateLimited?: boolean; error?: string };
+  const j = await r.json() as { qHash?: string; alreadyAsked?: boolean; rateLimited?: boolean; paused?: boolean; error?: string };
   if (!r.ok) {
-    return { qHash: '', alreadyAsked: false, rateLimited: r.status === 429, error: j.error ?? `HTTP ${r.status}` };
+    return {
+      qHash: '', alreadyAsked: false,
+      rateLimited: r.status === 429 && !j.paused,
+      paused: j.paused === true,
+      error: j.error ?? `HTTP ${r.status}`,
+    };
   }
   return {
     qHash: j.qHash ?? '',
@@ -292,7 +301,8 @@ export default function QAPanel(props: QAPanelProps): JSX.Element {
         }).catch(() => { /* swallow */ });
       }
     } catch (err) {
-      setOpenAnswers((m) => ({ ...m, [key]: { state: 'error', error: String((err as Error)?.message ?? err) } }));
+      const msg = isPausedError(err) ? t('qa.error.paused') : String((err as Error)?.message ?? err);
+      setOpenAnswers((m) => ({ ...m, [key]: { state: 'error', error: msg } }));
     }
   };
 
@@ -306,9 +316,11 @@ export default function QAPanel(props: QAPanelProps): JSX.Element {
     setAskError(null);
     const reply = await postAsk(mark(), props.tractate, props.page, instanceId(), instance(), q);
     if (reply.error) {
-      setAskError(reply.rateLimited
-        ? t('qa.error.rateLimit')
-        : reply.error);
+      setAskError(reply.paused
+        ? t('qa.error.paused')
+        : reply.rateLimited
+          ? t('qa.error.rateLimit')
+          : reply.error);
       return;
     }
     // Optimistically prepend to registry so it appears immediately, then

--- a/src/client/enrichmentQueue.ts
+++ b/src/client/enrichmentQueue.ts
@@ -37,6 +37,22 @@ export function isAbort(err: unknown): boolean {
   return (err as { name?: string } | null)?.name === 'AbortError';
 }
 
+/** Sentinel message thrown by run helpers when the server reports a spend
+ *  pause (`{ paused: true }` from /api/studio/run or run-status). The UI maps it
+ *  to a friendly localized message (t('qa.error.paused')) rather than showing a
+ *  raw error string. See src/worker/budget.ts. */
+export const PAUSED_ERROR = 'BUDGET_PAUSED';
+
+/** True if a run / run-status JSON body signals a budget pause. */
+export function isPausedBody(j: unknown): boolean {
+  return !!(j && typeof j === 'object' && (j as { paused?: boolean }).paused === true);
+}
+
+/** True if a caught error is the paused sentinel. */
+export function isPausedError(err: unknown): boolean {
+  return (err as { message?: string } | null)?.message === PAUSED_ERROR;
+}
+
 // ---------------------------------------------------------------------------
 // Client-side result cache
 // ---------------------------------------------------------------------------

--- a/src/client/i18n.ts
+++ b/src/client/i18n.ts
@@ -650,6 +650,10 @@ const CATALOG = {
     en: "You've asked a lot of new questions recently — please wait a bit before asking another.",
     he: 'שאלת הרבה שאלות חדשות לאחרונה — נא להמתין מעט לפני שאלה נוספת.',
   },
+  'qa.error.paused': {
+    en: 'AI generation is paused for now to keep this project sustainable. Please try again tomorrow.',
+    he: 'יצירת התוכן בבינה מלאכותית מושהית כעת כדי לשמור על קיימות הפרויקט. נא לנסות שוב מחר.',
+  },
 } satisfies Record<string, Entry>;
 
 /** Every known catalog key. Lets UI props (e.g. section labels) demand a real

--- a/src/worker/budget.ts
+++ b/src/worker/budget.ts
@@ -1,0 +1,294 @@
+/**
+ * LLM spend budget guard. Two independent ceilings, both enforced fail-safe:
+ *
+ *   - Custom questions: > $10 / rolling hour  -> pause custom Q&A for 1 hour.
+ *   - All LLM spend:    > $300 / UTC day       -> pause ALL generation until
+ *                                                 the next UTC midnight.
+ *
+ * Storage is KV (the only primitive this worker has), so accounting is
+ * best-effort: KV has no atomic increment and ~60s eventual consistency, and
+ * the queue runs 50-way concurrent. We accept a small overshoot and design
+ * around it:
+ *   - Counters are bucketed by wall-clock window (day / hour) so they expire on
+ *     their own -- no cleanup, and a new window always starts at $0.
+ *   - A "pause latch" is written the moment a counter crosses its cap. The latch
+ *     is the authoritative signal the gate reads, so the decision stays put even
+ *     as buckets roll over or a counter read is momentarily stale.
+ *   - The daily latch trips at DAILY_SAFETY_FACTOR x cap (default $270, below
+ *     the $300 hard cap) to leave headroom for in-flight concurrent jobs whose
+ *     cost is only known AFTER they return (we can't pre-charge them). The queue
+ *     runs up to 50 jobs at once, so up to ~50 calls can already be past the
+ *     gate when the latch trips; the ~$30 of headroom absorbs their cost so
+ *     actual spend stays at/under the $300 cap ("never more than $300, ever").
+ *
+ * Cost per call: OpenRouter returns billed USD in usage.cost; for priced models
+ * without it we fall back to pricing.ts list-price estimation; Workers-AI
+ * (@cf/*) calls are unpriced and contribute $0 (same as the existing ledger).
+ *
+ * Enforcement lives at the single chokepoint runLLM() (src/worker/llm.ts):
+ * checkBudget() before the call, recordSpend() after. Producer endpoints
+ * (qa/ask, studio/run, warm-daf) pre-check too, purely for instant UI feedback
+ * and to avoid pointless queue churn.
+ */
+import { costUsd, type TokenUsage } from './pricing';
+import { LLMError, NEITHER } from './llm-error';
+
+/** Env surface budget functions need. Bindings / LLMEnv both satisfy this. */
+export interface BudgetEnv {
+  CACHE?: KVNamespace;
+  /** Per-deploy override for the daily hard cap (USD). Defaults to 300. */
+  DAILY_BUDGET_USD?: string;
+  /** Per-deploy override for the hourly custom-question cap (USD). Defaults to 10. */
+  HOURLY_CUSTOM_BUDGET_USD?: string;
+}
+
+export type BudgetScope = 'all' | 'custom';
+
+const PREFIX = 'budget:v1:';
+const TOTAL_BUCKET = `${PREFIX}total:`; // + YYYYMMDD (UTC)
+const CUSTOM_BUCKET = `${PREFIX}custom:`; // + YYYYMMDDHH (UTC)
+const PAUSE_ALL = `${PREFIX}pause:all`;
+const PAUSE_CUSTOM = `${PREFIX}pause:custom`;
+
+// Daily counter must outlive its day enough to catch late-arriving cost from a
+// long job that started yesterday; the hourly counter only needs its window
+// plus slack. Both far shorter than the 7-day per-call ledger in llm.ts.
+const TOTAL_TTL_S = 48 * 3600;
+const CUSTOM_TTL_S = 3 * 3600;
+
+const DEFAULT_DAILY_CAP_USD = 300;
+const DEFAULT_HOURLY_CUSTOM_CAP_USD = 10;
+// Trip the daily pause at 90% of the cap. The remaining 10% is headroom for
+// jobs already past the gate when the latch trips (see file header).
+const DAILY_SAFETY_FACTOR = 0.9;
+const HOUR_MS = 3_600_000;
+
+type UsageWithCost = (TokenUsage & { cost?: number }) | null | undefined;
+
+interface PauseLatch {
+  until: number;
+  reason: string;
+  spentUsd: number;
+}
+
+export interface BudgetDecision {
+  ok: boolean;
+  scope?: BudgetScope;
+  /** Epoch ms when the pause lifts (next hour for custom, next UTC midnight for all). */
+  until?: number;
+  reason?: string;
+}
+
+function positiveNum(s: string | undefined, fallback: number): number {
+  const n = s == null ? NaN : Number(s);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+function dailyCap(env: BudgetEnv): number {
+  return positiveNum(env.DAILY_BUDGET_USD, DEFAULT_DAILY_CAP_USD);
+}
+function dailyTrip(env: BudgetEnv): number {
+  return dailyCap(env) * DAILY_SAFETY_FACTOR;
+}
+function hourlyCustomCap(env: BudgetEnv): number {
+  return positiveNum(env.HOURLY_CUSTOM_BUDGET_USD, DEFAULT_HOURLY_CUSTOM_CAP_USD);
+}
+
+function dayBucket(now: number): string {
+  // "2026-05-27T19:43:27.000Z" -> "20260527"
+  return new Date(now).toISOString().slice(0, 10).replace(/-/g, '');
+}
+function hourBucket(now: number): string {
+  // "2026-05-27T19:43:27.000Z" -> "2026052719"
+  return new Date(now).toISOString().slice(0, 13).replace(/[-T]/g, '');
+}
+function nextUtcMidnight(now: number): number {
+  const d = new Date(now);
+  return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + 1, 0, 0, 0, 0);
+}
+function round(n: number): number {
+  return Math.round(n * 1e6) / 1e6;
+}
+
+/** USD for one call: billed cost wins, else list-price estimate, else 0. */
+export function computeSpendUsd(model: string | null | undefined, usage: UsageWithCost): number {
+  const billed = usage?.cost;
+  if (typeof billed === 'number' && billed >= 0) return billed;
+  const est = costUsd(model, usage);
+  return typeof est === 'number' && est >= 0 ? est : 0;
+}
+
+async function readCounter(cache: KVNamespace, key: string): Promise<number> {
+  const raw = await cache.get(key);
+  const n = raw ? Number(raw) : 0;
+  return Number.isFinite(n) ? n : 0;
+}
+
+async function bumpCounter(cache: KVNamespace, key: string, delta: number, ttlS: number): Promise<number> {
+  // Best-effort read-add-write. Under concurrency a lost write undercounts,
+  // delaying (never falsely tripping) the pause -- checkBudget's defensive
+  // re-derivation closes that gap before the next call spends.
+  const prev = await readCounter(cache, key);
+  const next = prev + delta;
+  await cache.put(key, String(next), { expirationTtl: ttlS });
+  return next;
+}
+
+async function readLatch(cache: KVNamespace, key: string, now: number): Promise<PauseLatch | null> {
+  const raw = await cache.get(key);
+  if (!raw) return null;
+  try {
+    const l = JSON.parse(raw) as PauseLatch;
+    if (l && typeof l.until === 'number' && l.until > now) return l;
+  } catch {
+    /* corrupt latch -> treat as absent */
+  }
+  return null;
+}
+
+async function armLatch(cache: KVNamespace, key: string, latch: PauseLatch, now: number): Promise<void> {
+  const ttl = Math.max(60, Math.ceil((latch.until - now) / 1000));
+  await cache.put(key, JSON.stringify(latch), { expirationTtl: ttl });
+}
+
+/**
+ * Record a completed call's spend. Bumps the daily total (always) and the
+ * hourly custom bucket (when custom), arming the matching pause latch when a
+ * counter crosses its trip point. Never throws -- a ledger hiccup must not fail
+ * a call that already succeeded.
+ */
+export async function recordSpend(
+  env: BudgetEnv,
+  args: { model: string | null | undefined; usage: UsageWithCost; custom: boolean },
+  now: number = Date.now(),
+): Promise<void> {
+  const cache = env.CACHE;
+  if (!cache) return;
+  const usd = computeSpendUsd(args.model, args.usage);
+  if (usd <= 0) return; // unpriced (@cf/*) calls don't move the needle
+  try {
+    const total = await bumpCounter(cache, `${TOTAL_BUCKET}${dayBucket(now)}`, usd, TOTAL_TTL_S);
+    if (total >= dailyTrip(env)) {
+      await armLatch(cache, PAUSE_ALL, {
+        until: nextUtcMidnight(now),
+        reason: `daily spend $${total.toFixed(2)} reached trip $${dailyTrip(env).toFixed(2)} (cap $${dailyCap(env)})`,
+        spentUsd: total,
+      }, now);
+    }
+    if (args.custom) {
+      const spent = await bumpCounter(cache, `${CUSTOM_BUCKET}${hourBucket(now)}`, usd, CUSTOM_TTL_S);
+      if (spent >= hourlyCustomCap(env)) {
+        await armLatch(cache, PAUSE_CUSTOM, {
+          until: now + HOUR_MS,
+          reason: `custom-question spend $${spent.toFixed(2)} reached cap $${hourlyCustomCap(env)} this hour`,
+          spentUsd: spent,
+        }, now);
+      }
+    }
+  } catch {
+    /* best-effort accounting */
+  }
+}
+
+/**
+ * Decide whether a call may proceed. The daily 'all' pause overrides everything;
+ * the hourly 'custom' pause only blocks custom-question calls. Reads the sticky
+ * latches first (O(1)), then defensively re-derives from the bucket counter so a
+ * lost latch write still blocks before the next call spends. Fail-open only when
+ * there is no cache binding at all.
+ */
+export async function checkBudget(
+  env: BudgetEnv,
+  args: { custom: boolean },
+  now: number = Date.now(),
+): Promise<BudgetDecision> {
+  const cache = env.CACHE;
+  if (!cache) return { ok: true };
+
+  const all = await readLatch(cache, PAUSE_ALL, now);
+  if (all) return { ok: false, scope: 'all', until: all.until, reason: all.reason };
+
+  if (args.custom) {
+    const cust = await readLatch(cache, PAUSE_CUSTOM, now);
+    if (cust) return { ok: false, scope: 'custom', until: cust.until, reason: cust.reason };
+  }
+
+  // Defensive: a latch write may have been lost while the bucket counter still
+  // shows over-cap. Re-derive and re-arm so we never blow past the cap just
+  // because one KV write dropped.
+  const total = await readCounter(cache, `${TOTAL_BUCKET}${dayBucket(now)}`);
+  if (total >= dailyTrip(env)) {
+    const latch: PauseLatch = {
+      until: nextUtcMidnight(now),
+      reason: `daily spend $${total.toFixed(2)} over trip $${dailyTrip(env).toFixed(2)} (cap $${dailyCap(env)})`,
+      spentUsd: total,
+    };
+    await armLatch(cache, PAUSE_ALL, latch, now).catch(() => {});
+    return { ok: false, scope: 'all', until: latch.until, reason: latch.reason };
+  }
+  if (args.custom) {
+    const spent = await readCounter(cache, `${CUSTOM_BUCKET}${hourBucket(now)}`);
+    if (spent >= hourlyCustomCap(env)) {
+      const latch: PauseLatch = {
+        until: now + HOUR_MS,
+        reason: `custom-question spend $${spent.toFixed(2)} over cap $${hourlyCustomCap(env)} this hour`,
+        spentUsd: spent,
+      };
+      await armLatch(cache, PAUSE_CUSTOM, latch, now).catch(() => {});
+      return { ok: false, scope: 'custom', until: latch.until, reason: latch.reason };
+    }
+  }
+  return { ok: true };
+}
+
+/** Read-only snapshot for /api/admin/budget. */
+export async function budgetStatus(env: BudgetEnv, now: number = Date.now()): Promise<{
+  now: number;
+  daily: { spentUsd: number; capUsd: number; tripUsd: number; bucket: string };
+  customHourly: { spentUsd: number; capUsd: number; bucket: string };
+  pause: { all: { until: number; reason: string } | null; custom: { until: number; reason: string } | null };
+}> {
+  const cache = env.CACHE;
+  const total = cache ? await readCounter(cache, `${TOTAL_BUCKET}${dayBucket(now)}`) : 0;
+  const customHour = cache ? await readCounter(cache, `${CUSTOM_BUCKET}${hourBucket(now)}`) : 0;
+  const pauseAll = cache ? await readLatch(cache, PAUSE_ALL, now) : null;
+  const pauseCustom = cache ? await readLatch(cache, PAUSE_CUSTOM, now) : null;
+  return {
+    now,
+    daily: { spentUsd: round(total), capUsd: dailyCap(env), tripUsd: round(dailyTrip(env)), bucket: dayBucket(now) },
+    customHourly: { spentUsd: round(customHour), capUsd: hourlyCustomCap(env), bucket: hourBucket(now) },
+    pause: {
+      all: pauseAll ? { until: pauseAll.until, reason: pauseAll.reason } : null,
+      custom: pauseCustom ? { until: pauseCustom.until, reason: pauseCustom.reason } : null,
+    },
+  };
+}
+
+/** Manual un-pause: drop both latches (counters keep accruing in their bucket). */
+export async function clearPauses(env: BudgetEnv): Promise<{ cleared: BudgetScope[] }> {
+  const cache = env.CACHE;
+  const cleared: BudgetScope[] = [];
+  if (!cache) return { cleared };
+  await cache.delete(PAUSE_ALL);
+  cleared.push('all');
+  await cache.delete(PAUSE_CUSTOM);
+  cleared.push('custom');
+  return { cleared };
+}
+
+/** Thrown from runLLM when a budget pause is active. Status 429, classified
+ *  NEITHER so it surfaces immediately (not retried, not failed over to another
+ *  model). */
+export class BudgetPausedError extends LLMError {
+  readonly scope: BudgetScope;
+  readonly until?: number;
+  constructor(scope: BudgetScope, until?: number, reason?: string) {
+    super(429, `paused:${scope}${reason ? ` (${reason})` : ''}`, { cls: NEITHER });
+    this.name = 'BudgetPausedError';
+    this.scope = scope;
+    this.until = until;
+  }
+}
+
+export function isBudgetPaused(err: unknown): err is BudgetPausedError {
+  return err instanceof BudgetPausedError;
+}

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -59,6 +59,7 @@ import {
 } from '../lib/rabbi/types';
 import { wrapEnv, gatewayStatus, gatewayActive } from './ai-gateway';
 import { runLLM, type LLMModelId, type LLMResult, type LLMUsage } from './llm';
+import { checkBudget, isBudgetPaused, budgetStatus, clearPauses, type BudgetScope } from './budget';
 import { lookupRelationships } from './rabbi-graph';
 import { lintSynthesis } from '../lib/synthesisLint';
 import { lintHalachaParsed } from '../lib/halachaLint';
@@ -155,6 +156,16 @@ interface Bindings {
   // When '1', the background Sefaria Shas walk also enqueues rabbi.observations
   // per amud (full reverse-index backfill). OFF by default — see WarmEnv.
   OBSERVATIONS_WARM_SHAS?: string;
+  // Shared secret gating the privileged /api/studio/run knobs (ad_hoc,
+  // model_override, bypass_cache) and the admin mutation endpoints. Presented
+  // by trusted tools as the `x-studio-secret` header. UNSET => every request is
+  // treated as untrusted (fail-safe): the public app still works (it only uses
+  // the safe subset), but no one can use the worker as a free LLM proxy.
+  // Set via `wrangler secret put STUDIO_SECRET`.
+  STUDIO_SECRET?: string;
+  // Spend-budget overrides (USD) read by ./budget. Default 300 / 10 when unset.
+  DAILY_BUDGET_USD?: string;
+  HOURLY_CUSTOM_BUDGET_USD?: string;
 }
 
 // Message shape on the enrichment queue. Carries everything the consumer
@@ -185,6 +196,51 @@ export interface JobMessage {
    *  by /api/warm-daf to comprehensively pre-warm an adjacent daf so navigation
    *  lands on a fully-cached page. Mutually exclusive with mark_id/enrichment_id. */
   warm_deep?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Request trust + spend-pause helpers (see ./budget for the budget guard).
+// ---------------------------------------------------------------------------
+
+/** Constant-time-ish string compare (avoids early-exit timing leaks beyond
+ *  length). */
+function timingSafeEqualStr(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+/**
+ * True iff the request carries the STUDIO_SECRET (header `x-studio-secret`, or
+ * `Authorization: Bearer <secret>`). Returns FALSE whenever the secret is unset
+ * — fail-safe, so the privileged /api/studio/run knobs (ad_hoc, model_override,
+ * bypass_cache) and the admin mutation endpoints stay locked until the owner
+ * provisions the secret. The public daf app never needs these, so locking them
+ * by default doesn't degrade it.
+ */
+function isTrustedRequest(c: { req: { header: (k: string) => string | undefined }; env: Bindings }): boolean {
+  const secret = c.env.STUDIO_SECRET;
+  if (!secret) return false;
+  const presented =
+    c.req.header('x-studio-secret') ??
+    c.req.header('authorization')?.replace(/^Bearer\s+/i, '') ??
+    '';
+  return presented.length > 0 && timingSafeEqualStr(presented, secret);
+}
+
+/** Seconds until a pause lifts, for a Retry-After-style hint. */
+function pauseRetryAfterSec(until?: number): number {
+  if (!until) return 3600;
+  return Math.max(1, Math.ceil((until - Date.now()) / 1000));
+}
+
+/** Human fallback message for a paused response. The client maps the `paused`
+ *  flag to its own localized copy; this is for non-UI / API consumers. */
+function pauseErrorMessage(scope?: BudgetScope): string {
+  return scope === 'custom'
+    ? 'Custom-question generation is paused for now (hourly budget reached). Please try again later.'
+    : 'AI generation is paused for now (daily budget reached). Please try again tomorrow.';
 }
 
 function stripHtmlServer(html: string): string {
@@ -2207,6 +2263,9 @@ async function runEnrichmentOnce(
     thinking: def.thinking_off ? false : undefined,
     bypass_cache: bypassCache,
     tag: `enrich:${def.id}`,
+    // Custom Q&A enrichments (<mark>.qa) count against the hourly custom-question
+    // budget; everything else only against the daily total. See ./budget.
+    cost_class: def.id.endsWith('.qa') ? 'custom-question' : undefined,
   });
 
   let parsed: unknown = null;
@@ -2573,6 +2632,18 @@ app.post('/api/studio/run', async (c) => {
   catch { return c.json({ error: 'invalid JSON' }, 400); }
   const body = raw as Partial<JobMessage>;
   if (!body.tractate || !body.page) return c.json({ error: 'tractate and page required' }, 400);
+
+  // Hijack lockdown: the privileged knobs let a caller run arbitrary prompts
+  // (ad_hoc), pick an expensive model (model_override), or force fresh paid runs
+  // (bypass_cache) — i.e. use the worker as a free LLM proxy. Gate them behind
+  // STUDIO_SECRET. Public callers get the safe subset only: a registered
+  // mark/enrichment on real daf content, cached, default model.
+  const trusted = isTrustedRequest(c);
+  if (!trusted) {
+    if (body.ad_hoc !== undefined) return c.json({ error: 'ad_hoc runs require studio auth' }, 403);
+    if (body.model_override !== undefined) return c.json({ error: 'model_override requires studio auth' }, 403);
+  }
+
   if (body.model_override && !isLLMModelId(body.model_override)) {
     return c.json({ error: 'model_override must start with @cf/ or openrouter/' }, 400);
   }
@@ -2583,12 +2654,13 @@ app.post('/api/studio/run', async (c) => {
     runId: '',  // assigned below
     mark_id: body.mark_id,
     enrichment_id: body.enrichment_id,
-    ad_hoc: body.ad_hoc,
+    ad_hoc: trusted ? body.ad_hoc : undefined,
     tractate: body.tractate,
     page: body.page,
-    model_override: body.model_override,
+    model_override: trusted ? body.model_override : undefined,
     mark_input: body.mark_input,
-    bypass_cache: body.bypass_cache === true,
+    // Public callers can't force a fresh paid run; downgrade to cache-respecting.
+    bypass_cache: trusted ? body.bypass_cache === true : false,
     user_question: typeof body.user_question === 'string' && body.user_question.trim().length > 0
       ? body.user_question : undefined,
     lang: body.lang === 'he' ? 'he' : undefined,
@@ -2625,6 +2697,20 @@ app.post('/api/studio/run', async (c) => {
   if (!c.env.ENRICHMENT_QUEUE) {
     return c.json({ error: 'ENRICHMENT_QUEUE binding not available' }, 503);
   }
+  // Budget gate before enqueueing real LLM work. Cache hits already returned
+  // above (free, ungated). The queue consumer re-checks at the runLLM
+  // chokepoint, but failing here gives the client an immediate paused signal.
+  const customRun = !!(job.enrichment_id && job.enrichment_id.endsWith('.qa') && job.user_question);
+  const gate = await checkBudget(c.env, { custom: customRun });
+  if (!gate.ok) {
+    return c.json({
+      status: 'error',
+      error: pauseErrorMessage(gate.scope),
+      paused: true,
+      scope: gate.scope,
+      retryAfter: pauseRetryAfterSec(gate.until),
+    }, 429);
+  }
   job.runId = await makeRunId(job);
   // Compute the canonical cache key up-front so the client can use it as a
   // polling fallback. runEnrichmentOnce writes to this key right before the
@@ -2653,6 +2739,14 @@ app.post('/api/warm-daf', async (c) => {
   const body = raw as { tractate?: string; page?: string; lang?: string };
   if (!body.tractate || !body.page) return c.json({ error: 'tractate and page required' }, 400);
   if (!c.env.ENRICHMENT_QUEUE) return c.json({ error: 'ENRICHMENT_QUEUE binding not available' }, 503);
+  // Don't fan out a deep-warm storm once the daily budget is paused.
+  const gate = await checkBudget(c.env, { custom: false });
+  if (!gate.ok) {
+    return c.json({
+      status: 'error', error: pauseErrorMessage(gate.scope),
+      paused: true, scope: gate.scope, retryAfter: pauseRetryAfterSec(gate.until),
+    }, 429);
+  }
   const lang: 'en' | 'he' = body.lang === 'he' ? 'he' : 'en';
   const runId = `warm-deep:${body.tractate}:${body.page}:${lang}:${Math.floor(Date.now() / 1000)}`
     .replace(/[^a-zA-Z0-9._:-]+/g, '_').slice(0, 200);
@@ -2809,6 +2903,7 @@ app.get('/api/admin/llm-cost', async (c) => {
   const prefix = 'llmcost:v1:';
 
   if (c.req.query('clear') === '1') {
+    if (!isTrustedRequest(c)) return c.json({ error: 'clearing the cost ledger requires studio auth' }, 403);
     let cursor: string | undefined;
     let deleted = 0;
     do {
@@ -2871,6 +2966,26 @@ app.get('/api/admin/llm-cost', async (c) => {
     byTag,
     truncated: keys.length >= 10000,
   });
+});
+
+/**
+ * GET /api/admin/budget — spend-budget snapshot: today's total spend, this
+ * hour's custom-question spend, the caps, and any active pause latches. Read-
+ * only (open). See ./budget.
+ */
+app.get('/api/admin/budget', async (c) => {
+  return c.json(await budgetStatus(c.env));
+});
+
+/**
+ * POST /api/admin/budget/reset — manually lift the pause latches (trusted only).
+ * The bucket counters keep accruing in their window, so if spend is still over
+ * the cap the next call re-arms the pause immediately.
+ */
+app.post('/api/admin/budget/reset', async (c) => {
+  if (!isTrustedRequest(c)) return c.json({ error: 'studio auth required' }, 403);
+  const cleared = await clearPauses(c.env);
+  return c.json({ ok: true, ...cleared });
 });
 
 /**
@@ -2951,6 +3066,7 @@ app.get('/api/admin/warm-status', async (c) => {
  *   done
  */
 app.post('/api/admin/strip-ttl', async (c) => {
+  if (!isTrustedRequest(c)) return c.json({ error: 'studio auth required' }, 403);
   const cache = c.env.CACHE;
   if (!cache) return c.json({ error: 'no cache binding' }, 503);
   const prefix = c.req.query('prefix');
@@ -3250,6 +3366,19 @@ app.post('/api/qa/ask', async (c) => {
     existing.clickCount += 1;
     await writeQaRegistry(c.env, scope.mark, b.tractate, b.page, scope.instanceId, reg);
     return c.json({ qHash, alreadyAsked: true, remaining: -1 });
+  }
+
+  // Budget gate: pause new custom questions once the hourly custom budget (or
+  // the daily total) is exhausted. Checked before the per-IP rate limit so a
+  // paused request doesn't burn the user's quota.
+  const gate = await checkBudget(c.env, { custom: true });
+  if (!gate.ok) {
+    return c.json({
+      error: pauseErrorMessage(gate.scope),
+      paused: true,
+      scope: gate.scope,
+      retryAfter: pauseRetryAfterSec(gate.until),
+    }, 429);
   }
 
   // Novel question — gate behind the per-IP rate limit because this will
@@ -5911,6 +6040,7 @@ const FAMILY_INVERSE: Record<string, string> = {
 };
 
 app.post('/api/admin/rabbi-compile/graph', async (c) => {
+  if (!isTrustedRequest(c)) return c.json({ error: 'studio auth required' }, 403);
   const cache = c.env.CACHE;
   if (!cache) return c.json({ error: 'CACHE unavailable' }, 503);
 
@@ -5994,6 +6124,7 @@ interface RabbiCohortBlob {
 }
 
 app.post('/api/admin/rabbi-compile/cohort', async (c) => {
+  if (!isTrustedRequest(c)) return c.json({ error: 'studio auth required' }, 403);
   const cache = c.env.CACHE;
   if (!cache) return c.json({ error: 'CACHE unavailable' }, 503);
 
@@ -6026,6 +6157,7 @@ interface RabbiPlacesIndexBlob {
 }
 
 app.post('/api/admin/rabbi-compile/places-index', async (c) => {
+  if (!isTrustedRequest(c)) return c.json({ error: 'studio auth required' }, 403);
   const cache = c.env.CACHE;
   if (!cache) return c.json({ error: 'CACHE unavailable' }, 503);
 
@@ -6054,6 +6186,7 @@ interface RabbiAcademyRosterBlob {
 }
 
 app.post('/api/admin/rabbi-compile/academy-roster', async (c) => {
+  if (!isTrustedRequest(c)) return c.json({ error: 'studio auth required' }, 403);
   const cache = c.env.CACHE;
   if (!cache) return c.json({ error: 'CACHE unavailable' }, 503);
 
@@ -7030,8 +7163,17 @@ async function processEnrichmentJob(env: Bindings, job: JobMessage, ctx: Executi
     });
     recordTelemetry({ env: wrapped, executionCtx: ctx }, runTelemetryRec(job, result, Date.now() - t0));
   } catch (err) {
-    const errorMsg = String((err as Error)?.message ?? err);
     const totalMs = Date.now() - t0;
+    // A budget pause is an expected back-pressure outcome, not a failure: write
+    // it as a paused result the client poller can surface, and DON'T record it
+    // in the recent-errors buffer (it would drown out real failures).
+    const paused = isBudgetPaused(err);
+    if (paused) {
+      const scope = (err as { scope?: BudgetScope }).scope;
+      await writeResult({ status: 'error', error: pauseErrorMessage(scope), paused: true, scope, total_ms: totalMs });
+      return;
+    }
+    const errorMsg = String((err as Error)?.message ?? err);
     // eslint-disable-next-line no-console
     console.error('[queue] job failed', job.runId, '·', job.mark_id ?? job.enrichment_id ?? 'adhoc', job.tractate, job.page, '·', errorMsg.slice(0, 500));
     await writeResult({

--- a/src/worker/llm.ts
+++ b/src/worker/llm.ts
@@ -25,6 +25,7 @@
 import { runWithRetry } from './ai-gateway';
 import { LLMError, isFallbackWorthy, NEITHER, TIMEOUT } from './llm-error';
 import { DEFAULT_MODEL, DEFAULT_FALLBACK_CHAIN } from './settings';
+import { checkBudget, recordSpend, BudgetPausedError } from './budget';
 
 export type LLMModelId = `@cf/${string}` | `openrouter/${string}`;
 
@@ -37,6 +38,9 @@ export interface LLMEnv {
   CLOUDFLARE_ACCOUNT_ID?: string;
   OPENROUTER_GATEWAY_PROVIDER?: string;
   DEFAULT_LLM_MODEL?: string;
+  // Spend-budget overrides read by ./budget (checkBudget / recordSpend).
+  DAILY_BUDGET_USD?: string;
+  HOURLY_CUSTOM_BUDGET_USD?: string;
 }
 
 export interface LLMMessage {
@@ -88,6 +92,10 @@ export interface LLMCallOptions {
    *  'mark:rabbi', 'enrich:rabbi.synthesis'). Lets /api/admin/llm-cost break
    *  spend down by mark/enrichment. Untagged calls still count toward totals. */
   tag?: string;
+  /** Spend classification for the budget guard (./budget). 'custom-question'
+   *  counts against the hourly custom-Q&A cap AND the daily total; everything
+   *  else counts only against the daily total. */
+  cost_class?: 'custom-question';
 }
 
 export type LLMTransport = 'workers-ai' | 'openrouter-gateway';
@@ -182,6 +190,15 @@ export function resolveChain(env: LLMEnv, opts: LLMCallOptions): LLMModelId[] {
  * without trying fallback.
  */
 export async function runLLM(env: LLMEnv, opts: LLMCallOptions): Promise<LLMResult> {
+  // Budget gate (./budget): refuse before spending when a pause is latched. The
+  // thrown BudgetPausedError is classified NEITHER, so runLLM does NOT walk the
+  // fallback chain on it — it surfaces immediately to the caller. This is the
+  // single authoritative chokepoint: every paid path (marks, enrichments, QA,
+  // warm/yomi crons) funnels through here.
+  const custom = opts.cost_class === 'custom-question';
+  const gate = await checkBudget(env, { custom });
+  if (!gate.ok) throw new BudgetPausedError(gate.scope ?? 'all', gate.until, gate.reason);
+
   const chain = resolveChain(env, opts);
 
   let lastErr: unknown = null;
@@ -190,6 +207,8 @@ export async function runLLM(env: LLMEnv, opts: LLMCallOptions): Promise<LLMResu
     try {
       const result = await withHardTimeout(callOnce(env, model, opts), MODEL_CALL_HARD_TIMEOUT_MS, model);
       await recordLLMCost(env, model, opts.tag, i + 1, result);
+      // Feed the spend budget (./budget) so the next checkBudget sees this call.
+      await recordSpend(env, { model: result.model, usage: result.usage, custom });
       return { ...result, attempts: i + 1 };
     } catch (err) {
       lastErr = err;

--- a/tests/budget.test.ts
+++ b/tests/budget.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import {
+  recordSpend,
+  checkBudget,
+  budgetStatus,
+  clearPauses,
+  computeSpendUsd,
+  type BudgetEnv,
+} from '../src/worker/budget';
+
+// Minimal in-memory KV. budget.ts only uses get / put / delete; TTLs are
+// ignored (tests model window roll-over by passing a different `now`, not by
+// simulating expiry).
+function makeFakeKV(initial: Record<string, string> = {}) {
+  const store = new Map(Object.entries(initial));
+  const kv = {
+    get: async (k: string) => store.get(k) ?? null,
+    put: async (k: string, v: string) => { store.set(k, v); },
+    delete: async (k: string) => { store.delete(k); },
+    list: async () => ({ keys: [], list_complete: true, cursor: '' }),
+    getWithMetadata: async () => ({ value: null, metadata: null }),
+  };
+  return { kv: kv as unknown as KVNamespace, store };
+}
+
+// 2026-05-27 19:43 UTC -> day bucket 20260527, hour bucket 2026052719.
+const T = Date.UTC(2026, 4, 27, 19, 43, 0);
+const DAY = '20260527';
+const HOUR = '2026052719';
+
+describe('computeSpendUsd', () => {
+  it('prefers the billed cost when present', () => {
+    expect(computeSpendUsd('openrouter/deepseek/deepseek-v4-flash', { cost: 0.42, prompt_tokens: 1000, completion_tokens: 1000 })).toBe(0.42);
+  });
+  it('falls back to list-price estimation for priced models', () => {
+    // flash = $0.14 / $0.28 per 1M; 1M in + 1M out = 0.42
+    expect(computeSpendUsd('openrouter/deepseek/deepseek-v4-flash', { prompt_tokens: 1_000_000, completion_tokens: 1_000_000 })).toBeCloseTo(0.42, 6);
+  });
+  it('returns 0 for unpriced (@cf/*) models with no billed cost', () => {
+    expect(computeSpendUsd('@cf/google/gemma-4-26b-a4b-it', { prompt_tokens: 1000, completion_tokens: 1000 })).toBe(0);
+  });
+});
+
+describe('checkBudget — fail-open without cache', () => {
+  it('allows when there is no CACHE binding', async () => {
+    expect(await checkBudget({}, { custom: true }, T)).toEqual({ ok: true });
+  });
+});
+
+describe('daily total cap', () => {
+  it('does not pause while under the trip point', async () => {
+    const { kv } = makeFakeKV();
+    const env: BudgetEnv = { CACHE: kv, DAILY_BUDGET_USD: '10' }; // trip = 9.5
+    await recordSpend(env, { model: 'openrouter/deepseek/deepseek-v4-pro', usage: { cost: 5 }, custom: false }, T);
+    expect((await checkBudget(env, { custom: false }, T)).ok).toBe(true);
+  });
+
+  it('latches an all-scope pause once the trip point is reached, blocking even non-custom calls', async () => {
+    const { kv } = makeFakeKV();
+    const env: BudgetEnv = { CACHE: kv, DAILY_BUDGET_USD: '10' }; // trip = 9.5
+    await recordSpend(env, { model: 'openrouter/deepseek/deepseek-v4-pro', usage: { cost: 9.6 }, custom: false }, T);
+    const decision = await checkBudget(env, { custom: false }, T);
+    expect(decision.ok).toBe(false);
+    expect(decision.scope).toBe('all');
+    // Pause lifts at the next UTC midnight.
+    expect(decision.until).toBe(Date.UTC(2026, 4, 28, 0, 0, 0));
+  });
+
+  it('uses 90% of the cap as the trip point (in-flight headroom)', async () => {
+    const { kv } = makeFakeKV();
+    const env: BudgetEnv = { CACHE: kv, DAILY_BUDGET_USD: '100' }; // trip = 90
+    await recordSpend(env, { model: 'x', usage: { cost: 89 }, custom: false }, T);
+    expect((await checkBudget(env, { custom: false }, T)).ok).toBe(true);
+    await recordSpend(env, { model: 'x', usage: { cost: 2 }, custom: false }, T); // total 91 >= 90
+    expect((await checkBudget(env, { custom: false }, T)).ok).toBe(false);
+  });
+});
+
+describe('hourly custom cap', () => {
+  it('blocks custom calls but not background calls when only the custom cap is hit', async () => {
+    const { kv } = makeFakeKV();
+    const env: BudgetEnv = { CACHE: kv, HOURLY_CUSTOM_BUDGET_USD: '0.5', DAILY_BUDGET_USD: '1000' };
+    await recordSpend(env, { model: 'x', usage: { cost: 0.6 }, custom: true }, T);
+    const custom = await checkBudget(env, { custom: true }, T);
+    expect(custom.ok).toBe(false);
+    expect(custom.scope).toBe('custom');
+    expect(custom.until).toBe(T + 3_600_000); // one hour
+    // Non-custom (daily total still way under its cap) keeps flowing.
+    expect((await checkBudget(env, { custom: false }, T)).ok).toBe(true);
+  });
+
+  it('a fresh hour bucket starts at $0 (window roll-over)', async () => {
+    const { kv } = makeFakeKV();
+    const env: BudgetEnv = { CACHE: kv, HOURLY_CUSTOM_BUDGET_USD: '0.5', DAILY_BUDGET_USD: '1000' };
+    await recordSpend(env, { model: 'x', usage: { cost: 0.6 }, custom: true }, T);
+    // Latch was set with until = T + 1h; one hour later it has lifted AND the
+    // new hour's counter is empty, so a custom call is allowed again.
+    const nextHour = T + 3_600_000 + 1000;
+    expect((await checkBudget(env, { custom: true }, nextHour)).ok).toBe(true);
+  });
+});
+
+describe('defensive re-derivation', () => {
+  it('blocks (and re-arms the latch) when the counter is over-cap but no latch was written', async () => {
+    // Simulate a lost latch write: the daily counter shows over-cap, but the
+    // pause:all key is absent.
+    const { kv, store } = makeFakeKV({ [`budget:v1:total:${DAY}`]: '500' });
+    const env: BudgetEnv = { CACHE: kv }; // default cap 300 -> trip 285
+    expect(store.has('budget:v1:pause:all')).toBe(false);
+    const decision = await checkBudget(env, { custom: false }, T);
+    expect(decision.ok).toBe(false);
+    expect(decision.scope).toBe('all');
+    expect(store.has('budget:v1:pause:all')).toBe(true); // re-armed
+  });
+});
+
+describe('unpriced calls', () => {
+  it('do not move the counters', async () => {
+    const { kv, store } = makeFakeKV();
+    const env: BudgetEnv = { CACHE: kv };
+    await recordSpend(env, { model: '@cf/google/gemma-4-26b-a4b-it', usage: { prompt_tokens: 9999 }, custom: true }, T);
+    expect(store.has(`budget:v1:total:${DAY}`)).toBe(false);
+    expect(store.has(`budget:v1:custom:${HOUR}`)).toBe(false);
+  });
+});
+
+describe('budgetStatus + clearPauses', () => {
+  it('reports spend + caps and clears latches', async () => {
+    const { kv } = makeFakeKV();
+    const env: BudgetEnv = { CACHE: kv, DAILY_BUDGET_USD: '10', HOURLY_CUSTOM_BUDGET_USD: '0.5' };
+    await recordSpend(env, { model: 'x', usage: { cost: 0.6 }, custom: true }, T);
+
+    const status = await budgetStatus(env, T);
+    expect(status.daily.spentUsd).toBeCloseTo(0.6, 6);
+    expect(status.daily.capUsd).toBe(10);
+    expect(status.daily.tripUsd).toBeCloseTo(9.0, 6);
+    expect(status.customHourly.spentUsd).toBeCloseTo(0.6, 6);
+    expect(status.pause.custom).not.toBeNull();
+
+    await clearPauses(env);
+    const after = await budgetStatus(env, T);
+    expect(after.pause.custom).toBeNull();
+    // Counter still reflects spend, so a re-check immediately re-arms.
+    const recheck = await checkBudget(env, { custom: true }, T);
+    expect(recheck.ok).toBe(false);
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -65,6 +65,16 @@ OBSERVATIONS_WARM_SHAS = "1"
 # secret (`wrangler secret put CF_ZONE_ANALYTICS_TOKEN`); it falls back to
 # CF_ANALYTICS_TOKEN if that one is broadened to include zone analytics.
 CF_ZONE_TAG = "4808b439c50e3a42494ae7e0b2fa1bec"
+# LLM spend budget (USD), enforced by src/worker/budget.ts at the runLLM
+# chokepoint. DAILY_BUDGET_USD is a hard ceiling on ALL spend per UTC day (the
+# guard latches a pause at 95% of this to leave headroom for in-flight jobs);
+# HOURLY_CUSTOM_BUDGET_USD caps spend on user-submitted custom questions per
+# rolling hour. These are the code defaults made explicit/tunable here — edit +
+# redeploy to change them. The privileged /api/studio/run knobs + admin
+# mutations are gated by the STUDIO_SECRET secret (`wrangler secret put
+# STUDIO_SECRET`); unset => everyone is treated as untrusted (fail-safe).
+DAILY_BUDGET_USD = "300"
+HOURLY_CUSTOM_BUDGET_USD = "10"
 
 # Cloudflare Queue — long-running enrichment jobs run in the consumer worker
 # instead of holding the producer's request invocation. Producer (POST


### PR DESCRIPTION
## Why

The open LLM endpoints had no spend ceiling, and `POST /api/studio/run` accepted `ad_hoc` (arbitrary prompts — a free LLM proxy), `model_override`, and `bypass_cache` from anyone. This adds hard cost caps and locks the hijack vectors.

## What

**Budget guard (`src/worker/budget.ts`)** — KV bucketed spend counters + sticky pause latches, enforced at the single `runLLM` chokepoint (check before a call, record after):
- **Custom questions > $10 / rolling hour** → pause custom Q&A for an hour.
- **All spend reaching 90% of $300 / UTC day** → pause *all* generation (incl. warm/yomi crons) until midnight. The 10% headroom bounds in-flight concurrent overshoot (queue runs ≤50 at once, cost only known post-call) so actual spend stays at/under $300 — "never more than $300, ever."
- Caps tunable via `DAILY_BUDGET_USD` / `HOURLY_CUSTOM_BUDGET_USD` (wrangler vars).

**Producer pre-checks** on `/api/qa/ask`, `/api/studio/run`, `/api/warm-daf` return a structured `429 { paused: true, scope, retryAfter }` for instant UI feedback; the queue consumer re-checks at `runLLM` and writes a paused job result.

**Hijack lockdown** — `ad_hoc` / `model_override` / `bypass_cache` and the admin mutation endpoints (`llm-cost?clear`, `strip-ttl`, `rabbi-compile/*`) now require `STUDIO_SECRET` via the `x-studio-secret` header. Unset ⇒ everyone untrusted (fail-safe). The public daf app only uses the safe subset, so it is unaffected; for untrusted callers `bypass_cache` is silently downgraded to cache-respecting (no error).

**Admin** — `GET /api/admin/budget` snapshot; `POST /api/admin/budget/reset` (trusted) to lift latches.

**Client** — localized "generation is paused, please try again tomorrow" surfaced in `QAPanel` and the daf enrichment cards; the studio panel sends the secret from `localStorage.talmud_studio_secret` so force-fresh re-runs keep working.

## Deploy notes
- Set the secret before relying on the lockdown: `wrangler secret put STUDIO_SECRET`.
- To use the studio panel's force-fresh after that: `localStorage.setItem('talmud_studio_secret', '<secret>')` in the browser.

## Test
- `pnpm typecheck` + `pnpm test` green (new `tests/budget.test.ts`: trip points, window roll-over, lost-latch re-derivation, custom-vs-total scoping, unpriced calls, reset). `vite build` succeeds.