### PR TITLE
Render dafyomi charts as tables; relabel unplaced cards; testable DH extraction

### DIFF
--- a/src/client/AlignPage.tsx
+++ b/src/client/AlignPage.tsx
@@ -6,7 +6,8 @@ import { injectSegmentMarkers, type SegmentStats } from './injectSegmentMarkers'
 import { ContextSourcePanel } from './ContextSourcePanel';
 import type { ContextItem } from '../lib/context/types';
 import { applyMatches, type SegMatch } from '../lib/context/match';
-import { placementLevel, isAiGrounded } from '../lib/context/placement';
+import { placementLevel, isAiGrounded, isReferenceSource } from '../lib/context/placement';
+import { diburHaMaschil, leadingWords } from '../lib/context/dibur';
 import { buildHbWords, locateInHb, type HbWords, type LocateQuery } from './hbAlign';
 
 interface AlignedDaf extends TalmudPageData {
@@ -40,30 +41,6 @@ function renderAlignedHtml(mainHtml: string, segmentsHe: string[]): { html: stri
   return injectSegmentMarkers(hadran, segmentsHe);
 }
 
-/** Drop HTML markup (Sefaria text carries <b>/<strong>/<i>/<big>) for display. */
-function stripTags(s: string): string {
-  return s.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim();
-}
-
-/** First `n` whitespace words of a Hebrew string, or undefined. */
-function leadingWords(s: string | undefined, n: number): string | undefined {
-  if (!s) return undefined;
-  const w = stripTags(s).split(/\s+/).slice(0, n).join(' ');
-  return w || undefined;
-}
-
-/** The dibur ha'maschil (lemma) a commentary quotes from the Gemara — its
- *  opening Gemara words, separated from the comment body. */
-function diburHaMaschil(he: string | undefined): string | undefined {
-  if (!he) return undefined;
-  // Sefaria bolds the lemma at the start: "<b>נגר הנגרר נועלין בו במקדש</b> פיר…"
-  // (Rishonim, much of Rashi/Tosafot). Take that bold run as the DH.
-  const bold = /^\s*<(b|strong)>([\s\S]*?)<\/\1>/i.exec(he);
-  // Otherwise the lemma ends at the first separator: a dash, sentence period,
-  // colon, or "כו'/וכו'" — e.g. "המונח כאן וכאן אסור. פירש רש"י…".
-  const lemma = bold ? stripTags(bold[2]) : stripTags(he).split(/\s[-־–—]\s|\.\s|:\s|\s?[וב]?כו['׳]/)[0];
-  return leadingWords(lemma, 6);
-}
 
 /** Sources whose text opens with a Gemara lemma (dibur ha'maschil). */
 const DH_SOURCES = new Set(['sefaria-rashi', 'sefaria-tosafot', 'sefaria-rishonim']);
@@ -182,17 +159,13 @@ export function AlignPage(): JSX.Element {
     setMatches((prev) => [...prev, ...got]);
   };
 
-  // Sources that comment on a specific line are worth AI grounding. Sefaria
-  // halacha cross-refs and topic tags are daf-level REFERENCE context by nature
-  // — force-grounding them just yields whole-daf clutter (and LLM spend), so we
-  // leave them at their natural coarse level.
-  const GROUNDABLE_EXCLUDE = new Set(['sefaria-halacha', 'sefaria-topic']);
-
   // Items not yet grounded on a span (unplaced, or only amud-level), from a
-  // groundable source, that the AI placer hasn't already handled.
+  // groundable source, that the AI placer hasn't already handled. Reference
+  // sources (halachic cross-refs, topics) are daf-level by nature — force-
+  // grounding them just yields whole-daf clutter (and LLM spend), so skip them.
   const candidatesToGround = (): ContextItem[] =>
     contextItems().filter((it) => {
-      if (GROUNDABLE_EXCLUDE.has(it.source)) return false;
+      if (isReferenceSource(it)) return false;
       const lvl = placementLevel(it);
       return (lvl === null || lvl === 'amud') && !isAiGrounded(it);
     });

--- a/src/client/ContextSourcePanel.tsx
+++ b/src/client/ContextSourcePanel.tsx
@@ -1,6 +1,6 @@
 import { createSignal, createMemo, createEffect, For, Show, type JSX } from 'solid-js';
 import { type ContextItem, rangeLabel } from '../lib/context/types';
-import { isLocated, placementOf } from '../lib/context/placement';
+import { isLocated, placementOf, isReferenceSource } from '../lib/context/placement';
 
 /** Highlight payload: precise HB word indices + the segments they sit in, or a
  *  whole-daf wash (`daf`). */
@@ -145,7 +145,9 @@ function ContextCard(props: { item: ContextItem; onEnter: () => void; onLeave: (
       case 'daf': return 'whole daf';
       case 'words': return `${it.hbWords!.length} word${it.hbWords!.length === 1 ? '' : 's'}`;
       case 'amud': return `amud ${it.amud}`;
-      default: return rangeLabel(it.segs, it.amud); // 'segment' span or unplaced
+      case 'segment': return rangeLabel(it.segs, it.amud);
+      // unplaced: distinguish daf-level reference context from a placement miss.
+      default: return isReferenceSource(it) ? 'reference' : 'not located';
     }
   };
   // Word-precise → green, whole-daf → violet, segment → amber, else neutral.
@@ -202,9 +204,58 @@ function ContextCard(props: { item: ContextItem; onEnter: () => void; onLeave: (
           </button>
         </Show>
       </Show>
-      <Show when={!bodyEn() && it.body?.he}>
+      <Show when={it.table}>
+        {(tbl) => <ChartTable table={tbl()} />}
+      </Show>
+      <Show when={!it.table && !bodyEn() && it.body?.he}>
         <div dir="rtl" lang="he" style={{ 'font-family': '"Mekorot Vilna", serif', 'font-size': '0.9rem', 'line-height': 1.55 }}>{stripTags(it.body!.he)}</div>
       </Show>
     </article>
+  );
+}
+
+/** Render a dafyomi Hebrew comparison chart as a bordered RTL table: the first
+ *  cell of each row is the (blue, bold) row label; footnotes follow below. */
+function ChartTable(props: { table: NonNullable<ContextItem['table']> }): JSX.Element {
+  const cell = { border: '1px solid #4b5563', padding: '0.25rem 0.45rem', 'text-align': 'center', 'vertical-align': 'middle' } as const;
+  const hasHeaders = () => props.table.headers.some((h) => stripTags(h));
+  return (
+    <div style={{ 'overflow-x': 'auto', 'margin-top': '0.35rem' }}>
+      <table dir="rtl" lang="he" style={{ 'border-collapse': 'collapse', 'font-family': '"Mekorot Vilna", serif', 'font-size': '0.85rem', width: '100%' }}>
+        <Show when={hasHeaders()}>
+          <thead>
+            <tr>
+              <For each={props.table.headers}>
+                {(h) => <th style={{ ...cell, background: '#fef9c3', color: '#1e3a8a', 'font-weight': 700 }}>{stripTags(h)}</th>}
+              </For>
+            </tr>
+          </thead>
+        </Show>
+        <tbody>
+          <For each={props.table.rows}>
+            {(row) => (
+              <tr>
+                <For each={row}>
+                  {(c, ci) => (
+                    <td style={{ ...cell, color: ci() === 0 ? '#1e3a8a' : '#333', 'font-weight': ci() === 0 ? 700 : 400 }}>{stripTags(c)}</td>
+                  )}
+                </For>
+              </tr>
+            )}
+          </For>
+        </tbody>
+      </table>
+      <Show when={props.table.notes?.length}>
+        <div style={{ 'margin-top': '0.35rem', 'font-size': '0.72rem', color: '#666' }}>
+          <For each={props.table.notes}>
+            {(n) => (
+              <div dir="rtl" lang="he" style={{ 'font-family': '"Mekorot Vilna", serif' }}>
+                <span style={{ color: '#0369a1', 'font-family': 'monospace' }}>{n.marker}</span> {stripTags(n.text)}
+              </div>
+            )}
+          </For>
+        </div>
+      </Show>
+    </div>
   );
 }

--- a/src/lib/context/dibur.ts
+++ b/src/lib/context/dibur.ts
@@ -1,0 +1,33 @@
+/**
+ * @fileoverview Pure helpers for extracting the dibur ha'maschil — the Gemara
+ * lemma a commentary quotes — and leading Hebrew words. Kept out of the client
+ * component so they're unit-testable (the DH format has bitten us repeatedly:
+ * Rashi/Tosafot use a " - " dash, Rishonim bold the lemma `<b>…</b>`, and some
+ * use a sentence period/colon/"כו'").
+ */
+
+/** Drop HTML markup (Sefaria text carries <b>/<strong>/<i>/<big>) for display. */
+export function stripTags(s: string | undefined): string {
+  return s ? s.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim() : '';
+}
+
+/** First `n` whitespace words of a Hebrew string, or undefined. */
+export function leadingWords(s: string | undefined, n: number): string | undefined {
+  if (!s) return undefined;
+  const w = stripTags(s).split(/\s+/).slice(0, n).join(' ');
+  return w || undefined;
+}
+
+/**
+ * The dibur ha'maschil a commentary quotes from the Gemara — its opening Gemara
+ * words, separated from the comment body. Sefaria bolds the lemma at the start
+ * (`<b>נגר הנגרר נועלין בו במקדש</b> פיר…`); otherwise the lemma ends at the
+ * first separator — a dash, sentence period, colon, or "כו'/וכו'"
+ * (e.g. `המונח כאן וכאן אסור. פירש רש"י…`).
+ */
+export function diburHaMaschil(he: string | undefined): string | undefined {
+  if (!he) return undefined;
+  const bold = /^\s*<(b|strong)>([\s\S]*?)<\/\1>/i.exec(he);
+  const lemma = bold ? stripTags(bold[2]) : stripTags(he).split(/\s[-־–—]\s|\.\s|:\s|\s?[וב]?כו['׳]/)[0];
+  return leadingWords(lemma, 6);
+}

--- a/src/lib/context/fromDafyomi.ts
+++ b/src/lib/context/fromDafyomi.ts
@@ -74,11 +74,22 @@ function collectBlock(
       b.entries.forEach((e, i) => out.push({ ...base(b.type, `${type}:${amud}:${i}`), ...entryCard(e) }));
       break;
     case 'hebcharts':
-      b.tables.forEach((t, i) => out.push({
-        ...base('chart', `${type}:${amud}:${i}`),
-        title: t.caption,
-        body: { he: tableToText(t.headers.map((h) => h.he ?? ''), t.rows.map((r) => r.map((c) => c.he ?? ''))) },
-      }));
+      b.tables.forEach((t, i) => {
+        const headers = t.headers.map((h) => h.he ?? '');
+        const rows = t.rows.map((r) => r.map((c) => c.he ?? ''));
+        out.push({
+          ...base('chart', `${type}:${amud}:${i}`),
+          title: t.caption,
+          // body keeps the flattened text (AI-match input + plain fallback);
+          // `table` keeps the structure so the card renders a real table.
+          body: { he: tableToText(headers, rows) },
+          table: {
+            headers,
+            rows,
+            notes: t.notes?.map((n) => ({ marker: n.marker, text: n.text.he ?? '' })),
+          },
+        });
+      });
       break;
   }
 }

--- a/src/lib/context/placement.ts
+++ b/src/lib/context/placement.ts
@@ -104,6 +104,14 @@ export function isAiGrounded(it: ContextItem): boolean {
   return it.via === 'ai' || it.hbVia === 'ai-phrase' || it.hbVia === 'ai-segment' || it.hbVia === 'ai-daf';
 }
 
+/** Sources that are daf-level REFERENCE context by nature (halachic cross-refs,
+ *  topic tags) — not tied to a specific line. The workbench leaves these at
+ *  their coarse level rather than force-grounding them onto a segment. */
+export const REFERENCE_SOURCES: ReadonlySet<string> = new Set(['sefaria-halacha', 'sefaria-topic']);
+export function isReferenceSource(it: ContextItem): boolean {
+  return REFERENCE_SOURCES.has(it.source);
+}
+
 /** What an enrichment/anchor asks for: a specific segment, or the whole daf. */
 export type GroundingTarget = { seg: number } | { daf: true };
 

--- a/src/lib/context/types.ts
+++ b/src/lib/context/types.ts
@@ -46,6 +46,15 @@ export interface ContextItem {
    *  dafyomi Tosfos items; lets the matcher place them via Sefaria pieceKeys. */
   dhNormalized?: string;
 
+  /** Structured comparison table (dafyomi Hebrew charts) — kept so the card can
+   *  render a real table instead of the flattened pipe-text in `body`. Cells are
+   *  display-ready Hebrew; the first cell of each row is the row label. */
+  table?: {
+    headers: string[];
+    rows: string[][];
+    notes?: { marker: string; text: string }[];
+  };
+
   /** Client-side HB placement (computed in the alignment workbench, not from
    *  the server pool): the exact HebrewBooks word indices this item maps to,
    *  plus how it was located and a confidence. Drives word-level highlighting. */

--- a/tests/dafyomi-context.test.ts
+++ b/tests/dafyomi-context.test.ts
@@ -26,6 +26,20 @@ describe('fromDafyomi', () => {
     const gloss = items.filter((i) => i.kind === 'glossary');
     expect(gloss.some((g) => g.title?.he === 'ארכובה')).toBe(true);
   });
+  it('hebcharts items carry a structured table (headers + rows) plus flattened body', () => {
+    const charts = items.filter((i) => i.kind === 'chart');
+    expect(charts.length).toBeGreaterThan(0);
+    const c = charts[0];
+    // the structure the card renders as a real table
+    expect(c.table).toBeDefined();
+    expect(c.table!.headers.length).toBeGreaterThanOrEqual(2);
+    expect(c.table!.rows.length).toBeGreaterThanOrEqual(1);
+    // every row is an array of cells; the first cell is the (non-empty) row label
+    expect(Array.isArray(c.table!.rows[0])).toBe(true);
+    expect(c.table!.rows[0][0].trim().length).toBeGreaterThan(0);
+    // the flattened text fallback is kept for AI-match input / plain display
+    expect(c.body?.he).toContain(' | ');
+  });
 });
 
 describe('matchTosfos', () => {

--- a/tests/dibur.test.ts
+++ b/tests/dibur.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { diburHaMaschil, leadingWords, stripTags } from '../src/lib/context/dibur';
+
+describe('stripTags', () => {
+  it('drops markup and collapses whitespace; tolerates undefined', () => {
+    expect(stripTags('<b>נגר</b>  הנגרר')).toBe('נגר הנגרר');
+    expect(stripTags(undefined)).toBe('');
+  });
+});
+
+describe('leadingWords', () => {
+  it('takes the first n words, stripping tags', () => {
+    expect(leadingWords('<b>אחד</b> שנים שלשה ארבעה', 2)).toBe('אחד שנים');
+    expect(leadingWords('', 3)).toBeUndefined();
+    expect(leadingWords(undefined, 3)).toBeUndefined();
+  });
+});
+
+describe('diburHaMaschil', () => {
+  it('takes the bolded lemma when the comment bolds it (Rishonim / Sefaria)', () => {
+    // The exact bug fixed in #23: stripping tags first lost the </b> boundary
+    // and ran the lemma into the comment ("…במקדש פיר"), so it never matched.
+    expect(diburHaMaschil('<b>נגר הנגרר נועלין בו במקדש</b> פיר נגר שאין בראשו'))
+      .toBe('נגר הנגרר נועלין בו במקדש');
+    expect(diburHaMaschil('<strong>ההוא שריתא</strong> דהוה ביה')).toBe('ההוא שריתא');
+  });
+
+  it('splits on a sentence period when there is no bold (some Rishonim)', () => {
+    expect(diburHaMaschil('המונח כאן וכאן אסור. פירש רש"י ז"ל: בשתוקעו'))
+      .toBe('המונח כאן וכאן אסור');
+  });
+
+  it('splits on the " - " dash (Rashi/Tosafot lemma)', () => {
+    expect(diburHaMaschil('זמורה - של גפן:')).toBe('זמורה');
+    expect(diburHaMaschil('שהיא קשורה בטפיח - פך ששואבין בו')).toBe('שהיא קשורה בטפיח');
+  });
+
+  it('caps the lemma at 6 words and handles empty/undefined', () => {
+    expect(diburHaMaschil('א ב ג ד ה ו ז ח')).toBe('א ב ג ד ה ו');
+    expect(diburHaMaschil('')).toBeUndefined();
+    expect(diburHaMaschil(undefined)).toBeUndefined();
+  });
+});

--- a/tests/placement.test.ts
+++ b/tests/placement.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
-  placementOf, placementLevel, isLocated, isPrecise, isGrounded, isAiGrounded, contextForTarget,
+  placementOf, placementLevel, isLocated, isPrecise, isGrounded, isAiGrounded, isReferenceSource, contextForTarget,
 } from '../src/lib/context/placement';
 import type { ContextItem } from '../src/lib/context/types';
 
@@ -73,6 +73,13 @@ describe('grounding predicates', () => {
     expect(isAiGrounded(daf)).toBe(true);
     expect(isAiGrounded(item({ key: 'x', segs: [4], hbVia: 'ai-segment', hbWords: [1] }))).toBe(true);
     expect(isAiGrounded(seg)).toBe(false); // deterministic 'mishnah'
+  });
+
+  it('isReferenceSource flags daf-level reference sources only', () => {
+    expect(isReferenceSource(item({ key: 'h', source: 'sefaria-halacha' }))).toBe(true);
+    expect(isReferenceSource(item({ key: 't', source: 'sefaria-topic' }))).toBe(true);
+    expect(isReferenceSource(item({ key: 'r', source: 'sefaria-rishonim' }))).toBe(false);
+    expect(isReferenceSource(item({ key: 'i', source: 'dafyomi:insights' }))).toBe(false);
   });
 });
 


### PR DESCRIPTION
Three things from review (charts rendering, the whole-daf relabel) plus the requested regression tests.

## Charts as real tables
The parsed `DafyomiTable` (headers / rows / footnotes) is now carried through to the `ContextItem` and rendered as a **bordered RTL `<table>`** in the card — row labels blue/bold, header row tinted, footnotes listed below — instead of the `|`-flattened text blob. The flattened text is kept on `body` for AI-match input and as a plain fallback.

(The chart data was always clean UTF-8 — verified server-side and in the live DOM. The mojibake in the pasted text was a clipboard artifact of copying pipe-delimited RTL text; the structured table also just reads far better.)

## Relabel unplaced cards
Unplaced cards used to show "whole daf" (via `rangeLabel`), which read like a real placement. Now: **reference-by-nature** sources (Sefaria halacha cross-refs, topic tags) show **"reference"**; other unplaced items show **"not located"**. "whole daf" is reserved for a deliberate `ai-daf` grounding. `REFERENCE_SOURCES` is shared between the panel and the auto-grounder's exclude list.

## Testable DH extraction + regression tests
Extracted `diburHaMaschil`/`leadingWords`/`stripTags` into `src/lib/context/dibur.ts` (the DH format has bitten us three times) and added tests:
- **dibur**: bolded lemma (`<b>…</b>`), period split, " - " dash split, 6-word cap, empty/undefined.
- **fromDafyomi**: hebcharts items carry a structured `table` (headers ≥2, rows, non-empty row label) and keep the flattened `body`.
- **placement**: `isReferenceSource` flags halacha/topic only.

## Not in this PR
The mis-scoped **Rosh** (Eruvin 102a returns a Rosh about a different sugya) is a server-side Rishonim-fetch issue — `fetchRishonim` builds `"Rosh on <ref>"`, but the Rosh is structured by chapter, not daf. Tackling that next.

## Verification
`pnpm typecheck`, `pnpm build`, `pnpm test` (1139) green. Verifying the table render in-browser after deploy.