### PR TITLE
Formalize the grounding layer: first-class placement granularity

### DIFF
--- a/src/client/ContextSourcePanel.tsx
+++ b/src/client/ContextSourcePanel.tsx
@@ -1,5 +1,6 @@
 import { createSignal, createMemo, createEffect, For, Show, type JSX } from 'solid-js';
 import { type ContextItem, rangeLabel } from '../lib/context/types';
+import { isLocated, isPrecise, isAiGrounded, placementOf } from '../lib/context/placement';
 
 /** Highlight payload: precise HB word indices + the segments they sit in, or a
  *  whole-daf wash (`daf`). */
@@ -9,20 +10,6 @@ const EMPTY: Hl = { segs: [], words: [] };
 /** Drop HTML markup (Sefaria text carries <b>/<strong>/<i>/<big>) for display. */
 function stripTags(s: string | undefined): string {
   return s ? s.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim() : '';
-}
-
-/** Anchored to specific HB words (a segment span or tighter) — "located on the
- *  text". Whole-daf groundings are placed but not anchored to a span. */
-function isLocated(it: ContextItem): boolean {
-  return !!it.hbWords?.length;
-}
-/** Word-precise: a real phrase/AI-quote landing, not a whole-segment fallback. */
-function isPrecise(it: ContextItem): boolean {
-  return isLocated(it) && it.hbVia !== 'segment' && it.hbVia !== 'ai-segment';
-}
-/** Already grounded by the AI placer (so the AI button shouldn't re-offer it). */
-function aiGrounded(it: ContextItem): boolean {
-  return it.via === 'ai' || it.hbVia === 'ai-phrase' || it.hbVia === 'ai-segment' || it.hbVia === 'ai-daf';
 }
 
 /**
@@ -65,11 +52,11 @@ export function ContextSourcePanel(props: {
 
   const visible = createMemo(() => itemsOf(selected()));
   const locatedCount = createMemo(() => props.items.filter(isLocated).length);
-  const dafCount = createMemo(() => props.items.filter((i) => i.hbVia === 'ai-daf').length);
+  const dafCount = createMemo(() => props.items.filter((i) => placementOf(i)?.level === 'daf').length);
   // Candidates for the AI placer: not already word-precise and not yet grounded
   // by the AI (so a second click doesn't re-send what it already placed).
   const needAi = createMemo(() =>
-    selected() === 'all' ? [] : itemsOf(selected()).filter((i) => !isPrecise(i) && !aiGrounded(i)),
+    selected() === 'all' ? [] : itemsOf(selected()).filter((i) => !isPrecise(i) && !isAiGrounded(i)),
   );
 
   const pick = (source: string) => {
@@ -119,7 +106,7 @@ export function ContextSourcePanel(props: {
             <ContextCard
               item={item}
               onEnter={() => props.onHover(
-                item.hbVia === 'ai-daf'
+                placementOf(item)?.level === 'daf'
                   ? { segs: [], words: [], daf: true }
                   : { segs: item.segs, words: item.hbWords ?? [] },
               )}
@@ -155,14 +142,22 @@ function Tab(props: { active: boolean; label: string; n: number; onClick: () => 
 function ContextCard(props: { item: ContextItem; onEnter: () => void; onLeave: () => void }): JSX.Element {
   const [open, setOpen] = createSignal(false);
   const it = props.item;
-  const placed = () => isPrecise(it);
-  const wholeDaf = () => it.hbVia === 'ai-daf';
-  const via = () => it.hbVia ?? it.via;
-  const conf = () => it.hbConfidence ?? it.confidence;
-  const placeLabel = () =>
-    wholeDaf() ? 'whole daf'
-      : placed() ? `${it.hbWords!.length} word${it.hbWords!.length === 1 ? '' : 's'}`
-      : rangeLabel(it.segs, it.amud);
+  // One read of the grounding layer drives the card's label + colours.
+  const place = () => placementOf(props.item);
+  const level = () => place()?.level;
+  const via = () => place()?.via ?? it.hbVia ?? it.via;
+  const conf = () => place()?.confidence;
+  const placeLabel = () => {
+    switch (level()) {
+      case 'daf': return 'whole daf';
+      case 'words': return `${it.hbWords!.length} word${it.hbWords!.length === 1 ? '' : 's'}`;
+      case 'amud': return `amud ${it.amud}`;
+      default: return rangeLabel(it.segs, it.amud); // 'segment' span or unplaced
+    }
+  };
+  // Word-precise → green, whole-daf → violet, segment → amber, else neutral.
+  const accent = () => (level() === 'words' ? '#059669' : level() === 'daf' ? '#a78bfa' : level() === 'segment' ? '#f59e0b' : '#d1d5db');
+  const labelColor = () => (level() === 'words' ? '#059669' : level() === 'daf' ? '#7c3aed' : '#999');
   const bodyEn = () => stripTags(it.body?.en ?? '');
   const long = () => bodyEn().length > 280;
   const shown = () => (open() || !long() ? bodyEn() : bodyEn().slice(0, 280) + '…');
@@ -173,14 +168,14 @@ function ContextCard(props: { item: ContextItem; onEnter: () => void; onLeave: (
       onMouseLeave={props.onLeave}
       style={{
         border: '1px solid #eee', 'border-radius': '6px', padding: '0.55rem 0.7rem', background: '#fff',
-        'border-left': `3px solid ${placed() ? '#059669' : wholeDaf() ? '#a78bfa' : it.hbWords?.length ? '#f59e0b' : '#d1d5db'}`,
+        'border-left': `3px solid ${accent()}`,
       }}
     >
       <div style={{ display: 'flex', 'align-items': 'baseline', gap: '0.5rem', 'margin-bottom': '0.25rem', 'flex-wrap': 'wrap' }}>
         <span style={{ 'font-size': '0.68rem', 'font-weight': 700, color: '#8a2a2b', 'text-transform': 'uppercase', 'letter-spacing': '0.04em' }}>
           {it.sourceLabel}
         </span>
-        <span style={{ 'font-size': '0.68rem', 'font-family': 'monospace', color: placed() ? '#059669' : wholeDaf() ? '#7c3aed' : '#999' }}>
+        <span style={{ 'font-size': '0.68rem', 'font-family': 'monospace', color: labelColor() }}>
           {placeLabel()}
         </span>
         <Show when={via()}>

--- a/src/lib/context/placement.ts
+++ b/src/lib/context/placement.ts
@@ -1,0 +1,131 @@
+/**
+ * @fileoverview The grounding layer: where a piece of context sits on a daf,
+ * as a first-class typed concept — the "step before precise anchoring."
+ *
+ * Any content (a dafyomi note, a Sefaria comment, later an enrichment) is
+ * *grounded* at the coarsest-to-finest level the evidence justifies:
+ *
+ *   words   — exact HebrewBooks word indices (a phrase/AI-quote landing)
+ *   segment — one or more Sefaria main-text segments (which map to HB words)
+ *   amud    — a side of the daf, when nothing finer is known
+ *   daf     — the whole page (a general note, deliberately placed there)
+ *
+ * `placementOf` is the single reader that turns a ContextItem's stored fields
+ * (`segs`/`via`/`confidence` from the server pool + the client-resolved
+ * `hbWords`/`hbVia`/`hbConfidence`) into a normalized `Placement`. Granularity
+ * is DERIVED, not stored, so it can never drift from the underlying anchors.
+ * Producers (the deterministic matchers, the AI placer) write the fields;
+ * everyone else — the workbench panel, and downstream anchors/enrichments —
+ * reads through here so "what context applies here, at what level, how sure"
+ * has one answer.
+ */
+
+import type { ContextItem } from './types.ts';
+
+export type PlacementLevel = 'words' | 'segment' | 'amud' | 'daf';
+
+/** Coarsest→finest, for ranking "most specific grounding wins". */
+export const LEVEL_RANK: Record<PlacementLevel, number> = { daf: 0, amud: 1, segment: 2, words: 3 };
+
+export interface Placement {
+  /** The finest granularity this grounding reached. */
+  level: PlacementLevel;
+  /** Main-text segments it covers (set for 'segment' and 'words'). */
+  segs: number[];
+  /** Exact HB word indices (set only for 'words'). */
+  words?: number[];
+  /** Side of the daf, when known (set for 'amud', carried for finer levels). */
+  amud?: 'a' | 'b';
+  /** How it was placed: 'tosfos-dh' | 'pieceKeys' | 'mishnah' | 'ai' |
+   *  'phrase'|'phrase-in-seg'|'phrase-fuzzy' | 'ai-phrase'|'ai-segment'|'ai-daf' | … */
+  via?: string;
+  /** 0..1 confidence in the placement. */
+  confidence?: number;
+}
+
+/** `hbVia` values that mean a tight word landing (vs. a whole-segment span). */
+const WORD_VIAS = new Set(['phrase', 'phrase-in-seg', 'phrase-fuzzy', 'ai-phrase']);
+
+/**
+ * Normalize an item's grounding into a `Placement`, or `null` if it isn't
+ * grounded at all (no words, no segments, no amud, no whole-daf decision).
+ */
+export function placementOf(it: ContextItem): Placement | null {
+  const via = it.hbVia ?? it.via;
+  const confidence = it.hbConfidence ?? it.confidence;
+
+  // Whole-daf: a deliberate daf-level grounding (the AI placer's null segStart).
+  // `ai-daf` is the client-resolved marker; `via:'ai' + no anchors` is the same
+  // decision before HB resolution has run.
+  if (it.hbVia === 'ai-daf' || (it.via === 'ai' && it.segs.length === 0 && !it.hbWords?.length)) {
+    return { level: 'daf', segs: [], amud: it.amud, via, confidence };
+  }
+
+  // Resolved onto HB words: 'words' when it's a tight phrase landing, else a
+  // whole-segment span (e.g. the coarse 'segment'/'ai-segment' fallback).
+  if (it.hbWords?.length) {
+    const level: PlacementLevel = it.hbVia && WORD_VIAS.has(it.hbVia) ? 'words' : 'segment';
+    return { level, segs: it.segs, words: it.hbWords, amud: it.amud, via, confidence };
+  }
+
+  // Segment-level grounding without (or before) HB word resolution.
+  if (it.segs.length) return { level: 'segment', segs: it.segs, amud: it.amud, via, confidence };
+
+  // Nothing finer than a known side of the daf.
+  if (it.amud) return { level: 'amud', segs: [], amud: it.amud, via, confidence };
+
+  return null; // unplaced
+}
+
+/** The grounding level, or null when unplaced. */
+export function placementLevel(it: ContextItem): PlacementLevel | null {
+  return placementOf(it)?.level ?? null;
+}
+
+/** Anchored to a span of the text (a segment or exact words) — "located". */
+export function isLocated(it: ContextItem): boolean {
+  const l = placementLevel(it);
+  return l === 'words' || l === 'segment';
+}
+
+/** Word-precise: a real phrase/AI-quote landing, not a whole-segment fallback. */
+export function isPrecise(it: ContextItem): boolean {
+  return placementLevel(it) === 'words';
+}
+
+/** Placed at any level at all (words / segment / amud / whole-daf). */
+export function isGrounded(it: ContextItem): boolean {
+  return placementOf(it) != null;
+}
+
+/** Grounded by the AI semantic placer (so an AI pass shouldn't re-offer it). */
+export function isAiGrounded(it: ContextItem): boolean {
+  return it.via === 'ai' || it.hbVia === 'ai-phrase' || it.hbVia === 'ai-segment' || it.hbVia === 'ai-daf';
+}
+
+/** What an enrichment/anchor asks for: a specific segment, or the whole daf. */
+export type GroundingTarget = { seg: number } | { daf: true };
+
+/**
+ * The context items whose grounding applies to `target`, most-specific and
+ * most-confident first. For a segment target: items grounded ON that segment
+ * (words/segment whose `segs` include it) plus whole-daf items (they apply
+ * everywhere). For a daf target: everything that's grounded at all. Unplaced
+ * items are excluded. (Amud-level items match a daf target but not a bare
+ * segment target, since the seg→amud map isn't known here.)
+ */
+export function contextForTarget(items: ContextItem[], target: GroundingTarget): ContextItem[] {
+  const seg = 'seg' in target ? target.seg : null;
+  const hits: { it: ContextItem; p: Placement }[] = [];
+  for (const it of items) {
+    const p = placementOf(it);
+    if (!p) continue;
+    const applies =
+      'daf' in target
+        ? true
+        : p.level === 'daf' || ((p.level === 'words' || p.level === 'segment') && seg != null && p.segs.includes(seg));
+    if (applies) hits.push({ it, p });
+  }
+  hits.sort((a, b) => LEVEL_RANK[b.p.level] - LEVEL_RANK[a.p.level] || (b.p.confidence ?? 0) - (a.p.confidence ?? 0));
+  return hits.map((h) => h.it);
+}

--- a/tests/placement.test.ts
+++ b/tests/placement.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import {
+  placementOf, placementLevel, isLocated, isPrecise, isGrounded, isAiGrounded, contextForTarget,
+} from '../src/lib/context/placement';
+import type { ContextItem } from '../src/lib/context/types';
+
+/** Minimal ContextItem with the placement-relevant fields overridden. */
+function item(over: Partial<ContextItem> & { key: string }): ContextItem {
+  return {
+    source: 'dafyomi:insights', sourceLabel: 'Insights', kind: 'insights',
+    title: { en: over.key }, body: { en: 'x' }, segs: [], ...over,
+  };
+}
+
+describe('placementOf — derives the finest justified level', () => {
+  it('words: a tight phrase/AI-quote landing', () => {
+    const p = placementOf(item({ key: 'a', segs: [4], hbWords: [10, 11, 12], hbVia: 'ai-phrase', hbConfidence: 0.95 }))!;
+    expect(p.level).toBe('words');
+    expect(p.words).toEqual([10, 11, 12]);
+    expect(p.segs).toEqual([4]);
+    expect(p.via).toBe('ai-phrase');
+    expect(p.confidence).toBe(0.95);
+  });
+
+  it('segment: a whole-segment span (ai-segment / coarse fallback) is NOT word-precise', () => {
+    const aiSeg = placementOf(item({ key: 'b', segs: [4], hbWords: [10, 11, 12, 13], hbVia: 'ai-segment', hbConfidence: 0.8 }))!;
+    expect(aiSeg.level).toBe('segment');
+    expect(aiSeg.confidence).toBe(0.8);
+    const fallback = placementOf(item({ key: 'b2', segs: [4], hbWords: [10, 11], hbVia: 'segment', hbConfidence: 0.3 }))!;
+    expect(fallback.level).toBe('segment');
+  });
+
+  it('segment: server-side placement before HB word resolution', () => {
+    const p = placementOf(item({ key: 'c', segs: [2, 3], via: 'tosfos-dh' }))!;
+    expect(p.level).toBe('segment');
+    expect(p.words).toBeUndefined();
+    expect(p.via).toBe('tosfos-dh');
+  });
+
+  it('daf: an explicit whole-daf AI grounding (client-resolved or raw)', () => {
+    expect(placementOf(item({ key: 'd', segs: [], via: 'ai', hbVia: 'ai-daf', hbConfidence: 0.8 }))!.level).toBe('daf');
+    expect(placementOf(item({ key: 'd2', segs: [], via: 'ai', confidence: 0.7 }))!.level).toBe('daf');
+  });
+
+  it('amud: a known side with nothing finer', () => {
+    const p = placementOf(item({ key: 'e', segs: [], amud: 'b' }))!;
+    expect(p.level).toBe('amud');
+    expect(p.amud).toBe('b');
+  });
+
+  it('null: nothing grounded at all', () => {
+    expect(placementOf(item({ key: 'f' }))).toBeNull();
+    expect(placementLevel(item({ key: 'f' }))).toBeNull();
+  });
+});
+
+describe('grounding predicates', () => {
+  const words = item({ key: 'w', segs: [4], hbWords: [1], hbVia: 'phrase-in-seg' });
+  const seg = item({ key: 's', segs: [4], via: 'mishnah' });
+  const daf = item({ key: 'd', segs: [], via: 'ai', hbVia: 'ai-daf' });
+  const none = item({ key: 'n' });
+
+  it('isLocated = words|segment; isPrecise = words; isGrounded = any level', () => {
+    expect([words, seg, daf, none].map(isLocated)).toEqual([true, true, false, false]);
+    expect([words, seg, daf, none].map(isPrecise)).toEqual([true, false, false, false]);
+    expect([words, seg, daf, none].map(isGrounded)).toEqual([true, true, true, false]);
+  });
+
+  it('isAiGrounded flags anything the AI placer set', () => {
+    expect(isAiGrounded(daf)).toBe(true);
+    expect(isAiGrounded(item({ key: 'x', segs: [4], hbVia: 'ai-segment', hbWords: [1] }))).toBe(true);
+    expect(isAiGrounded(seg)).toBe(false); // deterministic 'mishnah'
+  });
+});
+
+describe('contextForTarget — the enrichment-facing query', () => {
+  const onSeg4 = item({ key: 'words4', segs: [4], hbWords: [1], hbVia: 'ai-phrase', hbConfidence: 0.9 });
+  const segOnly4 = item({ key: 'seg4', segs: [4], via: 'tosfos-dh', confidence: 0.6 });
+  const elsewhere = item({ key: 'seg9', segs: [9], via: 'mishnah' });
+  const wholeDaf = item({ key: 'daf', segs: [], via: 'ai', hbVia: 'ai-daf', hbConfidence: 0.5 });
+  const unplaced = item({ key: 'none' });
+  const all = [segOnly4, onSeg4, elsewhere, wholeDaf, unplaced];
+
+  it('segment target: items on that seg + whole-daf, finest & most-confident first', () => {
+    const got = contextForTarget(all, { seg: 4 }).map((i) => i.key);
+    // words (0.9) > segment (0.6) > daf (0.5); seg9 excluded; unplaced excluded
+    expect(got).toEqual(['words4', 'seg4', 'daf']);
+  });
+
+  it('daf target: everything grounded, unplaced excluded', () => {
+    const got = contextForTarget(all, { daf: true }).map((i) => i.key).sort();
+    expect(got).toEqual(['daf', 'seg4', 'seg9', 'words4']);
+  });
+});


### PR DESCRIPTION
Makes the grounding granularity a first-class, typed concept — the "step before precise anchoring" — so the workbench and (next) enrichments/syntheses read placement through one API instead of each inferring it from scattered fields.

## New: `src/lib/context/placement.ts`
- **`PlacementLevel`** = `'words' | 'segment' | 'amud' | 'daf'`, with `LEVEL_RANK` for most-specific-wins ordering.
- **`placementOf(item) -> Placement | null`** — the single reader. Derives the finest justified level from the stored anchors (`segs`/`via`/`confidence` from the server pool + client-resolved `hbWords`/`hbVia`/`hbConfidence`). Granularity is **derived, not stored**, so it can never drift from the underlying anchors.
- **Predicates** (`isLocated` / `isPrecise` / `isGrounded` / `isAiGrounded`) move here from `ContextSourcePanel` — one source of truth, no duplication.
- **`contextForTarget(items, {seg}|{daf})`** — the enrichment-facing query: which context applies to a given segment (or the whole daf), most-specific & most-confident first; whole-daf groundings apply everywhere; unplaced excluded.

## Workbench
`ContextSourcePanel` imports the predicates and drives each card's label + accent colour off `placementOf().level` (words→green, segment→amber, whole-daf→violet). No behaviour change — same placements, now read through the typed layer.

## Verification
`pnpm typecheck`, `pnpm build`, `pnpm test` (1129 passing, incl. new `tests/placement.test.ts` covering every level + the selector) green.