### PR TITLE
Auto-ground context on load; tighter Rishonim placement; cache AI matches

### DIFF
--- a/src/client/AlignPage.tsx
+++ b/src/client/AlignPage.tsx
@@ -1,4 +1,4 @@
-import { createResource, createSignal, For, Show, createMemo, type JSX } from 'solid-js';
+import { createResource, createSignal, For, Show, createMemo, createEffect, type JSX } from 'solid-js';
 import { TRACTATE_OPTIONS, type TalmudPageData } from '../lib/sefref';
 import { tokenizeHebrewHtml } from './tokenize';
 import { injectHadran } from './injectHadran';
@@ -6,6 +6,7 @@ import { injectSegmentMarkers, type SegmentStats } from './injectSegmentMarkers'
 import { ContextSourcePanel } from './ContextSourcePanel';
 import type { ContextItem } from '../lib/context/types';
 import { applyMatches, type SegMatch } from '../lib/context/match';
+import { placementLevel, isAiGrounded } from '../lib/context/placement';
 import { buildHbWords, locateInHb, type HbWords, type LocateQuery } from './hbAlign';
 
 interface AlignedDaf extends TalmudPageData {
@@ -55,18 +56,25 @@ function leadingWords(s: string | undefined, n: number): string | undefined {
  *  quotes, before the " - " that separates the lemma from the comment. */
 function diburHaMaschil(he: string | undefined): string | undefined {
   if (!he) return undefined;
-  const lemma = stripTags(he).split(/\s[-־–—]\s/)[0];
+  // The lemma ends at the first separator between it and the comment: a dash,
+  // a sentence period, a colon, or "כו'/וכו'". (Rashi/Tosafot use the dash;
+  // Rishonim like the Rashba use a period — "המונח כאן וכאן אסור. פירש רש"י…".)
+  const lemma = stripTags(he).split(/\s[-־–—]\s|\.\s|:\s|\s?[וב]?כו['׳]/)[0];
   return leadingWords(lemma, 6);
 }
 
+/** Sources whose text opens with a Gemara lemma (dibur ha'maschil). */
+const DH_SOURCES = new Set(['sefaria-rashi', 'sefaria-tosafot', 'sefaria-rishonim']);
+
 /** What Hebrew to look for per source. AI quote (if any) wins; else the item's
- *  natural Hebrew anchor — the dibur ha'maschil for Rashi/Tosafot, the term/DH
- *  for dafyomi, leading Hebrew otherwise. `segs` always passed (bias + fallback). */
+ *  natural Hebrew anchor — the dibur ha'maschil for Rashi/Tosafot/Rishonim, the
+ *  term/DH for dafyomi, leading Hebrew otherwise. `segs` always passed (bias +
+ *  fallback); when an item has none, the locator's no-window phrase search runs. */
 function hbQueryFor(item: ContextItem, quotes: Map<string, string>): LocateQuery {
   const segs = item.segs;
   const aiQuote = quotes.get(item.key);
   if (aiQuote) return { phrase: aiQuote, segs };
-  if (item.source === 'sefaria-rashi' || item.source === 'sefaria-tosafot') {
+  if (DH_SOURCES.has(item.source)) {
     return { phrase: diburHaMaschil(item.body?.he), segs };
   }
   return { phrase: leadingWords(item.title?.he, 6) ?? leadingWords(item.body?.he, 6), segs };
@@ -87,13 +95,14 @@ export function AlignPage(): JSX.Element {
   // AI matches + the Hebrew quotes they emit (resolved to HB spans client-side).
   const [matches, setMatches] = createSignal<SegMatch[]>([]);
   const [aiQuotes, setAiQuotes] = createSignal<Map<string, string>>(new Map());
-  const [matchingSource, setMatchingSource] = createSignal<string | null>(null);
+  // Auto-grounding progress: { left, total } while running, null when idle/done.
+  const [grounding, setGrounding] = createSignal<{ left: number; total: number } | null>(null);
 
   const ref = createMemo(() => ({ tractate: tractate(), page: page() }));
   const [daf] = createResource(ref, fetchDaf);
   const [context] = createResource(ref, fetchContext);
   // Reset client-side state when the daf changes.
-  createMemo(() => { ref(); setMatches([]); setAiQuotes(new Map()); setPinned(EMPTY); });
+  createMemo(() => { ref(); setMatches([]); setAiQuotes(new Map()); setPinned(EMPTY); setGrounding(null); });
 
   const rendered = createMemo(() => {
     const d = daf();
@@ -144,36 +153,74 @@ export function AlignPage(): JSX.Element {
     return items;
   });
 
-  const runAiMatch = async (source: string, items: ContextItem[]) => {
-    setMatchingSource(source);
-    try {
-      const res = await fetch('/api/context/match', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({
-          tractate: tractate(),
-          page: page(),
-          items: items.map((it) => ({
-            key: it.key,
-            label: it.sourceLabel,
-            title: it.title?.en ?? it.title?.he,
-            text: (it.body?.en ?? it.body?.he ?? '').slice(0, 600),
-          })),
-        }),
-      });
-      if (!res.ok) return;
-      const data = (await res.json()) as { matches?: SegMatch[] };
-      const got = data.matches ?? [];
-      if (got.length) {
-        const nextQuotes = new Map(aiQuotes());
-        for (const m of got) if (m.quote) nextQuotes.set(m.key, m.quote);
-        setAiQuotes(nextQuotes);
-        setMatches((prev) => [...prev, ...got]);
-      }
-    } finally {
-      setMatchingSource(null);
-    }
+  /** Ground one batch of items via the AI placer; apply the results. */
+  const groundBatch = async (items: ContextItem[]): Promise<void> => {
+    const res = await fetch('/api/context/match', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        tractate: tractate(),
+        page: page(),
+        items: items.map((it) => ({
+          key: it.key,
+          label: it.sourceLabel,
+          title: it.title?.en ?? it.title?.he,
+          text: (it.body?.en ?? it.body?.he ?? '').slice(0, 600),
+        })),
+      }),
+    });
+    if (!res.ok) return;
+    const data = (await res.json()) as { matches?: SegMatch[] };
+    const got = data.matches ?? [];
+    if (!got.length) return;
+    const nextQuotes = new Map(aiQuotes());
+    for (const m of got) if (m.quote) nextQuotes.set(m.key, m.quote);
+    setAiQuotes(nextQuotes);
+    setMatches((prev) => [...prev, ...got]);
   };
+
+  // Items that aren't grounded on a span yet (unplaced, or only amud-level) and
+  // that the AI placer hasn't already handled — the auto-grounding candidates.
+  const candidatesToGround = (): ContextItem[] =>
+    contextItems().filter((it) => {
+      const lvl = placementLevel(it);
+      return (lvl === null || lvl === 'amud') && !isAiGrounded(it);
+    });
+
+  /** Automatically ground everything on load, batched, with a progress count.
+   *  Server-cached per daf, so revisits are instant and don't re-spend. */
+  const runAutoGrounding = async (forKey: string) => {
+    let pending = candidatesToGround();
+    const total = pending.length;
+    if (!total) { setGrounding(null); return; }
+    setGrounding({ left: total, total });
+    const BATCH = 20;
+    let done = 0;
+    while (pending.length) {
+      if (`${tractate()}:${page()}` !== forKey) return; // daf changed mid-run
+      const batch = pending.slice(0, BATCH);
+      await groundBatch(batch);
+      done += batch.length;
+      setGrounding({ left: Math.max(0, total - done), total });
+      // Re-derive; drop the batch we just sent so an item the model couldn't
+      // place isn't retried forever.
+      const sent = new Set(batch.map((b) => b.key));
+      pending = candidatesToGround().filter((it) => !sent.has(it.key));
+    }
+    setGrounding(null);
+  };
+
+  // Fire once per daf, when the context pool and the HB word stream are ready.
+  let autoRunFor = '';
+  createEffect(() => {
+    const items = context();
+    const hb = hbWords();
+    const key = `${tractate()}:${page()}`;
+    if (!items || !items.length || !hb) return;
+    if (autoRunFor === key) return;
+    autoRunFor = key;
+    void runAutoGrounding(key);
+  });
 
   return (
     <main class="page-shell" style={{ '--page-max': '1400px', 'font-family': 'system-ui, -apple-system, sans-serif', color: '#222' }}>
@@ -265,8 +312,7 @@ export function AlignPage(): JSX.Element {
                   onHover={(h) => setHover(h)}
                   onLeave={() => setHover(EMPTY)}
                   onSelectSource={(_source, h) => setPinned(h)}
-                  onMatch={runAiMatch}
-                  matchingSource={matchingSource()}
+                  grounding={grounding()}
                 />
               </section>
             </div>

--- a/src/client/ContextSourcePanel.tsx
+++ b/src/client/ContextSourcePanel.tsx
@@ -1,6 +1,6 @@
 import { createSignal, createMemo, createEffect, For, Show, type JSX } from 'solid-js';
 import { type ContextItem, rangeLabel } from '../lib/context/types';
-import { isLocated, isPrecise, isAiGrounded, placementOf } from '../lib/context/placement';
+import { isLocated, placementOf } from '../lib/context/placement';
 
 /** Highlight payload: precise HB word indices + the segments they sit in, or a
  *  whole-daf wash (`daf`). */
@@ -23,8 +23,8 @@ export function ContextSourcePanel(props: {
   onHover: (h: Hl) => void;
   onLeave: () => void;
   onSelectSource?: (source: string, h: Hl) => void;
-  onMatch?: (source: string, items: ContextItem[]) => void;
-  matchingSource?: string | null;
+  /** Auto-grounding progress, or null when idle/done. */
+  grounding?: { left: number; total: number } | null;
 }): JSX.Element {
   const [selected, setSelected] = createSignal<string>('all');
 
@@ -53,11 +53,6 @@ export function ContextSourcePanel(props: {
   const visible = createMemo(() => itemsOf(selected()));
   const locatedCount = createMemo(() => props.items.filter(isLocated).length);
   const dafCount = createMemo(() => props.items.filter((i) => placementOf(i)?.level === 'daf').length);
-  // Candidates for the AI placer: not already word-precise and not yet grounded
-  // by the AI (so a second click doesn't re-send what it already placed).
-  const needAi = createMemo(() =>
-    selected() === 'all' ? [] : itemsOf(selected()).filter((i) => !isPrecise(i) && !isAiGrounded(i)),
-  );
 
   const pick = (source: string) => {
     setSelected(source);
@@ -79,24 +74,22 @@ export function ContextSourcePanel(props: {
         </span>
       </h2>
 
+      <style>{`@keyframes ctx-spin { to { transform: rotate(360deg); } } .ctx-spin { animation: ctx-spin 0.7s linear infinite; }`}</style>
       <div style={{ display: 'flex', 'flex-wrap': 'wrap', gap: '0.35rem', 'margin-bottom': '0.6rem', 'align-items': 'center' }}>
         <Tab active={selected() === 'all'} label="All" n={props.items.length} onClick={() => pick('all')} />
         <For each={sources()}>
           {(s) => <Tab active={selected() === s.source} label={s.label} n={s.n} onClick={() => pick(s.source)} />}
         </For>
-        <Show when={selected() !== 'all' && needAi().length > 0 && props.onMatch}>
-          <button
-            type="button"
-            disabled={props.matchingSource === selected()}
-            onClick={() => props.onMatch?.(selected(), needAi())}
-            style={{
-              'margin-left': '0.5rem', padding: '0.2rem 0.7rem', 'font-size': '0.78rem', 'border-radius': '6px',
-              border: '1px solid #0369a1', background: props.matchingSource === selected() ? '#e0f2fe' : '#0369a1',
-              color: props.matchingSource === selected() ? '#0369a1' : '#fff', cursor: 'pointer',
-            }}
-          >
-            {props.matchingSource === selected() ? 'matching…' : `Match ${needAi().length} to text (AI)`}
-          </button>
+        <Show when={props.grounding}>
+          {(g) => (
+            <span style={{ 'margin-left': '0.5rem', display: 'inline-flex', 'align-items': 'center', gap: '0.4rem', 'font-size': '0.78rem', color: '#0369a1' }}>
+              <span
+                class="ctx-spin"
+                style={{ width: '0.8rem', height: '0.8rem', border: '2px solid #bae6fd', 'border-top-color': '#0369a1', 'border-radius': '50%', 'box-sizing': 'border-box' }}
+              />
+              {g().left > 0 ? `grounding ${g().left} more…` : 'finishing…'}
+            </span>
+          )}
         </Show>
       </div>
 

--- a/src/client/hbAlign.ts
+++ b/src/client/hbAlign.ts
@@ -151,6 +151,14 @@ export function locateInHb(hb: HbWords, q: LocateQuery): Located | null {
       const at = findFuzzy(hb.raw, rawTokens, win.first, win.last);
       if (at >= 0) return mk(hb, at, rawTokens.length, 'phrase-fuzzy', conf(normTokens.length, true, true));
     }
+    // 3b. fuzzy, ANYWHERE — only for a distinctive (>=3-token) phrase with no
+    //     window, so an unsegmented Rishon's dibur-ha'maschil still lands
+    //     despite the daf's leading prefixes (וְ/הַ/…). First run wins; >=3
+    //     tokens keeps false hits unlikely.
+    if (!win && normTokens.length >= 3) {
+      const at = findFuzzy(hb.raw, rawTokens, 0, lastWord);
+      if (at >= 0) return mk(hb, at, rawTokens.length, 'phrase-fuzzy', conf(normTokens.length, false, true));
+    }
   }
 
   // 4. coarse fallback: the whole segment range.

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -4263,6 +4263,14 @@ app.get('/api/context/:tractate/:page', async (c) => {
 // AI segment-matcher: place a batch of whole-daf context items onto the
 // segment(s) they discuss. Returns SegMatches the client applies. On-demand
 // (LLM cost); the deterministic matchers in /api/context run for free.
+/** Stable 32-bit FNV-1a of a daf's item-key set, for caching AI placements. */
+function hashMatchKeys(keys: string[]): string {
+  const s = [...keys].sort().join('|');
+  let h = 2166136261 >>> 0;
+  for (let i = 0; i < s.length; i++) { h ^= s.charCodeAt(i); h = Math.imul(h, 16777619) >>> 0; }
+  return h.toString(36);
+}
+
 app.post('/api/context/match', async (c) => {
   let body: { tractate?: string; page?: string; items?: MatchInput[] };
   try { body = await c.req.json(); } catch { return c.json({ error: 'bad JSON body' }, 400); }
@@ -4270,10 +4278,21 @@ app.post('/api/context/match', async (c) => {
   const p = body.page;
   const items = Array.isArray(body.items) ? body.items.filter((i) => i && typeof i.key === 'string') : [];
   if (!t || !p || items.length === 0) return c.json({ error: 'tractate, page, and items[] required' }, 400);
+  const cache = c.env.CACHE;
+  // The AI placement for a fixed (daf, item-set) is stable, and auto-grounding
+  // re-requests it on every visit — so cache it forever (bump v1 to invalidate).
+  const cacheKey = `ctx-match:v1:${t}:${p}:${hashMatchKeys(items.map((i) => i.key))}`;
+  if (cache) {
+    const hit = await cache.get(cacheKey);
+    if (hit !== null) {
+      try { return c.json({ matches: JSON.parse(hit), cached: true }); } catch { /* fall through */ }
+    }
+  }
   try {
-    const segments = await getSefariaSegmentsCached(c.env.CACHE, t, p);
+    const segments = await getSefariaSegmentsCached(cache, t, p);
     if (!segments) return c.json({ matches: [], warning: 'no segments for daf' });
     const matches = await aiMatchToSegments(c.env, segments.he, segments.en, items);
+    if (cache) { try { await cache.put(cacheKey, JSON.stringify(matches)); } catch { /* ignore */ } }
     return c.json({ matches });
   } catch (err) {
     return c.json({ error: String(err) }, 502);

--- a/tests/hb-align.test.ts
+++ b/tests/hb-align.test.ts
@@ -77,4 +77,17 @@ describe('locateInHb', () => {
     expect(locateInHb(hb, { phrase: 'דבר אחר לגמרי' })).toBeNull();
     expect(locateInHb(hb, {})).toBeNull();
   });
+
+  // An unsegmented Rishon's dibur-ha'maschil has no window, and the daf prefixes
+  // its opening word (וְהַמּוּנָּח vs the lemma הַמּוּנָּח) — so a >=3-word phrase
+  // gets a fuzzy whole-daf placement; a 2-word one stays unplaced (too risky).
+  const dh = mkHb(['רבי', 'יוחנן', 'אמר', 'והמונח', 'כאן', 'וכאן', 'אסור'], [0, 0, 0, 1, 1, 1, 1]);
+  it('fuzzy-places a >=3-word phrase anywhere when it has no window (prefix-tolerant)', () => {
+    const r = locateInHb(dh, { phrase: 'המונח כאן וכאן' })!;
+    expect(r.via).toBe('phrase-fuzzy');
+    expect(r.words).toEqual([3, 4, 5]);
+  });
+  it('does NOT fuzzy-place a 2-word phrase with no window', () => {
+    expect(locateInHb(dh, { phrase: 'המונח כאן' })).toBeNull();
+  });
 });


### PR DESCRIPTION
Addresses two things from review: items that clearly quote a daf phrase were being dumped at whole-daf, and grounding required clicking a button per source.

## Changes
- **Auto-grounding on load** — opening a daf now automatically grounds every not-yet-located item via the AI placer, in batches, with a live `grounding N more…` spinner in the Connections header. The per-source "Match to text (AI)" button is gone.
- **Tighter Rishonim placement** — `sefaria-rishonim` (Rashba/Ritva/Rosh/…) text opens with a Gemara lemma just like Rashi/Tosafot, so dibur-ha'maschil extraction now covers it (splitting the lemma off at a period/colon/`כו'` as well as a dash). The HB locator gains a **no-window fuzzy step for ≥3-word phrases**, so an unsegmented Rishon's lemma lands on the daf despite the daf's leading prefixes (וְהַמּוּנָּח vs the lemma הַמּוּנָּח) — e.g. the Rashba on "המונח כאן וכאן אסור" now lands on those words instead of whole-daf.
- **Cache AI placements** — KV-cached per (daf, item-set), never-expiring, so auto-grounding is instant and free on revisits (and doesn't re-spend on the LLM). Bump `v1` to invalidate.

## Notes
- Cost: a cold daf pays one batched LLM pass on first open; cached forever after. The existing budget guard caps total spend.
- Genuinely general or mis-scoped pieces still ground at whole-daf (e.g. a Rosh snippet about a different sugya) — that's the honest result, not the bug being fixed here.

## Verification
`pnpm typecheck`, `pnpm build`, `pnpm test` (1131 passing, incl. new no-window fuzzy-locate cases) green. Verified in-browser after deploy.