### PR TITLE
Fix auto-grounding: stop the re-send loop, cut whole-daf clutter

### DIFF
--- a/src/client/AlignPage.tsx
+++ b/src/client/AlignPage.tsx
@@ -128,11 +128,12 @@ export function AlignPage(): JSX.Element {
     if (hb && hb.norm.length) {
       const quotes = aiQuotes();
       for (const it of items) {
-        // AI grounded this item at whole-daf level (placed by meaning, but no
-        // single segment fits): record it as such — no word span to highlight.
+        // AI returned no segment for this item. If we at least know its amud,
+        // keep that (more specific than whole-daf, and avoids clutter); only
+        // mark an explicit whole-daf grounding when nothing finer is known.
         if (it.via === 'ai' && it.segs.length === 0) {
-          it.hbVia = 'ai-daf';
           it.hbConfidence = it.confidence;
+          if (!it.amud) it.hbVia = 'ai-daf';
           continue;
         }
         const loc = locateInHb(hb, hbQueryFor(it, quotes));
@@ -179,10 +180,17 @@ export function AlignPage(): JSX.Element {
     setMatches((prev) => [...prev, ...got]);
   };
 
-  // Items that aren't grounded on a span yet (unplaced, or only amud-level) and
-  // that the AI placer hasn't already handled — the auto-grounding candidates.
+  // Sources that comment on a specific line are worth AI grounding. Sefaria
+  // halacha cross-refs and topic tags are daf-level REFERENCE context by nature
+  // — force-grounding them just yields whole-daf clutter (and LLM spend), so we
+  // leave them at their natural coarse level.
+  const GROUNDABLE_EXCLUDE = new Set(['sefaria-halacha', 'sefaria-topic']);
+
+  // Items not yet grounded on a span (unplaced, or only amud-level), from a
+  // groundable source, that the AI placer hasn't already handled.
   const candidatesToGround = (): ContextItem[] =>
     contextItems().filter((it) => {
+      if (GROUNDABLE_EXCLUDE.has(it.source)) return false;
       const lvl = placementLevel(it);
       return (lvl === null || lvl === 'amud') && !isAiGrounded(it);
     });
@@ -190,22 +198,22 @@ export function AlignPage(): JSX.Element {
   /** Automatically ground everything on load, batched, with a progress count.
    *  Server-cached per daf, so revisits are instant and don't re-spend. */
   const runAutoGrounding = async (forKey: string) => {
-    let pending = candidatesToGround();
-    const total = pending.length;
+    const total = candidatesToGround().length;
     if (!total) { setGrounding(null); return; }
     setGrounding({ left: total, total });
-    const BATCH = 20;
+    const BATCH = 30;
+    const sent = new Set<string>(); // CUMULATIVE — each item is sent at most once
     let done = 0;
-    while (pending.length) {
+    // Re-derive each round (a batch may place several items at once); only ever
+    // send items we haven't sent, so a model that omits an item can't loop us.
+    for (;;) {
       if (`${tractate()}:${page()}` !== forKey) return; // daf changed mid-run
-      const batch = pending.slice(0, BATCH);
+      const batch = candidatesToGround().filter((it) => !sent.has(it.key)).slice(0, BATCH);
+      if (!batch.length) break;
+      batch.forEach((b) => sent.add(b.key));
       await groundBatch(batch);
       done += batch.length;
       setGrounding({ left: Math.max(0, total - done), total });
-      // Re-derive; drop the batch we just sent so an item the model couldn't
-      // place isn't retried forever.
-      const sent = new Set(batch.map((b) => b.key));
-      pending = candidatesToGround().filter((it) => !sent.has(it.key));
     }
     setGrounding(null);
   };

--- a/src/lib/context/placement.ts
+++ b/src/lib/context/placement.ts
@@ -54,11 +54,12 @@ export function placementOf(it: ContextItem): Placement | null {
   const via = it.hbVia ?? it.via;
   const confidence = it.hbConfidence ?? it.confidence;
 
-  // Whole-daf: a deliberate daf-level grounding (the AI placer's null segStart).
-  // `ai-daf` is the client-resolved marker; `via:'ai' + no anchors` is the same
-  // decision before HB resolution has run.
-  if (it.hbVia === 'ai-daf' || (it.via === 'ai' && it.segs.length === 0 && !it.hbWords?.length)) {
-    return { level: 'daf', segs: [], amud: it.amud, via, confidence };
+  // Whole-daf: a deliberate daf-level grounding (the AI placer's null segStart),
+  // but only when nothing finer is known. `ai-daf` is the client-resolved
+  // marker; `via:'ai' + no anchors` is the same decision before HB resolution.
+  // A known amud is more specific, so don't collapse those to whole-daf.
+  if (it.hbVia === 'ai-daf' || (it.via === 'ai' && it.segs.length === 0 && !it.hbWords?.length && !it.amud)) {
+    return { level: 'daf', segs: [], via, confidence };
   }
 
   // Resolved onto HB words: 'words' when it's a tight phrase landing, else a

--- a/tests/placement.test.ts
+++ b/tests/placement.test.ts
@@ -46,6 +46,9 @@ describe('placementOf — derives the finest justified level', () => {
     const p = placementOf(item({ key: 'e', segs: [], amud: 'b' }))!;
     expect(p.level).toBe('amud');
     expect(p.amud).toBe('b');
+    // AI returned whole-daf, but a known amud is more specific — keep it as amud,
+    // not a whole-daf collapse (avoids clutter when bulk auto-grounding).
+    expect(placementLevel(item({ key: 'e2', segs: [], via: 'ai', amud: 'a', confidence: 0.5 }))).toBe('amud');
   });
 
   it('null: nothing grounded at all', () => {


### PR DESCRIPTION
Corrects three problems in the auto-grounder from #21, found while verifying in-browser.

- **Re-send loop (critical):** the "already sent" set was rebuilt per batch, so any item the model omitted from its JSON response stayed a candidate and got re-sent every round — an effective infinite loop that also burned LLM budget (grounding never finished). The set is now **cumulative**: each item is sent at most once and the loop terminates.
- **Whole-daf clutter:** auto-grounding was force-placing inherently daf-level sources — **Sefaria halacha cross-refs and topic tags** — which the model can only answer "whole daf" for (~19 of them on Eruvin 102a). These are now excluded; they stay at their natural coarse level, and we don't spend LLM calls on them.
- **Amud preserved:** when the model returns whole-daf for an item whose amud we already know, keep the amud (more specific) rather than collapsing to a whole-daf grounding.
- Batch size 20 → 30 (fewer round trips).

The Rashba/Ritva-type fix from #21 (dibur-ha'maschil → no-window fuzzy) is unchanged and still lands those deterministically on load, before any AI.

## Verification
`pnpm typecheck`, `pnpm build`, `pnpm test` (1131 passing) green. Verified in-browser after deploy.