### PR TITLE
Extract the bolded dibur ha'maschil from Rishonim/commentary

### DIFF
--- a/src/client/AlignPage.tsx
+++ b/src/client/AlignPage.tsx
@@ -52,14 +52,16 @@ function leadingWords(s: string | undefined, n: number): string | undefined {
   return w || undefined;
 }
 
-/** The dibur ha'maschil (lemma) of a Rashi/Tosafot piece — the Gemara words it
- *  quotes, before the " - " that separates the lemma from the comment. */
+/** The dibur ha'maschil (lemma) a commentary quotes from the Gemara — its
+ *  opening Gemara words, separated from the comment body. */
 function diburHaMaschil(he: string | undefined): string | undefined {
   if (!he) return undefined;
-  // The lemma ends at the first separator between it and the comment: a dash,
-  // a sentence period, a colon, or "כו'/וכו'". (Rashi/Tosafot use the dash;
-  // Rishonim like the Rashba use a period — "המונח כאן וכאן אסור. פירש רש"י…".)
-  const lemma = stripTags(he).split(/\s[-־–—]\s|\.\s|:\s|\s?[וב]?כו['׳]/)[0];
+  // Sefaria bolds the lemma at the start: "<b>נגר הנגרר נועלין בו במקדש</b> פיר…"
+  // (Rishonim, much of Rashi/Tosafot). Take that bold run as the DH.
+  const bold = /^\s*<(b|strong)>([\s\S]*?)<\/\1>/i.exec(he);
+  // Otherwise the lemma ends at the first separator: a dash, sentence period,
+  // colon, or "כו'/וכו'" — e.g. "המונח כאן וכאן אסור. פירש רש"י…".
+  const lemma = bold ? stripTags(bold[2]) : stripTags(he).split(/\s[-־–—]\s|\.\s|:\s|\s?[וב]?כו['׳]/)[0];
   return leadingWords(lemma, 6);
 }
 


### PR DESCRIPTION
Follow-up to #21/#22. Rishonim were still falling to whole-daf because their lemma is **bolded**, not period-delimited.

Sefaria returns commentary as `<b>lemma</b> comment` — e.g. the Ritva on Eruvin 102a is `<b>נגר הנגרר נועלין בו במקדש</b> פיר נגר…`. `diburHaMaschil` stripped tags *first*, lost the `</b>` boundary, and grabbed 6 words that ran into the comment ("…במקדש פיר"), which never matches the daf. Now it takes the leading `<b>`/`<strong>` run as the DH when present, falling back to the period/dash/colon split otherwise. The Ritva's "נגר הנגרר נועלין בו במקדש" (which is verbatim in the daf) now lands on those words deterministically, on load, before any AI.

## Verification
`pnpm typecheck`, `pnpm build`, `pnpm test` (1131) green; bold/period/dash extraction confirmed against the real Ritva text. Verified in-browser after deploy.