### PR TITLE
AI match as contextual grounding (best-fitting level, whole-daf included)

### DIFF
--- a/src/client/AlignPage.tsx
+++ b/src/client/AlignPage.tsx
@@ -72,7 +72,7 @@ function hbQueryFor(item: ContextItem, quotes: Map<string, string>): LocateQuery
   return { phrase: leadingWords(item.title?.he, 6) ?? leadingWords(item.body?.he, 6), segs };
 }
 
-interface HL { segs: number[]; words: number[] }
+interface HL { segs: number[]; words: number[]; daf?: boolean }
 const EMPTY: HL = { segs: [], words: [] };
 
 export function AlignPage(): JSX.Element {
@@ -83,7 +83,7 @@ export function AlignPage(): JSX.Element {
   // and two granularities: `words` = exact HB word indices, `segs` = segments.
   const [pinned, setPinned] = createSignal<HL>(EMPTY);
   const [hover, setHover] = createSignal<HL>(EMPTY);
-  const effective = () => (hover().segs.length || hover().words.length ? hover() : pinned());
+  const effective = () => (hover().segs.length || hover().words.length || hover().daf ? hover() : pinned());
   // AI matches + the Hebrew quotes they emit (resolved to HB spans client-side).
   const [matches, setMatches] = createSignal<SegMatch[]>([]);
   const [aiQuotes, setAiQuotes] = createSignal<Map<string, string>>(new Map());
@@ -119,8 +119,26 @@ export function AlignPage(): JSX.Element {
     if (hb && hb.norm.length) {
       const quotes = aiQuotes();
       for (const it of items) {
+        // AI grounded this item at whole-daf level (placed by meaning, but no
+        // single segment fits): record it as such — no word span to highlight.
+        if (it.via === 'ai' && it.segs.length === 0) {
+          it.hbVia = 'ai-daf';
+          it.hbConfidence = it.confidence;
+          continue;
+        }
         const loc = locateInHb(hb, hbQueryFor(it, quotes));
-        if (loc) { it.hbWords = loc.words; it.hbVia = loc.via; it.hbConfidence = loc.confidence; }
+        if (!loc) continue;
+        it.hbWords = loc.words;
+        if (it.via === 'ai') {
+          // Contextual AI placement: trust the segment pick (chosen by meaning);
+          // a verbatim quote only TIGHTENS it onto exact words when it lands.
+          // Either way carry the AI's own confidence, not the locator's coarse 0.3.
+          it.hbVia = loc.via === 'segment' ? 'ai-segment' : 'ai-phrase';
+          it.hbConfidence = it.confidence ?? loc.confidence;
+        } else {
+          it.hbVia = loc.via;
+          it.hbConfidence = loc.confidence;
+        }
       }
     }
     return items;
@@ -203,8 +221,11 @@ export function AlignPage(): JSX.Element {
                     'font-size': '1.05rem',
                     'line-height': 1.7,
                     padding: '1rem',
-                    border: '1px solid #eee',
                     'border-radius': '6px',
+                    // A whole-daf grounding (hovering an "ai-daf" item) washes the
+                    // entire canvas, since it's about the page as a whole.
+                    border: effective().daf ? '1px solid #fcd34d' : '1px solid #eee',
+                    'box-shadow': effective().daf ? 'inset 0 0 0 9999px rgba(252,211,77,0.12)' : 'none',
                     background: '#fff',
                     'text-align': 'justify',
                   }}

--- a/src/client/ContextSourcePanel.tsx
+++ b/src/client/ContextSourcePanel.tsx
@@ -1,8 +1,9 @@
 import { createSignal, createMemo, createEffect, For, Show, type JSX } from 'solid-js';
 import { type ContextItem, rangeLabel } from '../lib/context/types';
 
-/** Highlight payload: precise HB word indices + the segments they sit in. */
-interface Hl { segs: number[]; words: number[] }
+/** Highlight payload: precise HB word indices + the segments they sit in, or a
+ *  whole-daf wash (`daf`). */
+interface Hl { segs: number[]; words: number[]; daf?: boolean }
 const EMPTY: Hl = { segs: [], words: [] };
 
 /** Drop HTML markup (Sefaria text carries <b>/<strong>/<i>/<big>) for display. */
@@ -10,10 +11,18 @@ function stripTags(s: string | undefined): string {
   return s ? s.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim() : '';
 }
 
-/** Precisely located on the HB text (a real phrase/AI hit, not a coarse
- *  segment fallback). */
+/** Anchored to specific HB words (a segment span or tighter) — "located on the
+ *  text". Whole-daf groundings are placed but not anchored to a span. */
+function isLocated(it: ContextItem): boolean {
+  return !!it.hbWords?.length;
+}
+/** Word-precise: a real phrase/AI-quote landing, not a whole-segment fallback. */
 function isPrecise(it: ContextItem): boolean {
-  return !!it.hbWords?.length && it.hbVia !== 'segment';
+  return isLocated(it) && it.hbVia !== 'segment' && it.hbVia !== 'ai-segment';
+}
+/** Already grounded by the AI placer (so the AI button shouldn't re-offer it). */
+function aiGrounded(it: ContextItem): boolean {
+  return it.via === 'ai' || it.hbVia === 'ai-phrase' || it.hbVia === 'ai-segment' || it.hbVia === 'ai-daf';
 }
 
 /**
@@ -55,10 +64,12 @@ export function ContextSourcePanel(props: {
   };
 
   const visible = createMemo(() => itemsOf(selected()));
-  const preciseCount = createMemo(() => props.items.filter(isPrecise).length);
-  // Items in the selected source not yet precisely located (candidates for AI).
+  const locatedCount = createMemo(() => props.items.filter(isLocated).length);
+  const dafCount = createMemo(() => props.items.filter((i) => i.hbVia === 'ai-daf').length);
+  // Candidates for the AI placer: not already word-precise and not yet grounded
+  // by the AI (so a second click doesn't re-send what it already placed).
   const needAi = createMemo(() =>
-    selected() === 'all' ? [] : itemsOf(selected()).filter((i) => !isPrecise(i)),
+    selected() === 'all' ? [] : itemsOf(selected()).filter((i) => !isPrecise(i) && !aiGrounded(i)),
   );
 
   const pick = (source: string) => {
@@ -77,7 +88,7 @@ export function ContextSourcePanel(props: {
       <h2 style={{ 'font-size': '0.9rem', color: '#999', 'text-transform': 'uppercase', 'letter-spacing': '0.05em', 'margin-bottom': '0.4rem' }}>
         Connections
         <span style={{ 'text-transform': 'none', 'margin-left': '0.6rem', color: '#aaa', 'font-size': '0.8rem' }}>
-          {props.items.length} items · {preciseCount()} located on the text
+          {props.items.length} items · {locatedCount()} located on the text{dafCount() > 0 ? ` · ${dafCount()} whole-daf` : ''}
         </span>
       </h2>
 
@@ -105,7 +116,15 @@ export function ContextSourcePanel(props: {
       <div style={{ display: 'flex', 'flex-direction': 'column', gap: '0.5rem' }}>
         <For each={visible()}>
           {(item) => (
-            <ContextCard item={item} onEnter={() => props.onHover({ segs: item.segs, words: item.hbWords ?? [] })} onLeave={props.onLeave} />
+            <ContextCard
+              item={item}
+              onEnter={() => props.onHover(
+                item.hbVia === 'ai-daf'
+                  ? { segs: [], words: [], daf: true }
+                  : { segs: item.segs, words: item.hbWords ?? [] },
+              )}
+              onLeave={props.onLeave}
+            />
           )}
         </For>
         <Show when={visible().length === 0}>
@@ -137,9 +156,13 @@ function ContextCard(props: { item: ContextItem; onEnter: () => void; onLeave: (
   const [open, setOpen] = createSignal(false);
   const it = props.item;
   const placed = () => isPrecise(it);
+  const wholeDaf = () => it.hbVia === 'ai-daf';
   const via = () => it.hbVia ?? it.via;
   const conf = () => it.hbConfidence ?? it.confidence;
-  const placeLabel = () => (placed() ? `${it.hbWords!.length} word${it.hbWords!.length === 1 ? '' : 's'}` : rangeLabel(it.segs, it.amud));
+  const placeLabel = () =>
+    wholeDaf() ? 'whole daf'
+      : placed() ? `${it.hbWords!.length} word${it.hbWords!.length === 1 ? '' : 's'}`
+      : rangeLabel(it.segs, it.amud);
   const bodyEn = () => stripTags(it.body?.en ?? '');
   const long = () => bodyEn().length > 280;
   const shown = () => (open() || !long() ? bodyEn() : bodyEn().slice(0, 280) + '…');
@@ -150,14 +173,14 @@ function ContextCard(props: { item: ContextItem; onEnter: () => void; onLeave: (
       onMouseLeave={props.onLeave}
       style={{
         border: '1px solid #eee', 'border-radius': '6px', padding: '0.55rem 0.7rem', background: '#fff',
-        'border-left': `3px solid ${placed() ? '#059669' : it.hbWords?.length ? '#f59e0b' : '#d1d5db'}`,
+        'border-left': `3px solid ${placed() ? '#059669' : wholeDaf() ? '#a78bfa' : it.hbWords?.length ? '#f59e0b' : '#d1d5db'}`,
       }}
     >
       <div style={{ display: 'flex', 'align-items': 'baseline', gap: '0.5rem', 'margin-bottom': '0.25rem', 'flex-wrap': 'wrap' }}>
         <span style={{ 'font-size': '0.68rem', 'font-weight': 700, color: '#8a2a2b', 'text-transform': 'uppercase', 'letter-spacing': '0.04em' }}>
           {it.sourceLabel}
         </span>
-        <span style={{ 'font-size': '0.68rem', 'font-family': 'monospace', color: placed() ? '#059669' : '#999' }}>
+        <span style={{ 'font-size': '0.68rem', 'font-family': 'monospace', color: placed() ? '#059669' : wholeDaf() ? '#7c3aed' : '#999' }}>
           {placeLabel()}
         </span>
         <Show when={via()}>

--- a/src/lib/context/anchor/ai-prompt.ts
+++ b/src/lib/context/anchor/ai-prompt.ts
@@ -25,12 +25,13 @@ You are given the daf as a numbered list of Hebrew segments with English transla
 For EACH item, decide which segment (or contiguous range of segments) it most directly discusses or comments on.
 Rules:
 - Use the segment INDICES shown (0-based).
+- Match by MEANING, not shared words: read the English translations to understand what each item is about, then pick the segment that discusses the same point — even when the item and the segment share no vocabulary (e.g. an English study note about a Hebrew line).
 - Most study-note items DO comment on a specific line — localize whenever you reasonably can. Prefer the single best segment over a wide range.
 - If an item maps to one segment, set segEnd = segStart.
 - If it spans consecutive segments, set segStart..segEnd.
-- Only set segStart = null when the item is genuinely about the whole daf (e.g. a general summary or methodology note) and no single segment fits.
+- Set segStart = null ONLY when the item genuinely concerns the whole daf (a general summary or methodology note) and no single segment fits best. This is a real "whole-daf" placement, not a failure — still give a confidence.
 - confidence is 0..1 (how sure you are of the localization).
-- "quote": copy 3-8 CONSECUTIVE words of HEBREW exactly as they appear in the chosen segment — the precise phrase the item is about — so it can be located in the printed text. Do not translate, paraphrase, reorder, or merge non-adjacent words. Use "" only if no phrase fits.
+- "quote": copy 3-8 CONSECUTIVE words of HEBREW exactly as they appear in the chosen segment — the precise phrase the item is about — so it can be tightened onto the exact printed words. Do not translate, paraphrase, reorder, or merge non-adjacent words. Use "" when no contiguous phrase fits; the segment placement still stands.
 Reply with ONLY JSON: {"matches":[{"key":"<key>","segStart":<int|null>,"segEnd":<int|null>,"confidence":<number>,"quote":"<hebrew or empty>"}]}`;
 
 export function buildMatchPrompt(
@@ -56,8 +57,10 @@ export function buildMatchPrompt(
 
 interface RawMatch { key?: unknown; segStart?: unknown; segEnd?: unknown; confidence?: unknown; quote?: unknown }
 
-/** Parse the model's JSON into validated SegMatches. Drops unknown keys,
- *  out-of-range segments, and whole-daf (null) results. */
+/** Parse the model's JSON into validated SegMatches. Drops unknown keys and
+ *  out-of-range segments. An explicit null `segStart` is a deliberate whole-daf
+ *  placement (kept, marked `wholeDaf`); a non-null but out-of-range index is junk
+ *  (dropped). */
 export function parseMatchResponse(content: string, validKeys: Set<string>, segCount: number): SegMatch[] {
   let parsed: { matches?: RawMatch[] };
   try { parsed = JSON.parse(content); } catch { return []; }
@@ -65,10 +68,15 @@ export function parseMatchResponse(content: string, validKeys: Set<string>, segC
   const out: SegMatch[] = [];
   for (const m of matches) {
     if (typeof m.key !== 'string' || !validKeys.has(m.key)) continue;
-    const start = toSeg(m.segStart, segCount);
-    if (start == null) continue; // null / whole-daf / out of range
-    const end = toSeg(m.segEnd, segCount);
     const confidence = typeof m.confidence === 'number' ? clamp01(m.confidence) : undefined;
+    if (m.segStart == null) {
+      // Explicit whole-daf grounding — a placement, not a drop.
+      out.push({ key: m.key, segs: [], via: 'ai', wholeDaf: true, confidence });
+      continue;
+    }
+    const start = toSeg(m.segStart, segCount);
+    if (start == null) continue; // a number but out of range → junk
+    const end = toSeg(m.segEnd, segCount);
     const quote = typeof m.quote === 'string' && m.quote.trim() ? m.quote.trim() : undefined;
     out.push({ key: m.key, segs: segRange(start, end != null && end >= start ? end : start), via: 'ai', confidence, quote });
   }

--- a/src/lib/context/match.ts
+++ b/src/lib/context/match.ts
@@ -12,7 +12,8 @@ import type { ContextItem } from './types.ts';
 export interface SegMatch {
   /** ContextItem.key this placement applies to. */
   key: string;
-  /** Segments the item maps to. Empty = leave unplaced (no-op). */
+  /** Segments the item maps to. Empty = leave unplaced (no-op) UNLESS
+   *  `wholeDaf` is set, which is a deliberate daf-level placement. */
   segs: number[];
   /** Matcher id, e.g. 'tosfos-dh' | 'ai' | 'pieceKeys'. */
   via: string;
@@ -21,6 +22,10 @@ export interface SegMatch {
   /** Optional verbatim Hebrew phrase the item is about (AI matcher emits this);
    *  the client resolves it to exact HB word positions via the HB locator. */
   quote?: string;
+  /** The matcher grounded this item at WHOLE-DAF level on purpose (no single
+   *  segment fits — a general note). A placement, not a failure; `segs` stays
+   *  empty and the item is marked placed so the workbench shows "whole daf". */
+  wholeDaf?: boolean;
 }
 
 /** Write placements onto items in place. Returns the number changed. */
@@ -29,9 +34,10 @@ export function applyMatches(items: ContextItem[], matches: SegMatch[]): number 
   let changed = 0;
   for (const item of items) {
     const m = byKey.get(item.key);
-    if (!m || m.segs.length === 0) continue;
-    item.segs = dedupeSorted(m.segs);
-    item.via = m.via;
+    if (!m) continue;
+    if (!m.wholeDaf && m.segs.length === 0) continue; // unplaced no-op
+    item.segs = m.wholeDaf ? [] : dedupeSorted(m.segs);
+    item.via = m.via; // a whole-daf AI placement is `via:'ai'` + `segs:[]`
     item.confidence = m.confidence;
     changed++;
   }

--- a/tests/context-match.test.ts
+++ b/tests/context-match.test.ts
@@ -19,20 +19,25 @@ describe('segRange', () => {
 });
 
 describe('applyMatches', () => {
-  it('places matched items, recording provenance; ignores empty-seg matches', () => {
-    const items = [wholeDafItem('a'), wholeDafItem('b'), wholeDafItem('c')];
+  it('places matched items (incl. whole-daf); ignores empty-seg no-ops', () => {
+    const items = [wholeDafItem('a'), wholeDafItem('b'), wholeDafItem('c'), wholeDafItem('d')];
     const matches: SegMatch[] = [
       { key: 'a', segs: [4], via: 'ai', confidence: 0.9 },
       { key: 'b', segs: [2, 3, 4, 5], via: 'ai', confidence: 0.6 },
-      { key: 'c', segs: [], via: 'ai' }, // no-op
+      { key: 'c', segs: [], via: 'ai' }, // empty + not wholeDaf -> no-op
+      { key: 'd', segs: [], via: 'ai', wholeDaf: true, confidence: 0.4 }, // deliberate whole-daf
     ];
     const changed = applyMatches(items, matches);
-    expect(changed).toBe(2);
+    expect(changed).toBe(3);
     expect(items[0].segs).toEqual([4]);
     expect(items[0].via).toBe('ai');
     expect(items[0].confidence).toBe(0.9);
     expect(items[1].segs).toEqual([2, 3, 4, 5]);
-    expect(items[2].segs).toEqual([]); // empty match ignored
+    expect(items[2].segs).toEqual([]); // empty no-op: stays unplaced
+    expect(items[2].via).toBeUndefined();
+    expect(items[3].segs).toEqual([]); // whole-daf: placed, segs stay empty
+    expect(items[3].via).toBe('ai');
+    expect(items[3].confidence).toBe(0.4);
   });
 });
 
@@ -56,20 +61,21 @@ describe('AI match prompt + parse', () => {
     expect(m[0].quote).toBe('מן הארכובה ולמטה');
   });
 
-  it('parses valid matches, dropping unknown keys / out-of-range / null', () => {
+  it('parses matches: keeps null as whole-daf, drops unknown keys / out-of-range', () => {
     const content = JSON.stringify({
       matches: [
         { key: 'ins:0', segStart: 3, segEnd: 3, confidence: 0.8 },
         { key: 'ins:1', segStart: 2, segEnd: 4, confidence: 0.5 },
-        { key: 'ins:2', segStart: null, confidence: 0.1 },     // whole-daf -> dropped
+        { key: 'ins:2', segStart: null, confidence: 0.1 },     // whole-daf -> kept
         { key: 'ghost', segStart: 1, confidence: 0.9 },         // unknown key -> dropped
         { key: 'ins:3', segStart: 99, confidence: 0.9 },        // out of range -> dropped
       ],
     });
     const matches = parseMatchResponse(content, new Set(['ins:0', 'ins:1', 'ins:2', 'ins:3']), 10);
-    expect(matches).toHaveLength(2);
+    expect(matches).toHaveLength(3);
     expect(matches[0]).toEqual({ key: 'ins:0', segs: [3], via: 'ai', confidence: 0.8 });
     expect(matches[1].segs).toEqual([2, 3, 4]);
+    expect(matches[2]).toEqual({ key: 'ins:2', segs: [], via: 'ai', wholeDaf: true, confidence: 0.1 });
   });
 
   it('returns [] on non-JSON', () => {


### PR DESCRIPTION
Reworks the AI matcher into a **semantic grounding placer** — the "step before anchoring" that places any content at the coarsest-to-finest level the evidence justifies (exact words → segment(s) → whole-daf), leaning on the existing segment↔HB-word alignment instead of requiring a verbatim quote to land.

## Changes
- **Match by meaning** — the prompt now instructs the model to use the English translations to find the segment that discusses the same point, even when item and segment share no vocabulary.
- **Contextual picks are first-class** — an AI segment pick highlights that segment's HB words carrying the model's own confidence (`ai-segment`); a verbatim quote only *tightens* it onto exact words (`ai-phrase`). Previously a confident contextual match with no exact quote collapsed to a flat "segment 0.30".
- **Whole-daf is a placement, not a dropped null** — `parseMatchResponse` keeps an explicit `null` segStart as a `wholeDaf` grounding (out-of-range numbers are still dropped as junk); `applyMatches` records it; hovering such a card washes the whole canvas.
- **Panel** — "located on the text" counts anchored items (segment or tighter) with a separate whole-daf tally; the AI button no longer re-offers items it already grounded.

This is the first consumer of a general grounding layer: every placer (deterministic lemma-find, Sefaria link structure, AI semantic) emits the same placement shape, so downstream anchors/enrichments can read a uniform "what context applies here, at what granularity, how sure."

## Verification
`pnpm typecheck`, `pnpm build`, `pnpm test` (1114 passing) green. Verified in-browser after deploy.