### PR TITLE
Anchor Rishonim + halacha per-comment via Sefaria link anchorRefs

### DIFF
--- a/src/lib/context/fromSefaria.ts
+++ b/src/lib/context/fromSefaria.ts
@@ -46,26 +46,39 @@ export function fromCommentaryPieces(
   });
 }
 
-/** Rishonim (Rashba, Ritva, Ramban, …) — whole-daf snippets. */
-export function fromRishonim(bundle: RishonimBundle | undefined): ContextItem[] {
-  if (!bundle) return [];
-  return Object.entries(bundle).map(([label, snip]) =>
-    item('sefaria-rishonim', label, 'rishon', `rishon:${label}`, {
-      title: { en: label }, body: { he: snip.hebrew, en: snip.english }, url: refUrl(snip.ref),
-    }),
-  );
+/** Inclusive 0-indexed segment range, dropping negatives. */
+function segArr(start: number, end: number): number[] {
+  const out: number[] = [];
+  for (let s = Math.max(0, start); s <= end; s++) out.push(s);
+  return out;
 }
 
-/** Shulchan Aruch / halachic refs linked to this daf — whole-daf. */
+/** Rishonim (Rashba, Ritva, Rosh, …) — one item per comment, anchored to the
+ *  daf segment(s) Sefaria links it to (`via: 'sefaria-link'`). */
+export function fromRishonim(bundle: RishonimBundle | undefined): ContextItem[] {
+  if (!bundle) return [];
+  return bundle.map((c, i) => {
+    const segs = segArr(c.segStart, c.segEnd);
+    return item('sefaria-rishonim', c.label, 'rishon', `rishon:${c.ref || i}`, {
+      title: { en: c.label }, body: { he: c.hebrew, en: c.english }, url: refUrl(c.ref),
+      segs, via: segs.length ? 'sefaria-link' : undefined,
+    });
+  });
+}
+
+/** Halachic codifications (Mishneh Torah, Shulchan Aruch, …) linked to this daf
+ *  — one item per ref, anchored to its segment when Sefaria gives an anchorRef. */
 export function fromHalachaRefs(bundle: HalachicRefBundle | undefined): ContextItem[] {
   if (!bundle) return [];
   const out: ContextItem[] = [];
-  for (const [ref, snips] of Object.entries(bundle)) {
-    const first = snips[0];
-    if (!first) continue;
-    out.push(item('sefaria-halacha', 'Halacha', 'shulchanAruch', `halacha:${ref}`, {
-      title: { en: ref }, body: { he: first.hebrew, en: first.english }, url: refUrl(first.ref ?? ref),
-    }));
+  for (const [book, snips] of Object.entries(bundle)) {
+    snips.forEach((s, i) => {
+      const segs = s.segStart != null && s.segEnd != null ? segArr(s.segStart, s.segEnd) : [];
+      out.push(item('sefaria-halacha', 'Halacha', 'halachaRef', `halacha:${s.ref || `${book}:${i}`}`, {
+        title: { en: s.ref || book }, body: { he: s.hebrew, en: s.english }, url: refUrl(s.ref),
+        segs, via: segs.length ? 'sefaria-link' : undefined,
+      }));
+    });
   }
   return out;
 }

--- a/src/lib/sefref/sefaria/client.ts
+++ b/src/lib/sefref/sefaria/client.ts
@@ -77,12 +77,25 @@ export interface CommentatorSnippet {
   ref: string;
 }
 
-export type RishonimBundle = Record<string, CommentatorSnippet>;
+/** One Rishon comment, anchored to the daf segment(s) Sefaria links it to.
+ *  `segStart`/`segEnd` are 0-indexed against the gemara segment array. */
+export interface RishonComment {
+  label: string;
+  ref: string;
+  hebrew: string;
+  english: string;
+  segStart: number;
+  segEnd: number;
+}
+export type RishonimBundle = RishonComment[];
 
 export interface HalachicSnippet {
   ref: string;
   hebrew: string;
   english: string;
+  /** 0-indexed daf segment(s) this ref anchors to (from the link's anchorRef). */
+  segStart?: number;
+  segEnd?: number;
 }
 
 export type HalachicRefBundle = Record<string, HalachicSnippet[]>;
@@ -122,15 +135,28 @@ export type SefariaTopicBundle = SefariaTopic[];
  * or getText ref. Not every tractate has every commentator — missing ones are
  * simply omitted from the bundle.
  */
-const RISHONIM_BOOKS: ReadonlyArray<{ label: string; book: string }> = [
-  { label: 'Rashba',              book: 'Rashba' },
-  { label: 'Ritva',               book: 'Ritva' },
-  { label: 'Ramban',              book: 'Ramban' },
-  { label: 'Meiri',               book: 'Beit HaBechira' },
-  { label: 'Rosh',                book: 'Rosh' },
-  { label: 'Maharsha',            book: 'Maharsha' },
-  { label: 'Chidushei Aggadot',   book: 'Chidushei Aggadot of the Maharsha' },
-];
+/** Rishonim we surface, keyed by the "book part" of Sefaria's index_title
+ *  (the index_title with its trailing " on <Tractate>" / " <Tractate>"
+ *  stripped) → the short display label. Rashi/Tosafot are their own sources;
+ *  Steinsaltz is the modern translation — both excluded here. */
+const RISHONIM: ReadonlyMap<string, string> = new Map([
+  ['Rashba', 'Rashba'],
+  ['Ritva', 'Ritva'],
+  ['Ramban', 'Ramban'],
+  ['Beit HaBechira', 'Meiri'],
+  ['Rosh', 'Rosh'],
+  ['Ran', 'Ran'],
+  ['Rabbeinu Chananel', 'Rabbeinu Chananel'],
+  ['Rif', 'Rif'],
+]);
+
+/** Map a Sefaria commentary index_title (e.g. "Rashba on Eruvin", "Rif Eruvin",
+ *  "Beit HaBechira on Eruvin") to our Rishon label, or null if not one we keep. */
+export function rishonLabel(indexTitle: string, tractate: string): string | null {
+  const esc = tractate.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const book = indexTitle.replace(new RegExp(`\\s+(?:on\\s+)?${esc}\\b.*$`), '').trim();
+  return RISHONIM.get(book) ?? null;
+}
 
 /** Parse the trailing segment range from a Sefaria ref like
  *  "Berakhot 2a:1-5" → { start: 1, end: 5 } or "Shabbat 20b:5" →
@@ -355,23 +381,45 @@ class SefariaAPI {
    * Ramban, Meiri/Beit HaBechira, Rosh, Maharsha, Chidushei Aggadot).
    * Returns only the commentators Sefaria has for this tractate+page.
    */
-  async fetchRishonim(tractate: string, page: string): Promise<RishonimBundle> {
+  /**
+   * Rishonim on the daf, ONE item per comment, anchored to the segment(s)
+   * Sefaria links it to. Driven by /api/related (whose Commentary links carry
+   * `ref` = the comment and `anchorRef` = the daf segment) rather than the old
+   * `"<book> on <daf>"` whole-daf blob — so each comment lands on its line, and
+   * chapter-structured books like the Rosh anchor correctly instead of
+   * resolving to the wrong sugya.
+   */
+  async fetchRishonim(tractate: string, page: string, opts: { maxPerBook?: number } = {}): Promise<RishonimBundle> {
+    const maxPerBook = opts.maxPerBook ?? 12;
     const ref = `${tractate}.${page}`;
-    const out: RishonimBundle = {};
+    const related = await this.getRelated(ref).catch(() => null);
+    if (!related) return [];
+    const byBook = new Map<string, { ref: string; anchorRef: string }[]>();
+    for (const l of related.links) {
+      if (l.category !== 'Commentary') continue;
+      const label = rishonLabel(l.index_title, tractate);
+      if (!label) continue;
+      const arr = byBook.get(label) ?? [];
+      if (arr.length < maxPerBook && !arr.some((x) => x.ref === l.ref)) arr.push({ ref: l.ref, anchorRef: l.anchorRef });
+      byBook.set(label, arr);
+    }
+    const out: RishonComment[] = [];
     await Promise.all(
-      RISHONIM_BOOKS.map(async ({ label, book }) => {
-        try {
-          const text = await this.getText(`${book} on ${ref}`);
-          const hebrew = Array.isArray(text.he) ? text.he.join(' ') : (text.he ?? '');
-          const english = Array.isArray(text.text) ? text.text.join(' ') : (text.text ?? '');
+      Array.from(byBook.entries()).flatMap(([label, links]) =>
+        links.map(async ({ ref: cref, anchorRef }) => {
+          const range = parseAnchorRefRange(anchorRef);
+          if (!range) return;
+          const t = await this.getText(cref).catch(() => null);
+          if (!t) return;
+          const hebrew = Array.isArray(t.he) ? t.he.join(' ') : (t.he ?? '');
+          const english = Array.isArray(t.text) ? t.text.join(' ') : (t.text ?? '');
           if (hebrew || english) {
-            out[label] = { hebrew, english, ref: text.ref };
+            out.push({ label, ref: cref, hebrew, english, segStart: range.start - 1, segEnd: range.end - 1 });
           }
-        } catch {
-          // commentator not available for this daf — skip silently
-        }
-      })
+        }),
+      ),
     );
+    out.sort((a, b) => a.segStart - b.segStart || a.label.localeCompare(b.label));
     return out;
   }
 
@@ -390,11 +438,12 @@ class SefariaAPI {
     const related = await this.getRelated(ref).catch(() => null);
     if (!related) return {};
     const halakhahLinks = related.links.filter(l => l.category === 'Halakhah');
-    const grouped = new Map<string, string[]>();
+    // Keep each ref's anchorRef so the snippet can anchor to its daf segment.
+    const grouped = new Map<string, { ref: string; anchorRef: string }[]>();
     for (const link of halakhahLinks) {
       const book = link.index_title;
       const refs = grouped.get(book) ?? [];
-      if (!refs.includes(link.ref)) refs.push(link.ref);
+      if (!refs.some((r) => r.ref === link.ref)) refs.push({ ref: link.ref, anchorRef: link.anchorRef });
       grouped.set(book, refs);
     }
     const out: HalachicRefBundle = {};
@@ -402,14 +451,17 @@ class SefariaAPI {
       Array.from(grouped.entries()).map(async ([book, refs]) => {
         const capped = refs.slice(0, maxPerBook);
         const texts = await Promise.all(
-          capped.map(r => this.getText(r).catch(() => null))
+          capped.map(async (r) => ({ link: r, t: await this.getText(r.ref).catch(() => null) }))
         );
         const snippets: HalachicSnippet[] = [];
-        for (const t of texts) {
+        for (const { link, t } of texts) {
           if (!t) continue;
           const hebrew = Array.isArray(t.he) ? t.he.join(' ') : (t.he ?? '');
           const english = Array.isArray(t.text) ? t.text.join(' ') : (t.text ?? '');
-          if (hebrew || english) snippets.push({ ref: t.ref, hebrew, english });
+          const range = parseAnchorRefRange(link.anchorRef);
+          if (hebrew || english) {
+            snippets.push({ ref: t.ref, hebrew, english, segStart: range ? range.start - 1 : undefined, segEnd: range ? range.end - 1 : undefined });
+          }
         }
         if (snippets.length) out[book] = snippets;
       })

--- a/src/worker/context-providers.ts
+++ b/src/worker/context-providers.ts
@@ -55,7 +55,7 @@ export async function collectContext(
   const [dafyomi, sefariaPage, rishonim, halacha, mishna, topics] = await Promise.all([
     getDafyomiContentCached(cache, env.ASSETS, tractate, page, { assetOrigin, allowLive }).catch(() => null),
     getSefariaPageCached(cache, tractate, page).catch(() => null),
-    getRishonimCached(cache, tractate, page).catch(() => ({})),
+    getRishonimCached(cache, tractate, page).catch(() => []),
     getHalachaRefsCached(cache, tractate, page).catch(() => ({})),
     getMishnaBundleCached(cache, tractate, page).catch(() => []),
     getDafTopicsCached(cache, tractate, page).catch(() => []),

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -652,8 +652,21 @@ async function getCommentariesSlice(env: Bindings, tractate: string, page: strin
       try { return JSON.parse(cached) as CommentariesSlice; } catch { /* fall through */ }
     }
   }
+  // Rishonim now arrive as per-comment, segment-anchored entries; collapse them
+  // back into the per-commentator { hebrew, english, ref } map this slice
+  // exposes to enrichment prompts (joining a commentator's comments in order).
   const bundle = await getRishonimCached(cache, tractate, page);
-  const slice: CommentariesSlice = { tractate, page, by_commentator: bundle ?? {} };
+  const by_commentator: Record<string, { hebrew: string; english: string; ref: string }> = {};
+  for (const c of bundle ?? []) {
+    const ex = by_commentator[c.label];
+    if (ex) {
+      ex.hebrew = `${ex.hebrew} ${c.hebrew}`.trim();
+      ex.english = `${ex.english} ${c.english}`.trim();
+    } else {
+      by_commentator[c.label] = { hebrew: c.hebrew, english: c.english, ref: c.ref };
+    }
+  }
+  const slice: CommentariesSlice = { tractate, page, by_commentator };
   if (cache) await cache.put(key, JSON.stringify(slice), { expirationTtl: SLICE_TTL_S });
   return slice;
 }

--- a/src/worker/source-cache.ts
+++ b/src/worker/source-cache.ts
@@ -142,7 +142,9 @@ export async function getRishonimCached(
   tractate: string,
   page: string,
 ): Promise<RishonimBundle> {
-  const key = `rishonim:v1:${tractate}:${page}`;
+  // v2: per-comment, segment-anchored RishonComment[] (was a whole-daf blob
+  // Record<label, snippet>). Bumping forces a refetch into the new shape.
+  const key = `rishonim:v2:${tractate}:${page}`;
   const hit = await readCache<RishonimBundle>(cache, key);
   if (hit) return hit;
   try {
@@ -150,7 +152,7 @@ export async function getRishonimCached(
     await writeCache(cache, key, data);
     return data;
   } catch {
-    return {};
+    return [];
   }
 }
 
@@ -159,7 +161,8 @@ export async function getHalachaRefsCached(
   tractate: string,
   page: string,
 ): Promise<HalachicRefBundle> {
-  const key = `halacha-refs:v1:${tractate}:${page}`;
+  // v2: snippets now carry segStart/segEnd (the linked daf segment).
+  const key = `halacha-refs:v2:${tractate}:${page}`;
   const hit = await readCache<HalachicRefBundle>(cache, key);
   if (hit) return hit;
   try {

--- a/tests/context-pool.test.ts
+++ b/tests/context-pool.test.ts
@@ -25,15 +25,36 @@ describe('fromSefaria mappers', () => {
     expect(items[0].via).toBe('mishnah');
   });
 
-  it('maps Rishonim, halacha refs, and topics as whole-daf (segs:[])', () => {
-    const rishonim = fromRishonim({ Ramban: { hebrew: 'רמב"ן', english: 'Ramban text', ref: 'Ramban on Chullin 76a' } });
-    const halacha = fromHalachaRefs({ 'Shulchan Arukh, YD 55:1': [{ ref: 'Shulchan Arukh, YD 55:1', hebrew: 'ה', english: 'SA' }] });
+  it('anchors Rishonim per comment to the linked segment (via sefaria-link)', () => {
+    const rishonim = fromRishonim([
+      { label: 'Rashba', ref: 'Rashba on Eruvin 102a:2', hebrew: 'רשב"א', english: 'Rashba text', segStart: 3, segEnd: 3 },
+      { label: 'Rosh', ref: 'Rosh, Eruvin 10:5', hebrew: 'רא"ש', english: 'Rosh text', segStart: 5, segEnd: 6 },
+    ]);
+    expect(rishonim[0].segs).toEqual([3]);
+    expect(rishonim[0].via).toBe('sefaria-link');
+    expect(rishonim[0].sourceLabel).toBe('Rashba');
+    expect(rishonim[1].segs).toEqual([5, 6]); // multi-segment anchor
+  });
+
+  it('anchors halacha refs to their linked segment, leaving anchorless ones unplaced', () => {
+    const halacha = fromHalachaRefs({
+      'Mishneh Torah, Sabbath': [
+        { ref: 'Mishneh Torah, Sabbath 25:6', hebrew: 'ה', english: 'MT', segStart: 10, segEnd: 10 },
+        { ref: 'Mishneh Torah, Sabbath 25:7', hebrew: 'ה', english: 'MT' }, // no anchorRef
+      ],
+    });
+    expect(halacha).toHaveLength(2);
+    expect(halacha[0].segs).toEqual([10]);
+    expect(halacha[0].via).toBe('sefaria-link');
+    expect(halacha[0].source).toBe('sefaria-halacha');
+    expect(halacha[1].segs).toEqual([]);
+    expect(halacha[1].via).toBeUndefined();
+  });
+
+  it('leaves topics whole-daf (no per-segment anchor)', () => {
     const topics = fromTopics([{ slug: 'tereifah', titleEn: 'Tereifah', sources: [{ ref: 'Chullin 42a' }] }]);
-    for (const it of [rishonim[0], halacha[0], topics[0]]) {
-      expect(it.segs).toEqual([]);
-      expect(it.via).toBeUndefined();
-    }
-    expect(rishonim[0].sourceLabel).toBe('Ramban');
+    expect(topics[0].segs).toEqual([]);
+    expect(topics[0].via).toBeUndefined();
     expect(topics[0].body?.en).toContain('Sources: Chullin 42a');
   });
 });

--- a/tests/sefaria-client.test.ts
+++ b/tests/sefaria-client.test.ts
@@ -3,8 +3,26 @@ import {
   flattenPieces,
   flattenTalmudCommentaryPieces,
   pickV3Version,
+  rishonLabel,
   sefariaAPI,
 } from '../src/lib/sefref/sefaria/client';
+
+describe('rishonLabel', () => {
+  it('maps Rishonim index_titles (various naming) to a short label', () => {
+    expect(rishonLabel('Rashba on Eruvin', 'Eruvin')).toBe('Rashba');
+    expect(rishonLabel('Ritva on Eruvin', 'Eruvin')).toBe('Ritva');
+    expect(rishonLabel('Rosh on Eruvin', 'Eruvin')).toBe('Rosh');
+    expect(rishonLabel('Beit HaBechira on Eruvin', 'Eruvin')).toBe('Meiri');
+    expect(rishonLabel('Rif Eruvin', 'Eruvin')).toBe('Rif'); // no "on"
+    expect(rishonLabel('Rashba on Bava Metzia', 'Bava Metzia')).toBe('Rashba'); // spaced tractate
+  });
+  it('excludes Rashi/Tosafot/Steinsaltz and unknown books', () => {
+    expect(rishonLabel('Rashi on Eruvin', 'Eruvin')).toBeNull();
+    expect(rishonLabel('Tosafot on Eruvin', 'Eruvin')).toBeNull();
+    expect(rishonLabel('Steinsaltz on Eruvin', 'Eruvin')).toBeNull();
+    expect(rishonLabel('Tosafot Rid on Eruvin Second Recension', 'Eruvin')).toBeNull();
+  });
+});
 
 describe('flattenPieces', () => {
   it('returns a one-element array for a non-empty string', () => {


### PR DESCRIPTION
Fixes "Rashba/Halacha still not connecting" — and builds the well-anchored context pool that the RAG step needs.

## Root cause
Rishonim were fetched as `"<book> on <daf>"` and **joined into one whole-daf blob per book** — so a "Rashba" was a single giant card we could only anchor by its first lemma; chapter-structured books (the Rosh) resolved to the wrong sugya entirely. Halacha refs dropped their anchor and sat unplaced.

## Fix — use Sefaria's own per-link anchors (like Mishnah already does)
`/api/related` gives, per commentary/halakhah link, `ref` (the comment) + `anchorRef` (e.g. `"Eruvin 102a:11"` = the daf segment).
- **`fetchRishonim`** now reads those links, fetches each comment, and emits **one item per comment anchored to its segment** (`via: 'sefaria-link'`); the dibur-ha'maschil then refines to exact words within that segment. `rishonLabel()` maps index_title naming variants (`Rashba on X`, `Rif X`, `Beit HaBechira on X` → Meiri); Rashi/Tosafot/Steinsaltz excluded. Capped per book.
- **`fetchHalachicRefs`** keeps each link's `anchorRef` → snippet `segStart/segEnd`; **`fromHalachaRefs`** anchors each ref to its segment (anchorless ones stay unplaced).
- The enrichment **commentaries-slice** (`by_commentator`, fed to prompts) is rebuilt from the per-comment array — so prompts now get correctly-scoped Rishonim text. (First touch toward the RAG direction.)
- Cache bumped: `rishonim:v2`, `halacha-refs:v2`.

## Tests (regression)
`rishonLabel` naming variants + exclusions; `fromRishonim`/`fromHalachaRefs` anchoring incl. multi-segment + anchorless→unplaced; topics stay whole-daf. `pnpm typecheck` + `pnpm test` (1153) green.