### PR TITLE
Scope {{context}} enrichment dep to the instance's segments; feed argument.background

### DIFF
--- a/src/lib/context/select.ts
+++ b/src/lib/context/select.ts
@@ -19,6 +19,23 @@ export interface ContextSelectOpts {
   includeWholeDaf?: boolean;
 }
 
+/** The target segments an enrichment instance covers, from its mark-input
+ *  location (`startSegIdx`..`endSegIdx`). Returns `[]` when there's no segment
+ *  location (a whole-daf instance) — which `contextForAnchor` treats as "all".
+ *  So a section enrichment gets its own slice; a whole-daf one gets everything. */
+export function segsFromMarkInput(markInput: unknown): number[] {
+  const m = markInput && typeof markInput === 'object' ? (markInput as Record<string, unknown>) : null;
+  if (!m) return [];
+  const start = typeof m.startSegIdx === 'number' ? m.startSegIdx
+    : typeof m.endSegIdx === 'number' ? m.endSegIdx : null;
+  const end = typeof m.endSegIdx === 'number' ? m.endSegIdx
+    : typeof m.startSegIdx === 'number' ? m.startSegIdx : null;
+  if (start === null || end === null) return [];
+  const out: number[] = [];
+  for (let s = Math.max(0, Math.min(start, end)); s <= Math.max(start, end); s++) out.push(s);
+  return out;
+}
+
 /** Items relevant to a target. `targetSegs: []` (whole daf) returns everything.
  *  Otherwise: whole-daf items are in (unless disabled), and segment items are
  *  in when they overlap the target. */

--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -1753,7 +1753,10 @@ Mishnayot this gemara is discussing (anchored from Sefaria — the section above
 Rashi + Tosafot + other rishonim:
 {{commentaries}}
 
-Write the background per the schema. When the section directly elaborates one of the mishnayot above, name it explicitly (e.g. "Builds on Mishnah Berakhot 1:1").`;
+Study-aid context grounded to THIS section (dafyomi.co.il outline/background/halacha + Sefaria Rishonim/halacha anchored to these segments):
+{{context}}
+
+Write the background per the schema. Use the study-aid context to name prerequisite concepts and terms precisely. When the section directly elaborates one of the mishnayot above, name it explicitly (e.g. "Builds on Mishnah Berakhot 1:1").`;
 
 
 // ---------------- argument.synthesis (tightened, drops subsection/commentary/flow leaves) ----------------
@@ -1889,7 +1892,10 @@ const ARGUMENT_BACKGROUND_USER_TEMPLATE_HE = `מסכת: {{tractate}}, דף {{pag
 רש"י + תוספות + ראשונים נוספים:
 {{commentaries}}
 
-כתוב את הרקע לפי הסכימה. כאשר המקטע מבאר במישרין אחת מן המשניות שלמעלה, נקוב בה במפורש (למשל "נבנה על משנה ברכות א:א").`;
+חומר עזר ללימוד המעוגן למקטע זה (dafyomi.co.il — נקודות/רקע/הלכה + ראשונים והלכה מ-Sefaria המעוגנים לסגמנטים אלו):
+{{context}}
+
+כתוב את הרקע לפי הסכימה. השתמש בחומר העזר כדי לנקוב במושגים ומונחים מוקדמים בדייקנות. כאשר המקטע מבאר במישרין אחת מן המשניות שלמעלה, נקוב בה במפורש (למשל "נבנה על משנה ברכות א:א").`;
 
 const ARGUMENT_SYNTHESIS_SYSTEM_PROMPT_HE = `אתה תלמיד חכם הבקיא בש"ס. תקבל מקטע של דף, את רשימת ה-moves שבתוכו, ניתוח קולות לכל חכם, רקע, ותצוגת פירוש קצרה. חבר פסקה אחת הדוקה הנוקבת בשאלה הכוללת של המקטע, בעמדות הנקובות, והיכן הוא נוחת.
 
@@ -1955,8 +1961,8 @@ CODE_ENRICHMENTS.push(
     ARGUMENT_BACKGROUND_SYSTEM_PROMPT, ARGUMENT_BACKGROUND_USER_TEMPLATE, ARGUMENT_BACKGROUND_OUTPUT_SCHEMA,
     {
       mode: 'augment-content', scope: 'local',
-      dependencies: ['gemara', 'commentaries', 'mishna'],
-      defHash: 'argument.background-v3', cacheVersion: '3',
+      dependencies: ['gemara', 'commentaries', 'mishna', 'context'],
+      defHash: 'argument.background-v4', cacheVersion: '4',
       model: ARGUMENT_FLASH_MODEL,
       systemPromptHe: ARGUMENT_BACKGROUND_SYSTEM_PROMPT_HE,
       userPromptTemplateHe: ARGUMENT_BACKGROUND_USER_TEMPLATE_HE,

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -9,7 +9,7 @@ import {
 } from '../lib/sefref';
 import { getDafyomiMasechet } from '../lib/sefref/dafyomi/masechtos';
 import { collectContext } from './context-providers';
-import { formatContextForPrompt } from '../lib/context/select';
+import { formatContextForPrompt, contextForAnchor, segsFromMarkInput } from '../lib/context/select';
 import { aiMatchToSegments } from './context-match';
 import type { MatchInput } from '../lib/context/anchor/ai-prompt';
 import {
@@ -896,11 +896,14 @@ async function resolveDependencies(
       return;
     }
     if (dep === 'context') {
-      // Aggregated external context (dafyomi Points/Halacha/Charts + Sefaria),
-      // rendered as grouped plain text for the prompt. Each source that fails
+      // Aggregated external context (dafyomi Points/Halacha/Charts + Sefaria
+      // Rishonim/halacha/topics), SCOPED to the instance's segments: a section
+      // enrichment gets the context grounded to its own lines; a whole-daf one
+      // (no segment location) gets the full pool. Each source that fails
       // contributes nothing rather than throwing.
       const items = await collectContext(rc.env, tractate, page);
-      out.vars.context = formatContextForPrompt(items);
+      const scoped = contextForAnchor(items, segsFromMarkInput(markInput));
+      out.vars.context = formatContextForPrompt(scoped);
       return;
     }
     if (typeof dep === 'object' && dep !== null) {

--- a/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
+++ b/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
@@ -14,7 +14,7 @@ exports[`CODE_ENRICHMENTS cache identity > per-enrichment fingerprint is stable 
   "argument-move.synthesis@5 mode=aggregate scope=local mark=argument-move schema=argument_move_synthesis[synthesis] deps=[gemara|e:argument-move.commentaries|m:argument-move|m:rabbi]",
   "argument-overview.flow@1 mode=augment-content scope=local mark=argument-overview schema=argument_overview_flow[connections] deps=[gemara|context|m:argument|m:rabbi]",
   "argument-overview.synthesis@2 mode=aggregate scope=local mark=argument-overview schema=argument_overview_synthesis[synthesis] deps=[gemara|context|e:argument-overview.flow|m:argument|m:rabbi]",
-  "argument.background@3 mode=augment-content scope=local mark=argument schema=argument_background[background] deps=[gemara|commentaries|mishna]",
+  "argument.background@4 mode=augment-content scope=local mark=argument schema=argument_background[background] deps=[gemara|commentaries|mishna|context]",
   "argument.synthesis@10 mode=aggregate scope=local mark=argument schema=argument_synthesis[synthesis] deps=[gemara|commentaries|mishna|e:argument.voices|e:argument.background|m:rabbi|m:argument-move]",
   "argument.voices@5 mode=augment-content scope=local mark=argument schema=argument_voices[voices,edges] deps=[gemara|m:argument-move|m:rabbi]",
   "halacha.codification@3 mode=augment-content scope=local mark=halacha schema=halacha_codification[mishnehTorah,tur,shulchanAruch,rema,prose] deps=[gemara]",

--- a/tests/context-pool.test.ts
+++ b/tests/context-pool.test.ts
@@ -2,8 +2,27 @@ import { describe, it, expect } from 'vitest';
 import {
   fromCommentaryPieces, fromRishonim, fromHalachaRefs, fromMishna, fromTopics,
 } from '../src/lib/context/fromSefaria';
-import { contextForAnchor, formatContextForPrompt } from '../src/lib/context/select';
+import { contextForAnchor, formatContextForPrompt, segsFromMarkInput } from '../src/lib/context/select';
 import type { ContextItem } from '../src/lib/context/types';
+
+describe('segsFromMarkInput — instance location → target segments', () => {
+  it('expands a startSegIdx..endSegIdx range', () => {
+    expect(segsFromMarkInput({ startSegIdx: 2, endSegIdx: 4 })).toEqual([2, 3, 4]);
+  });
+  it('treats a single segIdx as a one-segment target', () => {
+    expect(segsFromMarkInput({ startSegIdx: 5 })).toEqual([5]);
+    expect(segsFromMarkInput({ endSegIdx: 3 })).toEqual([3]);
+  });
+  it('returns [] for a whole-daf instance (no segment location) → contextForAnchor takes all', () => {
+    expect(segsFromMarkInput({})).toEqual([]);
+    expect(segsFromMarkInput(null)).toEqual([]);
+    expect(segsFromMarkInput('nope')).toEqual([]);
+  });
+  it('clamps negatives and tolerates reversed bounds', () => {
+    expect(segsFromMarkInput({ startSegIdx: -2, endSegIdx: 1 })).toEqual([0, 1]);
+    expect(segsFromMarkInput({ startSegIdx: 4, endSegIdx: 2 })).toEqual([2, 3, 4]);
+  });
+});
 
 describe('fromSefaria mappers', () => {
   it('places Rashi/Tosafot pieces on segments via pieceKeys (S:P, 1-based)', () => {


### PR DESCRIPTION
Explores the RAG direction further. The `context` enrichment dependency (the seam another change wired in — dafyomi study material + Sefaria Rishonim/halacha/topics → `{{context}}`) was injecting the **whole-daf** pool regardless of the consumer.

## Changes
- **Segment-scope the dep.** `select.ts` was designed for this ("`contextForAnchor` with the instance's segments"). The resolver now calls `contextForAnchor(items, segsFromMarkInput(markInput))`:
  - **Section** enrichments get the context grounded to *their own lines*.
  - **Whole-daf (anchorless)** instances get `segs: []` → the full pool, unchanged — so the existing `argument-overview.flow`/`synthesis` (the whole-daf flow diagram) behave exactly as before. (`argument-overview` is an anchorless `whole-daf` mark, verified.)
- **New helper** `segsFromMarkInput` in `select.ts`: instance location (`startSegIdx`..`endSegIdx`) → target segments; `[]` for whole-daf.
- **Wire `context` into `argument.background`** — the per-section "prerequisite knowledge a reader needs". It now sees the dafyomi outline/background/halacha + segment-anchored Rishonim for its section. Bumped to `v4`.

## Tests
`segsFromMarkInput` (range / single / whole-daf / negative-clamp / reversed). `code-enrichments-snapshot` updated for the intended `argument.background@4` fingerprint. `pnpm typecheck` + `pnpm test` (1165) green.