### PR TITLE
Add hosted code-mode MCP server at /mcp + connect guide

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,14 @@
     "warm:skeleton:shas": "node scripts/warm-skeleton-shas.mjs"
   },
   "dependencies": {
+    "@cfworker/json-schema": "^4.1.1",
     "@chenglou/pretext": "^0.0.5",
+    "@cloudflare/codemode": "^0.3.8",
+    "@hono/mcp": "^0.3.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "daf-renderer": "^1.1.4",
     "hono": "^4.6.0",
+    "hono-rate-limiter": "^0.5.3",
     "node-html-parser": "^7.1.0",
     "solid-js": "^1.9.0",
     "zod": "^4.4.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,15 +8,30 @@ importers:
 
   .:
     dependencies:
+      '@cfworker/json-schema':
+        specifier: ^4.1.1
+        version: 4.1.1
       '@chenglou/pretext':
         specifier: ^0.0.5
         version: 0.0.5
+      '@cloudflare/codemode':
+        specifier: ^0.3.8
+        version: 0.3.8(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(zod@4.4.3)
+      '@hono/mcp':
+        specifier: ^0.3.0
+        version: 0.3.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(hono-rate-limiter@0.5.3(hono@4.12.14))(hono@4.12.14)(zod@4.4.3)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
       daf-renderer:
         specifier: ^1.1.4
         version: 1.1.4
       hono:
         specifier: ^4.6.0
         version: 4.12.14
+      hono-rate-limiter:
+        specifier: ^0.5.3
+        version: 0.5.3(hono@4.12.14)
       node-html-parser:
         specifier: ^7.1.0
         version: 7.1.0
@@ -161,8 +176,28 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
+  '@cfworker/json-schema@4.1.1':
+    resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
+
   '@chenglou/pretext@0.0.5':
     resolution: {integrity: sha512-A8GZN10REdFGsyuiUgLV8jjPDDFMg5GmgxGWV0I3igxBOnzj+jgz2VMmVD7g+SFyoctfeqHFxbNatKSzVRWtRg==}
+
+  '@cloudflare/codemode@0.3.8':
+    resolution: {integrity: sha512-PVe99dFf/dvf0JOh1SBTYL7YT0nXusmqaK0lRrrlHGIQdGAnKRSb4VtaE5atiDVgN/U9G16bSkej7Pn5lWhG1g==}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.25.0
+      '@tanstack/ai': '>=0.8.0 <1.0.0'
+      ai: ^6.0.0
+      zod: ^4.0.0
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+      '@tanstack/ai':
+        optional: true
+      ai:
+        optional: true
+      zod:
+        optional: true
 
   '@cloudflare/kv-asset-handler@0.5.0':
     resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
@@ -580,6 +615,20 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@hono/mcp@0.3.0':
+    resolution: {integrity: sha512-UhSWFbZwRxHBdptOn2r1HyB8Vt6gU+BL3AbTis2t8TBW69ZhG4soJQ09yEL/t/ymxszJnWp5Rq6tOXXOjuK1qg==}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.25.1
+      hono: '*'
+      hono-rate-limiter: ^0.5.3
+      zod: ^3.25.0 || ^4.0.0
+
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
@@ -735,6 +784,16 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@poppinss/colors@4.1.6':
     resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
@@ -918,6 +977,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
   '@vitest/expect@4.1.5':
     resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
 
@@ -946,6 +1008,26 @@ packages:
 
   '@vitest/utils@4.1.5':
     resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
+
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -987,6 +1069,10 @@ packages:
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -995,6 +1081,18 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
   caniuse-lite@1.0.30001788:
     resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
 
@@ -1002,12 +1100,40 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
@@ -1042,6 +1168,10 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -1066,8 +1196,19 @@ packages:
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   electron-to-chromium@1.5.340:
     resolution: {integrity: sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
@@ -1084,8 +1225,20 @@ packages:
   error-stack-parser-es@1.0.5:
     resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -1101,12 +1254,43 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1117,18 +1301,62 @@ packages:
       picomatch:
         optional: true
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+
+  hono-rate-limiter@0.5.3:
+    resolution: {integrity: sha512-M0DxbVMpPELEzLi0AJg1XyBHLGJXz7GySjsPoK+gc5YeeBsdGDGe+2RvVuCAv8ydINiwlbxqYMNxUEyYfRji/A==}
+    peerDependencies:
+      hono: ^4.10.8
+      unstorage: ^1.17.3
+    peerDependenciesMeta:
+      unstorage:
+        optional: true
 
   hono@4.12.14:
     resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
@@ -1141,12 +1369,40 @@ packages:
   html-entities@2.3.3:
     resolution: {integrity: sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==}
 
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-what@4.1.16:
     resolution: {integrity: sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==}
     engines: {node: '>=12.13'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -1164,6 +1420,12 @@ packages:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
     hasBin: true
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -1188,12 +1450,32 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
 
   merge-anything@5.1.7:
     resolution: {integrity: sha512-eRtbOb1N5iyH0tkQDAoQ4Ipsp/5qSR79Dzrz8hEPxRX10RWWR/iQXdoKmBSRCThY1Fh5EhISDtpSc93fpxUniQ==}
     engines: {node: '>=12.13'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   miniflare@4.20260508.0:
     resolution: {integrity: sha512-h3aG+PA8jEH76V4ZtBAbs3g7kjMfHJUF8hPvxeeajLTKwir+G+dqfBODg5yF9MT29LqrZKCRQRqzfHPWX4kCIg==}
@@ -1208,6 +1490,10 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   node-html-parser@7.1.0:
     resolution: {integrity: sha512-iJo8b2uYGT40Y8BTyy5ufL6IVbN8rbm/1QK2xffXU/1a/v3AAa0d1YAoqBNYqaS4R/HajkWIpIfdE6KcyFh1AQ==}
 
@@ -1217,8 +1503,23 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
@@ -1226,8 +1527,19 @@ packages:
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1239,6 +1551,10 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1247,9 +1563,25 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
@@ -1262,6 +1594,13 @@ packages:
     resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -1276,6 +1615,10 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   seroval-plugins@1.5.2:
     resolution: {integrity: sha512-qpY0Cl+fKYFn4GOf3cMiq6l72CpuVaawb6ILjubOQ+diJ54LfOWaSSPsaswN8DRPIPW4Yq+tE1k5aKd7ILyaFg==}
     engines: {node: '>=10'}
@@ -1286,9 +1629,40 @@ packages:
     resolution: {integrity: sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q==}
     engines: {node: '>=10'}
 
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -1307,6 +1681,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
@@ -1340,6 +1718,10 @@ packages:
     resolution: {integrity: sha512-yHBe+zVfzNZ3QfTPW/Z6KK1G2t340gFjMHqI/4KKSt/abzYydzuCnpqdaF5gCCABby+9Yfbj59oR5F2Fd5CBzg==}
     hasBin: true
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
@@ -1350,6 +1732,10 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -1367,11 +1753,19 @@ packages:
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite-plugin-solid@2.11.12:
     resolution: {integrity: sha512-FgjPcx2OwX9h6f28jli7A4bG7PP3te8uyakE5iqsmpq3Jqi1TWLgSroC9N6cMfGRU2zXsl4Q6ISvTr2VL0QHpA==}
@@ -1488,6 +1882,11 @@ packages:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -1507,6 +1906,9 @@ packages:
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   ws@8.18.0:
     resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
@@ -1535,6 +1937,11 @@ packages:
 
   youch@4.1.0-beta.10:
     resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -1678,7 +2085,17 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
+  '@cfworker/json-schema@4.1.1': {}
+
   '@chenglou/pretext@0.0.5': {}
+
+  '@cloudflare/codemode@0.3.8(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(zod@4.4.3)':
+    dependencies:
+      '@types/json-schema': 7.0.15
+      acorn: 8.16.0
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
+      zod: 4.4.3
 
   '@cloudflare/kv-asset-handler@0.5.0': {}
 
@@ -1909,6 +2326,18 @@ snapshots:
 
   '@exodus/bytes@1.15.1': {}
 
+  '@hono/mcp@0.3.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(hono-rate-limiter@0.5.3(hono@4.12.14))(hono@4.12.14)(zod@4.4.3)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
+      hono: 4.12.14
+      hono-rate-limiter: 0.5.3(hono@4.12.14)
+      pkce-challenge: 5.0.1
+      zod: 4.4.3
+
+  '@hono/node-server@1.19.14(hono@4.12.14)':
+    dependencies:
+      hono: 4.12.14
+
   '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
@@ -2028,6 +2457,30 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.14)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.14
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@poppinss/colors@4.1.6':
     dependencies:
@@ -2170,6 +2623,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/json-schema@7.0.15': {}
+
   '@vitest/expect@4.1.5':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -2211,6 +2666,24 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
+  acorn@8.16.0: {}
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   ansi-regex@5.0.1: {}
 
   ansi-styles@5.2.0: {}
@@ -2245,6 +2718,20 @@ snapshots:
 
   blake3-wasm@2.1.5: {}
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.2
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   boolbase@1.0.0: {}
 
   browserslist@4.28.2:
@@ -2255,13 +2742,46 @@ snapshots:
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
+  bytes@3.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
   caniuse-lite@1.0.30001788: {}
 
   chai@6.2.2: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
   convert-source-map@2.0.0: {}
 
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
   cookie@1.1.1: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
 
   css-select@5.2.2:
     dependencies:
@@ -2295,6 +2815,8 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  depd@2.0.0: {}
+
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
@@ -2319,7 +2841,17 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 5.0.3
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
   electron-to-chromium@1.5.340: {}
+
+  encodeurl@2.0.0: {}
 
   entities@4.5.0: {}
 
@@ -2329,7 +2861,15 @@ snapshots:
 
   error-stack-parser-es@1.0.5: {}
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@2.0.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -2391,22 +2931,121 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
 
+  etag@1.8.1: {}
+
+  eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
+
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.2
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.2: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   gensync@1.0.0-beta.2: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
+
+  gopd@1.2.0: {}
+
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
   he@1.2.0: {}
+
+  hono-rate-limiter@0.5.3(hono@4.12.14):
+    dependencies:
+      hono: 4.12.14
 
   hono@4.12.14: {}
 
@@ -2418,9 +3057,33 @@ snapshots:
 
   html-entities@2.3.3: {}
 
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  inherits@2.0.4: {}
+
+  ip-address@10.2.0: {}
+
+  ipaddr.js@1.9.1: {}
+
   is-potential-custom-element-name@1.0.1: {}
 
+  is-promise@4.0.0: {}
+
   is-what@4.1.16: {}
+
+  isexe@2.0.0: {}
+
+  jose@6.2.3: {}
 
   js-tokens@4.0.0: {}
 
@@ -2452,6 +3115,10 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
+
   json5@2.2.3: {}
 
   kleur@4.1.5: {}
@@ -2468,11 +3135,23 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  math-intrinsics@1.1.0: {}
+
   mdn-data@2.27.1: {}
+
+  media-typer@1.1.0: {}
 
   merge-anything@5.1.7:
     dependencies:
       is-what: 4.1.16
+
+  merge-descriptors@2.0.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   miniflare@4.20260508.0:
     dependencies:
@@ -2490,6 +3169,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  negotiator@1.0.0: {}
+
   node-html-parser@7.1.0:
     dependencies:
       css-select: 5.2.2
@@ -2501,7 +3182,19 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
   obug@2.1.1: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   parse5@7.3.0:
     dependencies:
@@ -2511,13 +3204,21 @@ snapshots:
     dependencies:
       entities: 8.0.0
 
+  parseurl@1.3.3: {}
+
+  path-key@3.1.1: {}
+
   path-to-regexp@6.3.0: {}
+
+  path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  pkce-challenge@5.0.1: {}
 
   postcss@8.5.10:
     dependencies:
@@ -2531,7 +3232,25 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   punycode@2.3.1: {}
+
+  qs@6.15.2:
+    dependencies:
+      side-channel: 1.1.0
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   react-is@17.0.2: {}
 
@@ -2568,6 +3287,18 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
+  safer-buffer@2.1.2: {}
+
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
@@ -2576,11 +3307,38 @@ snapshots:
 
   semver@7.7.4: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   seroval-plugins@1.5.2(seroval@1.5.2):
     dependencies:
       seroval: 1.5.2
 
   seroval@1.5.2: {}
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
 
   sharp@0.34.5:
     dependencies:
@@ -2613,6 +3371,40 @@ snapshots:
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
 
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   siginfo@2.0.0: {}
 
   solid-js@1.9.12:
@@ -2633,6 +3425,8 @@ snapshots:
   source-map-js@1.2.1: {}
 
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@4.1.0: {}
 
@@ -2657,6 +3451,8 @@ snapshots:
     dependencies:
       tldts-core: 7.4.0
 
+  toidentifier@1.0.1: {}
+
   tough-cookie@6.0.1:
     dependencies:
       tldts: 7.4.0
@@ -2668,6 +3464,12 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typescript@5.9.3: {}
 
   undici@7.24.8: {}
@@ -2678,11 +3480,15 @@ snapshots:
     dependencies:
       pathe: 2.0.3
 
+  unpipe@1.0.0: {}
+
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  vary@1.1.2: {}
 
   vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@6.4.2):
     dependencies:
@@ -2755,6 +3561,10 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
@@ -2785,6 +3595,8 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  wrappy@1.0.2: {}
+
   ws@8.18.0: {}
 
   xml-name-validator@5.0.0: {}
@@ -2805,5 +3617,9 @@ snapshots:
       '@speed-highlight/core': 1.2.15
       cookie: 1.1.1
       youch-core: 0.3.3
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
 
   zod@4.4.3: {}

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -8,6 +8,7 @@ import { AlignPage } from './AlignPage';
 import { SagesPage } from './SagesPage';
 import SettingsPage from './SettingsPage';
 import { AttributionsPage } from './AttributionsPage';
+import { McpPage } from './McpPage';
 
 function currentRoute() {
   // #sages/<slug> deep-links into SagesPage; treat the prefix as the route.
@@ -43,7 +44,11 @@ export default function App() {
           <Show when={route() === 'spike'} fallback={
             <Show when={route() === 'sages'} fallback={
               <Show when={route() === 'settings'} fallback={
-                <Show when={route() === 'about'} fallback={<DafViewer />}>
+                <Show when={route() === 'about'} fallback={
+                  <Show when={route() === 'mcp'} fallback={<DafViewer />}>
+                    <McpPage />
+                  </Show>
+                }>
                   <AttributionsPage />
                 </Show>
               }>

--- a/src/client/DafViewer.tsx
+++ b/src/client/DafViewer.tsx
@@ -2779,6 +2779,13 @@ export default function DafViewer(): JSX.Element {
         >
           {t('dev.alignmentDebug')}
         </a>
+        {' · '}
+        <a
+          href="#mcp"
+          style={{ color: 'inherit', 'text-decoration': 'none', 'border-bottom': '1px dotted #bbb' }}
+        >
+          {t('dev.mcpGuide')}
+        </a>
       </footer>
       </section>
       </div>

--- a/src/client/McpPage.tsx
+++ b/src/client/McpPage.tsx
@@ -1,0 +1,160 @@
+import { createSignal, For, Show, type JSX } from 'solid-js';
+
+/**
+ * Guide for connecting an MCP client (Claude Code / Desktop, etc.) to this app's
+ * hosted "code mode" MCP server at /mcp. Reached at #mcp, linked from the daf
+ * footer next to "Usage & reports" / "Alignment debug". Content is dev-facing
+ * (commands / JSON / code), so it stays in English like the credits page.
+ */
+
+const MCP_URL = 'https://talmud.shaunregenbaum.com/mcp';
+
+const CLAUDE_CODE_CMD = `claude mcp add --transport http talmud ${MCP_URL}`;
+
+const JSON_CONFIG = `{
+  "mcpServers": {
+    "talmud": {
+      "url": "${MCP_URL}"
+    }
+  }
+}`;
+
+const WORKED_EXAMPLE = `// Run inside the \`execute\` tool. One round trip:
+// fetch the daf, run a mark, poll until the anchors land.
+async () => {
+  const daf = await codemode.request({
+    method: "GET", path: "/api/daf/Berakhot/2a",
+  });
+
+  let run = await codemode.request({
+    method: "POST", path: "/api/studio/run",
+    body: { tractate: "Berakhot", page: "2a", mark_id: "argument-move" },
+  });
+  while (run.status === "pending") {
+    await new Promise((r) => setTimeout(r, 1500));
+    run = await codemode.request({
+      method: "GET",
+      path: \`/api/studio/run-status/\${run.runId}\`,
+      query: { k: run.cacheKey },
+    });
+  }
+
+  return {
+    segments: daf.mainSegmentsHe.length,
+    anchors: run.result?.parsed?.instances ?? run,
+  };
+}`;
+
+function CopyButton(props: { text: string }): JSX.Element {
+  const [copied, setCopied] = createSignal(false);
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        navigator.clipboard?.writeText(props.text).then(
+          () => { setCopied(true); setTimeout(() => setCopied(false), 1500); },
+          () => {},
+        );
+      }}
+      style={{
+        position: 'absolute', top: '0.5rem', right: '0.5rem',
+        'font-size': '0.7rem', padding: '0.15rem 0.5rem',
+        border: '1px solid #ccc', 'border-radius': '5px',
+        background: copied() ? '#2f7d32' : '#fff', color: copied() ? '#fff' : '#555',
+        cursor: 'pointer',
+      }}
+    >
+      {copied() ? 'copied' : 'copy'}
+    </button>
+  );
+}
+
+function Code(props: { children: string }): JSX.Element {
+  return (
+    <div style={{ position: 'relative', margin: '0.6rem 0 1.2rem' }}>
+      <CopyButton text={props.children} />
+      <pre style={{
+        margin: 0, padding: '0.9rem 1rem', 'padding-right': '3.5rem',
+        background: '#1e1e22', color: '#e6e6e6', 'border-radius': '8px',
+        overflow: 'auto', 'font-size': '0.8rem', 'line-height': 1.5,
+        'font-family': 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+      }}>
+        <code>{props.children}</code>
+      </pre>
+    </div>
+  );
+}
+
+const TOOLS = [
+  {
+    name: 'search',
+    blurb: 'Query the OpenAPI spec to discover endpoints — call codemode.spec() and filter it in code. No request leaves the sandbox.',
+  },
+  {
+    name: 'execute',
+    blurb: 'Run an async arrow function that calls codemode.request({ method, path, query, body }). Chain calls and poll inside one function; only the returned value comes back.',
+  },
+];
+
+export function McpPage(): JSX.Element {
+  return (
+    <main class="page-shell" style={{ '--page-max': '780px', 'font-family': 'system-ui, -apple-system, sans-serif', color: '#222' } as JSX.CSSProperties}>
+      <header style={{ 'margin-bottom': '1.25rem' }}>
+        <h1 style={{ margin: 0, 'font-size': '1.5rem' }}>Connect via MCP</h1>
+        <a href="#daf" style={{ color: '#666', 'font-size': '0.85rem', 'text-decoration': 'none' }}>← back to daf</a>
+      </header>
+
+      <p style={{ color: '#444', 'line-height': 1.6, 'margin-bottom': '1.25rem' }}>
+        This app hosts a <strong>Model Context Protocol</strong> server so an AI client can pull the
+        same data the daf page is built from — text, context, the marks/enrichments that produce the
+        anchors, rabbi data, and debug telemetry. It uses Cloudflare's <strong>code mode</strong>:
+        instead of dozens of separate tools you get just two — <code>search</code> and{' '}
+        <code>execute</code> — and the model writes small snippets that call the API and chain
+        results in a single round trip.
+      </p>
+
+      <h2 style={{ 'font-size': '1.05rem', 'margin-bottom': '0.4rem' }}>Endpoint</h2>
+      <Code>{MCP_URL}</Code>
+
+      <h2 style={{ 'font-size': '1.05rem', 'margin-bottom': '0.4rem' }}>Add it to Claude Code</h2>
+      <Code>{CLAUDE_CODE_CMD}</Code>
+
+      <h2 style={{ 'font-size': '1.05rem', 'margin-bottom': '0.4rem' }}>Or add it to any MCP client (JSON config)</h2>
+      <p style={{ color: '#555', 'font-size': '0.88rem', margin: '0 0 0.2rem' }}>
+        For Claude Desktop and other clients that take a streamable-HTTP server by URL:
+      </p>
+      <Code>{JSON_CONFIG}</Code>
+
+      <h2 style={{ 'font-size': '1.05rem', 'margin-bottom': '0.4rem' }}>The two tools</h2>
+      <For each={TOOLS}>
+        {(tool) => (
+          <p style={{ margin: '0 0 0.6rem', 'line-height': 1.55 }}>
+            <code style={{ background: '#f0f0f2', padding: '0.05rem 0.35rem', 'border-radius': '4px' }}>{tool.name}</code>
+            <span style={{ color: '#444', 'font-size': '0.9rem' }}> — {tool.blurb}</span>
+          </p>
+        )}
+      </For>
+
+      <h2 style={{ 'font-size': '1.05rem', 'margin': '1rem 0 0.4rem' }}>Worked example</h2>
+      <p style={{ color: '#555', 'font-size': '0.88rem', margin: '0 0 0.2rem' }}>
+        A daf page is text plus <em>marks</em> (structural extractors whose <code>excerpt</code>s are
+        the anchors) and <em>enrichments</em> (LLM passes on a mark instance). Marks/enrichments run
+        through <code>POST /api/studio/run</code>, which is async — poll{' '}
+        <code>/api/studio/run-status/&#123;runId&#125;</code> until it is done:
+      </p>
+      <Code>{WORKED_EXAMPLE}</Code>
+
+      <h2 style={{ 'font-size': '1.05rem', 'margin-bottom': '0.4rem' }}>Access</h2>
+      <p style={{ color: '#444', 'font-size': '0.9rem', 'line-height': 1.55, 'margin-bottom': '2rem' }}>
+        The endpoint is open and runs the public read-only subset: it can read everything and run the
+        registered marks/enrichments on real daf content (cached, default model). The sandbox has no
+        secrets and no outbound network of its own — its only access is the in-app API bridge. The
+        privileged <code>/api/studio/run</code> knobs (<code>ad_hoc</code>, <code>model_override</code>,{' '}
+        <code>bypass_cache</code>) require a studio secret; the owner can unlock them by adding an{' '}
+        <code>x-studio-secret</code> header in the client config (e.g.{' '}
+        <code>claude mcp add --transport http talmud {MCP_URL} --header "x-studio-secret: …"</code>).
+        Total AI spend is capped by a server-side budget guard.
+      </p>
+    </main>
+  );
+}

--- a/src/client/i18n.ts
+++ b/src/client/i18n.ts
@@ -118,6 +118,7 @@ const CATALOG = {
   },
   'dev.usageReports': { en: 'Usage & reports', he: 'שימוש ודוחות' },
   'dev.alignmentDebug': { en: 'Alignment debug', he: 'ניפוי יישור' },
+  'dev.mcpGuide': { en: 'Connect via MCP', he: 'חיבור דרך MCP' },
 
   // — Argument sidebar —
   'argument.title': { en: 'Argument', he: 'סוגיה' },

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -157,6 +157,10 @@ interface Bindings {
   // When '1', the background Sefaria Shas walk also enqueues rabbi.observations
   // per amud (full reverse-index backfill). OFF by default — see WarmEnv.
   OBSERVATIONS_WARM_SHAS?: string;
+  // Dynamic Worker Loader binding (wrangler.toml `worker_loaders`). Spins up the
+  // isolated sandbox the code-mode MCP `execute` tool runs in. Optional: when
+  // unset, GET/POST /mcp returns 503 and the rest of the worker is unaffected.
+  LOADER?: WorkerLoader;
   // Shared secret gating the privileged /api/studio/run knobs (ad_hoc,
   // model_override, bypass_cache) and the admin mutation endpoints. Presented
   // by trusted tools as the `x-studio-secret` header. UNSET => every request is
@@ -434,6 +438,60 @@ const STRATEGY_NAMES = [
 const app = new Hono<{ Bindings: Bindings }>();
 
 app.get('/api/health', (c) => c.json({ ok: true }));
+
+/**
+ * Code-mode MCP server (Streamable HTTP) at /mcp. Exposes two tools — `search`
+ * and `execute` — built from the curated OpenAPI spec (mcp-openapi.ts). The
+ * `execute` tool runs LLM-written code in an isolated sandbox (env.LOADER) whose
+ * only outside access is the `request` bridge below, which re-enters our own
+ * Hono app in-process for any /api/* path. The endpoint is public and gets the
+ * untrusted safe subset; a trusted operator can forward an `x-studio-secret`
+ * header on their MCP client to unlock the privileged /api/studio/run knobs.
+ */
+app.all('/mcp', async (c) => {
+  if (!c.env.LOADER) {
+    return c.json({ error: 'MCP unavailable: worker_loaders LOADER binding not configured' }, 503);
+  }
+  // Loaded lazily: @cloudflare/codemode imports `cloudflare:workers` (RpcTarget),
+  // which only resolves inside workerd. A static import would break the node
+  // unit tests that import this module (tests/*.test.ts -> src/worker/index).
+  const [{ StreamableHTTPTransport }, { buildCodeModeMcpServer }] = await Promise.all([
+    import('@hono/mcp'),
+    import('./mcp'),
+  ]);
+  const studioSecret = c.req.header('x-studio-secret');
+  const server = buildCodeModeMcpServer({
+    loader: c.env.LOADER,
+    request: async ({ method, path, query, body }) => {
+      if (typeof path !== 'string' || !path.startsWith('/api/')) {
+        return { error: 'request bridge only proxies /api/* paths' };
+      }
+      const u = new URL(path, 'http://internal');
+      if (query) {
+        for (const [k, v] of Object.entries(query)) {
+          if (v !== undefined) u.searchParams.set(k, String(v));
+        }
+      }
+      const headers: Record<string, string> = { 'content-type': 'application/json' };
+      if (studioSecret) headers['x-studio-secret'] = studioSecret;
+      try {
+        const res = await app.request(
+          u.pathname + u.search,
+          { method, headers, body: body == null || method === 'GET' ? undefined : JSON.stringify(body) },
+          c.env,
+        );
+        const text = await res.text();
+        try { return JSON.parse(text); } catch { return text; }
+      } catch (err) {
+        return { error: err instanceof Error ? err.message : String(err) };
+      }
+    },
+  });
+  const transport = new StreamableHTTPTransport();
+  await server.connect(transport);
+  const res = await transport.handleRequest(c);
+  return res ?? c.body(null, 204);
+});
 
 // AI Gateway smoke test. Reports gateway config + routes a tiny Kimi prompt
 // through whichever path is active (gateway when configured, else binding).

--- a/src/worker/mcp-openapi.ts
+++ b/src/worker/mcp-openapi.ts
@@ -1,0 +1,349 @@
+/**
+ * Curated OpenAPI 3.1 description of the Talmud app's HTTP API, consumed by the
+ * code-mode MCP server (src/worker/mcp.ts). The MCP `search` tool queries this
+ * spec to discover endpoints; the `execute` tool calls them through a host-side
+ * `request({ method, path, query, body })` bridge.
+ *
+ * Scope is the routes that go into building a daf page — text, context, the
+ * marks/enrichments that produce anchors, plus rabbi data and debug telemetry.
+ * The `execute` bridge can reach ANY `/api/*` route even if it isn't documented
+ * here; this spec just drives discovery.
+ *
+ * Keep descriptions tight: every byte is read by the model. When you add or
+ * rename an `/api/*` route worth surfacing, add it here too.
+ */
+
+const tractate = {
+  name: 'tractate',
+  in: 'path',
+  required: true,
+  schema: { type: 'string' },
+  description: 'Tractate name, capitalized (e.g. "Berakhot", "Pesachim").',
+} as const;
+
+const page = {
+  name: 'page',
+  in: 'path',
+  required: true,
+  schema: { type: 'string' },
+  description: 'Daf + amud, e.g. "2a", "2b", "14a".',
+} as const;
+
+const refresh = {
+  name: 'refresh',
+  in: 'query',
+  required: false,
+  schema: { type: 'string', enum: ['1'] },
+  description: 'Pass "1" to bypass the KV cache and refetch from source.',
+} as const;
+
+const slug = {
+  name: 'slug',
+  in: 'path',
+  required: true,
+  schema: { type: 'string' },
+  description: 'Rabbi slug (kebab-case canonical id, e.g. "rabbi-akiva"). Use /api/sages-index to discover slugs.',
+} as const;
+
+export const TALMUD_OPENAPI: Record<string, unknown> = {
+  openapi: '3.1.0',
+  info: {
+    title: 'Talmud Study App API',
+    version: '1.0.0',
+    description: [
+      'Read + debug the data behind talmud.shaunregenbaum.com.',
+      '',
+      'HOW A DAF PAGE IS BUILT (so you can reproduce/debug it):',
+      '1. GET /api/daf/{tractate}/{page} returns the segmented text:',
+      '   mainText {hebrew,english}, rashi, tosafot, and parallel',
+      '   mainSegmentsHe[] / mainSegmentsEn[] arrays (segment index = anchor coord).',
+      '2. MARKS are structural extractors that run over that text and return',
+      '   anchored instances: { instances: [{ excerpt, fields, ... }] }. The',
+      '   `excerpt` strings ARE the anchors highlighted on the page. There is no',
+      '   separate anchors endpoint. Mark ids include: rabbi, argument,',
+      '   argument-move, halacha, aggadata, pesukim, places, rishonim,',
+      '   rabbi.observations. List them with GET /api/studio/marks.',
+      '3. ENRICHMENTS are LLM passes that run ON a mark instance to produce the',
+      '   synthesized cards (e.g. explain an argument-move). List them with',
+      '   GET /api/studio/enrichments.',
+      '',
+      'RUNNING MARKS/ENRICHMENTS (the engine): POST /api/studio/run is the single',
+      'entry point. It is ASYNCHRONOUS:',
+      '  - On a cache hit it returns 200 { status: "ok", result }.',
+      '  - Otherwise it returns 202 { status: "pending", runId, cacheKey }; then',
+      '    poll GET /api/studio/run-status/{runId}?k={cacheKey} until you get',
+      '    200 { status: "ok", result } (it returns 202 { status: "pending" }',
+      '    while the job is still on the queue).',
+      'In code mode you can do this whole loop inside one `execute` call: run a',
+      'mark, take an instance from result.parsed.instances, then run an enrichment',
+      'with enrichment_id + mark_input = that instance, polling each time.',
+      '',
+      'AUTH: the MCP endpoint is public and gets the untrusted SAFE SUBSET — it',
+      'can read everything and run REGISTERED marks/enrichments on real daf',
+      'content (cached, default model). The privileged /api/studio/run knobs',
+      '(ad_hoc, model_override, bypass_cache) and admin mutation routes require a',
+      'studio secret; a trusted operator unlocks them by adding an',
+      '"x-studio-secret: <secret>" header to their MCP client config. Total LLM',
+      'spend is capped by a server-side budget guard.',
+    ].join('\n'),
+  },
+  servers: [{ url: 'https://talmud.shaunregenbaum.com', description: 'Production' }],
+  paths: {
+    '/api/health': {
+      get: { summary: 'Liveness check.', responses: { '200': { description: '{ ok: true }' } } },
+    },
+
+    '/api/daf/{tractate}/{page}': {
+      get: {
+        summary: 'Full daf text: Gemara + Rashi + Tosafot, segmented (he/en).',
+        description:
+          'Returns mainText {hebrew,english}, rashi/tosafot {hebrew,english,pieces?}, ' +
+          'parallel mainSegmentsHe[]/mainSegmentsEn[] (index = segment/anchor coord), ' +
+          '_source ("hebrewbooks"|"sefaria"), _cache.',
+        parameters: [
+          tractate,
+          page,
+          {
+            name: 'source',
+            in: 'query',
+            required: false,
+            schema: { type: 'string', enum: ['sefaria'] },
+            description: 'Force Sefaria as the base text instead of the default HebrewBooks.',
+          },
+        ],
+        responses: { '200': { description: 'TalmudPageData' } },
+      },
+    },
+
+    '/api/dafyomi/{tractate}/{page}': {
+      get: {
+        summary: 'Dafyomi.co.il study content for the daf (markdown + assets).',
+        parameters: [tractate, page, refresh],
+        responses: { '200': { description: 'Dafyomi study payload' } },
+      },
+    },
+
+    '/api/context/{tractate}/{page}': {
+      get: {
+        summary: 'Unified context pool: Sefaria commentary, mishnah, rishonim, halacha, topics.',
+        description: 'Returns { tractate, page, items: ContextItem[], fetchedAt }. Each item has a key, type, and text used as enrichment context.',
+        parameters: [tractate, page],
+        responses: { '200': { description: 'Context pool' } },
+      },
+    },
+
+    '/api/context/match': {
+      post: {
+        summary: 'AI-match context items to the daf segments they belong to.',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['tractate', 'page', 'items'],
+                properties: {
+                  tractate: { type: 'string' },
+                  page: { type: 'string' },
+                  items: {
+                    type: 'array',
+                    description: 'Context items (from /api/context) to anchor to segments.',
+                    items: { type: 'object', properties: { key: { type: 'string' }, type: { type: 'string' } } },
+                  },
+                },
+              },
+            },
+          },
+        },
+        responses: { '200': { description: '{ matches: SegMatch[], warning? }' } },
+      },
+    },
+
+    '/api/references/{tractate}/{page}': {
+      get: {
+        summary: 'Sefaria cross-references (links to/from other texts) grouped by work.',
+        parameters: [tractate, page, refresh],
+        responses: { '200': { description: '{ byWork: [...] }' } },
+      },
+    },
+
+    '/api/commentaries/{tractate}/{page}': {
+      get: {
+        summary: 'List Sefaria commentaries available for the daf.',
+        parameters: [tractate, page, refresh],
+        responses: { '200': { description: '{ works: [...] }' } },
+      },
+    },
+
+    '/api/studio/marks': {
+      get: {
+        summary: 'List all mark definitions (the structural extractors that produce anchors).',
+        responses: { '200': { description: '{ marks: MarkDefinition[] }' } },
+      },
+    },
+    '/api/studio/marks/{id}': {
+      get: {
+        summary: 'Get one mark definition by id.',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' }, description: 'Mark id, e.g. "argument-move".' }],
+        responses: { '200': { description: '{ mark: MarkDefinition }' }, '404': { description: 'unknown mark' } },
+      },
+    },
+
+    '/api/studio/enrichments': {
+      get: {
+        summary: 'List all enrichment definitions (LLM passes that run on a mark instance).',
+        responses: { '200': { description: '{ enrichments: EnrichmentDefinition[] }' } },
+      },
+    },
+    '/api/studio/enrichments/{id}': {
+      get: {
+        summary: 'Get one enrichment definition by id.',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        responses: { '200': { description: '{ enrichment: EnrichmentDefinition }' }, '404': { description: 'unknown enrichment' } },
+      },
+    },
+
+    '/api/studio/run': {
+      post: {
+        summary: 'Run a mark or enrichment for a daf. Async: cache hit => 200 result; else 202 { runId, cacheKey } to poll.',
+        description:
+          'Provide mark_id OR enrichment_id. For an enrichment, pass mark_input = ' +
+          'the specific mark instance to run it on. ad_hoc / model_override / ' +
+          'bypass_cache are privileged and need the x-studio-secret header.',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['tractate', 'page'],
+                properties: {
+                  tractate: { type: 'string' },
+                  page: { type: 'string' },
+                  mark_id: { type: 'string', description: 'Run a mark, e.g. "argument-move".' },
+                  enrichment_id: { type: 'string', description: 'Run an enrichment (usually with mark_input).' },
+                  mark_input: { type: 'object', description: 'The mark instance to enrich (from a prior mark run).' },
+                  user_question: { type: 'string', description: 'Free-text question for Q&A-style enrichments.' },
+                  lang: { type: 'string', enum: ['en', 'he'], description: 'Output language (default en).' },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          '200': { description: '{ status: "ok", result: RunResult }' },
+          '202': { description: '{ status: "pending", runId, cacheKey }' },
+        },
+      },
+    },
+    '/api/studio/run-status/{runId}': {
+      get: {
+        summary: 'Poll a queued run. 202 { status: "pending" } while running; 200 { status: "ok", result } when done.',
+        parameters: [
+          { name: 'runId', in: 'path', required: true, schema: { type: 'string' }, description: 'runId from POST /api/studio/run.' },
+          { name: 'k', in: 'query', required: false, schema: { type: 'string' }, description: 'cacheKey fallback returned by POST /api/studio/run.' },
+        ],
+        responses: { '200': { description: '{ status: "ok", result }' }, '202': { description: '{ status: "pending" }' } },
+      },
+    },
+
+    '/api/sages-index': {
+      get: { summary: 'Index of all sages: { sages: [{ slug, name, nameHe, aliases }] }.', responses: { '200': { description: 'sages index' } } },
+    },
+    '/api/rabbi/{slug}': {
+      get: {
+        summary: 'Static rabbi record: name, generation, region, places, bio.',
+        parameters: [slug],
+        responses: { '200': { description: '{ rabbi: {...} }' } },
+      },
+    },
+    '/api/rabbi-observations/{slug}': {
+      get: {
+        summary: 'Reverse index of every daf where this rabbi appears, by observation type.',
+        parameters: [
+          slug,
+          { name: 'type', in: 'query', required: false, schema: { type: 'string' }, description: 'Filter to one observation type (place, opinion, story, exegesis, lineage).' },
+          { name: 'min', in: 'query', required: false, schema: { type: 'integer' }, description: 'Minimum daf count to include an aggregated observation.' },
+        ],
+        responses: { '200': { description: '{ observations, aggregated, byType }' } },
+      },
+    },
+
+    '/api/mesorah/{tractate}/{page}': {
+      get: {
+        summary: 'Teacher -> student lineage chains for the sages on this daf.',
+        parameters: [
+          tractate,
+          page,
+          refresh,
+          { name: 'depth', in: 'query', required: false, schema: { type: 'integer', minimum: 1, maximum: 10 }, description: 'Walk depth (default 3).' },
+        ],
+        responses: { '200': { description: '{ chains: {...} }' } },
+      },
+    },
+    '/api/region/{tractate}/{page}': {
+      get: {
+        summary: 'Geographic distribution (Israel vs Babylon) of the sages on this daf.',
+        parameters: [tractate, page, refresh],
+        responses: { '200': { description: '{ distribution, migrated, sections }' } },
+      },
+    },
+
+    '/api/translate': {
+      post: {
+        summary: 'Context-aware translation of a Talmudic Hebrew/Aramaic word or phrase.',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['word', 'tractate', 'page'],
+                properties: {
+                  word: { type: 'string' },
+                  tractate: { type: 'string' },
+                  page: { type: 'string' },
+                  hebrewBefore: { type: 'string', description: 'Preceding context for disambiguation.' },
+                  hebrewAfter: { type: 'string', description: 'Following context.' },
+                  segIdx: { type: 'integer' },
+                },
+              },
+            },
+          },
+        },
+        responses: { '200': { description: '{ translation, cached }' } },
+      },
+    },
+    '/api/pasuk': {
+      get: {
+        summary: 'Fetch a single Tanakh verse (Hebrew + English).',
+        parameters: [{ name: 'ref', in: 'query', required: true, schema: { type: 'string' }, description: 'Sefaria-style ref, e.g. "Genesis 1:1".' }],
+        responses: { '200': { description: '{ ref, he, en, ... }' } },
+      },
+    },
+
+    '/api/usage': {
+      get: {
+        summary: 'Usage + performance rollups per endpoint / mark / enrichment, plus recent errors.',
+        responses: { '200': { description: '{ perEndpoint, perMark, perEnrichment, recentErrors }' } },
+      },
+    },
+    '/api/admin/recent-errors': {
+      get: {
+        summary: 'Recent queue-job failures (marks/enrichments that errored). Read-only, public.',
+        parameters: [
+          { name: 'id', in: 'query', required: false, schema: { type: 'string' }, description: 'Filter by mark/enrichment id.' },
+          { name: 'tractate', in: 'query', required: false, schema: { type: 'string' } },
+          { name: 'limit', in: 'query', required: false, schema: { type: 'integer' } },
+        ],
+        responses: { '200': { description: '{ count, errors: [...] }' } },
+      },
+    },
+    '/api/admin/cache-stats': {
+      get: { summary: 'KV cache hit/miss rates across buckets.', responses: { '200': { description: 'cache stats' } } },
+    },
+    '/api/log/recent': {
+      get: { summary: 'Recent client-side log records (last ~500).', responses: { '200': { description: '{ logs: [...] }' } } },
+    },
+  },
+};

--- a/src/worker/mcp.ts
+++ b/src/worker/mcp.ts
@@ -1,0 +1,40 @@
+/**
+ * Code-mode MCP server for the Talmud app.
+ *
+ * Instead of exposing ~30 endpoints as ~30 MCP tools, this exposes Cloudflare's
+ * "code mode" surface — two tools, `search` and `execute`:
+ *   - `search`  lets the model query the OpenAPI spec (src/worker/mcp-openapi.ts)
+ *               to discover endpoints.
+ *   - `execute` runs model-written TypeScript in an isolated Worker (spun up via
+ *               env.LOADER) that can call those endpoints and chain/poll in one
+ *               round trip, returning only the final result.
+ *
+ * The sandbox has no env/secrets and no outbound network: its only access to the
+ * outside is the host-side `request` bridge passed in by the caller (the /mcp
+ * route in index.ts), which proxies to our own /api/* routes. Auth headers never
+ * enter the sandbox.
+ */
+
+import { DynamicWorkerExecutor } from '@cloudflare/codemode';
+import { openApiMcpServer, type RequestOptions } from '@cloudflare/codemode/mcp';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { TALMUD_OPENAPI } from './mcp-openapi';
+
+export interface CodeModeMcpOptions {
+  /** wrangler.toml `worker_loaders` binding — the sandbox runtime. */
+  loader: WorkerLoader;
+  /** Host-side bridge the sandbox calls; proxies to our own /api/* routes. */
+  request: (options: RequestOptions) => Promise<unknown>;
+}
+
+/** Build the search+execute MCP server. One per request (stateless). */
+export function buildCodeModeMcpServer(opts: CodeModeMcpOptions): McpServer {
+  const executor = new DynamicWorkerExecutor({ loader: opts.loader });
+  return openApiMcpServer({
+    spec: TALMUD_OPENAPI,
+    executor,
+    request: opts.request,
+    name: 'talmud',
+    version: '1.0.0',
+  });
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,6 +3,12 @@ main = "src/worker/index.ts"
 compatibility_date = "2025-04-01"
 compatibility_flags = ["nodejs_compat"]
 
+# Dynamic Worker Loader — powers the code-mode MCP server at /mcp. The `execute`
+# tool runs LLM-written code in an isolated worker spun up via env.LOADER; the
+# sandbox has no env/secrets and no outbound network (its only host access is the
+# /api request bridge in src/worker/mcp.ts). See @cloudflare/codemode.
+worker_loaders = [{ binding = "LOADER" }]
+
 # Custom production domain. Requires shaunregenbaum.com to be an active zone
 # on the same Cloudflare account (PropheX) that `wrangler whoami` reports.
 routes = [


### PR DESCRIPTION
## Summary
- Adds a hosted **Cloudflare code-mode MCP server** at `/mcp` so an MCP client (Claude Code / Desktop, etc.) can pull the data behind a daf page — text, context, the marks/enrichments that produce anchors, rabbi data, and debug telemetry.
- **Code mode** = two tools instead of ~30: `search` (query a curated OpenAPI spec) and `execute` (run model-written TS that calls the API and chains/polls in one round trip). `execute` runs in a **Worker Loader sandbox** (`worker_loaders` `LOADER` binding) with no env/secrets and no outbound network — its only host access is an in-process `/api/*` bridge.
- **Open + untrusted by default**: anonymous callers get the public safe subset (read everything + run registered marks/enrichments, cached, default model). The privileged `/api/studio/run` knobs (`ad_hoc`, `model_override`, `bypass_cache`) stay gated by `STUDIO_SECRET`; a trusted operator can forward an `x-studio-secret` header from their MCP client to unlock them. LLM spend stays bounded by the existing budget guard.
- Adds a `#mcp` guide page (linked from the daf footer next to *Usage & reports · Alignment debug*) with the endpoint URL, copy-paste setup for Claude Code and generic JSON clients, the two-tool explanation, and a worked run -> poll example.

## Implementation
- New `src/worker/mcp.ts` (builds the `openApiMcpServer` + `DynamicWorkerExecutor`) and `src/worker/mcp-openapi.ts` (curated spec covering the daf-building routes; `info.description` explains marks/enrichments/anchors + the async run -> poll pattern).
- `/mcp` route in `src/worker/index.ts` mounts `@hono/mcp`'s `StreamableHTTPTransport`. The MCP machinery is **dynamically imported** inside the handler so importing `src/worker/index` from the node unit tests never pulls `cloudflare:workers`.
- New deps: `@cloudflare/codemode`, `@modelcontextprotocol/sdk`, `@hono/mcp`, `hono-rate-limiter`, `@cfworker/json-schema`.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 53 files / 1165 tests pass
- [x] `pnpm build` (worker + client) succeeds
- [x] Local `wrangler dev` smoke test: `tools/list` returns `search` + `execute`; `execute` runs in the sandbox and fetches a real daf (Berakhot 2a) + chains multiple `/api` calls; `search` reads the 24-path spec; untrusted `ad_hoc` is rejected with "requires studio auth"
- [ ] Interactive browser render of `#mcp` (blocked locally by a contended shared browser profile; verified via production build + typecheck)
- [ ] Post-deploy: confirm `worker_loaders` is enabled on the production account and point a live MCP client at `https://talmud.shaunregenbaum.com/mcp`