### PR TITLE
Load-bar notice on budget pause / failures; gate argument map to dev mode

### DIFF
--- a/src/client/DafLoadProgress.tsx
+++ b/src/client/DafLoadProgress.tsx
@@ -14,7 +14,7 @@
 
 import { createMemo, createEffect, createSignal, onCleanup, Show, type JSX } from 'solid-js';
 import { markStatuses } from './MarksRegistryPanel';
-import { prefetchProgress } from './dafPrefetch';
+import { prefetchProgress, loadNotice } from './dafPrefetch';
 import { t } from './i18n';
 
 const COMPLETE_LINGER_MS = 700;
@@ -85,8 +85,37 @@ export default function DafLoadProgress(): JSX.Element {
   });
   onCleanup(() => { if (hideTimer) clearTimeout(hideTimer); });
 
+  // Top-level notice: a budget pause or a wave of failures, so generation
+  // problems don't read as a silently-stuck bar. Persists (independent of the
+  // bar's auto-hide) until the next daf clears the cohort.
+  const notice = createMemo(() => loadNotice(prefetchProgress()));
+
   return (
-    <Show when={visible()}>
+    <>
+    <Show when={notice()}>
+      {(kind) => (
+        <div
+          role="status"
+          aria-live="polite"
+          style={{
+            display: 'flex', 'align-items': 'center', gap: '0.4rem',
+            position: 'sticky', top: 0, 'z-index': 50,
+            width: '100%', 'box-sizing': 'border-box',
+            padding: '0.4rem 0.55rem', 'margin-bottom': '0.5rem',
+            'border-radius': '4px',
+            border: `1px solid ${kind() === 'paused' ? '#f59e0b' : '#ef4444'}`,
+            background: kind() === 'paused' ? '#fffbeb' : '#fef2f2',
+            color: kind() === 'paused' ? '#92400e' : '#b91c1c',
+            'font-family': 'system-ui, -apple-system, sans-serif',
+            'font-size': '0.72rem', 'line-height': 1.4,
+          }}
+        >
+          <span aria-hidden="true">{kind() === 'paused' ? '⏸' : '⚠'}</span>
+          <span>{kind() === 'paused' ? t('dafLoad.paused') : t('dafLoad.failed')}</span>
+        </div>
+      )}
+    </Show>
+    <Show when={visible() && !notice()}>
       <div
         role="status"
         aria-live="polite"
@@ -140,5 +169,6 @@ export default function DafLoadProgress(): JSX.Element {
         </div>
       </div>
     </Show>
+    </>
   );
 }

--- a/src/client/DafViewer.tsx
+++ b/src/client/DafViewer.tsx
@@ -586,13 +586,16 @@ export default function DafViewer(): JSX.Element {
     if (relevant.length === 0) return;             // no marks enabled / loaded yet
     if (relevant.some((s) => s.kind === 'loading')) return; // anchors not done
     const runs = markRunsByMarkId();
-    const sig = `${t}:${p}|` + Object.entries(runs)
+    // The argument-overview warm only fires in dev mode (the chip is dev-only),
+    // so dev state is part of the signature — opening dev re-runs and warms it.
+    const dev = devOpen();
+    const sig = `${t}:${p}:${dev ? 'ov' : ''}|` + Object.entries(runs)
       .map(([m, r]) => `${m}=${(r?.parsed as { instances?: unknown[] } | undefined)?.instances?.length ?? 0}`)
       .sort()
       .join(',');
     if (sig === lastPrefetchSig) return;
     lastPrefetchSig = sig;
-    prefetchDaf(t, p, runs);
+    prefetchDaf(t, p, runs, { overview: dev });
   });
 
   // Comprehensively pre-warm the adjacent dapim on idle so navigating either
@@ -2599,7 +2602,9 @@ export default function DafViewer(): JSX.Element {
           above the daf as the reader scrolls. */}
       <DafLoadProgress />
 
-      <Show when={chipMarks().length > 0}>
+      {/* Whole-daf chip marks (argument map) are experimental — shown only when
+          dev mode is open. */}
+      <Show when={devOpen() && chipMarks().length > 0}>
         <div class="daf-chip-bar" style={{ display: 'flex', gap: '0.4rem', 'flex-wrap': 'wrap', margin: '0 0 0.6rem' }}>
           <For each={chipMarks()}>{(m) => {
             const color = (m.render as { color?: string }).color ?? '#8a2a2b';

--- a/src/client/dafPrefetch.ts
+++ b/src/client/dafPrefetch.ts
@@ -22,6 +22,7 @@
 
 import { createSignal } from 'solid-js';
 import { enqueueEnrichmentRun } from './MarkEnrichmentCards';
+import { isPausedError, isAbort } from './enrichmentQueue';
 
 export interface PrefetchProgress {
   /** `${tractate}:${page}` this cohort belongs to. */
@@ -31,6 +32,12 @@ export interface PrefetchProgress {
   /** i18n catalog KEY for the family currently being warmed (translated by the
    *  consumer via t()), or null when idle/done. */
   currentLabel: string | null;
+  /** A warm task hit the spend-budget pause (429). Sticky for the cohort so the
+   *  load bar can say so instead of silently filling. */
+  paused: boolean;
+  /** Count of warm tasks that errored for a non-pause, non-abort reason
+   *  (provider down, missing key, etc.). Drives the systemic-failure notice. */
+  failed: number;
 }
 
 const [progress, setProgress] = createSignal<PrefetchProgress>({
@@ -38,10 +45,21 @@ const [progress, setProgress] = createSignal<PrefetchProgress>({
   total: 0,
   done: 0,
   currentLabel: null,
+  paused: false,
+  failed: 0,
 });
 
 /** Read the live prefetch progress (consumed by DafLoadProgress). */
 export const prefetchProgress = progress;
+
+/** What top-level notice (if any) the load bar should surface for a cohort.
+ *  'paused' the moment any task is budget-paused; 'failed' once several tasks
+ *  have errored (a single transient hiccup stays quiet). Pure + tested. */
+export function loadNotice(p: PrefetchProgress): 'paused' | 'failed' | null {
+  if (p.paused) return 'paused';
+  if (p.failed >= 3) return 'failed';
+  return null;
+}
 
 // Enrichments to warm per mark instance, keyed by mark id. Keep in sync with
 // the aggregate/suggested-questions enrichments registered in
@@ -106,7 +124,7 @@ let activeController: AbortController | null = null;
  *  daf navigation so stale section-warming work is dropped immediately. */
 export function cancelPrefetch(): void {
   if (activeController) { activeController.abort(); activeController = null; }
-  setProgress({ dafKey: '', total: 0, done: 0, currentLabel: null });
+  setProgress({ dafKey: '', total: 0, done: 0, currentLabel: null, paused: false, failed: 0 });
 }
 
 interface MarkRun { parsed?: unknown }
@@ -120,6 +138,7 @@ export function prefetchDaf(
   tractate: string,
   page: string,
   marks: Record<string, MarkRun | undefined>,
+  opts?: { overview?: boolean },
 ): void {
   const dafKey = `${tractate}:${page}`;
   const myGen = ++gen;
@@ -146,10 +165,12 @@ export function prefetchDaf(
   // Whole-daf argument overview — one daf-level run, COUNTED in the bar. Warms
   // argument-overview.synthesis, which pulls the cross-section flow graph
   // (argument-overview.flow, deepseek-v4-pro + reasoning) in as a dependency,
-  // so opening the overview chip is a cache hit. Only when the daf actually has
-  // argument sections to relate.
+  // so opening the overview chip is a cache hit. Gated on `opts.overview` (dev
+  // mode) — the chip is dev-only/experimental, so we don't pay the reasoning
+  // pass on every daf load for users who can't open it. Only when the daf
+  // actually has argument sections to relate.
   const argInstances = (marks['argument']?.parsed as { instances?: MarkInstance[] } | undefined)?.instances;
-  if (Array.isArray(argInstances) && argInstances.length > 0) {
+  if (opts?.overview && Array.isArray(argInstances) && argInstances.length > 0) {
     tasks.push({
       enrichmentId: 'argument-overview.synthesis',
       instance: { fields: {} },
@@ -162,23 +183,31 @@ export function prefetchDaf(
     total: tasks.length,
     done: 0,
     currentLabel: tasks.length > 0 ? 'dafLoad.sections' : null,
+    paused: false,
+    failed: 0,
   });
   if (tasks.length === 0) return;
 
   for (const t of tasks) {
+    // Resolve with the error (or null) so we can classify the outcome — a card
+    // still generates on open, but a budget pause or a wave of failures should
+    // surface in the bar instead of filling silently.
     void enqueueEnrichmentRun(t.enrichmentId, tractate, page, t.instance, t.instanceKey, controller.signal)
-      // Best-effort: a failed or aborted prefetch just means the card
-      // generates on open.
-      .catch(() => undefined)
-      .finally(() => {
-        if (myGen !== gen) return; // superseded by a newer daf
+      .then(() => null, (err: unknown) => err)
+      .then((err: unknown) => {
+        if (myGen !== gen || controller.signal.aborted || isAbort(err)) return; // superseded / navigated away
+        const paused = isPausedError(err);
+        const failed = err != null && !paused;
         setProgress((p) => {
           if (p.dafKey !== dafKey) return p;
           const done = p.done + 1;
           return {
+            ...p,
             dafKey,
             total: p.total,
             done,
+            paused: p.paused || paused,
+            failed: p.failed + (failed ? 1 : 0),
             currentLabel: done < p.total ? (FRIENDLY[t.enrichmentId] ?? 'dafLoad.sections') : null,
           };
         });

--- a/src/client/i18n.ts
+++ b/src/client/i18n.ts
@@ -624,6 +624,14 @@ const CATALOG = {
   'dafLoad.loadingSections': { en: 'Loading {section} — {done} of {total}', he: 'טוען {section} — {done} מתוך {total}' },
   'dafLoad.sections': { en: 'sections', he: 'מקטעים' },
   'dafLoad.upToDate': { en: 'Up to date', he: 'מעודכן' },
+  'dafLoad.paused': {
+    en: 'AI generation is paused for now (spend budget reached). Cards will fill in once it resumes.',
+    he: 'יצירת התוכן בבינה מלאכותית מושהית כעת (תקציב ההוצאה הושג). הכרטיסים יתמלאו כשהיא תתחדש.',
+  },
+  'dafLoad.failed': {
+    en: 'Some content couldn’t be generated just now. Open a card to retry.',
+    he: 'חלק מהתוכן לא נוצר כעת. פתחו כרטיס כדי לנסות שוב.',
+  },
   // Prefetch family labels — substituted into dafLoad.loadingSections. Keyed
   // from dafPrefetch's FRIENDLY map so the warmed-family name localizes too.
   'dafLoad.family.arguments': { en: 'arguments', he: 'סוגיות' },

--- a/tests/load-notice.test.ts
+++ b/tests/load-notice.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { loadNotice, type PrefetchProgress } from '../src/client/dafPrefetch';
+
+const base: PrefetchProgress = {
+  dafKey: 'Shabbat:126a', total: 10, done: 0, currentLabel: null, paused: false, failed: 0,
+};
+
+describe('loadNotice — daf-load bar notice', () => {
+  it('returns null when nothing is wrong', () => {
+    expect(loadNotice(base)).toBeNull();
+  });
+
+  it('surfaces a pause the moment any task is budget-paused (takes precedence over failures)', () => {
+    expect(loadNotice({ ...base, paused: true })).toBe('paused');
+    expect(loadNotice({ ...base, paused: true, failed: 9 })).toBe('paused');
+  });
+
+  it('stays quiet on one or two transient failures, then flags a systemic failure', () => {
+    expect(loadNotice({ ...base, failed: 1 })).toBeNull();
+    expect(loadNotice({ ...base, failed: 2 })).toBeNull();
+    expect(loadNotice({ ...base, failed: 3 })).toBe('failed');
+  });
+});


### PR DESCRIPTION
## Why

Two things from the last round:
1. A budget pause (or a wave of generation failures) made the daf-load bar fill **silently** — the prefetch swallowed every error and ticked the counter regardless. No signal to the user that anything was wrong (the "stuck with no explanation" problem).
2. The whole-daf **argument map** chip should be experimental — visible only in dev mode.

## What

**Load-bar notice (`DafLoadProgress` + `dafPrefetch`):**
- Each warm task's outcome is now classified into the progress signal: budget-pause vs real failure vs abort (aborts/superseded cohorts ignored).
- A top-level notice renders above the daf: an **amber "AI generation is paused"** banner the moment any task is budget-paused, or a **"some content couldn't be generated"** notice once ≥3 tasks fail (a single transient hiccup stays quiet). It persists independent of the bar's auto-hide, until the next daf.
- Pure `loadNotice(progress)` helper, unit-tested.

**Dev-gate the argument map:**
- The chip shows only when dev mode is open.
- Its on-load reasoning warm (`argument-overview.synthesis` → the deepseek-v4-pro `argument-overview.flow` pass) is likewise gated on dev — so we don't pay a frontier reasoning call on every daf load for users who can't open the chip. Toggling dev re-runs prefetch and warms it.

## Tests
- `tests/load-notice.test.ts` — pause precedence, the ≥3 failure threshold, null when clean.
- Full suite green (1152); build clean.