### PR TITLE
Inspect every enrichment section, with prompts for leaves

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -13,6 +13,7 @@ import ArgumentFlowGraph, { type FlowConnection } from './ArgumentFlowGraph';
 import { selectSectionMoves } from '../lib/argumentMoves';
 import { t, lang } from './i18n';
 import { ACCENTS, HebrewProse, Panel, QASection, SectionCard, Synthesis, kindLabelKey } from './sidebar/primitives';
+import { InspectDot } from './MarkEnrichmentCards';
 
 /** Localize an era date-range ("c. 290 – 320 CE") for Hebrew display. */
 function eraLabel(era: string): string {
@@ -508,7 +509,12 @@ export function ArgumentBody(props: {
         onResolved={handleResolved}
       />
       <Show when={voicesData()}>
-        {(data) => <ArgumentVoiceMap data={data()} onClickVoice={props.onPushRabbi} />}
+        {(data) => (
+          <div style={{ position: 'relative' }}>
+            <InspectDot instanceKey={instanceKey()} leafId="argument.voices" style={{ position: 'absolute', top: '0.2rem', right: 0, 'z-index': 2 }} />
+            <ArgumentVoiceMap data={data()} onClickVoice={props.onPushRabbi} />
+          </div>
+        )}
       </Show>
       <Show when={sectionMoves()}>
         {(moves) => (
@@ -863,24 +869,30 @@ export function RabbiBody(props: {
       />
       <Show when={relationships()}>
         {(rel) => (
-          <RabbiLineageTree
-            subjectName={props.rabbi.name}
-            subjectGeneration={props.rabbi.generation}
-            data={rel()}
-            evidence={relationshipsEvidence()}
-            generationByName={props.generationByName}
-            onHighlightRange={props.onHighlightRange}
-          />
+          <div style={{ position: 'relative' }}>
+            <InspectDot instanceKey={instanceKey()} leafId="rabbi.relationships" style={{ position: 'absolute', top: '0.2rem', right: 0, 'z-index': 2 }} />
+            <RabbiLineageTree
+              subjectName={props.rabbi.name}
+              subjectGeneration={props.rabbi.generation}
+              data={rel()}
+              evidence={relationshipsEvidence()}
+              generationByName={props.generationByName}
+              onHighlightRange={props.onHighlightRange}
+            />
+          </div>
         )}
       </Show>
       <Show when={geography()}>
         {(geo) => (
-          <RabbiPlacesTimeline
-            data={geo()}
-            evidence={geographyEvidence()}
-            location={location()}
-            onHighlightRange={props.onHighlightRange}
-          />
+          <div style={{ position: 'relative' }}>
+            <InspectDot instanceKey={instanceKey()} leafId="rabbi.geography" style={{ position: 'absolute', top: '0.2rem', right: 0, 'z-index': 2 }} />
+            <RabbiPlacesTimeline
+              data={geo()}
+              evidence={geographyEvidence()}
+              location={location()}
+              onHighlightRange={props.onHighlightRange}
+            />
+          </div>
         )}
       </Show>
     </Panel>
@@ -981,7 +993,11 @@ export function HalachaBody(props: {
             <div style={{
               'font-size': '0.7rem', 'text-transform': 'uppercase',
               'letter-spacing': '0.08em', color: '#888', 'margin-bottom': '0.5rem',
-            }}>{t('halacha.codification')}</div>
+              display: 'flex', 'align-items': 'center', gap: '0.4rem',
+            }}>
+              <span>{t('halacha.codification')}</span>
+              <InspectDot instanceKey={instanceKey()} leafId="halacha.codification" style={{ 'margin-left': 'auto' }} />
+            </div>
             <RulingRow
               source="mishnehTorah" label={t('source.mishnehTorah')} color="#8a2a2b"
               ruling={cod().mishnehTorah ? { ref: cod().mishnehTorah!.ref, summary: cod().mishnehTorah!.ruling } : undefined}
@@ -1020,7 +1036,7 @@ export function HalachaBody(props: {
       </Show>
       <Show when={practical()}>
         {(pr) => (
-          <SectionCard label="halacha.practical">
+          <SectionCard label="halacha.practical" inspect={{ instanceKey: instanceKey(), leafId: 'halacha.practical' }}>
             <Show when={pr().lechatchila}>
               <div style={{ 'margin-bottom': '0.4rem' }}>
                 <div style={{ 'font-size': '0.65rem', color: '#999', 'text-transform': 'uppercase', 'letter-spacing': '0.06em', 'margin-bottom': '0.15rem' }}>
@@ -1075,7 +1091,7 @@ export function HalachaBody(props: {
         )}
       </Show>
       <Show when={disputes().length > 0}>
-        <SectionCard label="halacha.disputes">
+        <SectionCard label="halacha.disputes" inspect={{ instanceKey: instanceKey(), leafId: 'halacha.disputes' }}>
           <For each={disputes()}>{(d) => (
             <div style={{ 'margin-bottom': '0.6rem' }}>
               <div style={{ 'font-weight': 500, color: '#333', 'font-size': '0.88rem', 'margin-bottom': '0.25rem' }}>
@@ -1200,10 +1216,10 @@ export function PasukPanel(props: { pasuk: Pasuk; tractate: string; page: string
         page={props.page}
         onResolved={handleResolved}
       />
-      <Show when={tanachContext()}>{(tc) => <SectionCard label="pasuk.tanachContext" text={tc()} />}</Show>
-      <Show when={whyHere()}>{(wh) => <SectionCard label="pasuk.whyHere" text={wh()} />}</Show>
-      <Show when={mechanism()}>{(me) => <SectionCard label="pasuk.mechanism" text={me()} />}</Show>
-      <Show when={landing()}>{(la) => <SectionCard label="pasuk.landing" text={la()} />}</Show>
+      <Show when={tanachContext()}>{(tc) => <SectionCard label="pasuk.tanachContext" text={tc()} inspect={{ instanceKey: props.pasuk.verseRef, leafId: 'pesukim.tanach-context' }} />}</Show>
+      <Show when={whyHere()}>{(wh) => <SectionCard label="pasuk.whyHere" text={wh()} inspect={{ instanceKey: props.pasuk.verseRef, leafId: 'pesukim.why-here' }} />}</Show>
+      <Show when={mechanism()}>{(me) => <SectionCard label="pasuk.mechanism" text={me()} inspect={{ instanceKey: props.pasuk.verseRef, leafId: 'pesukim.mechanism' }} />}</Show>
+      <Show when={landing()}>{(la) => <SectionCard label="pasuk.landing" text={la()} inspect={{ instanceKey: props.pasuk.verseRef, leafId: 'pesukim.landing' }} />}</Show>
       {/* Questions panel: curated follow-ups + community + free-form asking. */}
       <QASection
         mark="pesukim"
@@ -1316,14 +1332,14 @@ export function AggadataPanel(props: {
         onResolved={handleResolved}
       />
       <Show when={background()}>
-        {(bg) => <SectionCard label="aggadata.background" text={bg().background} />}
+        {(bg) => <SectionCard label="aggadata.background" text={bg().background} inspect={{ instanceKey: instanceKey(), leafId: 'aggadata.background' }} />}
       </Show>
       <Show when={interpretation()}>
-        {(ip) => <SectionCard label="aggadata.interpretation" text={ip().interpretation} />}
+        {(ip) => <SectionCard label="aggadata.interpretation" text={ip().interpretation} inspect={{ instanceKey: instanceKey(), leafId: 'aggadata.interpretation' }} />}
       </Show>
       <Show when={visibleParallels()}>
         {(pa) => (
-          <SectionCard label="aggadata.parallels">
+          <SectionCard label="aggadata.parallels" inspect={{ instanceKey: instanceKey(), leafId: 'aggadata.parallels' }}>
             <Show when={pa().prose}>
               <div style={{
                 'font-size': '0.82rem', color: '#555', 'line-height': 1.5,

--- a/src/client/MarkEnrichmentCards.tsx
+++ b/src/client/MarkEnrichmentCards.tsx
@@ -33,6 +33,47 @@ import { lang, t } from './i18n';
 // Single global "which card has the inspector open?" signal — keyed by the
 // card's instanceKey. Only one drawer at a time across the whole page.
 const [openInspectorKey, setOpenInspectorKey] = createSignal<string | null>(null);
+// Which leaf the open inspector is focused on (null = the synthesis aggregate).
+// Module-level so a section card rendered OUTSIDE the owning MarkEnrichmentCards
+// (e.g. HalachaBody's Codification card) can open the drawer focused on its leaf.
+const [inspectorView, setInspectorView] = createSignal<string | null>(null);
+
+/** Open the instance inspector for `instanceKey`, optionally focused on a
+ *  specific leaf enrichment id (null = the synthesis). Any section affordance
+ *  can call this; the MarkEnrichmentCards with that key owns the drawer. */
+export function openInstanceInspector(instanceKey: string, leafId: string | null = null): void {
+  setInspectorView(leafId);
+  setOpenInspectorKey(instanceKey);
+}
+
+/** The small circular "i" affordance. Dev-mode only. Drop next to any section
+ *  (a SectionCard label, a viz header) to open the inspector focused on that
+ *  section's leaf. Highlights when its target is the one currently shown. */
+export function InspectDot(props: { instanceKey: string; leafId?: string | null; title?: string; style?: JSX.CSSProperties }): JSX.Element {
+  const active = () =>
+    openInspectorKey() === props.instanceKey && (inspectorView() ?? null) === (props.leafId ?? null);
+  return (
+    <Show when={devModeActive()}>
+      <button
+        type="button"
+        onClick={(e) => { e.stopPropagation(); openInstanceInspector(props.instanceKey, props.leafId ?? null); }}
+        title={props.title ?? 'Inspect this section'}
+        aria-label={props.title ?? 'Inspect this section'}
+        style={{
+          width: '1.25rem', height: '1.25rem', padding: 0, cursor: 'pointer',
+          background: active() ? '#000' : 'transparent',
+          color: active() ? '#fff' : '#aaa',
+          border: '1px solid #ddd', 'border-radius': '50%',
+          'font-size': '0.62rem', 'font-family': 'ui-serif, Georgia, serif',
+          'font-style': 'italic', 'line-height': 1, 'flex-shrink': 0,
+          ...(props.style ?? {}),
+        }}
+      >
+        i
+      </button>
+    </Show>
+  );
+}
 
 interface EnrichmentDef {
   id: string;
@@ -242,10 +283,16 @@ interface Props {
 export default function MarkEnrichmentCards(props: Props) {
   const [defs] = createResource(fetchEnrichments);
   const [runs, setRuns] = createSignal<Record<string, RunState>>({});
-  const [selectedDevView, setSelectedDevView] = createSignal<string | null>(null);
 
   const setRun = (id: string, state: RunState) =>
     setRuns((cur) => ({ ...cur, [id]: state }));
+
+  // Is THIS instance's inspector open, and which leaf is it focused on? Reads
+  // the module-level signals so section cards (which live outside this
+  // component) can drive the drawer. inspectorSelectedId() is null when the
+  // synthesis is shown.
+  const isInspectorOpen = () => openInspectorKey() === props.instanceKey;
+  const inspectorSelectedId = () => (isInspectorOpen() ? inspectorView() : null);
 
   const allMatching = () => (defs() ?? []).filter((d) => d.mark === props.markId && d.status !== 'draft');
   // The user-facing card is the aggregate (synthesis). Leaves only render
@@ -260,16 +307,10 @@ export default function MarkEnrichmentCards(props: Props) {
     if (a.length > 0) return a;
     return leaves();
   };
-  // What to render when user selects a specific leaf in dev mode.
-  const devSelected = () => {
-    const id = selectedDevView();
-    if (!id) return null;
-    return allMatching().find((d) => d.id === id) ?? null;
-  };
-  const matching = () => {
-    const sel = devSelected();
-    return sel ? [sel] : primary();
-  };
+  // The card body + auto-fire always track the PRIMARY (synthesis) view. The
+  // inspector's leaf selection is independent (it fetches the leaf on demand),
+  // so opening a section's inspector never mutates the synthesis card.
+  const matching = () => primary();
 
   // lang() is part of the stamp so a language switch re-runs the auto-fire
   // effect below and re-fetches the card under the new lang (the worker keys
@@ -375,19 +416,57 @@ export default function MarkEnrichmentCards(props: Props) {
     return tail.replace(/[-_]/g, ' ').replace(/\b\w/, (m) => m.toUpperCase());
   };
 
-  // Which enrichment is currently the focal one? In dev mode this follows
-  // the dropdown / badge selection; otherwise it's the first aggregate
-  // (= synthesis) or, if none, the first leaf.
-  const currentView = (): EnrichmentDef | null => {
-    const sel = selectedDevView();
-    if (sel) return allMatching().find((d) => d.id === sel) ?? null;
+  // The synthesis/aggregate view — what the sidebar card always shows.
+  const primaryView = (): EnrichmentDef | null => {
     const a = aggregates();
     if (a.length > 0) return a[0];
     const l = leaves();
     return l.length > 0 ? l[0] : null;
   };
+  const primaryRun = (): RunState => runs()[primaryView()?.id ?? ''] ?? { kind: 'idle' };
+
+  // The inspector's focal view — follows its leaf selection, else the primary.
+  const currentView = (): EnrichmentDef | null => {
+    const sel = inspectorSelectedId();
+    if (sel) return allMatching().find((d) => d.id === sel) ?? null;
+    return primaryView();
+  };
   const currentRun = (): RunState =>
     runs()[currentView()?.id ?? ''] ?? { kind: 'idle' };
+
+  // When a leaf is selected in the inspector, make sure we have its FULL run
+  // (prompt + telemetry). Leaves fanned out from the aggregate's deps_resolved
+  // carry only content — no `resolved` — so fetch the leaf directly. The worker
+  // cached it under its own key during dep resolution (with the same
+  // mark_input), so this is a cache hit, not a fresh LLM call. Fetched in the
+  // background so the visible content doesn't flicker to a spinner.
+  createEffect(() => {
+    const id = inspectorSelectedId();
+    if (!id) return;
+    const def = untrack(() => allMatching().find((d) => d.id === id));
+    if (!def) return;
+    const cur = untrack(() => runs()[id]);
+    if (cur?.kind === 'loading') return;
+    if (cur?.kind === 'ok' && cur.result.resolved) return; // already have prompts
+    const s = stamp();
+    const curLang = lang();
+    const controller = new AbortController();
+    onCleanup(() => controller.abort());
+    const { id: actId, label: actLabel } = enrichmentActivityKey(
+      id, props.tractate, props.page, props.instance, props.instanceKey,
+    );
+    void enrichmentQueue.enqueue(actId, actLabel, (sig) =>
+      runEnrichment(id, props.tractate, props.page, props.instance, props.instanceKey, sig),
+      controller.signal,
+      QUEUE_PRIORITY.high,
+    ).then(
+      (result) => {
+        runResultCache.set(runCacheKey(id, props.tractate, props.page, props.instanceKey, curLang), result);
+        if (stamp() === s) setRun(id, { kind: 'ok', stamp: s, result });
+      },
+      (err) => { if (!isAbort(err) && stamp() === s) { /* keep synthetic content; inspection just lacks prompts */ } },
+    );
+  });
 
   // Dependencies that fed the current view. For a synthesis-style aggregate
   // the deps are the leaves it consumed (taken from deps_resolved on the
@@ -452,10 +531,10 @@ export default function MarkEnrichmentCards(props: Props) {
     return t('loading.default');
   };
 
-  // Body renderer shared across dev / non-dev: loading state, error, or
-  // the content paragraph (Hebraized + parsed JSON aware).
-  const renderBody = (): JSX.Element => {
-    const r = currentRun();
+  // Body renderer for a given run: loading state, error, or the content
+  // paragraph (Hebraized + parsed JSON aware). The card renders the primary
+  // run; the inspector renders its selected view's run.
+  const renderRunBody = (r: RunState): JSX.Element => {
     if (r.kind === 'loading' || r.kind === 'idle') {
       return (
         <div style={{
@@ -496,6 +575,8 @@ export default function MarkEnrichmentCards(props: Props) {
       </p>
     );
   };
+  const renderCardBody = (): JSX.Element => renderRunBody(primaryRun());
+  const renderInspectorBody = (): JSX.Element => renderRunBody(currentRun());
 
   // Human-friendly label for the instance (used in the inspector header).
   const instanceLabel = (): string => {
@@ -511,14 +592,13 @@ export default function MarkEnrichmentCards(props: Props) {
     );
   };
 
-  const isInspectorOpen = () => openInspectorKey() === props.instanceKey;
-  const closeInspector = () => setOpenInspectorKey(null);
+  const closeInspector = () => { setOpenInspectorKey(null); setInspectorView(null); };
   const openInspector = (e?: MouseEvent) => {
     // Cards may live inside an outer click-target (e.g. ArgumentMoveCard's
     // toggleHighlight wrapper). Stop propagation so the inspector affordance
     // doesn't double as a highlight toggle.
     if (e) e.stopPropagation();
-    setOpenInspectorKey(props.instanceKey);
+    openInstanceInspector(props.instanceKey, null);
   };
 
   // Sidebar card: production view in all modes — clean synthesis output in
@@ -534,7 +614,7 @@ export default function MarkEnrichmentCards(props: Props) {
         'border-radius': '6px',
         padding: '0.85rem 1rem',
       }}>
-        {renderBody()}
+        {renderCardBody()}
         <Show when={devModeActive()}>
           <button
             onClick={openInspector}
@@ -546,8 +626,8 @@ export default function MarkEnrichmentCards(props: Props) {
               width: '1.4rem', height: '1.4rem',
               padding: 0,
               cursor: 'pointer',
-              background: isInspectorOpen() ? '#000' : 'transparent',
-              color: isInspectorOpen() ? '#fff' : '#888',
+              background: (isInspectorOpen() && inspectorSelectedId() === null) ? '#000' : 'transparent',
+              color: (isInspectorOpen() && inspectorSelectedId() === null) ? '#fff' : '#888',
               border: '1px solid #ddd',
               'border-radius': '50%',
               'font-size': '0.7rem',
@@ -572,13 +652,13 @@ export default function MarkEnrichmentCards(props: Props) {
             markId={props.markId}
             aggregates={aggregates()}
             leaves={leaves()}
-            selected={selectedDevView()}
-            onSelect={(id) => setSelectedDevView(id)}
+            selected={inspectorSelectedId()}
+            onSelect={(id) => setInspectorView(id)}
             currentView={currentView()}
             currentRun={currentRun()}
             depBadges={currentDepBadges()}
             prettyDepLabel={(depId) => prettyDepLabel(depId, props.markId)}
-            renderBody={renderBody}
+            renderBody={renderInspectorBody}
             onClose={closeInspector}
           />
         </Portal>

--- a/src/client/sidebar/primitives.tsx
+++ b/src/client/sidebar/primitives.tsx
@@ -22,7 +22,7 @@
 import { Show, type JSX } from 'solid-js';
 import { lang, t, type CatalogKey } from '../i18n';
 import { HebraizedWithRabbis } from '../rabbiLinks';
-import MarkEnrichmentCards from '../MarkEnrichmentCards';
+import MarkEnrichmentCards, { InspectDot } from '../MarkEnrichmentCards';
 import QAPanel from '../QAPanel';
 
 /** Per-type accent (the title color). Bodies pass `accent={ACCENTS.x}` so the
@@ -129,11 +129,22 @@ export function SectionCard(props: {
   spacing?: 'tight' | 'loose';
   text?: string;
   children?: JSX.Element;
+  /** Dev-mode 'i' affordance: opens the instance inspector focused on this
+   *  section's leaf enrichment. `leafId` is the enrichment id that produced
+   *  the section (e.g. 'pesukim.tanach-context'). */
+  inspect?: { instanceKey: string; leafId: string };
 }): JSX.Element {
   return (
     <div style={SECTION_BOX}>
-      <div style={{ ...SECTION_LABEL, 'margin-bottom': props.spacing === 'loose' ? '0.5rem' : '0.4rem' }}>
-        {t(props.label)}
+      <div style={{
+        ...SECTION_LABEL,
+        'margin-bottom': props.spacing === 'loose' ? '0.5rem' : '0.4rem',
+        display: 'flex', 'align-items': 'center', gap: '0.4rem',
+      }}>
+        <span>{t(props.label)}</span>
+        <Show when={props.inspect}>
+          {(ins) => <InspectDot instanceKey={ins().instanceKey} leafId={ins().leafId} style={{ 'margin-left': 'auto' }} />}
+        </Show>
       </div>
       <Show when={props.text != null} fallback={props.children}>
         <div style={SECTION_PROSE}>


### PR DESCRIPTION
## Summary
Answers two dev-mode gaps in the instance inspector.

- **Leaf prompts were blank.** Leaves are fanned out from a synthesis's `deps_resolved`, which carries only the parsed content — not the rendered prompt or telemetry. Selecting a leaf in the inspector now fetches it directly. Because dependency resolution already ran each leaf through `runEnrichmentOnce` with the **same** `mark_input` and cached it under the leaf's own key, this is a **cache hit** (no new LLM call) that returns the full result with `resolved` prompts + telemetry.
- **The "i" only existed on the synthesis.** Added a per-section "i" across every mark body. Inspector open + focused-leaf state is lifted to module level (`openInstanceInspector`), and a reusable dev-only `InspectDot` drops onto each section: `SectionCard` gained an optional `inspect` prop (halacha practical/disputes, pesukim ×4, aggadata ×3), and the bespoke sections get it inline/overlaid (halacha codification, argument voices, rabbi relationships + geography). Each opens the drawer focused on that section's leaf.
- The synthesis card no longer mutates when a leaf is selected: the card body tracks the primary (synthesis) view; the inspector tracks its own selection independently.

Dev-mode only — every affordance is gated on `devModeActive()`; reader-facing rendering is unchanged.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 1165 passed
- [x] Dev server boots; client + `/api/studio/enrichments` serve with no bundle errors
- [x] Verified all 13 wired leaf ids are real, defined enrichments in code-marks.ts
- [ ] In-browser dev-mode check (blocked locally: another agent held the shared Chrome DevTools profile)