### PR TITLE
Fix windows-1255 mojibake in dafyomi Hebrew (charset sniffing)

### DIFF
--- a/scripts/scrape-dafyomi.mjs
+++ b/scripts/scrape-dafyomi.mjs
@@ -29,6 +29,7 @@ import {
   getDafyomiMasechet, DAFYOMI_CONTENT_TYPES, buildDafyomiUrl, buildRevachUrl, dafToNNN,
 } from '../src/lib/sefref/dafyomi/masechtos.ts';
 import { assembleDaf } from '../src/lib/sefref/dafyomi/assemble.ts';
+import { decodeDafyomiHtml } from '../src/lib/sefref/dafyomi/decode.ts';
 
 // Revach l'Daf lives in the memdb app (revdaf.php?tid=&id=), not the
 // {dir}/{folder}/{prefix}-{typecode}-{NNN}.htm tree, so it has no
@@ -103,7 +104,8 @@ async function fetchWithRetry(url, marker) {
       const res = await fetch(url, { headers: { 'User-Agent': USER_AGENT, Accept: 'text/html' } });
       if (res.status === 404) return { absent: true };
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const body = await res.text();
+      // Sniff charset: dafyomi mixes UTF-8 and windows-1255 with no header.
+      const body = decodeDafyomiHtml(await res.arrayBuffer());
       if (!body.includes(marker)) return { absent: true };
       return { html: body };
     } catch (err) {

--- a/src/lib/sefref/dafyomi/decode.ts
+++ b/src/lib/sefref/dafyomi/decode.ts
@@ -1,0 +1,25 @@
+/**
+ * @fileoverview Charset-sniffing decode for dafyomi.co.il HTML.
+ *
+ * The site serves a MIX of encodings with NO charset in the Content-Type
+ * header: newer pages (e.g. Chullin) are UTF-8, older ones (e.g. Berachos) are
+ * windows-1255 (legacy Hebrew). A blanket `res.text()` assumes UTF-8 and turns
+ * every windows-1255 Hebrew byte into a U+FFFD replacement char (the "????"
+ * mojibake seen in the alignment cards).
+ *
+ * Sniff instead: valid UTF-8 wins (Hebrew in UTF-8 is multi-byte and decodes
+ * cleanly); otherwise the bytes are windows-1255. Runs of windows-1255 Hebrew
+ * (single high bytes 0xE0-0xFA) don't form valid UTF-8 continuation sequences,
+ * so a strict UTF-8 decode reliably throws on those pages and we fall back.
+ * Both the Worker (live fetch) and Node (offline scraper) runtimes support
+ * `TextDecoder('windows-1255')`.
+ */
+
+export function decodeDafyomiHtml(buf: ArrayBuffer | Uint8Array): string {
+  const bytes = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch {
+    return new TextDecoder('windows-1255').decode(bytes);
+  }
+}

--- a/src/worker/cache-keys.ts
+++ b/src/worker/cache-keys.ts
@@ -129,9 +129,11 @@ export function keyForGemara(tractate: string, page: string): string {
  *  cached dapim become unreachable and re-fetch fresh.
  *  v1 -> v2: added the Revach l'Daf content type (entries cached under v1
  *  predate it and would otherwise never show Revach, since the positive cache
- *  has no TTL). */
+ *  has no TTL).
+ *  v2 -> v3: charset-sniff decode (UTF-8 vs windows-1255) — v2 entries fetched
+ *  from windows-1255 pages cached mojibake'd Hebrew (U+FFFD "????"). */
 export function keyForDafyomi(tractate: string, daf: string): string {
-  return `dafyomi:v2:${slugDaf(tractate, daf)}`;
+  return `dafyomi:v3:${slugDaf(tractate, daf)}`;
 }
 export function keyForCommentaries(tractate: string, page: string): string {
   return `ctx:commentaries:v1:${slugDaf(tractate, page)}`;

--- a/src/worker/dafyomi-live.ts
+++ b/src/worker/dafyomi-live.ts
@@ -13,6 +13,7 @@
 
 import { getDafyomiMasechet, buildRevachUrl, type DafyomiContentType } from '../lib/sefref/dafyomi/masechtos';
 import { assembleDaf, type FetchedType } from '../lib/sefref/dafyomi/assemble';
+import { decodeDafyomiHtml } from '../lib/sefref/dafyomi/decode';
 import type { DafyomiDaf } from '../lib/sefref/dafyomi/schema';
 
 const ORIGIN = 'https://www.dafyomi.co.il';
@@ -34,7 +35,9 @@ async function fetchText(url: string, requiredMarker: string | null): Promise<st
     try {
       const res = await fetch(url, { headers: { 'User-Agent': USER_AGENT, accept: 'text/html' } });
       if (res.ok) {
-        const body = await res.text();
+        // dafyomi serves a mix of UTF-8 and windows-1255 with no charset header;
+        // sniff so Hebrew doesn't mojibake into U+FFFD ("????").
+        const body = decodeDafyomiHtml(await res.arrayBuffer());
         if (requiredMarker && !body.includes(requiredMarker)) return null;
         return body;
       }

--- a/tests/dafyomi-decode.test.ts
+++ b/tests/dafyomi-decode.test.ts
@@ -1,0 +1,46 @@
+/**
+ * dafyomi.co.il serves a mix of UTF-8 and windows-1255 pages with NO charset
+ * header. decodeDafyomiHtml must sniff: UTF-8 pages decode as UTF-8, and
+ * windows-1255 Hebrew (the older pages, e.g. Berachos) must NOT mojibake into
+ * U+FFFD — the "????" the user saw in the alignment cards.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { decodeDafyomiHtml } from '../src/lib/sefref/dafyomi/decode';
+
+const REPLACEMENT = '�';
+
+describe('decodeDafyomiHtml', () => {
+  it('decodes UTF-8 Hebrew correctly (e.g. the Chullin pages)', () => {
+    const utf8 = new TextEncoder().encode('<p>ארכובה knee-joint</p>');
+    const s = decodeDafyomiHtml(utf8);
+    expect(s).toContain('ארכובה');
+    expect(s).not.toContain(REPLACEMENT);
+  });
+
+  it('decodes windows-1255 Hebrew without mojibake (e.g. the Berachos pages)', () => {
+    // windows-1255: 0xE0..0xFA map to Hebrew Alef..Tav. אבת = E0 E1 FA.
+    const win1255 = new Uint8Array([0x3C, 0x70, 0x3E, 0xE0, 0xE1, 0xFA, 0x3C, 0x2F, 0x70, 0x3E]); // <p>אבת</p>
+    const s = decodeDafyomiHtml(win1255);
+    expect(s).toBe('<p>אבת</p>');
+    expect(s).not.toContain(REPLACEMENT);
+  });
+
+  it('the same windows-1255 bytes decoded as UTF-8 WOULD mojibake (guards the regression)', () => {
+    const win1255 = new Uint8Array([0xE0, 0xE1, 0xFA]);
+    // Non-fatal UTF-8 (what res.text() effectively does) produces replacement chars.
+    expect(new TextDecoder('utf-8').decode(win1255)).toContain(REPLACEMENT);
+    // The sniffing decoder recovers the Hebrew instead.
+    expect(decodeDafyomiHtml(win1255)).toBe('אבת');
+  });
+
+  it('handles plain ASCII (English Revach pages) unchanged', () => {
+    const ascii = new TextEncoder().encode('SUMMARY 1. Rav ruled...');
+    expect(decodeDafyomiHtml(ascii)).toBe('SUMMARY 1. Rav ruled...');
+  });
+
+  it('accepts an ArrayBuffer as well as a Uint8Array', () => {
+    const u8 = new TextEncoder().encode('שלום');
+    expect(decodeDafyomiHtml(u8.buffer)).toBe('שלום');
+  });
+});

--- a/tests/dafyomi-live.test.ts
+++ b/tests/dafyomi-live.test.ts
@@ -29,7 +29,13 @@ const insightsHtml = readFileSync(
 );
 
 function res(body: string, status = 200) {
-  return { ok: status >= 200 && status < 300, status, text: async () => body };
+  // fetchText now reads arrayBuffer() (to charset-sniff); keep text() too.
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => body,
+    arrayBuffer: async () => new TextEncoder().encode(body).buffer,
+  };
 }
 
 /** Install a fetch stub driven by a (url) -> Response map function. Records the


### PR DESCRIPTION
## Problem

The alignment cards showed dafyomi Hebrew as `????` (U+FFFD). Cause: dafyomi.co.il serves a **mix of encodings with no charset header** — newer pages (Chullin) are UTF-8, older ones (Berachos 5, etc.) are **windows-1255**. The worker's `res.text()` assumes UTF-8, so every windows-1255 Hebrew byte became a replacement char. (Chullin 76 looked fine only because that page happens to be UTF-8.)

Confirmed live: the Berachos background page is windows-1255 (874 U+FFFD under UTF-8), Chullin's is valid UTF-8.

## Fix

`decodeDafyomiHtml(buf)`: strict UTF-8 decode first; on failure fall back to `windows-1255`. Runs of windows-1255 Hebrew (single high bytes 0xE0–0xFA) don't form valid UTF-8, so the strict decode reliably throws on those pages. Verified the Workers runtime supports `TextDecoder('windows-1255')` (decoded `E0 E1 FA → אבת`). Wired into both the live worker fetch and the offline scraper.

Bumps the dafyomi cache `v2 -> v3` so dapim already cached with mojibake re-fetch and decode correctly.

## Tests

`tests/dafyomi-decode.test.ts`: UTF-8 Hebrew stays clean, windows-1255 Hebrew decodes without U+FFFD, the same bytes as UTF-8 *would* mojibake (regression guard), ASCII unchanged, ArrayBuffer accepted. Updated the dafyomi-live fetch stub to expose `arrayBuffer()`. Full suite 1191 passing.