### PR TITLE
Email a spend alert when a daily/hourly LLM budget cap trips

### DIFF
--- a/src/worker/budget.ts
+++ b/src/worker/budget.ts
@@ -33,6 +33,12 @@
 import { costUsd, type TokenUsage } from './pricing';
 import { LLMError, NEITHER } from './llm-error';
 
+/** Minimal Cloudflare Email-send binding (send_email). Structurally compatible
+ *  with the one in warm-cron.ts and the EMAIL binding in wrangler.toml. */
+export interface EmailBinding {
+  send(message: { to: string; from: string; subject: string; html?: string; text?: string }): Promise<{ messageId: string }>;
+}
+
 /** Env surface budget functions need. Bindings / LLMEnv both satisfy this. */
 export interface BudgetEnv {
   CACHE?: KVNamespace;
@@ -40,6 +46,9 @@ export interface BudgetEnv {
   DAILY_BUDGET_USD?: string;
   /** Per-deploy override for the hourly custom-question cap (USD). Defaults to 10. */
   HOURLY_CUSTOM_BUDGET_USD?: string;
+  /** Cloudflare send_email binding. When present, recordSpend emails an alert
+   *  (deduped per window) the first time a daily/hourly cap trips. */
+  EMAIL?: EmailBinding;
 }
 
 export type BudgetScope = 'all' | 'custom';
@@ -49,6 +58,16 @@ const TOTAL_BUCKET = `${PREFIX}total:`; // + YYYYMMDD (UTC)
 const CUSTOM_BUCKET = `${PREFIX}custom:`; // + YYYYMMDDHH (UTC)
 const PAUSE_ALL = `${PREFIX}pause:all`;
 const PAUSE_CUSTOM = `${PREFIX}pause:custom`;
+// Dedup flags so a tripped cap emails at most once per window (the daily latch
+// re-arms on every subsequent call; the queue runs 50-way concurrent).
+const ALERTED_DAILY = `${PREFIX}alerted:daily:`; // + YYYYMMDD (UTC)
+const ALERTED_CUSTOM = `${PREFIX}alerted:custom:`; // + YYYYMMDDHH (UTC)
+
+// Spend-alert recipient + sender. `to` must be a verified Cloudflare Email
+// Routing destination address; `from` must be on a zone we control.
+const ALERT_TO = 'shaunregenbaum@gmail.com';
+const ALERT_FROM = 'budget-alert@shaunregenbaum.com';
+const APP_URL = 'https://talmud.shaunregenbaum.com';
 
 // Daily counter must outlive its day enough to catch late-arriving cost from a
 // long job that started yesterday; the hourly counter only needs its window
@@ -150,6 +169,30 @@ async function armLatch(cache: KVNamespace, key: string, latch: PauseLatch, now:
   await cache.put(key, JSON.stringify(latch), { expirationTtl: ttl });
 }
 
+/** Best-effort: send a spend alert, swallowing any failure. A send needs a
+ *  verified destination (see ALERT_TO) — until then it just logs and returns. */
+async function sendBudgetAlert(env: BudgetEnv, subject: string, text: string): Promise<void> {
+  const email = env.EMAIL;
+  if (!email) return;
+  try {
+    await email.send({ from: ALERT_FROM, to: ALERT_TO, subject, text });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('[budget] alert email failed:', err);
+  }
+}
+
+/** Send `subject`/`text` at most once per window. Sets the dedup flag BEFORE
+ *  sending so a concurrent crosser skips; under KV's ~60s consistency a burst
+ *  may still emit a couple duplicate alerts, which is acceptable. */
+async function alertOnce(
+  cache: KVNamespace, flagKey: string, ttlS: number, env: BudgetEnv, subject: string, text: string,
+): Promise<void> {
+  if (await cache.get(flagKey)) return;
+  await cache.put(flagKey, '1', { expirationTtl: ttlS });
+  await sendBudgetAlert(env, subject, text);
+}
+
 /**
  * Record a completed call's spend. Bumps the daily total (always) and the
  * hourly custom bucket (when custom), arming the matching pause latch when a
@@ -168,11 +211,20 @@ export async function recordSpend(
   try {
     const total = await bumpCounter(cache, `${TOTAL_BUCKET}${dayBucket(now)}`, usd, TOTAL_TTL_S);
     if (total >= dailyTrip(env)) {
+      const until = nextUtcMidnight(now);
       await armLatch(cache, PAUSE_ALL, {
-        until: nextUtcMidnight(now),
+        until,
         reason: `daily spend $${total.toFixed(2)} reached trip $${dailyTrip(env).toFixed(2)} (cap $${dailyCap(env)})`,
         spentUsd: total,
       }, now);
+      await alertOnce(
+        cache, `${ALERTED_DAILY}${dayBucket(now)}`, Math.max(60, Math.ceil((until - now) / 1000) + 300), env,
+        `[talmud] Daily LLM spend paused — $${total.toFixed(2)}`,
+        `Daily LLM spend reached $${total.toFixed(2)} (trip $${dailyTrip(env).toFixed(2)}, hard cap $${dailyCap(env)}).\n` +
+        `ALL AI generation is now paused until the next UTC midnight (${new Date(until).toISOString()}).\n\n` +
+        `If this is unexpected, check for runaway/abusive usage.\n\n` +
+        `Budget status: ${APP_URL}/api/admin/budget\nUsage dashboard: ${APP_URL}/usage\n`,
+      );
     }
     if (args.custom) {
       const spent = await bumpCounter(cache, `${CUSTOM_BUCKET}${hourBucket(now)}`, usd, CUSTOM_TTL_S);
@@ -182,6 +234,13 @@ export async function recordSpend(
           reason: `custom-question spend $${spent.toFixed(2)} reached cap $${hourlyCustomCap(env)} this hour`,
           spentUsd: spent,
         }, now);
+        await alertOnce(
+          cache, `${ALERTED_CUSTOM}${hourBucket(now)}`, 3600 + 300, env,
+          `[talmud] Hourly custom-question spend cap hit — $${spent.toFixed(2)}`,
+          `Custom-question spend hit $${spent.toFixed(2)} (cap $${hourlyCustomCap(env)}) within the hour ${hourBucket(now)} UTC.\n` +
+          `Custom Q&A is paused for the rest of the hour. A sudden hit here often means someone is hammering custom questions to use the LLM.\n\n` +
+          `Budget status: ${APP_URL}/api/admin/budget\nUsage dashboard: ${APP_URL}/usage\n`,
+        );
       }
     }
   } catch {

--- a/src/worker/llm.ts
+++ b/src/worker/llm.ts
@@ -25,7 +25,7 @@
 import { runWithRetry } from './ai-gateway';
 import { LLMError, isFallbackWorthy, NEITHER, TIMEOUT } from './llm-error';
 import { DEFAULT_MODEL, DEFAULT_FALLBACK_CHAIN } from './settings';
-import { checkBudget, recordSpend, BudgetPausedError } from './budget';
+import { checkBudget, recordSpend, BudgetPausedError, type EmailBinding } from './budget';
 
 export type LLMModelId = `@cf/${string}` | `openrouter/${string}`;
 
@@ -41,6 +41,8 @@ export interface LLMEnv {
   // Spend-budget overrides read by ./budget (checkBudget / recordSpend).
   DAILY_BUDGET_USD?: string;
   HOURLY_CUSTOM_BUDGET_USD?: string;
+  // send_email binding — recordSpend uses it to email a spend alert on cap trips.
+  EMAIL?: EmailBinding;
 }
 
 export interface LLMMessage {

--- a/tests/budget.test.ts
+++ b/tests/budget.test.ts
@@ -23,6 +23,13 @@ function makeFakeKV(initial: Record<string, string> = {}) {
   return { kv: kv as unknown as KVNamespace, store };
 }
 
+// Fake send_email binding that captures every message it's asked to send.
+function makeFakeEmail() {
+  const sent: Array<{ to: string; from: string; subject: string; text?: string }> = [];
+  const email = { send: async (m: { to: string; from: string; subject: string; text?: string }) => { sent.push(m); return { messageId: `m${sent.length}` }; } };
+  return { email, sent };
+}
+
 // 2026-05-27 19:43 UTC -> day bucket 20260527, hour bucket 2026052719.
 const T = Date.UTC(2026, 4, 27, 19, 43, 0);
 const DAY = '20260527';
@@ -131,6 +138,45 @@ describe('unpriced calls', () => {
     await recordSpend(env, { model: '@cf/google/gemma-4-26b-a4b-it', usage: { prompt_tokens: 9999 }, custom: true }, T);
     expect(store.has(`budget:v1:total:${DAY}`)).toBe(false);
     expect(store.has(`budget:v1:custom:${HOUR}`)).toBe(false);
+  });
+});
+
+describe('spend alert emails', () => {
+  it('emails once when the daily cap trips, and dedupes within the same day', async () => {
+    const { kv } = makeFakeKV();
+    const { email, sent } = makeFakeEmail();
+    const env: BudgetEnv = { CACHE: kv, DAILY_BUDGET_USD: '10', EMAIL: email }; // trip = 9.5
+    await recordSpend(env, { model: 'x', usage: { cost: 9.6 }, custom: false }, T);
+    expect(sent).toHaveLength(1);
+    expect(sent[0].to).toBe('shaunregenbaum@gmail.com');
+    expect(sent[0].subject).toContain('Daily LLM spend paused');
+    // Subsequent over-trip spend the same day must NOT send again.
+    await recordSpend(env, { model: 'x', usage: { cost: 1 }, custom: false }, T + 1000);
+    expect(sent).toHaveLength(1);
+  });
+
+  it('emails when the hourly custom cap trips', async () => {
+    const { kv } = makeFakeKV();
+    const { email, sent } = makeFakeEmail();
+    const env: BudgetEnv = { CACHE: kv, HOURLY_CUSTOM_BUDGET_USD: '0.5', DAILY_BUDGET_USD: '1000', EMAIL: email };
+    await recordSpend(env, { model: 'x', usage: { cost: 0.6 }, custom: true }, T);
+    expect(sent).toHaveLength(1);
+    expect(sent[0].subject).toContain('custom-question spend cap');
+  });
+
+  it('does not email while under the trip point', async () => {
+    const { kv } = makeFakeKV();
+    const { email, sent } = makeFakeEmail();
+    const env: BudgetEnv = { CACHE: kv, DAILY_BUDGET_USD: '10', EMAIL: email };
+    await recordSpend(env, { model: 'x', usage: { cost: 5 }, custom: false }, T);
+    expect(sent).toHaveLength(0);
+  });
+
+  it('still records spend (no throw) when no EMAIL binding is present', async () => {
+    const { kv, store } = makeFakeKV();
+    const env: BudgetEnv = { CACHE: kv, DAILY_BUDGET_USD: '10' };
+    await recordSpend(env, { model: 'x', usage: { cost: 9.6 }, custom: false }, T);
+    expect(store.has('budget:v1:pause:all')).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds spend alerting to the budget guard: `recordSpend` (the single post-call chokepoint in `runLLM`) emails `shaunregenbaum@gmail.com` via the `send_email` EMAIL binding the first time **the daily spend pause** (~90% of the $300 cap) or **the hourly custom-question cap** ($10/hr) trips.
- **Deduped** per UTC day / hour via KV flags so a burst or the 50-way-concurrent queue can't spam; **best-effort** (wrapped in try/catch) so a send failure never breaks a call that already succeeded.
- Threads the `EMAIL` binding through `LLMEnv` → `BudgetEnv`; `wrapEnv` already spreads bindings so it propagates.

## Cloudflare setup (done via CF MCP)
- The only verified Email Routing destination was `shaun@402.email`; **`shaunregenbaum@gmail.com` was not verified**, so the `send_email` binding could not deliver there. Created it as a destination address — **Cloudflare has sent a verification link to that Gmail; it must be clicked before alerts deliver.**

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 53 files / 1169 tests pass (4 new: daily trip emails once + dedupes, custom trip emails, no email under trip, no throw without EMAIL binding)
- [ ] After the Gmail address is verified: live trip test (confirm an alert actually lands)