### PR TITLE
Add Revach l'Daf as an alignable, cached dafyomi.co.il source

### DIFF
--- a/scripts/scrape-dafyomi.mjs
+++ b/scripts/scrape-dafyomi.mjs
@@ -26,9 +26,26 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import {
-  getDafyomiMasechet, DAFYOMI_CONTENT_TYPES, buildDafyomiUrl, dafToNNN,
+  getDafyomiMasechet, DAFYOMI_CONTENT_TYPES, buildDafyomiUrl, buildRevachUrl, dafToNNN,
 } from '../src/lib/sefref/dafyomi/masechtos.ts';
 import { assembleDaf } from '../src/lib/sefref/dafyomi/assemble.ts';
+
+// Revach l'Daf lives in the memdb app (revdaf.php?tid=&id=), not the
+// {dir}/{folder}/{prefix}-{typecode}-{NNN}.htm tree, so it has no
+// DAFYOMI_CONTENT_TYPES spec. We give it a pseudo-spec only so the cache path
+// and --types filtering work uniformly; its URL + presence marker are
+// special-cased below.
+const REVACH_SPEC = { type: 'revach', folder: 'memdb', typecode: 'rev' };
+const ALL_SPECS = [...DAFYOMI_CONTENT_TYPES, REVACH_SPEC];
+
+/** Live page URL for a spec (Revach uses a different URL shape). */
+function urlFor(m, spec, daf) {
+  return spec.type === 'revach' ? buildRevachUrl(m, daf) : buildDafyomiUrl(m, spec, daf);
+}
+/** Substring a real page must contain (Revach pages have no #content). */
+function markerFor(spec) {
+  return spec.type === 'revach' ? 'A BIT MORE' : 'id="content"';
+}
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CACHE_DIR = join(__dirname, '.cache', 'dafyomi');
@@ -57,8 +74,8 @@ if (!masechet) { console.error(`error: tractate "${TRACTATE}" is not mapped in m
 if (!masechet.verified) console.warn(`[warn] masechet "${TRACTATE}" (dir=${masechet.dir} prefix=${masechet.prefix}) is UNVERIFIED — wrong dir/prefix will show as all-absent dafim`);
 
 const specs = TYPES
-  ? DAFYOMI_CONTENT_TYPES.filter((s) => TYPES.includes(s.type))
-  : DAFYOMI_CONTENT_TYPES;
+  ? ALL_SPECS.filter((s) => TYPES.includes(s.type))
+  : ALL_SPECS;
 if (specs.length === 0) { console.error(`error: no content types match --types ${TYPES}`); process.exit(1); }
 
 const dafs = ONE_DAF
@@ -76,7 +93,7 @@ function absentMarkerPath(typecode, daf) {
   return join(CACHE_DIR, masechet.dir, typecode, `${dafToNNN(daf)}.absent`);
 }
 
-async function fetchWithRetry(url) {
+async function fetchWithRetry(url, marker) {
   let lastErr;
   for (let attempt = 0; attempt < 3; attempt++) {
     const wait = Date.now() - lastFetchTs;
@@ -87,7 +104,7 @@ async function fetchWithRetry(url) {
       if (res.status === 404) return { absent: true };
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const body = await res.text();
-      if (!body.includes('id="content"')) return { absent: true };
+      if (!body.includes(marker)) return { absent: true };
       return { html: body };
     } catch (err) {
       lastErr = err;
@@ -105,8 +122,9 @@ async function getHtml(spec, daf) {
     if (existsSync(htmlPath)) return { html: await readFile(htmlPath, 'utf-8'), cached: true };
     if (existsSync(absPath)) return { absent: true, cached: true };
   }
-  const url = buildDafyomiUrl(masechet, spec, daf);
-  const result = await fetchWithRetry(url);
+  const url = urlFor(masechet, spec, daf);
+  if (!url) return { absent: true }; // e.g. Revach with no known tid for this masechet
+  const result = await fetchWithRetry(url, markerFor(spec));
   await mkdir(dirname(htmlPath), { recursive: true });
   if (result.absent) { await writeFile(absPath, '', 'utf-8'); return { absent: true }; }
   await writeFile(htmlPath, result.html, 'utf-8');
@@ -134,7 +152,7 @@ async function main() {
       try { r = await getHtml(spec, daf); }
       catch (err) { console.error(`  [err] ${TRACTATE} ${daf} ${spec.type}: ${err.message}`); r = { absent: true }; }
       if (!r.cached && (r.html || r.absent)) fetchedCount++;
-      fetched.push({ type: spec.type, url: buildDafyomiUrl(masechet, spec, daf), html: r.absent ? null : r.html });
+      fetched.push({ type: spec.type, url: urlFor(masechet, spec, daf) ?? '', html: r.absent ? null : r.html });
     }
 
     const { daf: dafObj, warnings } = assembleDaf(TRACTATE, daf, fetched);

--- a/src/client/AttributionsPage.tsx
+++ b/src/client/AttributionsPage.tsx
@@ -28,7 +28,7 @@ const SOURCES: SourceCredit[] = [
   {
     name: 'Kollel Iyun HaDaf (Dafyomi Advancement Forum)',
     url: 'https://www.dafyomi.co.il',
-    role: 'Per-daf study material: Background, Insights, Halacha, Tosfos outlines, Review questions, Points outlines, charts, and Yerushalmi parallels',
+    role: 'Per-daf study material: Background, Insights, Halacha, Tosfos outlines, Review questions, Points outlines, charts, Yerushalmi parallels, and Revach l\'Daf highlights (co-published with Revach l\'Neshamah, revach.net)',
     note: 'Headed by Rav Mordecai Kornfeld. Content © Kollel Iyun HaDaf, ingested as a study source with attribution and links back to the original pages. Not redistributed as a standalone copy.',
   },
 ];

--- a/src/lib/context/fromDafyomi.ts
+++ b/src/lib/context/fromDafyomi.ts
@@ -17,6 +17,7 @@ const SOURCE_LABEL: Record<DafyomiContentType, string> = {
   // label it so it reads as a companion to the Sefaria "Tosafot" source.
   insights: 'Insights', background: 'Background', halacha: 'Halacha', tosfos: 'Tosafot explanation',
   review: 'Review', points: 'Points', hebcharts: 'Charts', yerushalmi: 'Yerushalmi',
+  revach: 'Revach l\'Daf',
 };
 
 export function fromDafyomi(daf: DafyomiDaf): ContextItem[] {
@@ -71,6 +72,7 @@ function collectBlock(
     case 'review':
     case 'points':
     case 'yerushalmi':
+    case 'revach':
       b.entries.forEach((e, i) => out.push({ ...base(b.type, `${type}:${amud}:${i}`), ...entryCard(e) }));
       break;
     case 'hebcharts':

--- a/src/lib/sefref/dafyomi/masechtos.ts
+++ b/src/lib/sefref/dafyomi/masechtos.ts
@@ -24,7 +24,12 @@ export type DafyomiContentType =
   | 'review'
   | 'points'
   | 'hebcharts'
-  | 'yerushalmi';
+  | 'yerushalmi'
+  // Revach l'Daf — brief per-daf highlights (SUMMARY + "A BIT MORE"). Unlike the
+  // eight above it lives in the memdb app (revdaf.php?tid=&id=), not the
+  // {dir}/{folder}/{prefix}-{typecode}-{NNN}.htm tree, so it has no
+  // DAFYOMI_CONTENT_TYPES spec and is fetched via buildRevachUrl below.
+  | 'revach';
 
 export interface DafyomiContentTypeSpec {
   type: DafyomiContentType;
@@ -69,11 +74,15 @@ interface DafyomiMasechetSeed {
   dir: string;
   prefix: string;
   gid: number;
+  /** Revach l'Daf masechet id (revdaf.php?tid=). Differs from `gid`; only set
+   *  for tractates whose Revach `tid` has been confirmed. Absent => Revach is
+   *  skipped for that masechet (never guessed). */
+  tid?: number;
   verified?: boolean;
 }
 
 const SEED: DafyomiMasechetSeed[] = [
-  { tractate: 'Chullin', dir: 'chulin', prefix: 'ch', gid: 33, verified: true },
+  { tractate: 'Chullin', dir: 'chulin', prefix: 'ch', gid: 33, tid: 31, verified: true },
 
   // TODO: verify dir/prefix/gid against live pages before scraping these.
   { tractate: 'Berakhot',     dir: 'berachos',   prefix: 'br', gid: 1 },
@@ -123,6 +132,8 @@ export interface DafyomiMasechet {
   prefix: string;
   /** galei gid query param. */
   gid: number;
+  /** Revach l'Daf masechet id (revdaf.php?tid=), or undefined if not mapped. */
+  tid?: number;
   /** Highest Bavli daf number (dafim run 2..lastDaf), derived from amudim.ts. */
   lastDaf: number;
   /** Whether the dir/prefix/gid have been confirmed against live pages. */
@@ -169,4 +180,13 @@ export function buildDafyomiUrl(
   daf: number,
 ): string {
   return `${ORIGIN}/${m.dir}/${spec.folder}/${m.prefix}-${spec.typecode}-${dafToNNN(daf)}.htm${spec.query ?? ''}`;
+}
+
+/** Build the Revach l'Daf page URL for `daf`, or null when the masechet has no
+ *  known Revach `tid` (so we never guess one). Revach uses the memdb app
+ *  (revdaf.php?tid=&id=NN), not the folder/typecode .htm tree — `id` is the
+ *  plain Bavli daf number with no zero-padding. */
+export function buildRevachUrl(m: DafyomiMasechet, daf: number): string | null {
+  if (m.tid == null) return null;
+  return `${ORIGIN}/memdb/revdaf.php?tid=${m.tid}&id=${daf}`;
 }

--- a/src/lib/sefref/dafyomi/parse/index.ts
+++ b/src/lib/sefref/dafyomi/parse/index.ts
@@ -12,6 +12,7 @@ import { parseTosfos } from './tosfos.ts';
 import { parseBackground } from './background.ts';
 import { parseReview } from './review.ts';
 import { parseHebCharts } from './hebcharts.ts';
+import { parseRevach } from './revach.ts';
 import type {
   DafyomiContentType, DafyomiAmudContent, DafyomiBody, DafyomiEntry, DafyomiPointsEntry,
 } from '../schema.ts';
@@ -26,6 +27,20 @@ export interface ParsedContent {
 export function parseDafyomiContent(type: DafyomiContentType, html: string): ParsedContent {
   const warnings: string[] = [];
   const title = titleLine(html);
+
+  // Revach pages have no #content container (they predate it) — parse the
+  // SUMMARY / A BIT MORE cells directly, before the #content guard below.
+  if (type === 'revach') {
+    const { entries } = parseRevach(html);
+    if (entries.length === 0) warnings.push('no revach entries parsed');
+    return {
+      type,
+      titleLine: title,
+      blocks: entries.length ? [{ type, amud: 'a', wholeDaf: true, titleLine: title, body: { type, entries } }] : [],
+      parseWarnings: warnings,
+    };
+  }
+
   const content = contentRoot(html);
   if (!content) {
     warnings.push('no #content container found');

--- a/src/lib/sefref/dafyomi/parse/revach.ts
+++ b/src/lib/sefref/dafyomi/parse/revach.ts
@@ -1,0 +1,78 @@
+/**
+ * @fileoverview Parser for Revach l'Daf pages (revdaf.php?tid=&id=).
+ *
+ * Unlike the eight folder-based content types, a Revach page has no `#content`
+ * container: it is two table cells, "SUMMARY" (brief numbered highlights) and
+ * "A BIT MORE" (the matching numbered elaborations). Both lists are numbered
+ * 1..N and pair up by number, so we emit one entry per number with the SUMMARY
+ * line as the entry title and the "A BIT MORE" text as the body.
+ *
+ * The page predates `id=`/class conventions, so we locate each cell by its
+ * centered heading and split its markup on `<br>` (items are separated by
+ * `<br>&nbsp;<br>`). Numbers embedded in prose ("Pesachim (50a)") never start a
+ * `<br>`-delimited line, so they don't false-trigger a new item.
+ */
+
+import { parseHtml, collapse, HTMLElement } from './common.ts';
+import type { DafyomiEntry } from '../schema.ts';
+
+export interface ParsedRevach {
+  entries: DafyomiEntry[];
+}
+
+/** Find the table cell (`<td>`) whose centered heading matches `heading`. */
+function cellForHeading(root: HTMLElement, heading: string): HTMLElement | null {
+  for (const c of root.querySelectorAll('center')) {
+    if (collapse(c.text).toUpperCase() !== heading) continue;
+    let el: HTMLElement | null = c;
+    while (el && el.tagName !== 'TD') el = el.parentNode as HTMLElement | null;
+    if (el) return el;
+  }
+  return null;
+}
+
+/** Numbered items of one cell, keyed by their printed number. */
+function itemsOf(cell: HTMLElement | null, heading: string): Map<number, string> {
+  const out = new Map<number, string>();
+  if (!cell) return out;
+  // Drop everything up to and including the heading's first occurrence (the
+  // centered title), then split the remaining markup on <br>. Each non-empty
+  // piece is one list line.
+  const idx = cell.innerHTML.search(new RegExp(heading, 'i'));
+  const afterHeading = idx >= 0 ? cell.innerHTML.slice(idx + heading.length) : cell.innerHTML;
+  const pieces = afterHeading.split(/<br\s*\/?>/i);
+  let current = 0;
+  for (const piece of pieces) {
+    const txt = collapse(parseHtml(piece).text);
+    if (!txt) continue;
+    const m = txt.match(/^(\d+)[.)]\s*([\s\S]*)$/);
+    if (m) {
+      current = parseInt(m[1], 10);
+      out.set(current, m[2].trim());
+    } else if (current) {
+      // Continuation line of the current item (rare).
+      out.set(current, `${out.get(current) ?? ''} ${txt}`.trim());
+    }
+  }
+  return out;
+}
+
+export function parseRevach(html: string): ParsedRevach {
+  const root = parseHtml(html);
+  const summary = itemsOf(cellForHeading(root, 'SUMMARY'), 'SUMMARY');
+  const more = itemsOf(cellForHeading(root, 'A BIT MORE'), 'A BIT MORE');
+
+  const nums = [...new Set([...summary.keys(), ...more.keys()])].sort((a, b) => a - b);
+  const entries: DafyomiEntry[] = [];
+  for (const n of nums) {
+    const head = summary.get(n);
+    const detail = more.get(n);
+    entries.push({
+      marker: `${n}.`,
+      level: 0,
+      ...(head ? { title: { en: head } } : {}),
+      body: detail ? { en: detail } : {},
+    });
+  }
+  return { entries };
+}

--- a/src/lib/sefref/dafyomi/schema.ts
+++ b/src/lib/sefref/dafyomi/schema.ts
@@ -92,7 +92,10 @@ export type DafyomiBody =
   | { type: 'review';     entries: DafyomiEntry[] }
   | { type: 'points';     entries: DafyomiPointsEntry[] }
   | { type: 'hebcharts';  tables: DafyomiTable[] }
-  | { type: 'yerushalmi'; entries: DafyomiEntry[] };
+  | { type: 'yerushalmi'; entries: DafyomiEntry[] }
+  // Revach l'Daf: each entry pairs a brief SUMMARY highlight (entry.title) with
+  // its "A BIT MORE" elaboration (entry.body), keyed by the printed number.
+  | { type: 'revach';     entries: DafyomiEntry[] };
 
 /** One content type's parsed result, scoped to one amud. Content types that
  *  don't subdivide by amud on the site report a single `amud: 'a'` block whose

--- a/src/worker/dafyomi-live.ts
+++ b/src/worker/dafyomi-live.ts
@@ -11,7 +11,7 @@
  * never fabricated.
  */
 
-import { getDafyomiMasechet, type DafyomiContentType } from '../lib/sefref/dafyomi/masechtos';
+import { getDafyomiMasechet, buildRevachUrl, type DafyomiContentType } from '../lib/sefref/dafyomi/masechtos';
 import { assembleDaf, type FetchedType } from '../lib/sefref/dafyomi/assemble';
 import type { DafyomiDaf } from '../lib/sefref/dafyomi/schema';
 
@@ -24,19 +24,18 @@ const FOLDER_TO_TYPE: Record<string, DafyomiContentType> = {
   review: 'review', points: 'points', hebcharts: 'hebcharts', yerushalmi: 'yerushalmi',
 };
 
-async function fetchText(url: string, expectContent: boolean): Promise<string | null> {
-  // One retry: firing the hub + up to 8 content pages in parallel occasionally
-  // sees a transient failure, and since the result is cached we don't want a
-  // partial daf persisted. A genuine 404 (page has no #content) returns null
-  // without burning the retry on a real "absent".
+/** Fetch a page, retrying once on a transient failure. `requiredMarker` is a
+ *  substring that a real page must contain (folder pages have `id="content"`;
+ *  Revach pages predate it and instead carry "A BIT MORE"); pass null for the
+ *  hub page, which has neither. A page missing its marker (a 404/landing/SPA
+ *  fallback) returns null = "absent", without burning the retry. */
+async function fetchText(url: string, requiredMarker: string | null): Promise<string | null> {
   for (let attempt = 0; attempt < 2; attempt++) {
     try {
       const res = await fetch(url, { headers: { 'User-Agent': USER_AGENT, accept: 'text/html' } });
       if (res.ok) {
         const body = await res.text();
-        // Real content pages always have the #content container; 404/landing
-        // pages don't. (The hub page itself is exempt.)
-        if (expectContent && !body.includes('id="content"')) return null;
+        if (requiredMarker && !body.includes(requiredMarker)) return null;
         return body;
       }
       if (res.status === 404) return null; // genuinely absent — no retry
@@ -65,9 +64,14 @@ export async function scrapeDafyomiLive(tractate: string, daf: number): Promise<
   const m = getDafyomiMasechet(tractate);
   if (!m || daf < 2 || daf > m.lastDaf) return null;
 
-  const hub = await fetchText(`${ORIGIN}/new_daflinks.php?gid=${m.gid}&daf=${daf}`, false);
+  const hub = await fetchText(`${ORIGIN}/new_daflinks.php?gid=${m.gid}&daf=${daf}`, null);
   if (!hub) return null;
   const urls = urlsFromHub(hub);
+
+  // Revach l'Daf isn't in the hub (it lives in the memdb app), so fetch it
+  // directly when the masechet has a known tid.
+  const revachUrl = buildRevachUrl(m, daf);
+  if (revachUrl) urls.set('revach', revachUrl);
   if (urls.size === 0) return null;
 
   // Fetch sequentially, not in a burst: hammering their Apache server with ~9
@@ -75,7 +79,8 @@ export async function scrapeDafyomiLive(tractate: string, daf: number): Promise<
   // partial daf) and is impolite. Sequential is ~3s for a cold daf, then cached.
   const fetched: FetchedType[] = [];
   for (const [type, url] of urls) {
-    fetched.push({ type, url, html: await fetchText(url, true) });
+    const marker = type === 'revach' ? 'A BIT MORE' : 'id="content"';
+    fetched.push({ type, url, html: await fetchText(url, marker) });
   }
 
   const { daf: dafObj } = assembleDaf(tractate, daf, fetched);

--- a/static/dafyomi/Chullin/76.json
+++ b/static/dafyomi/Chullin/76.json
@@ -13,9 +13,10 @@
       "review": "https://www.dafyomi.co.il/chulin/review/ch-rg-076.htm?q=1",
       "points": "https://www.dafyomi.co.il/chulin/points/ch-ps-076.htm",
       "hebcharts": "https://www.dafyomi.co.il/chulin/hebcharts/ch-tl-076.htm",
-      "yerushalmi": "https://www.dafyomi.co.il/chulin/yerushalmi/ch-yr-076.htm"
+      "yerushalmi": "https://www.dafyomi.co.il/chulin/yerushalmi/ch-yr-076.htm",
+      "revach": "https://www.dafyomi.co.il/memdb/revdaf.php?tid=31&id=76"
     },
-    "fetchedAt": "2026-05-27T09:00:54.062Z"
+    "fetchedAt": "2026-05-29T08:21:04.447Z"
   },
   "amudim": {
     "a": {
@@ -2709,6 +2710,127 @@
                   }
                 }
               ]
+            }
+          ]
+        }
+      },
+      "revach": {
+        "type": "revach",
+        "amud": "a",
+        "wholeDaf": true,
+        "titleLine": "REVACH L'DAF - CHULIN 76",
+        "body": {
+          "type": "revach",
+          "entries": [
+            {
+              "marker": "1.",
+              "level": 0,
+              "title": {
+                "en": "If the hind leg of an animal is severed below the joint, the animal is Kosher. If it is severed above the joint, the animal is a Tereifah."
+              },
+              "body": {
+                "en": "According to Rav Yehudah, the joint in this context is the lower joint (tarsus). According to Ula, it is the upper joint (patella)."
+              }
+            },
+            {
+              "marker": "2.",
+              "level": 0,
+              "title": {
+                "en": "If the junction of the sinews was removed or severed, the animal is a Tereifah."
+              },
+              "body": {
+                "en": "If the junction of the sinews was severed, then even if the bone remains intact the animal is a Tereifah."
+              }
+            },
+            {
+              "marker": "3.",
+              "level": 0,
+              "title": {
+                "en": "There are differences of opinion regarding the precise location of the junction of the sinews."
+              },
+              "body": {
+                "en": "According to one opinion, the junction of the sinews is the outer part of the sinews which faces away from the bone. According to a second opinion, it is the inner part of the sinews, toward the bone. A third opinion maintains that it is the area above the bone and is called the \"Arkum.\""
+              }
+            },
+            {
+              "marker": "4.",
+              "level": 0,
+              "title": {
+                "en": "Ameimar says in the name of Rav Zevid that the junction of the sinews of an animal consists of three strands: one thick and two thin. If the thick one or the two thin ones are severed, the animal is a Tereifah."
+              },
+              "body": {
+                "en": "The one thick strand is regarded as the majority of the structure of the sinews, and the two thin ones are the majority of the strands. Therefore, the animal is a Tereifah, according to Ameimar."
+              }
+            },
+            {
+              "marker": "5.",
+              "level": 0,
+              "title": {
+                "en": "Mar bar Rav Ashi says in the name of Rav Zevid that if one thick strand or two thin strands are severed, the animal is not a Tereifah."
+              },
+              "body": {
+                "en": "If the thick strand is severed, the majority of the strands are still intact, and if the two thin strands are severed, the majority of the structure is intact. Therefore, the animal is not a Tereifah, according to Mar bar Rav Ashi."
+              }
+            },
+            {
+              "marker": "6.",
+              "level": 0,
+              "title": {
+                "en": "The junction of the sinews of a bird consists of sixteen strands. If even one of them is severed, the bird is a Tereifah."
+              },
+              "body": {
+                "en": "When one of the strands is severed, all of the strands are in danger of tearing. Therefore, the bird is a Tereifah."
+              }
+            },
+            {
+              "marker": "7.",
+              "level": 0,
+              "title": {
+                "en": "When an animal suffered a compound fracture of its leg, it is permitted if most of the flesh remains."
+              },
+              "body": {
+                "en": "This is true whether the fracture is above or below the joint."
+              }
+            },
+            {
+              "marker": "8.",
+              "level": 0,
+              "title": {
+                "en": "When an animal suffered a compound fracture of its leg below the joint, and most of the flesh is not remaining, the limb is forbidden but the animal it is permitted. If the fracture occurred above the joint, there is a disagreement about whether the animal is a Tereifah."
+              },
+              "body": {
+                "en": "According to Rav, if the compound fracture occurred above the joint and most of the flesh does not remain, the animal is a Tereifah. Shmuel maintains that only the limb is forbidden, but the animal is permitted."
+              }
+            },
+            {
+              "marker": "9.",
+              "level": 0,
+              "title": {
+                "en": "When the limb is forbidden but the animal is permitted, the forbidden limb is Metamei with Masa."
+              },
+              "body": {
+                "en": "The limb is considered to have fallen off at the time of the Shechitah and is an Ever Min ha'Chai, which conveys Tum'as Neveilah."
+              }
+            },
+            {
+              "marker": "10.",
+              "level": 0,
+              "title": {
+                "en": "When an animal suffered a compound fracture of its leg, and the skin and flesh cover most of the thickness of the bone (or, according to another version, most of the circumference of the bone), it is Kosher."
+              },
+              "body": {
+                "en": "Rav Papa maintains that the skin and the flesh must cover most of the thickness and most of the circumference of the bone."
+              }
+            },
+            {
+              "marker": "11.",
+              "level": 0,
+              "title": {
+                "en": "Ula says in the name of Rebbi Yochanan that if only skin covers the bone, it is Kosher. However, in the second version, Ula says that the skin can combine with the flesh to cover the bone."
+              },
+              "body": {
+                "en": "According to the second version of Ula in the name of Rebbi Yochanan, if the bone is covered by half flesh and half skin, it is Kosher, but if only skin covers the bone, it is a Tereifah."
+              }
             }
           ]
         }

--- a/static/dafyomi/NOTICE.md
+++ b/static/dafyomi/NOTICE.md
@@ -16,5 +16,7 @@ If you are from Kollel Iyun HaDaf and would like anything changed, please reach
 out via the project repository.
 
 Content types ingested: Insights, Background, Halacha, Tosfos outlines, Review
-questions, Points outline, Hebrew charts, Yerushalmi outlines. Regenerate with
+questions, Points outline, Hebrew charts, Yerushalmi outlines, and Revach l'Daf
+(brief per-daf highlights, co-published with Revach l'Neshamah,
+<https://www.revach.net>). Regenerate with
 `node scripts/scrape-dafyomi.mjs --tractate <Tractate>`.

--- a/tests/dafyomi-context.test.ts
+++ b/tests/dafyomi-context.test.ts
@@ -11,9 +11,17 @@ describe('fromDafyomi', () => {
   const items = fromDafyomi(corpus());
   it('produces items for every present content type', () => {
     const sources = new Set(items.map((i) => i.source));
-    for (const t of ['insights', 'background', 'halacha', 'tosfos', 'review', 'points', 'hebcharts', 'yerushalmi']) {
+    for (const t of ['insights', 'background', 'halacha', 'tosfos', 'review', 'points', 'hebcharts', 'yerushalmi', 'revach']) {
       expect(sources.has(`dafyomi:${t}`)).toBe(true);
     }
+  });
+  it('revach items pair the SUMMARY highlight (title) with the A BIT MORE body', () => {
+    const rev = items.filter((i) => i.source === 'dafyomi:revach');
+    expect(rev.length).toBeGreaterThan(1);
+    expect(rev[0].sourceLabel).toBe("Revach l'Daf");
+    expect(rev[0].title?.en?.length ?? 0).toBeGreaterThan(0);
+    expect(rev[0].body?.en?.length ?? 0).toBeGreaterThan(0);
+    expect(rev[0].segs).toEqual([]); // unplaced until the AI matcher anchors it
   });
   it('tosfos items start unplaced (segs:[]) with an amud + DH key', () => {
     const tos = items.filter((i) => i.kind === 'tosfos-piece');

--- a/tests/dafyomi-parse.test.ts
+++ b/tests/dafyomi-parse.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import { parseDafyomiContent } from '../src/lib/sefref/dafyomi/parse/index';
 import { assembleDaf } from '../src/lib/sefref/dafyomi/assemble';
 import {
-  getDafyomiMasechet, dafToNNN, buildDafyomiUrl, getContentTypeSpec, DAFYOMI_CONTENT_TYPES,
+  getDafyomiMasechet, dafToNNN, buildDafyomiUrl, buildRevachUrl, getContentTypeSpec, DAFYOMI_CONTENT_TYPES,
 } from '../src/lib/sefref/dafyomi/masechtos';
 
 const fixture = (name: string) =>
@@ -106,6 +106,38 @@ describe('points parser', () => {
     const sub = a.entries[0].children?.[0];
     expect(sub?.speaker?.roleEn).toBe('Mishnah');
     expect(sub?.body.he?.length ?? 0).toBeGreaterThan(0); // ptshebtext attached
+  });
+});
+
+describe('revach parser', () => {
+  const r = parseDafyomiContent('revach', fixture('chulin-revach-110.htm'));
+  it('reads the title and one whole-daf block (no #content container)', () => {
+    expect(r.titleLine).toBe("REVACH L'DAF - CHULIN 110");
+    expect(r.parseWarnings).toEqual([]);
+    expect(r.blocks).toHaveLength(1);
+    expect(r.blocks[0].wholeDaf).toBe(true);
+  });
+  it('pairs each SUMMARY highlight (title) with its A BIT MORE elaboration (body)', () => {
+    const body = r.blocks[0].body;
+    if (body.type !== 'revach') throw new Error('wrong body type');
+    expect(body.entries).toHaveLength(5);
+    const first = body.entries[0];
+    expect(first.marker).toBe('1.');
+    expect(first.title?.en).toBe('The Gemara explains that Rav did not really maintain that it is forbidden to eat udders.');
+    expect(first.body.en).toContain('Tatalfush');
+    // numbers embedded in prose ("Pesachim (50a)") must NOT start a new item
+    expect(body.entries[2].body.en).toContain('Pesachim (50a)');
+  });
+});
+
+describe('buildRevachUrl', () => {
+  it('builds the memdb URL for a masechet with a known tid (no zero-padding)', () => {
+    const m = getDafyomiMasechet('Chullin')!;
+    expect(buildRevachUrl(m, 110)).toBe('https://www.dafyomi.co.il/memdb/revdaf.php?tid=31&id=110');
+  });
+  it('returns null when the masechet has no known Revach tid', () => {
+    const m = getDafyomiMasechet('Berakhot')!; // unverified, no tid
+    expect(buildRevachUrl(m, 2)).toBeNull();
   });
 });
 

--- a/tests/fixtures/dafyomi/chulin-revach-110.htm
+++ b/tests/fixtures/dafyomi/chulin-revach-110.htm
@@ -1,0 +1,99 @@
+<html>
+<head>
+<TITLE>REVACH L'DAF - CHULIN 110</TITLE>
+<meta charset="windows-1255">
+<META Name="KEYWORDS" Content="Dafyomi Talmud Torah Gemara Judaism Daf Yomi">
+<META Name="DESCRIPTION" Content="Comprehensive site dedicated to supplying free, multi-level study material and lists of resources for those studying Talmud according to the 7-year Dafyomi cycle.">
+</head>
+
+<style type="text/css">
+.yosef1 {
+    font-family: "Times New Roman",Times, serif,verdana;
+    font-size: 16px;
+    line-height:120%;
+    }
+  </style>
+
+<BODY BGCOLOR="#FFFFFF">
+<P>
+
+<CENTER>
+<TABLE WIDTH=705 class="yosef1">
+<TR><TD>
+
+<HR WIDTH=60% ALIGN=center SIZE=3 NOSHADE><br>
+<!--begin extra-->
+             <FONT SIZE="+1" COLOR=""> <CENTER><B>REVACH L'DAF</B></CENTER><P>
+
+        <CENTER>brought to you by Kollel Iyun Hadaf of Yerushalayim
+		<br><A HREF="mailto:daf@dafyomi.co.il">daf@dafyomi.co.il</A> &nbsp;&nbsp;&nbsp;<A HREF="http://www.dafyomi.co.il">http://www.dafyomi.co.il</A>
+
+		<br>&amp; Revach l'Neshamah - <A HREF="http://www.revach.net">http://www.revach.net</A></CENTER>
+
+		<P></FONT>
+
+<HR WIDTH=60% ALIGN=center SIZE=3 NOSHADE><P>
+<!--end extra-->
+<table width="100%" class="yosef1">
+<tr align=left><td width="15%" valign=top><!--begin extra--><a href="http://www.dafyomi.co.il/memdb/revdaf.php?tid=31&id=109">Previous Daf</a><!--end extra--></td>
+<td width="70%" valign=center><CENTER><font size=+1 color=#3300CC><B>CHULIN 110</font></CENTER></B></td>
+
+<td width="15%" valign=center><!--begin extra-->
+<table align=right class="yosef1">
+<tr align=center><td><A HREF="http://www.dafyomi.co.il/askollel.htm"><img src="https://www.dafyomi.co.il/quest-mark.gif" alt="Ask the Kollel"><br>Ask the<br>Kollel</a></td></tr></table>
+<!--end extra--></td></tr></table>
+
+<!--begin extra-->
+<!-- Start Dedication Here -->
+<center>
+<table cellpadding="10" width="75%" class="yosef1">
+<tbody><tr>
+<td bordercolor="#3300CC" align="center" bgcolor="#3300cc" valign="middle"><font color="white"></font></td></tr></tbody></table></center><p><b>
+<!-- End dedication here -->
+<!--end extra-->
+<!-- -->
+<table width="700" cellpadding=10 class="yosef1"><tr><td valign=top>
+	</td><td valign=top>
+<!--  -->
+<font><b><center>SUMMARY</center></b></font>
+<br>1. The Gemara explains that Rav did not really maintain that it is forbidden to eat udders.<BR>&nbsp;<BR>2. The Gemara discusses whether the custom was to eat udders.<BR>&nbsp;<BR>3. One who is lenient and eats udders may not do so in a city where the custom is not to eat them.<BR>&nbsp;<BR>4. One who cannot control his bowel movements is exempt from the Mitzvah of Tefilin.<BR>&nbsp;<BR>5. While Beis Din, when in power, may force people to perform positive commandments, there are exceptions to this rule.<p>
+
+<!-- --></td><td width="50%" valign=top align=left><!--  -->
+<B><center>A BIT MORE</center></B>
+<br>1. Rav ruled that one should not eat udders in the city of Tatalfush, because he saw a woman asking her friend for a recipe for cooking meat together with milk. In order to show them how stringent this law is, he forbade the eating of udders.<BR>&nbsp;<BR>2. Rav Yitzchak bar Yosef ate udders, while Rabin did not. In Sura the custom was not to eat udders, while in Pumbedisa the custom was to permit it.<BR>&nbsp;<BR>3. This is because the Mishnah in Pesachim (50a) states that when a person travels to another city, he must observe both his own stringencies and the stringencies of the place he is visiting.<BR>&nbsp;<BR>4. This is because wearing Tefilin requires a clean body (one may not pass gas or go to the bathroom while wearing Tefilin).<BR>&nbsp;<BR>5. The Torah states explicitly regarding certain Mitzvos, such as honoring one's parents, a specific reward for keeping these Mitzvos. Accordingly, if someone does not perform one of these Mitzvos, Beis Din does not force him to perform it, but merely tells him that he clearly will not receive this reward.<p>
+
+</td></tr></table><p>
+
+<!--begin extra-->
+<a href="http://www.dafyomi.co.il/memdb/revdaf.php?tid=31&id=111">Next Daf</a><br>
+<CENTER> <A HREF="http://www.dafyomi.co.il/memdb/revindex.php?fr=chul">Index to Revach for Maseches Chulin</A></CENTER>
+<br>
+
+<TABLE align=center><CENTER>
+
+<tr><td colspan=21><center><a href="http://www.dafyomi.co.il/chulin/index.htm" target="_parent"><br>MAIN CHULIN PAGE</a></CENTER></td></tr>
+ 
+<tr><td colspan=21><center><a href="http://www.dafyomi.co.il/index.htm" target="_parent"><br><img src="https://www.dafyomi.co.il/kih-logo-tiny.gif" align=bottom  alt="KIH Logo" border=0><br>D.A.F. Home Page</a></CENTER></td></tr>
+<p></CENTER><P></TABLE>
+
+<HR SIZE=4><P>
+<center>
+<table width="70%">
+<tr>
+	<td align=center width=80%>
+	<a href="http://www.dafyomi.co.il/today.htm" class=footer>Other Masechtos</a>
+	&nbsp;&#149;&nbsp;&nbsp;<a href="http://www.dafyomi.co.il/subscribe.htm" class=footer>Join Mailing Lists</a>
+	&nbsp;&#149;&nbsp;&nbsp;<a href="http://www.dafyomi.co.il/askollel.htm" class=footer>Ask the Kollel</a><br>
+	<a href="http://www.dafyomi.co.il/calendars/calendar.htm" target="_parent" class=footer>Dafyomi Calendar</a>
+	&nbsp;&#149;&nbsp;&nbsp;<a href="http://www.dafyomi.co.il/index_heb.htm" class=footer><span class=chomerbivrit>חומר 	בעברית</span></a><br>
+	<a href="http://www.dafyomi.co.il/sponsors.htm" class=footer>Donations</a>
+	&nbsp;&#149;&nbsp;&nbsp;<a href="http://www.dafyomi.co.il/fanmail.htm" class=footer>Feedback</a>
+	&nbsp;&#149;&nbsp;&nbsp;<a href="http://www.dafyomi.co.ilcentral.htm" class=footer>Dafyomi Links</a>
+</td>
+</tr>
+</table>
+<!--end extra-->
+</td></table>
+</body>
+</html>
+<!--2026_06 missing the file content.html -->


### PR DESCRIPTION
## What

Brings in **Revach l'Daf** (Kollel Iyun HaDaf's brief per-daf highlights — a SUMMARY list paired with an "A BIT MORE" elaboration list, co-published with Revach l'Neshamah) as a ninth dafyomi.co.il content type, set up as a source to align against the daf and cached like the others.

## How it fits the existing pipeline

Revach reuses the whole dafyomi ingestion machinery (structured `DafyomiDaf` -> `ContextItem` -> alignment workbench + AI matcher + KV cache), but differs in two ways that are handled explicitly:

- **Different URL shape.** It lives in the memdb app (`revdaf.php?tid=&id=`), not the `{dir}/{folder}/{prefix}-{typecode}-{NNN}.htm` tree and is not listed in the daf hub. So it gets a per-masechet `tid` + a dedicated `buildRevachUrl`, and the live fetcher requests it directly alongside the hub-discovered types.
- **No `#content` container** (the page predates it). The parser reads the SUMMARY / A BIT MORE table cells directly, and the live/offline fetchers use `"A BIT MORE"` as the presence marker instead of `id="content"`.

Each numbered entry pairs the SUMMARY highlight (entry title) with its matching A BIT MORE text (entry body), keyed by the printed number — numbers embedded in prose (e.g. "Pesachim (50a)") don't false-trigger new items.

## Caching / coverage

Same KV-memoized path as the other types: `Chullin/76.json` now carries Revach (regenerated), and every other daf is fetched live on demand then cached. Only **Chullin**'s `tid` (31) is verified; other masechtos skip Revach until their tid is mapped (never guessed), matching the existing dir/prefix convention.

## Tests

- New `revach` parser tests + `buildRevachUrl` tests (fixture: real Chulin 110 page).
- `fromDafyomi` context test asserts Revach items appear, labeled "Revach l'Daf", paired title/body, unplaced until the AI matcher anchors them.
- Full suite: 1174 passing. Attribution updated in `NOTICE.md` and the in-app attributions page.

Note: `pnpm typecheck` reports 2 pre-existing errors in `index.ts`/`mcp.ts` (missing `@hono/mcp` / `@cloudflare/codemode` packages, absent from the installed node_modules) — unrelated to this change and present on master.