### PR TITLE
Whole-daf argument-overview mark + strictly-orthogonal flowchart edges

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -75,7 +75,8 @@ export type SidebarContent =
   | { kind: 'rabbi'; rabbi: IdentifiedRabbi }
   | { kind: 'place'; place: PlaceInstance }
   | { kind: 'voice-group'; group: { name: string; nameHe: string; bio: string } }
-  | { kind: 'rishonim'; instance: RishonimInstance; index: number };
+  | { kind: 'rishonim'; instance: RishonimInstance; index: number }
+  | { kind: 'argument-overview' };
 
 export interface ArgumentSidebarProps {
   content: SidebarContent | null;
@@ -534,6 +535,52 @@ export function ArgumentBody(props: {
       </Show>
     </Panel>
     </Show>
+  );
+}
+
+/** Whole-daf argument overview. Runs the daf-level `argument-overview`
+ *  enrichments (one synthesis paragraph + a single voice graph for the entire
+ *  page) and renders the same ArgumentVoiceMap used per-section. Mirrors
+ *  ArgumentBody's voices flow, minus the per-section move list. */
+function ArgumentOverviewBody(props: {
+  tractate: string;
+  page: string;
+  onPushRabbi: (name: string) => void;
+}): JSX.Element {
+  // Whole-daf voices+edges, surfaced from the synthesis aggregate's
+  // deps_resolved (exactly like the per-section panel). Drives ArgumentVoiceMap.
+  const [voicesData, setVoicesData] = createSignal<ArgumentVoicesData | null>(null);
+
+  // Reset when the daf changes so a stale graph doesn't linger.
+  createEffect(() => {
+    void `${props.tractate}/${props.page}`;
+    setVoicesData(null);
+  });
+
+  const handleResolved = (r: { deps_resolved?: Record<string, unknown>; anchors_resolved?: Record<string, unknown> }) => {
+    const voices = r.deps_resolved?.['argument-overview.voices'] as ArgumentVoicesData | undefined;
+    if (voices && Array.isArray(voices.voices)) {
+      setVoicesData({ voices: voices.voices, edges: Array.isArray(voices.edges) ? voices.edges : [] });
+    }
+  };
+
+  return (
+    <Panel accent={ACCENTS.argument} title={t('overview.title')}>
+      <HebrewProse size="0.8rem" color="#999" margin="0 0 0.6rem">
+        {t('overview.experimental')}
+      </HebrewProse>
+      <Synthesis
+        markId="argument-overview"
+        instance={{ fields: {} }}
+        instanceKey={`${props.tractate}/${props.page}/overview`}
+        tractate={props.tractate}
+        page={props.page}
+        onResolved={handleResolved}
+      />
+      <Show when={voicesData()}>
+        {(data) => <ArgumentVoiceMap data={data()} onClickVoice={props.onPushRabbi} />}
+      </Show>
+    </Panel>
   );
 }
 
@@ -1507,6 +1554,14 @@ export function ArgumentSidebar(props: ArgumentSidebarProps): JSX.Element {
                 index={(c() as Extract<SidebarContent, { kind: 'aggadata' }>).index}
                 tractate={props.tractate}
                 page={props.page}
+              />
+            </Show>
+
+            <Show when={c().kind === 'argument-overview'}>
+              <ArgumentOverviewBody
+                tractate={props.tractate}
+                page={props.page}
+                onPushRabbi={props.onPushRabbi}
               />
             </Show>
 

--- a/src/client/ArgumentVoiceMap.tsx
+++ b/src/client/ArgumentVoiceMap.tsx
@@ -22,6 +22,7 @@
 
 import { For, Show, type JSX } from 'solid-js';
 import { t, lang } from './i18n';
+import { orthogonalEdgePath } from './flow/orthogonalEdge';
 
 /** Translate an argument-taxonomy role to the active language, falling back to
  *  the raw role string when the catalog has no entry for it. */
@@ -226,28 +227,13 @@ function buildLayout(data: ArgumentVoicesData): { nodes: LaidNode[]; edges: Laid
   return { nodes, edges, rows, width, height };
 }
 
-/** Edge path. Same-row → short horizontal line between the near edges.
- *  Different rows → L-shape through a midline Y. */
+/** Edge path — delegated to the shared orthogonal router so connectors are
+ *  always horizontal/vertical/L-shaped, never diagonal. */
 function edgePath(from: LaidNode, to: LaidNode): string {
-  const fromMidX = from.x + NODE_W / 2;
-  const toMidX = to.x + NODE_W / 2;
-  if (from.y === to.y) {
-    const startX = from.x + (toMidX > fromMidX ? NODE_W : 0);
-    const endX = to.x + (toMidX > fromMidX ? 0 : NODE_W);
-    return `M ${startX} ${from.y + NODE_H / 2} L ${endX} ${to.y + NODE_H / 2}`;
-  }
-  if (Math.abs(fromMidX - toMidX) < 1) {
-    // Same column, different row — straight vertical.
-    if (to.y > from.y) return `M ${fromMidX} ${from.y + NODE_H} L ${toMidX} ${to.y}`;
-    return `M ${fromMidX} ${from.y} L ${toMidX} ${to.y + NODE_H}`;
-  }
-  // L-shape: down/up from `from`, across, then up/down into `to`.
-  if (to.y > from.y) {
-    const midY = (from.y + NODE_H + to.y) / 2;
-    return `M ${fromMidX} ${from.y + NODE_H} L ${fromMidX} ${midY} L ${toMidX} ${midY} L ${toMidX} ${to.y}`;
-  }
-  const midY = (to.y + NODE_H + from.y) / 2;
-  return `M ${fromMidX} ${from.y} L ${fromMidX} ${midY} L ${toMidX} ${midY} L ${toMidX} ${to.y + NODE_H}`;
+  return orthogonalEdgePath(
+    { x: from.x, y: from.y, w: NODE_W, h: NODE_H },
+    { x: to.x, y: to.y, w: NODE_W, h: NODE_H },
+  );
 }
 
 function edgeColor(kind: ArgumentEdge['kind']): string {

--- a/src/client/DafViewer.tsx
+++ b/src/client/DafViewer.tsx
@@ -728,6 +728,7 @@ export default function DafViewer(): JSX.Element {
     if (c.kind === 'place') return c.place.fields.name || 'Place';
     if (c.kind === 'voice-group') return c.group.name;
     if (c.kind === 'rishonim') return `Rishonim · seg ${c.instance.segIdx + 1}`;
+    if (c.kind === 'argument-overview') return t('overview.chip');
     return 'Back';
   };
   const sidebarKey = (c: SidebarContent): string => {
@@ -739,7 +740,19 @@ export default function DafViewer(): JSX.Element {
     if (c.kind === 'place') return `place:${c.place.fields.name}`;
     if (c.kind === 'voice-group') return `voice-group:${c.group.name}`;
     if (c.kind === 'rishonim') return `rishonim:${c.instance.segIdx}`;
+    if (c.kind === 'argument-overview') return 'argument-overview';
     return 'unknown';
+  };
+
+  // Whole-daf 'chip' marks (anchor: 'whole-daf', render.kind: 'chip') surface
+  // as a button bar above the daf. Clicking opens the mark's daf-level sidebar
+  // panel. Generic over the registry — any future chip mark gets a button; the
+  // open routing is per-mark id.
+  const chipMarks = createMemo(() =>
+    enabledMarkDefs().filter((m) => (m.render as { kind?: string }).kind === 'chip'),
+  );
+  const openChip = (id: string) => {
+    if (id === 'argument-overview') setSidebar({ kind: 'argument-overview' });
   };
   // Set by ArgumentSidebar when the user clicks an argument-move card. Paints
   // a yellow band over the move's segment range in the main daf text. When
@@ -1825,6 +1838,7 @@ export default function DafViewer(): JSX.Element {
     if (s.kind === 'rabbi') return `rabbi:${s.rabbi.name}`;
     if (s.kind === 'place') return `place:${s.place.fields.name}`;
     if (s.kind === 'voice-group') return `voice-group:${s.group.name}`;
+    if (s.kind === 'argument-overview') return 'argument-overview';
     return `${s.kind}:${s.index}`;
   });
 
@@ -2584,6 +2598,34 @@ export default function DafViewer(): JSX.Element {
           body column so it's exactly the daf's width, pinned (sticky) directly
           above the daf as the reader scrolls. */}
       <DafLoadProgress />
+
+      <Show when={chipMarks().length > 0}>
+        <div class="daf-chip-bar" style={{ display: 'flex', gap: '0.4rem', 'flex-wrap': 'wrap', margin: '0 0 0.6rem' }}>
+          <For each={chipMarks()}>{(m) => {
+            const color = (m.render as { color?: string }).color ?? '#8a2a2b';
+            const label = m.id === 'argument-overview' ? t('overview.chip') : m.id;
+            const active = () => sidebar()?.kind === 'argument-overview' && m.id === 'argument-overview';
+            return (
+              <button
+                type="button"
+                onClick={() => openChip(m.id)}
+                title={label}
+                style={{
+                  'font-size': '0.75rem',
+                  'font-weight': 600,
+                  padding: '0.25rem 0.7rem',
+                  'border-radius': '999px',
+                  border: `1px solid ${color}`,
+                  color: active() ? '#fff' : color,
+                  background: active() ? color : '#fff',
+                  cursor: 'pointer',
+                  'font-family': 'system-ui, -apple-system, sans-serif',
+                }}
+              >{label}</button>
+            );
+          }}</For>
+        </div>
+      </Show>
 
       <div ref={surfaceEl} class="daf-surface" onMouseUp={onMouseUpRoot} style={{ display: 'flex', 'justify-content': 'center' }}>
         <Show

--- a/src/client/MobileShelf.tsx
+++ b/src/client/MobileShelf.tsx
@@ -164,5 +164,6 @@ function labelForSidebar(s: SidebarContent | null): string {
     case 'place': return 'Place';
     case 'voice-group': return 'Voice';
     case 'rishonim': return 'Rishonim';
+    case 'argument-overview': return 'Argument map';
   }
 }

--- a/src/client/RabbiLineageTree.tsx
+++ b/src/client/RabbiLineageTree.tsx
@@ -18,6 +18,7 @@
 import { For, Show, createSignal, type JSX } from 'solid-js';
 import { GENERATION_BY_ID, GENERATION_IDS, generationLabelHe, type GenerationId } from './generations';
 import { t, lang } from './i18n';
+import { orthogonalEdgePath, type EdgeRect } from './flow/orthogonalEdge';
 
 /** Generation label in the active language. */
 function genLabel(id: GenerationId): string {
@@ -347,49 +348,21 @@ function buildLayout(
   return { nodes, edges, width, height };
 }
 
-/** SVG line path for a parent edge — connects the bottom-center of the upper
- *  node to the top-center of the lower node (a vertical drop). */
-function parentPath(from: LaidNode, to: LaidNode): string {
-  const fromMidX = from.x + NODE_W / 2;
-  const toMidX = to.x + NODE_W / 2;
-  const sameColumn = Math.abs(fromMidX - toMidX) < 1;
-
-  // Teacher above subject (`to` is the teacher in graph terms, but rendering-
-  // wise `to.y < from.y` since earlier generation = lower y).
-  if (to.y < from.y) {
-    if (sameColumn) {
-      // Clean vertical drop from teacher's bottom to subject's top.
-      return `M ${toMidX} ${to.y + NODE_H} L ${fromMidX} ${from.y}`;
-    }
-    // Off-column teacher: L-shape. Down from teacher's bottom to a midline
-    // Y, then horizontal to subject's column, then down to subject's top.
-    const midY = (to.y + NODE_H + from.y) / 2;
-    return `M ${toMidX} ${to.y + NODE_H} L ${toMidX} ${midY} L ${fromMidX} ${midY} L ${fromMidX} ${from.y}`;
-  }
-
-  // Student below subject.
-  if (to.y > from.y) {
-    if (sameColumn) {
-      return `M ${fromMidX} ${from.y + NODE_H} L ${toMidX} ${to.y}`;
-    }
-    const midY = (from.y + NODE_H + to.y) / 2;
-    return `M ${fromMidX} ${from.y + NODE_H} L ${fromMidX} ${midY} L ${toMidX} ${midY} L ${toMidX} ${to.y}`;
-  }
-
-  // Same-row fallback (teacher in subject's row — rare). Short horizontal
-  // line between the nearer edges.
-  const startX = from.x + (toMidX > fromMidX ? NODE_W : 0);
-  const endX = to.x + (toMidX > fromMidX ? 0 : NODE_W);
-  return `M ${startX} ${from.y + NODE_H / 2} L ${endX} ${to.y + NODE_H / 2}`;
+function rect(n: LaidNode): EdgeRect {
+  return { x: n.x, y: n.y, w: NODE_W, h: NODE_H };
 }
 
-/** Partner edge — horizontal dashed line between the two nodes. */
+/** Parent edge (teacher↔student) — delegated to the shared orthogonal router
+ *  so it is always a clean vertical drop or L-shape, never diagonal. */
+function parentPath(from: LaidNode, to: LaidNode): string {
+  return orthogonalEdgePath(rect(from), rect(to));
+}
+
+/** Partner edge — same orthogonal router. When the partner sits in the
+ *  subject's row this is a horizontal line; off-row it routes as an L-shape
+ *  rather than the diagonal the old single-segment version drew. */
 function partnerPath(from: LaidNode, to: LaidNode): string {
-  const fromMidY = from.y + NODE_H / 2;
-  const toMidY = to.y + NODE_H / 2;
-  const startX = from.x + (to.x > from.x ? NODE_W : 0);
-  const endX = to.x + (to.x > from.x ? 0 : NODE_W);
-  return `M ${startX} ${fromMidY} L ${endX} ${toMidY}`;
+  return orthogonalEdgePath(rect(from), rect(to));
 }
 
 export default function RabbiLineageTree(props: Props): JSX.Element {

--- a/src/client/flow/orthogonalEdge.ts
+++ b/src/client/flow/orthogonalEdge.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared orthogonal edge router for the SVG flowchart components
+ * (ArgumentVoiceMap, RabbiLineageTree, …). Connector segments are ALWAYS
+ * axis-aligned — horizontal, vertical, or an L-shape through a midline — so a
+ * connector can never render as a diagonal line. A single segment where both
+ * x and y change at once is exactly the "random diagonal" we want to forbid.
+ *
+ * Routing, decided purely from geometry (caller order is irrelevant):
+ *   - Same row (equal top edge)      -> one horizontal segment between the
+ *                                       nearer vertical edges.
+ *   - Same column (equal mid-x)      -> one vertical segment between the
+ *                                       nearer horizontal edges.
+ *   - Otherwise                      -> L-shape: vertical out of the upper
+ *                                       box, horizontal across a midline Y,
+ *                                       vertical into the lower box.
+ */
+
+export interface EdgeRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export function orthogonalEdgePath(from: EdgeRect, to: EdgeRect): string {
+  const fromMidX = from.x + from.w / 2;
+  const toMidX = to.x + to.w / 2;
+
+  // Same row -> straight horizontal between the nearer vertical edges. Use a
+  // single Y for both endpoints so unequal heights can't introduce a tilt.
+  if (from.y === to.y) {
+    const y = from.y + from.h / 2;
+    const startX = toMidX > fromMidX ? from.x + from.w : from.x;
+    const endX = toMidX > fromMidX ? to.x : to.x + to.w;
+    return `M ${startX} ${y} L ${endX} ${y}`;
+  }
+
+  // Same column -> straight vertical between the nearer horizontal edges.
+  if (Math.abs(fromMidX - toMidX) < 1) {
+    if (to.y > from.y) return `M ${fromMidX} ${from.y + from.h} L ${fromMidX} ${to.y}`;
+    return `M ${fromMidX} ${from.y} L ${fromMidX} ${to.y + to.h}`;
+  }
+
+  // Otherwise -> L-shape (vertical, horizontal, vertical) through a midline Y.
+  if (to.y > from.y) {
+    const midY = (from.y + from.h + to.y) / 2;
+    return `M ${fromMidX} ${from.y + from.h} L ${fromMidX} ${midY} L ${toMidX} ${midY} L ${toMidX} ${to.y}`;
+  }
+  const midY = (to.y + to.h + from.y) / 2;
+  return `M ${fromMidX} ${from.y} L ${fromMidX} ${midY} L ${toMidX} ${midY} L ${toMidX} ${to.y + to.h}`;
+}

--- a/src/client/i18n.ts
+++ b/src/client/i18n.ts
@@ -170,6 +170,15 @@ const CATALOG = {
   'sidebar.kind.rishonim': { en: 'Rishonim', he: 'ראשונים' },
   'sidebar.kind.voice-group': { en: 'Voice', he: 'קול' },
   'sidebar.kind.rabbi': { en: 'Rabbi', he: 'חכם' },
+  'sidebar.kind.argument-overview': { en: 'Argument map', he: 'מפת הטיעון' },
+
+  // — Whole-daf argument overview —
+  'overview.chip': { en: 'Argument map', he: 'מפת הטיעון' },
+  'overview.title': { en: 'Whole-daf argument map', he: 'מפת הטיעון של הדף' },
+  'overview.experimental': {
+    en: 'Experimental — synthesized from dafyomi.co.il study context; positions are inferred.',
+    he: 'ניסיוני — מסונתז מתוכן הלימוד של dafyomi.co.il; העמדות מוסקות.',
+  },
 
   // — Common —
   'common.open': { en: 'Open {name}', he: 'פתיחת {name}' },

--- a/src/client/sidebar/primitives.tsx
+++ b/src/client/sidebar/primitives.tsx
@@ -29,6 +29,7 @@ import QAPanel from '../QAPanel';
  *  six hardcoded hex values stop drifting. */
 export const ACCENTS = {
   argument: '#8a2a2b',
+  'argument-overview': '#8a2a2b',
   halacha: '#1e40af',
   aggadata: '#7c3aed',
   pesuk: '#9a3412',
@@ -45,6 +46,7 @@ export type SidebarKind = keyof typeof ACCENTS;
 export function kindLabelKey(kind: SidebarKind): CatalogKey {
   switch (kind) {
     case 'argument': return 'sidebar.kind.argument';
+    case 'argument-overview': return 'sidebar.kind.argument-overview';
     case 'halacha': return 'sidebar.kind.halacha';
     case 'aggadata': return 'sidebar.kind.aggadata';
     case 'pesuk': return 'sidebar.kind.pesuk';

--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -511,6 +511,29 @@ export const CODE_MARKS: MarkDefinition[] = [
     updated_at: NOW,
   },
   {
+    id: 'argument-overview',
+    label: 'Argument map',
+    description: 'Whole-daf argument flowchart (one button → sidebar voice map for the entire page), grounded on dafyomi.co.il study context.',
+    category: 'experimental',
+    anchor: 'whole-daf',
+    render: {
+      kind: 'chip',
+      color: '#8a2a2b',
+      position: 'header',
+    },
+    // Deterministic single anchorless instance — the chip + daf-level
+    // enrichments hang off it; no LLM at the mark layer.
+    extractor: {
+      kind: 'computed',
+      fn: 'whole-daf-instance',
+    },
+    status: 'promoted',
+    def_hash: 'argument-overview-v1',
+    cache_version: '1',
+    source: 'code',
+    updated_at: NOW,
+  },
+  {
     id: 'halacha',
     label: 'Halachot',
     description: 'Halacha-topic gutter icons + sidebar.',
@@ -1948,6 +1971,125 @@ CODE_ENRICHMENTS.push(
       model: ARGUMENT_FLASH_MODEL,
       systemPromptHe: ARGUMENT_SYNTHESIS_SYSTEM_PROMPT_HE,
       userPromptTemplateHe: ARGUMENT_SYNTHESIS_USER_TEMPLATE_HE,
+    },
+  ),
+);
+
+// ---------------------------------------------------------------------------
+// argument-overview mark enrichments — a SINGLE whole-daf voice graph for the
+// entire page (vs argument.voices, which is per-section). Reuses the voices
+// JSON contract + the ArgumentVoiceMap renderer; grounded on the aggregated
+// dafyomi.co.il study context ({{context}}: point-by-point outline, halacha
+// summary, comparison charts) plus the daf's own argument sections + rabbis.
+// ---------------------------------------------------------------------------
+
+const ARGUMENT_OVERVIEW_VOICES_SYSTEM_PROMPT = `You are a Talmud scholar. Emit a SINGLE graph of the major argumentative voices across this ENTIRE daf — who argues with whom, who supports whom — at the level of the whole page (not one section). Daf-local: about what these figures do on this daf, not their biography.
+
+Output STRICT JSON only:
+
+{
+  "voices": [
+    {
+      "name": "Conventional English name (e.g. 'Rav Yehudah', 'Ula'). Use 'Stam' for the anonymous Gemara when it meaningfully links voices.",
+      "nameHe": "Hebrew name as written (e.g. 'רב יהודה'). Empty string if not present.",
+      "role": "originator" | "transmitter" | "respondent" | "objector" | "supporter" | "cited-authority" | "questioner",
+      "side": "The camp this voice argues for in the daf's main dispute. 'A' for the first distinct position, 'B' for the opposing one, 'C' for a third. 'stam' for the anonymous redactor. 'support-A' / 'support-B' for figures cited only to back a side. 'unaligned' for questioners/transmitters who take no position.",
+      "stance": "1-2 plain-English sentences: the position this figure takes on the daf and what they respond to.",
+      "opinionStart": "First 3-5 Hebrew/Aramaic words of their opening line, verbatim. Empty string if not anchored to one phrase."
+    }
+  ],
+  "edges": [
+    { "from": "name of the voice doing the action (must match a voices 'name')", "to": "name of the targeted voice (must match a voices 'name')", "kind": "opposes" | "supports" | "responds-to" | "cites" | "resolves", "note": "OPTIONAL 1-clause edge label, else empty string" }
+  ]
+}
+
+EDGE KINDS: opposes (objects to / rejects), supports (argues for / cites in favor), responds-to (answers a question raised), cites (quotes as authority, no clear stance), resolves (concludes a dispute; "to" is the upheld side).
+
+Rules:
+- One voice entry per distinct figure even if they appear in several sections.
+- Keep it to the MAJOR voices that drive the daf's argument — do not list every name mentioned in passing. Aim for the disputants and those who respond to / support / resolve them.
+- 'side' letters are local to THIS daf — Position A is whoever is introduced first as a distinct position.
+- Every edge's "from" and "to" MUST match a name in voices. Validate before emitting.
+- If the daf has no real dispute, emit voices with an EMPTY edges array.
+- Use the study-aid context (point-by-point outline, halacha summary, charts) to identify positions and who opposes whom — it already lays out the debate structure. Prefer it where it conflicts with your own segmentation.
+- NO puff in "stance" — concrete: what they hold and against whom.
+
+${HEBREW_GLOSS_STYLE}`;
+
+const ARGUMENT_OVERVIEW_VOICES_USER_TEMPLATE = `Tractate: {{tractate}}, page {{page}}.
+
+Full daf:
+{{gemara}}
+
+Argument sections already extracted on this daf:
+{{anchors.argument}}
+
+Rabbis identified on this daf (with generation):
+{{anchors.rabbi}}
+
+Study-aid context (dafyomi.co.il — point-by-point outline, halacha summary, comparison charts):
+{{context}}
+
+Emit ONE whole-daf voice graph per the schema: the major disputants across the entire page, who argues with whom, who supports whom.`;
+
+const ARGUMENT_OVERVIEW_SYNTHESIS_SYSTEM_PROMPT = `You are a Talmud scholar. You'll receive a full daf, its argument sections, the whole-daf voice graph, and study-aid context. Compose ONE tight paragraph orienting a reader to the WHOLE page: its central question(s), the main named positions, and where the daf lands.
+
+Output STRICT JSON only:
+
+{
+  "synthesis": "ONE paragraph, MAX 4 sentences. Each sentence MAX 25 words. (1) The daf's central question or topic. (2) The main named positions, one terse clause each. (3) ONE optional sentence on how the sections connect. (4) ONE closing sentence: where the daf lands (open / resolved / shifts on). Do NOT recap section by section."
+}
+
+HARD RULES:
+- MAX 4 sentences. MAX 25 words per sentence. Cut, don't pad.
+- Whole-daf orientation, not a section recap. Per-section detail lives in argument.synthesis.
+- NO puff. Forbidden: "this teaches us", "we see that", "highlights", "underscores", "intricate", "profound", "lens", "captures".
+- Hebrew script (not transliteration) for technical terms in parentheses.
+
+${HEBREW_GLOSS_STYLE}`;
+
+const ARGUMENT_OVERVIEW_SYNTHESIS_USER_TEMPLATE = `Tractate: {{tractate}}, page {{page}}.
+
+Full daf:
+{{gemara}}
+
+Argument sections on this daf:
+{{anchors.argument}}
+
+Whole-daf voice graph:
+{{depends.argument-overview.voices}}
+
+Study-aid context (dafyomi.co.il):
+{{context}}
+
+Write the whole-daf overview paragraph per the schema.`;
+
+CODE_ENRICHMENTS.push(
+  makeEnrichment(
+    'argument-overview', 'argument-overview.voices', 'Voices',
+    'A single whole-daf graph of the major argumentative voices.',
+    ARGUMENT_OVERVIEW_VOICES_SYSTEM_PROMPT, ARGUMENT_OVERVIEW_VOICES_USER_TEMPLATE, ARGUMENT_VOICES_OUTPUT_SCHEMA,
+    {
+      mode: 'augment-content', scope: 'local',
+      dependencies: ['gemara', 'context', { mark: 'argument' }, { mark: 'rabbi' }],
+      defHash: 'argument-overview.voices-v1', cacheVersion: '1',
+      model: ARGUMENT_FLASH_MODEL,
+    },
+  ),
+  makeSynthesis(
+    'argument-overview', 'argument-overview.synthesis',
+    'One tight paragraph orienting a reader to the whole daf: its question, the main positions, where it lands.',
+    ARGUMENT_OVERVIEW_SYNTHESIS_SYSTEM_PROMPT, ARGUMENT_OVERVIEW_SYNTHESIS_USER_TEMPLATE,
+    {
+      dependencies: [
+        'gemara',
+        'context',
+        { enrichment: 'argument-overview.voices' },
+        { mark: 'argument' },
+        { mark: 'rabbi' },
+      ],
+      defHash: 'argument-overview.synthesis-v1', cacheVersion: '1',
+      model: ARGUMENT_FLASH_MODEL,
     },
   ),
 );

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -9,6 +9,7 @@ import {
 } from '../lib/sefref';
 import { getDafyomiMasechet } from '../lib/sefref/dafyomi/masechtos';
 import { collectContext } from './context-providers';
+import { formatContextForPrompt } from '../lib/context/select';
 import { aiMatchToSegments } from './context-match';
 import type { MatchInput } from '../lib/context/anchor/ai-prompt';
 import {
@@ -823,6 +824,14 @@ async function resolveDependencies(
       out.vars.mishna = mishnaBundleToString(filtered);
       return;
     }
+    if (dep === 'context') {
+      // Aggregated external context (dafyomi Points/Halacha/Charts + Sefaria),
+      // rendered as grouped plain text for the prompt. Each source that fails
+      // contributes nothing rather than throwing.
+      const items = await collectContext(rc.env, tractate, page);
+      out.vars.context = formatContextForPrompt(items);
+      return;
+    }
     if (typeof dep === 'object' && dep !== null) {
       if ('enrichment' in dep) {
         const depId = dep.enrichment;
@@ -973,6 +982,10 @@ const COMPUTED_FNS: Record<string, ComputedMarkFn> = {
       }));
     return { instances };
   },
+  // Whole-daf marks (anchor: 'whole-daf') carry no per-segment anchor — they
+  // represent one daf-level concept. Emit a single anchorless instance so the
+  // chip renders and daf-level enrichments have something to attach to.
+  'whole-daf-instance': async () => ({ instances: [{ fields: {} }] }),
 };
 
 // Per-section fan-out concurrency. Each section call is small (~3-6 moves);

--- a/src/worker/studio-schema.ts
+++ b/src/worker/studio-schema.ts
@@ -318,6 +318,9 @@ export type Extractor = LLMExtractor | SefariaExtractor | ComputedExtractor | Ma
 //   'gemara'             → {{gemara}} / {{gemara_he}} / {{gemara_en}} /
 //                          {{segments_he}} / {{segments_en}}
 //   'commentaries'       → {{commentaries}}
+//   'context'            → {{context}}  (aggregated external context for the
+//                          daf: dafyomi.co.il Points/Halacha/Charts + Sefaria,
+//                          grouped plain text via collectContext)
 //   { enrichment: id }   → {{depends.<id>}}    (recursively resolved)
 //   { mark: id }         → {{anchors.<id>}}    (mark extractor for same daf)
 //
@@ -331,6 +334,7 @@ export type EnrichmentDependency =
   | 'gemara'
   | 'commentaries'
   | 'mishna'
+  | 'context'
   | { enrichment: string }
   | { mark: string };
 

--- a/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
+++ b/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
@@ -12,6 +12,8 @@ exports[`CODE_ENRICHMENTS cache identity > per-enrichment fingerprint is stable 
   "argument-move.qa@5 mode=augment-content scope=local mark=argument-move schema=argument_move_qa[answer,confidence] deps=[gemara|e:argument-move.synthesis|e:argument-move.commentaries|m:argument-move]",
   "argument-move.suggested-questions@3 mode=augment-content scope=local mark=argument-move schema=argument_move_suggested_questions[questions] deps=[gemara|m:argument-move|e:argument-move.synthesis]",
   "argument-move.synthesis@5 mode=aggregate scope=local mark=argument-move schema=argument_move_synthesis[synthesis] deps=[gemara|e:argument-move.commentaries|m:argument-move|m:rabbi]",
+  "argument-overview.synthesis@1 mode=aggregate scope=local mark=argument-overview schema=argument_overview_synthesis[synthesis] deps=[gemara|context|e:argument-overview.voices|m:argument|m:rabbi]",
+  "argument-overview.voices@1 mode=augment-content scope=local mark=argument-overview schema=argument_voices[voices,edges] deps=[gemara|context|m:argument|m:rabbi]",
   "argument.background@3 mode=augment-content scope=local mark=argument schema=argument_background[background] deps=[gemara|commentaries|mishna]",
   "argument.synthesis@10 mode=aggregate scope=local mark=argument schema=argument_synthesis[synthesis] deps=[gemara|commentaries|mishna|e:argument.voices|e:argument.background|m:rabbi|m:argument-move]",
   "argument.voices@5 mode=augment-content scope=local mark=argument schema=argument_voices[voices,edges] deps=[gemara|m:argument-move|m:rabbi]",

--- a/tests/orthogonal-edge.test.ts
+++ b/tests/orthogonal-edge.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { orthogonalEdgePath, type EdgeRect } from '../src/client/flow/orthogonalEdge';
+
+/** Parse an SVG path of only M/L commands into its ordered points. */
+function points(path: string): Array<[number, number]> {
+  const out: Array<[number, number]> = [];
+  const re = /[ML]\s+(-?\d+(?:\.\d+)?)\s+(-?\d+(?:\.\d+)?)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(path)) !== null) out.push([Number(m[1]), Number(m[2])]);
+  return out;
+}
+
+/** Every consecutive segment must be axis-aligned: equal x OR equal y. */
+function assertOrthogonal(path: string): void {
+  const pts = points(path);
+  expect(pts.length).toBeGreaterThanOrEqual(2);
+  for (let i = 1; i < pts.length; i++) {
+    const [ax, ay] = pts[i - 1];
+    const [bx, by] = pts[i];
+    const aligned = Math.abs(ax - bx) < 1e-9 || Math.abs(ay - by) < 1e-9;
+    expect(aligned, `segment ${JSON.stringify(pts[i - 1])}->${JSON.stringify(pts[i])} in "${path}" is diagonal`).toBe(true);
+  }
+}
+
+const W = 152;
+const H = 40;
+const at = (x: number, y: number): EdgeRect => ({ x, y, w: W, h: H });
+
+describe('orthogonalEdgePath', () => {
+  it('same row -> single horizontal segment', () => {
+    const p = orthogonalEdgePath(at(0, 100), at(300, 100));
+    assertOrthogonal(p);
+    const pts = points(p);
+    expect(pts.length).toBe(2);
+    expect(pts[0][1]).toBe(pts[1][1]); // flat
+  });
+
+  it('same column, different row -> single vertical segment', () => {
+    const p = orthogonalEdgePath(at(0, 0), at(0, 200));
+    assertOrthogonal(p);
+    const pts = points(p);
+    expect(pts.length).toBe(2);
+    expect(pts[0][0]).toBe(pts[1][0]); // plumb
+  });
+
+  it('off-row and off-column -> L-shape, still orthogonal', () => {
+    assertOrthogonal(orthogonalEdgePath(at(0, 0), at(300, 200)));
+    assertOrthogonal(orthogonalEdgePath(at(300, 200), at(0, 0))); // reversed order
+    assertOrthogonal(orthogonalEdgePath(at(0, 200), at(300, 0)));
+  });
+
+  it('partner placed off-row no longer draws a diagonal (the bug)', () => {
+    // Old partnerPath drew a single M..L between two differing-y centers.
+    assertOrthogonal(orthogonalEdgePath(at(200, 100), at(360, 184)));
+  });
+
+  it('is orthogonal across a randomized battery of rect pairs', () => {
+    let seed = 1234567;
+    const rnd = () => {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+      return seed / 0x7fffffff;
+    };
+    for (let i = 0; i < 500; i++) {
+      const a = at(Math.round(rnd() * 800), Math.round(rnd() * 600));
+      const b = at(Math.round(rnd() * 800), Math.round(rnd() * 600));
+      assertOrthogonal(orthogonalEdgePath(a, b));
+    }
+  });
+});


### PR DESCRIPTION
## What

A new whole-daf **Argument map** that fits the existing marks/enrichment framework: a single chip button above the daf opens a sidebar panel showing one argument flowchart for the *entire* page (vs the per-section `argument.voices` map), reusing the existing `ArgumentVoiceMap` renderer.

It's "a new type of thing" done natively:
- **New `whole-daf` mark `argument-overview`** (`render: chip`) — a deterministic computed mark emitting one anchorless instance; the chip + daf-level enrichments hang off it (no LLM at the mark layer).
- **New reusable `'context'` enrichment dependency** — resolves via the existing `collectContext` + `formatContextForPrompt`, exposing `{{context}}` (aggregated dafyomi.co.il Points/Halacha/Charts + Sefaria). Any future mark/enrichment can now declare `'context'`.
- **`argument-overview.voices`** reuses `ARGUMENT_VOICES_OUTPUT_SCHEMA` (so it renders through `ArgumentVoiceMap` unchanged) + **`argument-overview.synthesis`**, grounded on dafyomi context + the daf's own `argument`/`rabbi` marks.
- **Client**: a chip bar in `DafViewer` (generic over enabled `render.kind === 'chip'` marks) opens a new `argument-overview` sidebar panel that mirrors `ArgumentSectionPanel`'s `onResolved → ArgumentVoiceMap` path. Reuses `Synthesis`, the sidebar stack, i18n.

## Also: no more diagonal flowchart edges

Extracted a shared orthogonal edge router (`src/client/flow/orthogonalEdge.ts`) used by `ArgumentVoiceMap` and `RabbiLineageTree`. Fixes `RabbiLineageTree.partnerPath`, which drew a single diagonal segment whenever a partner node sat in a different row than the subject. Connectors are now always horizontal / vertical / L-shaped.

## Verification

- `pnpm typecheck` clean; `pnpm test` 1107/1107 pass (incl. new `tests/orthogonal-edge.test.ts` no-diagonal invariant; enrichments snapshot updated); `pnpm build` clean for worker + client.
- Live LLM run could not be exercised locally — `wrangler dev` has no `OPENROUTER_API_KEY` (production secret), so the enrichment pipeline was confirmed only up to the LLM boundary (job enqueues, deps incl. the new `'context'` resolve, model chain invoked). The voice graph itself should be verified on prod (Chullin 76a, which has committed dafyomi context).

## Notes for review

- First-visit auto-enable means the `argument-overview` mark (and its chip) is **on by default** for new visitors.
- Daf-load prefetch was intentionally **not** wired for this enrichment — the whole-daf voices+synthesis LLM call runs lazily on chip-click, not on every daf load.
- Category is `experimental`; the panel carries an "experimental — positions are inferred" banner.