### PR TITLE
Tidy dev panels: collapse AI queue, cache-aware marks, unified inspector

### DIFF
--- a/src/client/AIActivityPanel.tsx
+++ b/src/client/AIActivityPanel.tsx
@@ -3,14 +3,15 @@
  * `aiActivity` store. Renders one row per active or recently-completed
  * entry, with a state-specific indicator on the left:
  *   - loading: spinning red dot          + "running 4.2s" ticker
- *   - queued:  pulsing amber dot, dim    + "waited 12s" ticker
- *              (in the FIFO, no slot yet — visually clearly NOT active)
  *   - ok:      green check               + final "1.1s"
  *   - error:   red ✗                     + "error"
  *
+ * Queued entries are collapsed into a single "N queued" summary row (a
+ * cold daf enqueues dozens at once, which otherwise buries the handful
+ * actually running). Click the summary to expand the full FIFO list.
+ *
  * Mounted in DevModeShelf above the marks panel so dev-mode users see a
- * heartbeat for what the worker is chewing on. Could also be promoted to
- * the main header later for production users — for now it's dev-scoped.
+ * heartbeat for what the worker is chewing on.
  */
 
 import { createMemo, createSignal, For, Show, onCleanup, type JSX } from 'solid-js';
@@ -22,35 +23,96 @@ function fmtMs(ms: number): string {
 }
 
 export default function AIActivityPanel(): JSX.Element {
-  // Tick once a second so the "running 4.2s" / "waited 12s" badges update
-  // on loading + queued entries. Cleanup on unmount.
+  // Tick once a second so the "running 4.2s" / queued-wait badges update.
   const [now, setNow] = createSignal(Date.now());
   const interval = setInterval(() => setNow(Date.now()), 1000);
   onCleanup(() => clearInterval(interval));
 
-  // Single sort key across all states: loading first (eye lands on what's
-  // actually working), queued next in FIFO order (next-up at the top),
-  // then most-recent completions.
-  const rows = createMemo<ActivityEntry[]>(() => {
-    const stateRank = (e: ActivityEntry): number => {
-      if (e.state.kind === 'loading') return 0;
-      if (e.state.kind === 'queued') return 1;
-      return 2;
+  const [showQueued, setShowQueued] = createSignal(false);
+
+  // Partition into loading (active) / queued (waiting on a slot) / terminal
+  // (recently finished, still lingering). Order top-to-bottom by lifecycle:
+  // running → waiting → done.
+  const groups = createMemo(() => {
+    const all = Object.values(aiActivity());
+    const startedAt = (e: ActivityEntry) =>
+      e.state.kind === 'loading' || e.state.kind === 'ok' || e.state.kind === 'error' ? e.state.startedAt : 0;
+    const enqueuedAt = (e: ActivityEntry) => (e.state.kind === 'queued' ? e.state.enqueuedAt : 0);
+    const finishedAt = (e: ActivityEntry) =>
+      e.state.kind === 'ok' || e.state.kind === 'error' ? e.state.finishedAt : 0;
+    return {
+      loading: all.filter((e) => e.state.kind === 'loading').sort((a, b) => startedAt(a) - startedAt(b)),
+      queued: all.filter((e) => e.state.kind === 'queued').sort((a, b) => enqueuedAt(a) - enqueuedAt(b)),
+      terminal: all.filter((e) => e.state.kind === 'ok' || e.state.kind === 'error').sort((a, b) => finishedAt(b) - finishedAt(a)),
     };
-    const tieBreaker = (e: ActivityEntry): number => {
-      if (e.state.kind === 'loading') return -e.state.startedAt;
-      if (e.state.kind === 'queued') return e.state.enqueuedAt;
-      return -e.state.finishedAt;
-    };
-    return Object.values(aiActivity()).sort((a, b) => {
-      const r = stateRank(a) - stateRank(b);
-      if (r !== 0) return r;
-      return tieBreaker(a) - tieBreaker(b);
-    });
   });
 
+  // Oldest queued wait — surfaced on the summary row so a stalled queue
+  // (jobs sitting for minutes) is obvious at a glance.
+  const oldestQueuedWait = createMemo(() => {
+    const q = groups().queued;
+    if (q.length === 0) return 0;
+    const oldest = Math.min(...q.map((e) => (e.state.kind === 'queued' ? e.state.enqueuedAt : Date.now())));
+    return now() - oldest;
+  });
+
+  const total = createMemo(() => {
+    const g = groups();
+    return g.loading.length + g.queued.length + g.terminal.length;
+  });
+
+  const renderEntry = (entry: ActivityEntry): JSX.Element => {
+    const state = entry.state;
+    if (state.kind === 'loading') {
+      const elapsed = () => now() - state.startedAt;
+      return (
+        <div style={{ display: 'flex', 'align-items': 'center', gap: '0.4rem', padding: '0.15rem 0' }}>
+          <span style={{
+            display: 'inline-block', width: '0.7rem', height: '0.7rem',
+            'border-radius': '50%',
+            border: '2px solid #d6d3d1', 'border-top-color': '#8a2a2b',
+            animation: 'daf-spin 0.8s linear infinite',
+            'flex-shrink': 0,
+          }} />
+          <span style={{ flex: 1, 'min-width': 0, 'white-space': 'nowrap', 'text-overflow': 'ellipsis', overflow: 'hidden' }}>{entry.label}</span>
+          <span style={{ color: '#888', 'font-variant-numeric': 'tabular-nums', 'flex-shrink': 0 }}>{fmtMs(elapsed())}</span>
+        </div>
+      );
+    }
+    if (state.kind === 'queued') {
+      const waited = () => now() - state.enqueuedAt;
+      return (
+        <div style={{ display: 'flex', 'align-items': 'center', gap: '0.4rem', padding: '0.15rem 0 0.15rem 1rem', color: '#9a8b6f' }}>
+          <span style={{
+            display: 'inline-block', width: '0.45rem', height: '0.45rem',
+            'border-radius': '50%', background: '#f59e0b', 'flex-shrink': 0,
+          }} />
+          <span style={{ flex: 1, 'min-width': 0, 'white-space': 'nowrap', 'text-overflow': 'ellipsis', overflow: 'hidden', 'font-size': '0.72rem' }}>{entry.label}</span>
+          <span style={{ color: '#b8a98c', 'font-variant-numeric': 'tabular-nums', 'font-size': '0.7rem', 'flex-shrink': 0 }}>{fmtMs(waited())}</span>
+        </div>
+      );
+    }
+    if (state.kind === 'ok') {
+      const totalMs = state.finishedAt - state.startedAt;
+      return (
+        <div style={{ display: 'flex', 'align-items': 'center', gap: '0.4rem', padding: '0.15rem 0', color: '#444' }}>
+          <span style={{ color: '#15803d', 'flex-shrink': 0 }}>✓</span>
+          <span style={{ flex: 1, 'min-width': 0, 'white-space': 'nowrap', 'text-overflow': 'ellipsis', overflow: 'hidden' }}>{entry.label}</span>
+          <span style={{ color: '#888', 'font-variant-numeric': 'tabular-nums', 'flex-shrink': 0 }}>{fmtMs(totalMs)}</span>
+        </div>
+      );
+    }
+    return (
+      <div style={{ display: 'flex', 'align-items': 'center', gap: '0.4rem', padding: '0.15rem 0', color: '#c00' }}>
+        <span style={{ 'flex-shrink': 0 }}>✗</span>
+        <span style={{ flex: 1, 'min-width': 0, 'white-space': 'nowrap', 'text-overflow': 'ellipsis', overflow: 'hidden' }} title={state.error}>{entry.label}</span>
+        <span style={{ color: '#888', 'font-size': '0.7rem', 'flex-shrink': 0 }}>error</span>
+      </div>
+    );
+  };
+
   return (
-    <Show when={rows().length > 0}>
+    <Show when={total() > 0}>
       <div style={{
         border: '1px solid #eee',
         'border-radius': '4px',
@@ -66,70 +128,35 @@ export default function AIActivityPanel(): JSX.Element {
           color: '#888',
           'margin-bottom': '0.3rem',
         }}>AI activity</div>
-        <For each={rows()}>{(entry) => {
-          const state = entry.state;
-          if (state.kind === 'loading') {
-            const elapsed = () => now() - state.startedAt;
-            return (
-              <div style={{ display: 'flex', 'align-items': 'center', gap: '0.4rem', padding: '0.15rem 0' }}>
-                <span style={{
-                  display: 'inline-block', width: '0.7rem', height: '0.7rem',
-                  'border-radius': '50%',
-                  border: '2px solid #d6d3d1', 'border-top-color': '#8a2a2b',
-                  animation: 'daf-spin 0.8s linear infinite',
-                  'flex-shrink': 0,
-                }} />
-                <span style={{ flex: 1, 'min-width': 0, 'white-space': 'nowrap', 'text-overflow': 'ellipsis', overflow: 'hidden' }}>{entry.label}</span>
-                <span style={{ color: '#888', 'font-variant-numeric': 'tabular-nums', 'flex-shrink': 0 }}>{fmtMs(elapsed())}</span>
-              </div>
-            );
-          }
-          if (state.kind === 'queued') {
-            const waited = () => now() - state.enqueuedAt;
-            return (
-              <div style={{ display: 'flex', 'align-items': 'center', gap: '0.4rem', padding: '0.15rem 0', color: '#9a8b6f' }}>
-                {/* Solid amber dot (no spin) — visually distinct from the
-                    loading spinner. Pulses gently so the user can tell it's
-                    a live "waiting" indicator rather than a stale row. */}
-                <span style={{
-                  display: 'inline-block', width: '0.55rem', height: '0.55rem',
-                  'border-radius': '50%',
-                  background: '#f59e0b',
-                  'flex-shrink': 0,
-                  animation: 'daf-pulse 1.6s ease-in-out infinite',
-                }} title="queued — waiting on a concurrency slot" />
-                <span style={{ flex: 1, 'min-width': 0, 'white-space': 'nowrap', 'text-overflow': 'ellipsis', overflow: 'hidden' }}>{entry.label}</span>
-                <span style={{
-                  color: '#b8a98c',
-                  'font-variant-numeric': 'tabular-nums',
-                  'font-size': '0.7rem',
-                  'flex-shrink': 0,
-                  'text-transform': 'uppercase',
-                  'letter-spacing': '0.04em',
-                  'margin-right': '0.15rem',
-                }}>queued</span>
-                <span style={{ color: '#b8a98c', 'font-variant-numeric': 'tabular-nums', 'font-size': '0.72rem', 'flex-shrink': 0 }}>{fmtMs(waited())}</span>
-              </div>
-            );
-          }
-          if (state.kind === 'ok') {
-            const total = state.finishedAt - state.startedAt;
-            return (
-              <div style={{ display: 'flex', 'align-items': 'center', gap: '0.4rem', padding: '0.15rem 0', color: '#444' }}>
-                <span style={{ color: '#15803d', 'flex-shrink': 0 }}>✓</span>
-                <span style={{ flex: 1, 'min-width': 0, 'white-space': 'nowrap', 'text-overflow': 'ellipsis', overflow: 'hidden' }}>{entry.label}</span>
-                <span style={{ color: '#888', 'font-variant-numeric': 'tabular-nums', 'flex-shrink': 0 }}>{fmtMs(total)}</span>
-              </div>
-            );
-          }
-          return (
-            <div style={{ display: 'flex', 'align-items': 'center', gap: '0.4rem', padding: '0.15rem 0', color: '#c00' }}>
-              <span style={{ 'flex-shrink': 0 }}>✗</span>
-              <span style={{ flex: 1, 'min-width': 0, 'white-space': 'nowrap', 'text-overflow': 'ellipsis', overflow: 'hidden' }} title={state.error}>{entry.label}</span>
-              <span style={{ color: '#888', 'font-size': '0.7rem', 'flex-shrink': 0 }}>error</span>
-            </div>
-          );
-        }}</For>
+
+        {/* Active work first */}
+        <For each={groups().loading}>{(entry) => renderEntry(entry)}</For>
+
+        {/* Queued — collapsed to a single count by default. */}
+        <Show when={groups().queued.length > 0}>
+          <div
+            onClick={() => setShowQueued((v) => !v)}
+            title={showQueued() ? 'Hide queued' : 'Show queued'}
+            style={{ display: 'flex', 'align-items': 'center', gap: '0.4rem', padding: '0.15rem 0', cursor: 'pointer', color: '#9a8b6f' }}
+          >
+            <span style={{
+              display: 'inline-block', width: '0.55rem', height: '0.55rem',
+              'border-radius': '50%', background: '#f59e0b', 'flex-shrink': 0,
+              animation: 'daf-pulse 1.6s ease-in-out infinite',
+            }} />
+            <span style={{ flex: 1, 'min-width': 0 }}>
+              {groups().queued.length} queued
+              <span style={{ color: '#888', 'font-size': '0.7rem' }}> {showQueued() ? '▾' : '▸'}</span>
+            </span>
+            <span style={{ color: '#b8a98c', 'font-variant-numeric': 'tabular-nums', 'font-size': '0.72rem', 'flex-shrink': 0 }}>{fmtMs(oldestQueuedWait())}</span>
+          </div>
+          <Show when={showQueued()}>
+            <For each={groups().queued}>{(entry) => renderEntry(entry)}</For>
+          </Show>
+        </Show>
+
+        {/* Recently finished */}
+        <For each={groups().terminal}>{(entry) => renderEntry(entry)}</For>
       </div>
     </Show>
   );

--- a/src/client/InstanceInspectorShelf.tsx
+++ b/src/client/InstanceInspectorShelf.tsx
@@ -10,7 +10,7 @@
  * handler enforces single-open by setting a module-level signal).
  */
 
-import { createSignal, For, Show, type JSX } from 'solid-js';
+import { For, Show, type JSX } from 'solid-js';
 
 interface EnrichmentDef {
   id: string;
@@ -31,6 +31,7 @@ interface RunResult {
   transport?: string;
   attempts?: number;
   elapsed_ms?: number;
+  cache_hit?: boolean;
   resolved?: { system_prompt: string; user_prompt: string };
   deps_resolved?: Record<string, unknown>;
   anchors_resolved?: Record<string, unknown>;
@@ -57,15 +58,23 @@ interface Props {
   onClose: () => void;
 }
 
-type Tab = 'synthesis' | 'prompts' | 'telemetry';
-
 export default function InstanceInspectorShelf(props: Props) {
-  const [tab, setTab] = createSignal<Tab>('synthesis');
-
   const result = (): RunResult | null =>
     props.currentRun.kind === 'ok' ? props.currentRun.result : null;
   const errorMsg = (): string | null =>
     props.currentRun.kind === 'error' ? props.currentRun.error : null;
+
+  // Compact one-line telemetry — everything tied to this single run, so it
+  // sits with the generation instead of behind a separate tab. On a cache
+  // hit total_ms is 0, so report the persisted generation time (elapsed_ms).
+  const metaLine = (r: RunResult): string => {
+    const parts = [r.model, r.cache_hit ? 'cached' : 'fresh'];
+    if (typeof r.elapsed_ms === 'number') parts.push(`gen ${r.elapsed_ms}ms`);
+    const tok = r.usage?.total_tokens;
+    if (typeof tok === 'number') parts.push(`${tok} tok`);
+    if (typeof r.usage?.cost === 'number') parts.push(`$${r.usage.cost.toFixed(6)}`);
+    return parts.join(' · ');
+  };
 
   return (
     <div style={{
@@ -94,14 +103,6 @@ export default function InstanceInspectorShelf(props: Props) {
       }}>
         <strong>{props.instanceLabel}</strong>
         <code style={{ color: '#888', 'font-size': '0.75rem' }}>{props.markId}</code>
-        <Show when={result()}>{(r) => (
-          <span style={{ color: '#666', 'font-size': '0.75rem', 'font-family': 'ui-monospace, Menlo, monospace' }}>
-            {r().model} · {r().total_ms}ms
-            <Show when={r().usage?.cost}>
-              {' '}· ${(r().usage?.cost ?? 0).toFixed(6)}
-            </Show>
-          </span>
-        )}</Show>
         <Show when={errorMsg()}>
           <span style={{ 'font-size': '0.75rem', color: '#c00' }}>✗ failed</span>
         </Show>
@@ -113,27 +114,9 @@ export default function InstanceInspectorShelf(props: Props) {
         </button>
       </div>
 
-      {/* Tabs */}
-      <div style={{ display: 'flex', 'border-bottom': '1px solid #eee', background: '#fafafa' }}>
-        <For each={(['synthesis', 'prompts', 'telemetry'] as const)}>{(t) => (
-          <button
-            onClick={() => setTab(t)}
-            style={{
-              padding: '6px 14px',
-              'font-size': '13px',
-              border: 0,
-              'border-bottom': tab() === t ? '2px solid #000' : '2px solid transparent',
-              background: 'transparent',
-              cursor: 'pointer',
-              'font-weight': tab() === t ? 600 : 400,
-            }}
-          >
-            {t}
-          </button>
-        )}</For>
-      </div>
-
-      {/* Body */}
+      {/* Body — one unified view: view picker + built-from, a compact
+          telemetry line, the generation, then collapsible prompt + raw
+          telemetry. Everything here belongs to the single selected run. */}
       <div style={{ flex: 1, 'overflow-y': 'auto', padding: '0.75rem' }}>
         <Show when={errorMsg()}>{(msg) => (
           <div style={{ background: '#fee', color: '#900', padding: '0.6rem', 'border-radius': '4px', 'margin-bottom': '0.6rem', 'font-family': 'ui-monospace, Menlo, monospace', 'font-size': '12px' }}>
@@ -141,101 +124,101 @@ export default function InstanceInspectorShelf(props: Props) {
           </div>
         )}</Show>
 
-        <Show when={tab() === 'synthesis'}>
-          <div style={{ 'font-size': '0.72rem', color: '#888', display: 'flex', 'align-items': 'center', gap: '0.4rem', 'margin-bottom': '0.6rem' }}>
-            <span>view:</span>
-            <select
-              value={props.selected ?? ''}
-              onChange={(e) => props.onSelect(e.currentTarget.value || null)}
-              style={{ 'font-size': '0.78rem', padding: '2px 6px', 'font-family': 'inherit' }}
-            >
-              <Show when={props.aggregates.length > 0}>
-                <option value="">{`[${props.aggregates[0]?.scope ?? 'local'}] synthesis`}</option>
-              </Show>
-              <For each={props.leaves}>{(d) => (
-                <option value={d.id}>{`[${d.scope ?? 'global'}] ${props.prettyDepLabel(d.id)}`}</option>
-              )}</For>
-            </select>
-            <Show when={props.currentView?.mode === 'aggregate'}>
-              <span style={{ color: '#aaa' }}>aggregate</span>
+        {/* view picker + aggregate marker */}
+        <div style={{ 'font-size': '0.72rem', color: '#888', display: 'flex', 'align-items': 'center', gap: '0.4rem', 'margin-bottom': '0.5rem' }}>
+          <span>view:</span>
+          <select
+            value={props.selected ?? ''}
+            onChange={(e) => props.onSelect(e.currentTarget.value || null)}
+            style={{ 'font-size': '0.78rem', padding: '2px 6px', 'font-family': 'inherit' }}
+          >
+            <Show when={props.aggregates.length > 0}>
+              <option value="">{`[${props.aggregates[0]?.scope ?? 'local'}] synthesis`}</option>
             </Show>
-          </div>
-
-          <div style={{
-            background: '#fafafa',
-            border: '1px solid #eee',
-            'border-radius': '6px',
-            padding: '0.7rem 0.85rem',
-            'margin-bottom': '0.6rem',
-          }}>
-            {props.renderBody()}
-          </div>
-
-          <Show when={props.depBadges.length > 0}>
-            <div style={{
-              display: 'flex', gap: '0.3rem', 'align-items': 'center',
-              'flex-wrap': 'wrap',
-            }}>
-              <span style={{ 'font-size': '0.7rem', color: '#888' }}>built from</span>
-              <For each={props.depBadges}>{(depId) => (
-                <button
-                  onClick={() => props.onSelect(depId === props.currentView?.id ? null : depId)}
-                  title={`View ${depId}`}
-                  style={{
-                    padding: '2px 9px', 'font-size': '0.72rem', cursor: 'pointer',
-                    background: props.selected === depId ? '#000' : '#f0f0f0',
-                    color: props.selected === depId ? '#fff' : '#444',
-                    border: '1px solid #ddd', 'border-radius': '10px',
-                    'font-family': 'inherit',
-                  }}
-                >
-                  {props.prettyDepLabel(depId)}
-                </button>
-              )}</For>
-            </div>
+            <For each={props.leaves}>{(d) => (
+              <option value={d.id}>{`[${d.scope ?? 'global'}] ${props.prettyDepLabel(d.id)}`}</option>
+            )}</For>
+          </select>
+          <Show when={props.currentView?.mode === 'aggregate'}>
+            <span style={{ color: '#aaa' }}>aggregate</span>
           </Show>
+        </div>
+
+        {/* compact telemetry line for this run */}
+        <Show when={result()}>{(r) => (
+          <div style={{ 'font-size': '0.72rem', color: '#666', 'font-family': 'ui-monospace, Menlo, monospace', 'margin-bottom': '0.5rem' }}>
+            {metaLine(r())}
+          </div>
+        )}</Show>
+
+        {/* generation */}
+        <div style={{
+          background: '#fafafa',
+          border: '1px solid #eee',
+          'border-radius': '6px',
+          padding: '0.7rem 0.85rem',
+          'margin-bottom': '0.6rem',
+        }}>
+          {props.renderBody()}
+        </div>
+
+        <Show when={props.depBadges.length > 0}>
+          <div style={{
+            display: 'flex', gap: '0.3rem', 'align-items': 'center',
+            'flex-wrap': 'wrap', 'margin-bottom': '0.6rem',
+          }}>
+            <span style={{ 'font-size': '0.7rem', color: '#888' }}>built from</span>
+            <For each={props.depBadges}>{(depId) => (
+              <button
+                onClick={() => props.onSelect(depId === props.currentView?.id ? null : depId)}
+                title={`View ${depId}`}
+                style={{
+                  padding: '2px 9px', 'font-size': '0.72rem', cursor: 'pointer',
+                  background: props.selected === depId ? '#000' : '#f0f0f0',
+                  color: props.selected === depId ? '#fff' : '#444',
+                  border: '1px solid #ddd', 'border-radius': '10px',
+                  'font-family': 'inherit',
+                }}
+              >
+                {props.prettyDepLabel(depId)}
+              </button>
+            )}</For>
+          </div>
         </Show>
 
-        <Show when={tab() === 'prompts'}>
-          <Show when={result()?.resolved} fallback={
-            <div style={{ color: '#999', 'font-style': 'italic' }}>
-              {props.currentRun.kind === 'loading' ? 'Thinking…' : 'no run output yet (or this leaf is served from a cached parent — re-run via the marks panel to capture prompts)'}
-            </div>
-          }>{(resolved) => (
-            <>
-              <details open style={{ 'margin-bottom': '0.5rem' }}>
-                <summary style={{ color: '#666', cursor: 'pointer' }}>system_prompt</summary>
-                <pre style={{ 'white-space': 'pre-wrap', 'font-family': 'ui-monospace, Menlo, monospace', 'font-size': '12px', margin: '0.4rem 0 0', background: '#f8f8f8', padding: '0.6rem', 'border-radius': '3px' }}>
-                  {resolved().system_prompt}
-                </pre>
-              </details>
-              <details open>
-                <summary style={{ color: '#666', cursor: 'pointer' }}>user_prompt</summary>
-                <pre style={{ 'white-space': 'pre-wrap', 'font-family': 'ui-monospace, Menlo, monospace', 'font-size': '12px', margin: '0.4rem 0 0', background: '#f8f8f8', padding: '0.6rem', 'border-radius': '3px' }}>
-                  {resolved().user_prompt}
-                </pre>
-              </details>
-            </>
-          )}</Show>
-        </Show>
+        {/* prompt sent to the model — collapsed by default */}
+        <Show when={result()?.resolved}>{(resolved) => (
+          <details style={{ 'margin-bottom': '0.5rem' }}>
+            <summary style={{ color: '#666', cursor: 'pointer', 'font-size': '0.78rem' }}>prompt (system + user)</summary>
+            <div style={{ color: '#888', 'font-size': '0.7rem', margin: '0.4rem 0 0.1rem' }}>system</div>
+            <pre style={{ 'white-space': 'pre-wrap', 'font-family': 'ui-monospace, Menlo, monospace', 'font-size': '12px', margin: 0, background: '#f8f8f8', padding: '0.6rem', 'border-radius': '3px' }}>
+              {resolved().system_prompt}
+            </pre>
+            <div style={{ color: '#888', 'font-size': '0.7rem', margin: '0.5rem 0 0.1rem' }}>user</div>
+            <pre style={{ 'white-space': 'pre-wrap', 'font-family': 'ui-monospace, Menlo, monospace', 'font-size': '12px', margin: 0, background: '#f8f8f8', padding: '0.6rem', 'border-radius': '3px' }}>
+              {resolved().user_prompt}
+            </pre>
+          </details>
+        )}</Show>
 
-        <Show when={tab() === 'telemetry'}>
-          <Show when={result()} fallback={
-            <div style={{ color: '#999', 'font-style': 'italic' }}>no run output yet</div>
-          }>{(r) => (
-            <pre style={{ 'white-space': 'pre-wrap', 'font-family': 'ui-monospace, Menlo, monospace', 'font-size': '12px', margin: 0 }}>
+        {/* raw telemetry — collapsed by default */}
+        <Show when={result()}>{(r) => (
+          <details>
+            <summary style={{ color: '#666', cursor: 'pointer', 'font-size': '0.78rem' }}>raw telemetry</summary>
+            <pre style={{ 'white-space': 'pre-wrap', 'font-family': 'ui-monospace, Menlo, monospace', 'font-size': '12px', margin: '0.4rem 0 0' }}>
               {JSON.stringify({
                 model: r().model,
                 transport: r().transport,
                 attempts: r().attempts,
+                cache_hit: r().cache_hit,
                 elapsed_ms: r().elapsed_ms,
                 total_ms: r().total_ms,
                 usage: r().usage,
                 parse_error: r().parse_error,
               }, null, 2)}
             </pre>
-          )}</Show>
-        </Show>
+          </details>
+        )}</Show>
       </div>
     </div>
   );

--- a/src/client/MarksRegistryPanel.tsx
+++ b/src/client/MarksRegistryPanel.tsx
@@ -126,6 +126,10 @@ export interface RunResult {
   elapsed_ms: number;
   resolved: { system_prompt: string; user_prompt: string };
   total_ms: number;
+  /** True when the worker served this from the KV cache (no LLM call). On a
+   *  hit total_ms is injected as 0, but elapsed_ms still carries the original
+   *  generation time from when the result was first computed. */
+  cache_hit?: boolean;
 }
 
 export type RunState =
@@ -586,7 +590,7 @@ export default function MarksRegistryPanel(props: Props) {
         )}</Show>
 
         {/* Render a single Row (mark / seed / enrichment) with the
-            checkbox, status, re-run, etc. Used for both top-level marks
+            on/off switch, status, re-run, etc. Used for both top-level marks
             and the nested enrichments. */}
         {(() => {
           const renderRow = (row: Row, nested: boolean): JSX.Element => {
@@ -650,16 +654,23 @@ export default function MarksRegistryPanel(props: Props) {
                       }}
                     >{isExpanded() ? '▾' : '▸'}</button>
                   </Show>
-                  <input
-                    type="checkbox"
-                    checked={isOn()}
-                    onChange={(e) => setOn(e.currentTarget.checked)}
-                    style={{ cursor: 'pointer' }}
-                  />
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-checked={isOn()}
+                    onClick={() => setOn(!isOn())}
+                    title={isOn() ? 'turn off' : 'turn on'}
+                    style={{
+                      background: 'transparent', border: 'none', cursor: 'pointer',
+                      padding: 0, width: '0.9rem', 'flex-shrink': 0,
+                      color: isOn() ? '#444' : '#ccc', 'font-size': '0.7rem',
+                      'line-height': 1,
+                    }}
+                  >{isOn() ? '●' : '○'}</button>
                   <span style={{ 'font-weight': nested ? 400 : 500, 'font-size': nested ? '0.8rem' : '0.85rem' }}>
                     {label()}
                   </span>
-                  <span title={`${anchor()} · ${render()}`} style={{ color: '#aaa', 'font-size': '0.7rem', 'font-family': 'monospace' }}>
+                  <span title={`anchored on ${anchor()} · rendered ${render()}`} style={{ color: '#aaa', 'font-size': '0.7rem', 'font-family': 'monospace' }}>
                     {anchor()[0]}/{String(render())[0]}
                   </span>
                   <Show when={row.source !== 'seed' && isOn()}>
@@ -674,7 +685,15 @@ export default function MarksRegistryPanel(props: Props) {
                         }} />
                       </Show>
                       <Show when={state().kind === 'ok'}>
-                        <span>✓ {(state() as Extract<RunState, { kind: 'ok' }>).result.total_ms}ms</span>
+                        {(() => {
+                          const res = () => (state() as Extract<RunState, { kind: 'ok' }>).result;
+                          return (
+                            <Show when={res().cache_hit} fallback={<span>✓ {res().elapsed_ms}ms</span>}>
+                              <span style={{ 'font-size': '0.62rem', color: '#15803d', background: '#dcfce7', padding: '0 0.3rem', 'border-radius': '3px' }}>cached</span>
+                              <span style={{ color: '#888' }}>{res().elapsed_ms}ms</span>
+                            </Show>
+                          );
+                        })()}
                       </Show>
                       <Show when={state().kind === 'error'}>
                         <span>✗</span>
@@ -759,16 +778,17 @@ export default function MarksRegistryPanel(props: Props) {
         <div style={{ display: 'flex', gap: '0.4rem', 'margin-top': '0.4rem', 'flex-wrap': 'wrap' }}>
           <button
             onClick={() => refetchDefs()}
+            title="Re-fetch the mark/enrichment definitions from the server (use after editing a def). Does not re-run anything."
             style={{ padding: '2px 8px', 'font-size': '0.7rem', cursor: 'pointer', background: 'transparent', border: '1px solid #ddd', 'border-radius': '3px', color: '#888' }}
           >
-            refresh registry
+            reload defs
           </button>
           <button
             onClick={() => setRuns({})}
-            title="Clear cached run results so enabled marks re-fire (use after changing models / prompts)"
+            title="Clear cached results so every mark re-fetches for this daf (cache-respecting). For a true bypass-cache re-run of one mark, use its ↻."
             style={{ padding: '2px 8px', 'font-size': '0.7rem', cursor: 'pointer', background: 'transparent', border: '1px solid #ddd', 'border-radius': '3px', color: '#888' }}
           >
-            re-run all
+            refresh results
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
Cleans up the three dev-mode surfaces so they read at a glance.

- **AI Activity**: active runs render first; all queued work collapses into a single `N queued` line (click to expand the FIFO list). The oldest wait is shown on the summary so a stalled queue is obvious. Fixes the panel flooding when a cold daf fans out dozens of enrichments.
- **Marks**: the misleading `✓ 0ms` on cache hits is replaced by a `cached` badge + the real generation time (`elapsed_ms`, which the cached payload still carries). Per-row checkboxes become a subtle inline `●`/`○` switch. The `p/i`/`s/g` anchor codes keep a readable tooltip ("anchored on phrase · rendered inline"). The footer buttons are relabeled with clear tooltips: `refresh registry` → **reload defs**, `re-run all` → **refresh results**.
- **Inspector drawer**: the synthesis / prompts / telemetry tabs merge into one unified view — a compact `model · cached · gen Xms · N tok · $cost` line, the generation, then a collapsible prompt block and a collapsible raw-telemetry block. They all derive from one `RunResult`, so they now live together.

No worker/API changes — the worker already sends `cache_hit` and the persisted `elapsed_ms`; the client just surfaces them.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 1165 passed
- [x] Dev server boots; client + `/api/studio/marks` serve with no bundle errors
- [ ] Visual in-browser check of the three panels on a real daf (blocked locally: another agent held the shared Chrome DevTools profile — worth an eyeball before/after merge)