### PR TITLE
Chunk the AI context-matcher so large item sets actually anchor

### DIFF
--- a/src/worker/context-match.ts
+++ b/src/worker/context-match.ts
@@ -1,17 +1,30 @@
 /**
  * @fileoverview Worker side of the AI segment-matcher: wires the pure prompt
  * builder/parser to runLLM. Given a daf's segments and a batch of whole-daf
- * context items, returns AnchorPromotions placing each on the segment(s) it
+ * context items, returns SegMatches placing each on the segment(s) it
  * discusses. On-demand (token cost) — the deterministic matchers in
  * collectContext stay free and always-on.
+ *
+ * Items are CHUNKED across several small LLM calls rather than sent as one big
+ * prompt. The matcher localizes confidently on small batches (~0.9 confidence
+ * at <=8 items) but degrades badly on large ones — handed ~16+ items it dumps
+ * everything to "whole-daf, ~0 confidence" instead of localizing, and a batch
+ * full of localized entries + Hebrew quotes can also overrun max_tokens and
+ * truncate. Chunking keeps each call in the quality sweet spot; results merge.
  */
 
 import { runLLM, type LLMEnv } from './llm';
 import { buildMatchPrompt, parseMatchResponse, type MatchInput } from '../lib/context/anchor/ai-prompt';
 import type { SegMatch } from '../lib/context/match';
 
-/** Cap items per call so the prompt stays bounded; callers can batch. */
-const MAX_ITEMS = 40;
+/** Items per LLM call — kept small to stay in the matcher's accurate range. */
+export const MATCH_CHUNK_SIZE = 8;
+/** Overall ceiling on items matched per request, so a pathological caller can't
+ *  fan out unbounded LLM calls. Items beyond this are left unplaced (not
+ *  silently mis-placed). */
+export const MAX_ITEMS = 160;
+/** Concurrent chunk calls — bounds wall-clock without bursting the LLM gateway. */
+const CHUNK_CONCURRENCY = 4;
 
 export async function aiMatchToSegments(
   env: LLMEnv,
@@ -20,7 +33,37 @@ export async function aiMatchToSegments(
   items: MatchInput[],
 ): Promise<SegMatch[]> {
   if (segmentsHe.length === 0 || items.length === 0) return [];
+
   const batch = items.slice(0, MAX_ITEMS);
+  const chunks: MatchInput[][] = [];
+  for (let i = 0; i < batch.length; i += MATCH_CHUNK_SIZE) {
+    chunks.push(batch.slice(i, i + MATCH_CHUNK_SIZE));
+  }
+
+  // Bounded-concurrency worker pool over the chunks; preserve chunk order in
+  // the merged output.
+  const results: SegMatch[][] = new Array(chunks.length);
+  let next = 0;
+  const worker = async (): Promise<void> => {
+    for (;;) {
+      const idx = next++;
+      if (idx >= chunks.length) return;
+      results[idx] = await matchChunk(env, segmentsHe, segmentsEn, chunks[idx]);
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(CHUNK_CONCURRENCY, chunks.length) }, worker),
+  );
+  return results.flat();
+}
+
+/** One LLM call for a single small chunk of items. */
+async function matchChunk(
+  env: LLMEnv,
+  segmentsHe: string[],
+  segmentsEn: string[],
+  batch: MatchInput[],
+): Promise<SegMatch[]> {
   const { system, user } = buildMatchPrompt(segmentsHe, segmentsEn, batch);
   const result = await runLLM(env, {
     messages: [

--- a/tests/context-match-chunk.test.ts
+++ b/tests/context-match-chunk.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Regression test for the AI segment-matcher chunking (src/worker/context-match.ts).
+ *
+ * The matcher used to send up to 40 items in ONE prompt. In practice the LLM
+ * localizes well on small batches but, handed ~16+ items, dumps everything to
+ * "whole-daf, ~0 confidence" — so dafyomi/Revach content never got anchored in
+ * the workbench (which sends all whole-daf items at once). The fix chunks items
+ * into small LLM calls and merges. These tests mock runLLM so they assert the
+ * chunking contract without hitting the network.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Capture every runLLM call and answer per-chunk: place each item on a segment
+// derived from its key (so we can assert every item is covered, across chunks).
+const runLLM = vi.fn();
+vi.mock('../src/worker/llm', () => ({ runLLM: (...args: unknown[]) => runLLM(...args) }));
+
+import { aiMatchToSegments, MATCH_CHUNK_SIZE, MAX_ITEMS } from '../src/worker/context-match';
+
+const segHe = Array.from({ length: 20 }, (_, i) => `seg ${i}`);
+const segEn = segHe.map((s) => `en ${s}`);
+const items = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({ key: `k${i}`, label: 'Insights', title: `t${i}`, text: 'x' }));
+
+beforeEach(() => {
+  runLLM.mockReset();
+  // Echo back a localized match for each item in the chunk's prompt.
+  runLLM.mockImplementation(async (_env, opts: { messages: { content: string }[] }) => {
+    const user = opts.messages[1].content;
+    const keys = [...user.matchAll(/key=(k\d+)/g)].map((m) => m[1]);
+    return {
+      content: JSON.stringify({
+        matches: keys.map((key) => ({ key, segStart: 1, segEnd: 1, confidence: 0.9, quote: '' })),
+      }),
+    };
+  });
+});
+
+describe('aiMatchToSegments chunking', () => {
+  it('splits a large item set into chunks of MATCH_CHUNK_SIZE', async () => {
+    const n = 20;
+    const out = await aiMatchToSegments({} as never, segHe, segEn, items(n));
+    expect(runLLM).toHaveBeenCalledTimes(Math.ceil(n / MATCH_CHUNK_SIZE)); // 3 calls for 20 @ 8
+    // every item is placed (the old single-call path returned 0 for n>=16)
+    expect(out).toHaveLength(n);
+    expect(new Set(out.map((m) => m.key)).size).toBe(n);
+    expect(out.every((m) => m.segs.length === 1 && m.confidence === 0.9)).toBe(true);
+  });
+
+  it('each LLM call receives at most MATCH_CHUNK_SIZE items', async () => {
+    await aiMatchToSegments({} as never, segHe, segEn, items(19));
+    for (const call of runLLM.mock.calls) {
+      const user = (call[1] as { messages: { content: string }[] }).messages[1].content;
+      const count = [...user.matchAll(/key=k\d+/g)].length;
+      expect(count).toBeGreaterThan(0);
+      expect(count).toBeLessThanOrEqual(MATCH_CHUNK_SIZE);
+    }
+  });
+
+  it('a single small batch still makes exactly one call', async () => {
+    const out = await aiMatchToSegments({} as never, segHe, segEn, items(5));
+    expect(runLLM).toHaveBeenCalledTimes(1);
+    expect(out).toHaveLength(5);
+  });
+
+  it('short-circuits with no LLM call when there are no items or no segments', async () => {
+    expect(await aiMatchToSegments({} as never, segHe, segEn, [])).toEqual([]);
+    expect(await aiMatchToSegments({} as never, [], [], items(3))).toEqual([]);
+    expect(runLLM).not.toHaveBeenCalled();
+  });
+
+  it('caps total items at MAX_ITEMS (never fans out unbounded LLM calls)', async () => {
+    await aiMatchToSegments({} as never, segHe, segEn, items(MAX_ITEMS + 25));
+    expect(runLLM).toHaveBeenCalledTimes(Math.ceil(MAX_ITEMS / MATCH_CHUNK_SIZE));
+  });
+});


### PR DESCRIPTION
## Problem (found while exploring alignment via the MCP)

The deterministic Sefaria anchoring is great (~100% of Rashi/Tosafot/Rishonim/Halacha placed). But **none of the dafyomi.co.il study content — Insights, Background, Halacha, Points, and Revach l'Daf — gets anchored to the text**, even though the on-demand AI matcher is supposed to place them.

Root cause: `aiMatchToSegments` sent up to **40 items in a single prompt** with `max_tokens: 2000`. The matcher localizes confidently on small batches (~0.9 confidence at ≤8 items) but, handed ~16+ items, **dumps every item to "whole-daf, ~0 confidence"** instead of localizing (and a batch full of localized entries + Hebrew quotes overruns max_tokens and truncates). The workbench sends all whole-daf items at once (60–97 per daf), so the matcher silently no-ops on the whole set.

Evidence (same 18 items, Chullin 76a): **one batch → 0 placed; chunked by 6 → 12 placed at conf 0.9.**

## Fix

Chunk items into small LLM calls (`MATCH_CHUNK_SIZE = 8`) with bounded concurrency (4) and merge the results — each call stays in the matcher's accurate range. Also replaces the silent 40-item truncation (items 41+ were dropped) with a 160-item ceiling.

Verified placements are good, e.g. Revach's Sura/Pumbedisa highlights land on the exact Aramaic line (`בְּסוּרָא לָא אָכְלִי כַּחְלֵי`).

## Tests

New `tests/context-match-chunk.test.ts` (mocks `runLLM`): asserts N items → ⌈N/8⌉ calls, every item covered across chunks, ≤8 per call, single call for small sets, no call when empty, and the MAX_ITEMS ceiling. Full suite 1186 passing.

Typecheck: same pre-existing `@hono/mcp`/`@cloudflare/codemode` errors as master, unrelated.