### PR TITLE
Argument flow graph: drop piled-up edge labels, lane connectors cleanly

### DIFF
--- a/src/client/ArgumentFlowGraph.tsx
+++ b/src/client/ArgumentFlowGraph.tsx
@@ -35,8 +35,7 @@ interface Props {
 const NODE_W = 300;
 const NODE_H = 46;
 const ROW_GAP = 30;
-const LANE_W = 92;        // right-side gutter the connectors route through
-const LANE_STEP = 16;     // x offset per concurrent connector
+const LANE_STEP = 16;     // x offset per concurrent connector lane
 const TOP_PAD = 8;
 const LEFT_PAD = 8;
 const NAME_MAX = 46;
@@ -72,22 +71,52 @@ export function filterFlowConnections(connections: FlowConnection[], nodeCount: 
   );
 }
 
+/** Assign each connection a routing lane (0-based) so connectors that share
+ *  vertical extent never sit in the same lane — interval-graph coloring, which
+ *  keeps parallel runs from drawing on top of each other (the old `i % 4`
+ *  cycling collided whenever >4 edges, or fewer edges overlapped in range).
+ *  Returns a lane per connection in input order. Pure + exported for tests. */
+export function assignLanes(connections: FlowConnection[]): number[] {
+  const order = connections
+    .map((c, i) => ({ i, lo: Math.min(c.from, c.to), hi: Math.max(c.from, c.to) }))
+    .sort((a, b) => a.lo - b.lo || a.hi - b.hi);
+  const laneHi: number[] = []; // highest row index currently occupying each lane
+  const lanes = new Array<number>(connections.length).fill(0);
+  for (const { i, lo, hi } of order) {
+    let lane = laneHi.findIndex((h) => h < lo); // a lane whose last run ended above us
+    if (lane === -1) { lane = laneHi.length; laneHi.push(hi); }
+    else laneHi[lane] = hi;
+    lanes[i] = lane;
+  }
+  return lanes;
+}
+
 export default function ArgumentFlowGraph(props: Props): JSX.Element {
   const nodeY = (i: number) => TOP_PAD + i * (NODE_H + ROW_GAP);
   const rowMidY = (i: number) => nodeY(i) + NODE_H / 2;
   const height = () => TOP_PAD * 2 + props.nodes.length * NODE_H + (props.nodes.length - 1) * ROW_GAP;
-  const width = () => LEFT_PAD + NODE_W + LANE_W + 8;
 
   const edges = () => filterFlowConnections(props.connections, props.nodes.length);
+  const lanes = () => assignLanes(edges());
+  const laneCount = () => { const ls = lanes(); return ls.length ? Math.max(...ls) + 1 : 0; };
+  // Gutter only as wide as the lanes actually used (min one step of breathing room).
+  const gutter = () => Math.max(LANE_STEP, laneCount() * LANE_STEP) + 16;
+  const width = () => LEFT_PAD + NODE_W + gutter();
 
-  // Each connector gets its own lane x (cycled) so parallel runs don't overlap.
-  const laneX = (i: number) => LEFT_PAD + NODE_W + 10 + (i % 4) * LANE_STEP;
+  const laneX = (lane: number) => LEFT_PAD + NODE_W + 12 + lane * LANE_STEP;
+
+  // Distinct kinds present, for the legend (color/dash carry the meaning now —
+  // inline labels piled up and were unreadable, mirroring ArgumentVoiceMap).
+  const kindsPresent = (): FlowConnection['kind'][] => {
+    const seen = new Set<FlowConnection['kind']>();
+    for (const e of edges()) seen.add(e.kind);
+    return (Object.keys(KIND_COLOR) as FlowConnection['kind'][]).filter((k) => seen.has(k));
+  };
 
   // Orthogonal connector hugging the right gutter: out of the source's right
-  // edge, into the lane, vertical to the target's row, back into the target.
-  // Arrowhead points into the target node.
-  const edgePath = (c: FlowConnection, i: number): string => {
-    const x = laneX(i);
+  // edge, into its lane, vertical to the target's row, back into the target.
+  const edgePath = (c: FlowConnection, lane: number): string => {
+    const x = laneX(lane);
     const y1 = rowMidY(c.from);
     const y2 = rowMidY(c.to);
     const rightX = LEFT_PAD + NODE_W;
@@ -111,30 +140,20 @@ export default function ArgumentFlowGraph(props: Props): JSX.Element {
             )}</For>
           </defs>
 
-          {/* Connectors (behind nodes). Hover the path for the note. */}
+          {/* Connectors (behind nodes). Hover the path for the kind + note. */}
           <For each={edges()}>{(c, i) => {
             const color = KIND_COLOR[c.kind];
             return (
-              <>
-                <path
-                  d={edgePath(c, i())}
-                  fill="none"
-                  stroke={color}
-                  stroke-width={1.5}
-                  stroke-dasharray={KIND_DASH[c.kind]}
-                  marker-end={`url(#flow-arrow-${c.kind})`}
-                >
-                  <title>{`§${c.from + 1} ${c.kind} §${c.to + 1}${c.note ? ` — ${c.note}` : ''}`}</title>
-                </path>
-                <text
-                  x={laneX(i()) + 3}
-                  y={(rowMidY(c.from) + rowMidY(c.to)) / 2}
-                  font-size="8"
-                  font-family="system-ui, -apple-system, sans-serif"
-                  fill={color}
-                  transform={`rotate(90 ${laneX(i()) + 3} ${(rowMidY(c.from) + rowMidY(c.to)) / 2})`}
-                >{c.kind}</text>
-              </>
+              <path
+                d={edgePath(c, lanes()[i()])}
+                fill="none"
+                stroke={color}
+                stroke-width={1.5}
+                stroke-dasharray={KIND_DASH[c.kind]}
+                marker-end={`url(#flow-arrow-${c.kind})`}
+              >
+                <title>{`§${c.from + 1} ${c.kind} §${c.to + 1}${c.note ? ` — ${c.note}` : ''}`}</title>
+              </path>
             );
           }}</For>
 
@@ -163,6 +182,24 @@ export default function ArgumentFlowGraph(props: Props): JSX.Element {
           }}</For>
         </svg>
       </div>
+
+      {/* Legend: color + dash → connection kind (only the kinds in use). */}
+      <Show when={kindsPresent().length > 0}>
+        <div style={{
+          display: 'flex', 'flex-wrap': 'wrap', gap: '0.4rem 0.85rem',
+          'margin-top': '0.5rem', 'font-size': '0.64rem', color: '#888',
+        }}>
+          <For each={kindsPresent()}>{(kind) => (
+            <span style={{ display: 'inline-flex', 'align-items': 'center', gap: '0.3rem' }}>
+              <span style={{
+                display: 'inline-block', width: '16px', height: 0,
+                'border-top': `1.5px ${KIND_DASH[kind] ? 'dashed' : 'solid'} ${KIND_COLOR[kind]}`,
+              }} />
+              {kind}
+            </span>
+          )}</For>
+        </div>
+      </Show>
     </Show>
   );
 }

--- a/tests/argument-overview-flow.test.ts
+++ b/tests/argument-overview-flow.test.ts
@@ -1,8 +1,29 @@
 import { describe, it, expect } from 'vitest';
-import { filterFlowConnections, type FlowConnection } from '../src/client/ArgumentFlowGraph';
+import { filterFlowConnections, assignLanes, type FlowConnection } from '../src/client/ArgumentFlowGraph';
 import { tokenizeRabbiMentions } from '../src/client/rabbiLinks';
 
 const conn = (from: number, to: number): FlowConnection => ({ from, to, kind: 'continues', note: '' });
+
+describe('assignLanes — connectors that overlap vertically get different lanes', () => {
+  it('puts non-overlapping (sequential) connectors in the same lane', () => {
+    // 0→1 ends at row 1; 2→3 starts at row 2 — no overlap, reuse lane 0.
+    expect(assignLanes([conn(0, 1), conn(2, 3)])).toEqual([0, 0]);
+  });
+  it('separates connectors whose row-spans overlap', () => {
+    // 0→3 spans rows 0..3; 1→2 sits inside it — must be a different lane.
+    expect(assignLanes([conn(0, 3), conn(1, 2)])).toEqual([0, 1]);
+  });
+  it('reuses a freed lane once a run has ended', () => {
+    // 0→2 and 1→4 overlap (lanes 0,1); 3→5 starts after 0→2 ended → lane 0 again.
+    expect(assignLanes([conn(0, 2), conn(1, 4), conn(3, 5)])).toEqual([0, 1, 0]);
+  });
+  it('handles reversed (upward) connectors by row extent, not direction', () => {
+    expect(assignLanes([conn(3, 0), conn(1, 2)])).toEqual([0, 1]);
+  });
+  it('empty in -> empty out', () => {
+    expect(assignLanes([])).toEqual([]);
+  });
+});
 
 describe('filterFlowConnections — overview flow graph edges', () => {
   it('keeps valid in-range connections', () => {


### PR DESCRIPTION
Cleans up the whole-daf argument flow graph (`ArgumentFlowGraph`) — the text-overlap in the screenshot.

## Problem
Each connection's `kind` was drawn as **rotated `<text>` at the connector's vertical midpoint**, and lanes were assigned by `i % 4`. So the "continues / resolves / depends-on" labels stacked on top of each other in the right gutter, and connectors overlapped once more than four (or fewer overlapping in range) were present.

## Fix
- **Remove the inline rotated labels.** Convey the kind by **colour + dash + the per-edge hover tooltip**, and add a small **legend** below the graph showing only the kinds in use. This mirrors what `ArgumentVoiceMap` already does for exactly this reason ("inline pill labels stacked on top of each other and read as visual noise").
- **`assignLanes()`** — interval-graph colouring so connectors that share vertical extent never share a lane (sequential ones reuse a freed lane). The right gutter is sized to the lanes actually used.

## Tests
`assignLanes` reuse / separation / lane-freeing / reversed-direction / empty. `pnpm typecheck` + `pnpm test` (1161) green. Verifying in-browser after deploy.