### PR TITLE
Anchor Background glossary/girsa terms to their segments

### DIFF
--- a/src/lib/context/anchor/bg-term.ts
+++ b/src/lib/context/anchor/bg-term.ts
@@ -1,0 +1,91 @@
+/**
+ * @fileoverview Background-term matcher (deterministic, high confidence).
+ *
+ * dafyomi.co.il "Background" glossary/girsa items carry the exact Hebrew term
+ * they gloss (`title.he`, from the page's `span.defheb` / `girsalocheb`) — and
+ * that term is a verbatim phrase quoted from the Gemara. So we locate it: find
+ * the daf segment(s) whose Hebrew text contains the term as a run of whole
+ * words, and place the item there. Matching is whole-word (so "טורף" doesn't
+ * match inside "מטורף"), except the FIRST word may carry a leading Hebrew
+ * prefix (ו/ה/ב/כ/ל/מ/ש/ד), since a glossed lemma like "ארכובה" appears in the
+ * Gemara as "הארכובה".
+ *
+ * Background blocks are whole-daf (both amudim), but the segments handed in are
+ * one amud — so a term from the OTHER amud simply finds no match and stays
+ * unplaced (correct: it isn't on this amud). Common/ambiguous terms that hit
+ * many segments are left unplaced rather than smeared across the daf.
+ */
+
+import type { ContextItem } from '../types.ts';
+
+const NIQQUD = /[֑-ׇ]/g;
+/** Mirror of the other matchers' Hebrew normalization: strip niqqud,
+ *  punctuation, and treat maqaf/hyphen as a word break. */
+function normHe(s: string): string {
+  return (s || '')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(NIQQUD, '')
+    .replace(/[.,:;?!"'״׳()[\]{}]/g, '')
+    .replace(/[־-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/** One or two stacked Hebrew prefix letters (vav/he/bet/kaf/lamed/mem/shin/dalet). */
+const PREFIX = /^[ובהכלמשד]{1,2}$/;
+
+/** Match a segment word to a term word — exact, or (first word only) the
+ *  segment word is the term word carrying a leading Hebrew prefix. */
+function wordEq(segWord: string, termWord: string, allowPrefix: boolean): boolean {
+  if (segWord === termWord) return true;
+  if (!allowPrefix || segWord.length <= termWord.length || !segWord.endsWith(termWord)) return false;
+  return PREFIX.test(segWord.slice(0, segWord.length - termWord.length));
+}
+
+/** True if `term` (as whole words) appears as a contiguous run in `seg`. The
+ *  first term word may be prefixed; the rest must match exactly. */
+function wordsContain(seg: string[], term: string[]): boolean {
+  if (term.length === 0) return false;
+  for (let i = 0; i + term.length <= seg.length; i++) {
+    if (!wordEq(seg[i], term[0], true)) continue;
+    let ok = true;
+    for (let j = 1; j < term.length; j++) {
+      if (seg[i + j] !== term[j]) { ok = false; break; }
+    }
+    if (ok) return true;
+  }
+  return false;
+}
+
+/** Min normalized-character length for a term to be specific enough to place
+ *  (one- or two-letter tokens are too generic). */
+const MIN_TERM_CHARS = 3;
+/** Place a term that hits at most this many segments; more = too ambiguous. */
+const MAX_HIT_SEGS = 3;
+
+/** Place dafyomi Background glossary/girsa items onto the segment(s) whose
+ *  Hebrew contains their term. Mutates matched items (sets `segs`/`via`/
+ *  `confidence`). Returns the count placed. */
+export function matchBackgroundTerms(items: ContextItem[], segmentsHe: string[] | undefined): number {
+  if (!segmentsHe || segmentsHe.length === 0) return 0;
+  const segWords = segmentsHe.map((h) => normHe(h).split(' ').filter(Boolean));
+
+  let placed = 0;
+  for (const item of items) {
+    if (item.source !== 'dafyomi:background') continue;
+    if (item.kind !== 'glossary' && item.kind !== 'girsa') continue;
+    if (item.segs.length > 0) continue; // already placed
+    const termWords = normHe(item.title?.he ?? '').split(' ').filter(Boolean);
+    if (termWords.join('').length < MIN_TERM_CHARS) continue;
+
+    const hits: number[] = [];
+    segWords.forEach((seg, i) => { if (wordsContain(seg, termWords)) hits.push(i); });
+    if (hits.length === 0 || hits.length > MAX_HIT_SEGS) continue;
+
+    item.segs = hits;
+    item.via = 'bg-term';
+    item.confidence = hits.length === 1 ? 0.9 : 0.6;
+    placed++;
+  }
+  return placed;
+}

--- a/src/worker/context-providers.ts
+++ b/src/worker/context-providers.ts
@@ -20,6 +20,7 @@
 import {
   getDafyomiContentCached,
   getSefariaPageCached,
+  getSefariaSegmentsCached,
   getRishonimCached,
   getHalachaRefsCached,
   getMishnaBundleCached,
@@ -30,6 +31,7 @@ import {
   fromCommentaryPieces, fromRishonim, fromHalachaRefs, fromMishna, fromTopics,
 } from '../lib/context/fromSefaria';
 import { matchTosfos } from '../lib/context/anchor/tosfos';
+import { matchBackgroundTerms } from '../lib/context/anchor/bg-term';
 import type { ContextItem } from '../lib/context/types';
 
 export interface ContextEnv {
@@ -52,9 +54,10 @@ export async function collectContext(
 ): Promise<ContextItem[]> {
   const cache = env.CACHE;
   const allowLive = env.DAFYOMI_LIVE !== '0';
-  const [dafyomi, sefariaPage, rishonim, halacha, mishna, topics] = await Promise.all([
+  const [dafyomi, sefariaPage, segments, rishonim, halacha, mishna, topics] = await Promise.all([
     getDafyomiContentCached(cache, env.ASSETS, tractate, page, { assetOrigin, allowLive }).catch(() => null),
     getSefariaPageCached(cache, tractate, page).catch(() => null),
+    getSefariaSegmentsCached(cache, tractate, page).catch(() => null),
     getRishonimCached(cache, tractate, page).catch(() => []),
     getHalachaRefsCached(cache, tractate, page).catch(() => ({})),
     getMishnaBundleCached(cache, tractate, page).catch(() => []),
@@ -74,6 +77,8 @@ export async function collectContext(
     const dy = fromDafyomi(dafyomi);
     // Promote dafyomi Tosfos pieces to segments via Sefaria's tosafot pieceKeys.
     matchTosfos(dy, sefariaPage?.tosafot);
+    // Place Background glossary/girsa terms onto the segment(s) that quote them.
+    matchBackgroundTerms(dy, segments?.he);
     items.push(...dy);
   }
   return items;

--- a/tests/bg-term-match.test.ts
+++ b/tests/bg-term-match.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for the deterministic Background-term matcher (src/lib/context/anchor/bg-term.ts).
+ * It anchors dafyomi Background glossary/girsa items onto the daf segment(s)
+ * that quote their Hebrew term verbatim.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { matchBackgroundTerms } from '../src/lib/context/anchor/bg-term';
+import type { ContextItem } from '../src/lib/context/types';
+
+function bg(key: string, he: string, kind = 'glossary'): ContextItem {
+  return {
+    source: 'dafyomi:background', sourceLabel: 'Background', kind, key,
+    title: { he, en: key }, body: { en: 'def' }, segs: [],
+  };
+}
+
+// A small daf: niqqud + maqaf in seg 2 to exercise normalization.
+const SEGS = [
+  'אמר רב יהודה',                       // 0
+  'תנו רבנן בהמה בחייה',                  // 1
+  'מִן הָאַרְכּוּבָה וּלְמַטָּה כָּשֵׁר',  // 2 (the term, vocalized)
+  'דאגרמא ולבר',                         // 3
+  'אמר רב יהודה שוב',                     // 4 (repeats "אמר רב יהודה")
+];
+
+describe('matchBackgroundTerms', () => {
+  it('places a term on the single segment that quotes it (niqqud-insensitive)', () => {
+    const items = [bg('g1', 'ארכובה')];
+    const placed = matchBackgroundTerms(items, SEGS);
+    expect(placed).toBe(1);
+    expect(items[0].segs).toEqual([2]);
+    expect(items[0].via).toBe('bg-term');
+    expect(items[0].confidence).toBe(0.9);
+  });
+
+  it('matches a multi-word term as a contiguous run', () => {
+    const items = [bg('g2', 'דאגרמא ולבר')];
+    matchBackgroundTerms(items, SEGS);
+    expect(items[0].segs).toEqual([3]);
+  });
+
+  it('matches whole words only — does not match inside a longer word', () => {
+    // "רכובה" is a substring of "ארכובה" but not a whole word -> no placement.
+    const items = [bg('g3', 'רכובה')];
+    expect(matchBackgroundTerms(items, SEGS)).toBe(0);
+    expect(items[0].segs).toEqual([]);
+  });
+
+  it('places on multiple segments (<=3) with lower confidence', () => {
+    const items = [bg('g4', 'אמר רב יהודה')]; // segs 0 and 4
+    matchBackgroundTerms(items, SEGS);
+    expect(items[0].segs).toEqual([0, 4]);
+    expect(items[0].confidence).toBe(0.6);
+  });
+
+  it('leaves too-short and absent terms unplaced', () => {
+    const items = [bg('s', 'בו'), bg('absent', 'מילה שאיננה')];
+    expect(matchBackgroundTerms(items, SEGS)).toBe(0);
+    expect(items.every((i) => i.segs.length === 0)).toBe(true);
+  });
+
+  it('only touches Background glossary/girsa items, and not already-placed ones', () => {
+    const other: ContextItem = {
+      source: 'dafyomi:insights', sourceLabel: 'Insights', kind: 'insights', key: 'x',
+      title: { he: 'ארכובה' }, body: {}, segs: [],
+    };
+    const already = bg('placed', 'ארכובה');
+    already.segs = [1]; already.via = 'ai';
+    matchBackgroundTerms([other, already], SEGS);
+    expect(other.segs).toEqual([]);          // wrong source -> untouched
+    expect(already.segs).toEqual([1]);       // already placed -> untouched
+    expect(already.via).toBe('ai');
+  });
+
+  it('handles girsa items too', () => {
+    const items = [bg('gir', 'ארכובה', 'girsa')];
+    matchBackgroundTerms(items, SEGS);
+    expect(items[0].segs).toEqual([2]);
+  });
+
+  it('no-ops when there are no segments', () => {
+    const items = [bg('g', 'ארכובה')];
+    expect(matchBackgroundTerms(items, undefined)).toBe(0);
+    expect(matchBackgroundTerms(items, [])).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

Implements the deferred **Background-term matcher**. dafyomi Background glossary/girsa items carry the exact Hebrew lemma they gloss (`title.he`) — a verbatim phrase from the Gemara — but they all sat "not located". This places them on the segment(s) that quote them.

## How

`matchBackgroundTerms(items, segmentsHe)` (deterministic, in `collectContext` next to the Tosfos-DH matcher): normalize the term and each segment (strip niqqud/punct, maqaf→space), then whole-word match the term as a contiguous run. The first word may carry a leading Hebrew prefix (ו/ה/ב/כ/ל/מ/ש/ד) so a lemma like `ארכובה` matches `הארכובה`; subsequent words match exactly (so `טורף` never matches inside `מטורף`).

- 1 hit → place, confidence 0.9
- 2–3 hits → place all, confidence 0.6
- 0 or >3 hits → left unplaced (the latter is too ambiguous to force)

Uses `getSefariaSegmentsCached` — the same Sefaria segment space as the pieceKeys/AI matchers, so highlighting stays consistent. Background is whole-daf; terms from the other amud find no match and correctly stay unplaced.

Measured on production data: ~17–20 of ~30–50 glossary terms per daf now anchor (`ארכובה→seg2`, `קיקיון דיונה→seg2`, `חבוש→seg12`), the rest being the other amud's terms or non-verbatim glosses.

## Tests

`tests/bg-term-match.test.ts`: single/multi-word placement, niqqud + prefix handling, whole-word-only (no substring), the ≤3 ambiguity cap, source/already-placed guards, girsa items, empty-segments no-op. Full suite 1199 passing.

No cache bump needed — `/api/context` recomputes the pool per request from cached sources, so this takes effect on deploy. Typecheck: same pre-existing `@hono/mcp` errors as master.