### PR TITLE
Render inline commentary diagrams as centered block figures

### DIFF
--- a/src/lib/daf-render/styles.css
+++ b/src/lib/daf-render/styles.css
@@ -180,6 +180,18 @@
   font-weight: bold;
 }
 
+/* Some Sefaria commentary pieces (e.g. Rashi on Eruvin 102a) embed the printed
+   page's geometric diagrams as inline base64 <img> data URIs. With no rule they
+   render baseline-aligned mid-paragraph, inflating that one line box and
+   stranding its few words in a band of whitespace. Render each as its own
+   centered block, capped to the column width, matching the printed page. */
+.daf-root .daf-text img {
+  display: block;
+  margin: 0.5em auto;
+  max-width: 100%;
+  height: auto;
+}
+
 /* HebrewBooks wraps each Tosafot/commentary section in a block-level div with
    margin-bottom:3px. We want sections to flow inline (short sections continue
    on the same line as the next section) rather than each taking its own line,


### PR DESCRIPTION
## Problem

On dapim like **Eruvin 102a**, the Gemara's geometric diagrams (the `גג` and `כילה`/`טפח` triangles) render badly: the figure sits baseline-aligned mid-paragraph and the few words sharing its line float against a band of whitespace, instead of reading as a centered figure like the printed page.

## Root cause

The diagrams come from **Sefaria's Rashi commentary pieces**, embedded as inline base64 PNG `<img>` data URIs and overlaid onto the response (`src/worker/index.ts` `rashi.pieces`). They reach the DOM via `innerHTML` with **no `img` styling anywhere** in the daf stylesheet, so they default to `display: inline`, baseline-aligned.

## Fix

Add one rule to `src/lib/daf-render/styles.css`: daf-text images render as centered blocks, capped to the column width (`max-width: 100%`). No data-pipeline change — the images already arrive correctly.

`pnpm typecheck` clean; `pnpm test` 1165/1165 pass.