### PR TITLE
Fix Background parser dropping glossary on no-girsa pages

### DIFF
--- a/src/lib/sefref/dafyomi/parse/background.ts
+++ b/src/lib/sefref/dafyomi/parse/background.ts
@@ -23,46 +23,42 @@ export interface BackgroundResult {
   lineCounts?: string;
 }
 
-type Section = 'girsa' | 'glossary';
-
 export function parseBackground(content: HTMLElement): BackgroundResult {
   const girsa: DafyomiEntry[] = [];
   const glossary: DafyomiEntry[] = [];
   let lineCounts: string | undefined;
-  let section: Section = 'girsa';
   let lastGirsa: DafyomiEntry | null = null;
 
   for (const el of elementChildren(content)) {
     const cls = el.getAttribute('class') ?? '';
 
     if (/\blinecount\b/.test(cls)) { lineCounts = text(el).replace(/^\[|\]$/g, ''); continue; }
-    if (/\bgirsasep\b/.test(cls)) {
-      // Any separator after the first opening one moves us toward glossary.
-      if (/GLOSSARY/i.test(text(el)) || (girsa.length > 0 && /\bbase\b/.test(cls))) {
-        section = 'glossary';
-      }
+    if (/\b(girsasep|girsatext)\b/.test(cls)) continue; // separators / section preamble
+
+    // Classify by the element's OWN class, not a stateful girsa->glossary flip
+    // keyed on the `girsasep` separator: some background pages have no girsa
+    // section at all (and so no separator), and the state machine would stay
+    // stuck in "girsa" and swallow their entire glossary. girsaloc/girsa are
+    // girsa; a plain `def` is a glossary entry — order matters since girsa
+    // elements also carry the `def` class.
+    if (/\bgirsaloc\b/.test(cls)) {
+      const term = collapse((el.querySelector('.girsalocheb') ?? el.querySelector('.defheb'))?.text ?? '');
+      const entry: DafyomiEntry = {
+        marker: collapse(el.querySelector('.nm')?.text ?? '') || undefined,
+        level: 0,
+        title: txt(stripMarker(text(el)), term),
+        body: {},
+        children: [],
+      };
+      const refs = extractRefs(el);
+      if (refs.length) entry.refs = refs;
+      girsa.push(entry);
+      lastGirsa = entry;
       continue;
     }
-    if (/\bgirsatext\b/.test(cls)) continue; // section preamble
-
-    if (section === 'girsa') {
-      if (/\bgirsaloc\b/.test(cls)) {
-        const term = collapse((el.querySelector('.girsalocheb') ?? el.querySelector('.defheb'))?.text ?? '');
-        const entry: DafyomiEntry = {
-          marker: collapse(el.querySelector('.nm')?.text ?? '') || undefined,
-          level: 0,
-          title: txt(stripMarker(text(el)), term),
-          body: {},
-          children: [],
-        };
-        const refs = extractRefs(el);
-        if (refs.length) entry.refs = refs;
-        girsa.push(entry);
-        lastGirsa = entry;
-      } else if (/\bgirsa\b/.test(cls)) {
-        const body = text(el);
-        if (lastGirsa && body) lastGirsa.body.en = lastGirsa.body.en ? `${lastGirsa.body.en}\n${body}` : body;
-      }
+    if (/\bgirsa\b/.test(cls)) {
+      const body = text(el);
+      if (lastGirsa && body) lastGirsa.body.en = lastGirsa.body.en ? `${lastGirsa.body.en}\n${body}` : body;
       continue;
     }
 

--- a/src/worker/cache-keys.ts
+++ b/src/worker/cache-keys.ts
@@ -131,9 +131,11 @@ export function keyForGemara(tractate: string, page: string): string {
  *  predate it and would otherwise never show Revach, since the positive cache
  *  has no TTL).
  *  v2 -> v3: charset-sniff decode (UTF-8 vs windows-1255) — v2 entries fetched
- *  from windows-1255 pages cached mojibake'd Hebrew (U+FFFD "????"). */
+ *  from windows-1255 pages cached mojibake'd Hebrew (U+FFFD "????").
+ *  v3 -> v4: background parser fix — pages with no girsa section (no girsasep)
+ *  had their entire glossary swallowed; v3 cached those as empty background. */
 export function keyForDafyomi(tractate: string, daf: string): string {
-  return `dafyomi:v3:${slugDaf(tractate, daf)}`;
+  return `dafyomi:v4:${slugDaf(tractate, daf)}`;
 }
 export function keyForCommentaries(tractate: string, page: string): string {
   return `ctx:commentaries:v1:${slugDaf(tractate, page)}`;

--- a/tests/dafyomi-parse.test.ts
+++ b/tests/dafyomi-parse.test.ts
@@ -89,10 +89,24 @@ describe('background parser', () => {
     const body = r.blocks[0].body;
     if (body.type !== 'background') throw new Error('wrong body type');
     expect(body.glossary.length).toBeGreaterThan(10);
+    expect(body.girsa.length).toBeGreaterThan(0); // this page HAS a girsa section
     const arkuvah = body.glossary[0];
     expect(arkuvah.title?.he).toBe('ארכובה');
     expect(arkuvah.title?.en).toBe('ARKUVAH');
     expect(arkuvah.body.en).toContain('knee-joint');
+  });
+
+  it('parses the glossary on a page with NO girsa section (no girsasep separator)', () => {
+    // Regression: the parser used to stay stuck in "girsa" mode without a
+    // girsasep separator and swallow every glossary entry (Sanhedrin 37a).
+    const sr = parseDafyomiContent('background', fixture('sanhedrin-backgrnd-037.htm'));
+    const body = sr.blocks[0].body;
+    if (body.type !== 'background') throw new Error('wrong body type');
+    expect(body.girsa.length).toBe(0);
+    expect(body.glossary.length).toBeGreaterThan(40); // ~62 terms
+    expect(body.glossary[0].title?.he).toBe('ושלש שורות');
+    expect(body.glossary[0].title?.en).toBe('SHALOSH SHUROS');
+    expect(sr.parseWarnings).toEqual([]);
   });
 });
 

--- a/tests/fixtures/dafyomi/sanhedrin-backgrnd-037.htm
+++ b/tests/fixtures/dafyomi/sanhedrin-backgrnd-037.htm
@@ -1,0 +1,257 @@
+﻿<!DOCTYPE HTML>
+<html lang="en">
+<head>
+<!--85:15  12/30/24-->
+<!--hr84.1-->    
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<!-- The above 3 meta tags *must* come first in the head -->
+<!-- no remmed css links allowed -->
+
+
+<meta name="Keywords" content="Gemara, Talmud, Dafyomi, Daf Yomi, Translation, Background">
+
+<title>BACKGROUND TO THE DAF - SANHEDRIN 37</title>
+
+<!--BKMRK1-->
+
+
+
+<link href="../../headerset.css" rel="stylesheet" type="text/css">
+<link href="../../footerset.css" rel="stylesheet" type="text/css">
+<link href="../../backgroundstyles4.css" rel="stylesheet" type="text/css">
+<link rel="shortcut icon" href="http://www.dafyomi.co.il/kih_icon_clear.ico">
+<!--BKMRK2-->
+</head>
+
+<body>
+<div id="int">
+<div id="wrapper">
+    
+    <div id="header">    
+        <div class="horiz_rule"></div>
+        <div class="title">BACKGROUND TO THE DAILY DAF</div>
+
+<div class="headerdedication"><div align="center" style="margin:0in;margin-top:6pt;margin-bottom:.0001pt;text-align:center">
+	<p>
+		<strong style="font-size: 14px;">THE MORDECAI (MARCUS) BEN ELIMELECH SHMUEL&nbsp;</strong><strong style="font-size: 14px;">KORNFELD</strong></p>
+</div>
+ <b>MASECHES SANHEDRIN</b><!--2026_06 missing the file content.html --></div>
+<div class="headerspecialsection"><br />
+<!--2026_06 missing the file content.html --></div>
+
+  
+        <img class="kih_logo" src="http://www.dafyomi.co.il/kih-logo-tiny.gif" alt="Kollel Iyun Hadaf">
+<div class="headerline">prepared by Kollel Iyun Hadaf<br class="smallbreak"> of Yerushalayim</div>
+<div class="email"><a href="mailto:daf@dafyomi.co.il">daf@dafyomi.co.il</a>, <a href="https://dafyomi.co.il">www.dafyomi.co.il</a> </div>
+<div class="roshkollel">Rosh Kollel: Rabbi Mordecai Kornfeld</div>
+
+        <div class="horiz_rule"></div>
+
+
+        <div id="nav">
+<!--prevdaf1-->
+            <div class="left"><a href="sn-in-036.htm"><img src="http://www.dafyomi.co.il/left.gif" alt="Previous"></a></div>
+<!--prevdaf2-->
+
+
+   <div class="daf">SANHEDRIN 37</div>
+
+
+
+
+<!--nextdaf1-->
+            <div class="right"><a href="sn-in-038.htm"><img src="http://www.dafyomi.co.il/right.gif" alt="Next"></a></div>
+<!--nextdaf2-->
+        </div>  <!-- end #nav1 -->
+
+
+
+     
+
+<!--askkollel1-->
+        <div class="clear"></div>
+        <div class="ask">
+            <a href="http://www.dafyomi.co.il/askollel.htm">
+                <img src="http://www.dafyomi.co.il/quest-mark.gif" alt="Ask the Kollel">
+                <br><span>Ask the<br>Kollel</span>
+            </a>
+        </div>
+<!--askkollel2--> 
+    </div>  
+
+
+ 
+   <!-- end #header -->
+    <div class="clear"></div>
+
+<div class="dedicationbox"> </div>    
+<!--ADVERTTEXT-->
+    
+	    <div id="content">
+
+<p class="linecount">[37a - 46 lines; 37b - 55 lines]</p>
+
+<p class="spacer"></p>
+<p id="1" class="def"><span class="nm">1<span>)</span></span><span class="ln">[line 1]</span><span class="defheb">ושלש שורות</span><span class="hack"></span><span class="deftext">SHALOSH SHUROS</span>- three rows [of Talmidim, student judges]. These three rows are comprised of young, potential judges. If the need arises to add additional judges to the Beis Din of 23 judging a capital case (for example, 12 of the judges said the defendant was guilty, and 11 said that he was innocent, in which case the verdict cannot be passed, since a guilty verdict needs a majority of 2 judges), the judges are added from those who are sitting in these three rows. Each of the student rows also consists of 23 judges, such that three rows are necessary in order to provide up to 48 additional judges (to reach a Beis Din of 71).</p>
+<p id="2" class="def"><span class="nm">2<span>)</span></span><span class="ln">[line 6]</span><span class="defheb">אחד מן הקהל</span><span class="hack"></span><span class="deftext">ECHAD MIN HA'KAHAL</span>- one [of the Talmidim] from the assembly. The students of the assembly are less qualified and less experienced that those who sit in the three rows as candidate judges.</p>
+<p id="3" class="def"><span class="nm">3<span>)</span></span><span class="ln">[line 9]</span><span class="defheb">"שָׁרְרֵךְ אַגַּן הַסַּהַר אַל יֶחְסַר הַמָּזֶג; בִּטְנֵךְ עֲרֵימַת חִטִּים סוּגָה בַּשּׁוֹשַׁנִּים"</span><span class="hack"></span><span class="deftext">"SHARERECH AGAN HA'SAHAR, AL YECHSAR HA'MAZEG; BITNECH AREMAS CHITIM, SUGAH BA'SHOSHANIM"</span>- "Your navel is like a goblet shaped like the moon, that never lacks blended wine; your stomach is like a heap of wheat, fenced in with roses" <span class="pasuksource">(Shir ha'Shirim 7:3)</span>.</p>
+<p id="4" class="def"><span class="nm">4<span>)</span></span><span class="ln">[line 12]</span><span class="defheb">בטיבורו של עולם</span><span class="hack"></span><span class="deftext">TIBURO SHEL OLAM</span>- the center (lit. navel, which is at the center of the body) of the world. The Sanhedrin convened in the Beis ha'Mikdash, which is the center of the world.</p>
+<p id="5" class="def"><span class="nm">5<span>)</span></span><span class="ln">[line 13]</span><span class="defheb">שהיא דומה לסהר</span><span class="hack"></span><span class="deftext">SHE'HI DOMAH L'SAHAR</span>- for it is similar to the moon (in that the Sanhedrin sits in the shape of a semi-circle, like a crescent moon)</p>
+<p id="6" class="def"><span class="nm">6<span>)</span></span><span class="ln">[line 20]</span><span class="defheb">אפילו כסוגה של שושנים</span><span class="hack"></span><span class="deftext">AFILU K'SUGAH SHEL SHOSHANIM</span>- [a protective measure] even [as thin] as a fence of roses [keeps the Jewish people away from sin]</p>
+<p id="7" class="def"><span class="nm">7<span>)</span></span><span class="ln">[line 21]</span><span class="defheb">ההוא מינא</span><span class="hack"></span><span class="deftext">HA'HU MINA</span>- that certain heretic</p>
+<p id="8" class="def"><span class="nm">8<span>)</span></span><span class="ln">[line 23]</span><span class="defheb">בנעורת</span><span class="hack"></span><span class="deftext">NE'ORES</span>- thoroughly beaten flax</p>
+<p id="9" class="def"><span class="nm">9<span>)</span></span><span class="ln">[line 23]</span><span class="defheb">מהבהבת</span><span class="hack"></span><span class="deftext">MEHAVHEVES</span>- (O.F. flamer) catch fire, combust</p>
+<p id="10" class="def"><span class="nm">10<span>)</span></span><span class="ln">[line 25]</span><span class="defheb">"כְּפֶלַח הָרִמּוֹן רַקָּתֵךְ מִבַּעַד לְצַמָּתֵךְ"</span><span class="hack"></span><span class="deftext">"K'FELACH HA'RIMON RAKASECH..."</span>- "As a section of a pomegranate is your cheek [within your veil]" <span class="pasuksource">(Shir ha'Shirim 6:7)</span> - Reish Lakish reads this verse to mean: "As many as a pomegranate's seeds are the merits of your unworthiest" (The word for "your cheek," "Rakasech," hints at the word "רֵיק" "Reik," or "empty.")</p>
+<p id="11" class="def"><span class="nm">11<span>)</span></span><span class="ln">[line 25]</span><span class="defheb">ריקנין</span><span class="hack"></span><span class="deftext">REIKANIN</span>- the empty ones</p>
+<p id="12" class="def"><span class="nm">12<span>)</span></span><span class="ln">[line 26]</span><span class="defheb">"[וַיִּגַּשׁ וַיִּשַּׁק לוֹ,] וַיָּרַח אֶת רֵיחַ בְּגָדָיו [וַיְבָרְכֵהוּ...]"</span><span class="hack"></span><span class="deftext">"... VA'YARACH ES REI'ACH BEGADAV [VAY'VARECHEIHU...]"</span>- "... and he smelled the fragrance of his clothing, [and blessed him...]" <span class="pasuksource">(Bereishis 27:27)</span> - The Torah relates that when Yakov came to receive the blessing from Yitzchak, Yitzchak smelled the fragrance of his son's clothing.</p>
+<p id="13" class="def"><span class="nm">13<span>)</span></span><span class="ln">[line 27]</span><span class="defheb">בוגדיו</span><span class="hack"></span><span class="deftext">BOGDAV</span>-  his sinners (lit. traitors), referring to the Jewish descendants of Yakov who would sin (even they have a good fragrance - see Insights)</p>
+<p id="14" class="def"><span class="nm">14<span>)</span></span><span class="ln">[line 27]</span><span class="defheb">בריוני</span><span class="hack"></span><span class="deftext">BIRYONEI</span>- ruffians</p>
+<p id="15" class="def"><span class="nm">15<span>)</span></span><span class="ln">[line 27]</span><span class="defheb">בשיבבותיה דרבי זירא</span><span class="hack"></span><span class="deftext">SHIVEVUSEI D'REBBI ZEIRA</span>- the neighborhood of Rebbi Zeira</p>
+<p id="16" class="def"><span class="nm">16<span>)</span></span><span class="ln">[line 27]</span><span class="defheb">דהוה מקרב להו כי היכי דניהדרו להו בתיובתא</span><span class="hack"></span><span class="deftext">D'HAVAH MEKAREV LEHU KI HEICHI D'NIHADRU LEHU BI'TEYUVTA</span>- he (Rebbi Zeira) would bring them close [to him] in order that they return in repentance</p>
+<p id="17" class="def"><span class="nm">17<span>)</span></span><span class="ln">[line 28]</span><span class="defheb">והוו קפדי רבנן</span><span class="hack"></span><span class="deftext">HAVU KAPDEI RABANAN</span>- the Rabanan were strict with Rebbi Zeira (they did not want him to bring those sinners close to him, as they felt that the sinners were doing Teshuvah only to impress Rebbi Zeira)</p>
+<p id="18" class="def"><span class="nm">18<span>)</span></span><span class="ln">[line 28]</span><span class="defheb">כי נח נפשיה דרבי זירא</span><span class="hack"></span><span class="deftext">KI NACH NAFSHEI D'REBBI ZEIRA</span>- when Rebbi Zeira died</p>
+<p id="19" class="def"><span class="nm">19<span>)</span></span><span class="ln">[line 28]</span><span class="defheb">עד האידנא הוה חריכא קטין שקיה</span><span class="hack"></span><span class="deftext">AD HA'IDNA HAVAH CHARIKA KATIN SHAKEI</span>- until now, the burned, short-legged one was alive (referring to Rebbi Zeira, who was short and who had burned his legs; see Bava Metzia 85a, which describes the incident in which Rebbi Zeira went into a fiery oven in order to test himself)</p>
+<p id="20" class="def"><span class="nm">20<span>)</span></span><span class="ln">[line 29]</span><span class="defheb">דהוה בעי עלן רחמי</span><span class="hack"></span><span class="deftext">D'HAVAH BA'I ALAN RACHAMEI</span>- who would pray for mercy for us</p>
+<p id="21" class="def"><span class="nm">21<span>)</span></span><span class="ln">[line 30]</span><span class="defheb">כי ניידי, כולהו ניידי</span><span class="hack"></span><span class="deftext">KI NAIDEI, KULHU NAIDEI</span>- when they moved (the one or two candidate judges who were selected from the front of the three rows to become members of Beis Din), all of them moved (all of the candidate judges in the three rows moved, by shifting seats, each person moving up one (or two) seats)</p>
+<p id="22" class="def"><span class="nm">22<span>)</span></span><span class="ln">[line 31]</span><span class="defheb">השתא מותביתו לי בדנבי</span><span class="hack"></span><span class="deftext">HASHTA MOSVISU LI B'DANVEI</span>- now they are seating me at the tail (one who was seated at the head of the second row, for example, would be seated at the end of the first row when they all moved up one seat)</p>
+<p id="23" class="def"><span class="nm">23<span>)</span></span><span class="ln">[line 33]</span><span class="defheb">מאיימין</span><span class="hack"></span><span class="deftext">ME'AIMIN</span>- threaten, frighten, intimidate</p>
+<p id="24a" class="def"><span class="nm">24<span>a)</span></span><span class="ln">[line 34]</span><span class="defheb">מאומד</span><span class="hack"></span><span class="deftext">ME'OMED</span>- based on a conjecture [of what occurred]</p>
+<p id="24b" class="def"><span class="nm"><span>b)</span></span><span class="ln">[line 34]</span><span class="defheb">ומשמועה</span><span class="hack"></span><span class="deftext">MI'SHEMU'AH</span>- based on hearsay</p>
+<p id="25" class="def"><span class="nm">25<span>)</span></span><span class="ln">[line 34]</span><span class="defheb">עד מפי עד</span><span class="hack"></span><span class="deftext">ED MI'PI ED</span>- a witness who testifies based on what he heard from an actual witness (and not what he himself saw)</p>
+<p id="26" class="def"><span class="nm">26<span>)</span></span><span class="ln">[line 43]</span><span class="defheb">רשויות</span><span class="hack"></span><span class="deftext">RASHUYOS</span>- powers</p>
+<p id="27" class="def"><span class="nm">27<span>)</span></span><span class="ln">[line 44]</span><span class="defheb">שאדם טובע כמה מטבעות בחותם אחד</span><span class="hack"></span><span class="deftext">ADAM TOVE'A KAMAH MATBE'OS B'CHOSAM ECHAD</span>- a person mints many coins with a single mold</p>
+<b><div class="bbbline" id="amudb">37b--------------<span>------------</span>--------------37b</b></div>
+<p class="spacer"></p>
+<p id="28" class="def"><span class="nm">28<span>)</span></span><span class="ln">[line 2]</span><span class="defheb">"[וְנֶפֶשׁ כִּי תֶחֱטָא וְשָׁמְעָה קוֹל אָלָה,] וְהוּא עֵד אוֹ רָאָה אוֹ יָדָע; אִם לוֹא יַגִּיד וְנָשָׂא עֲוֹנוֹ"</span><span class="hack"></span><span class="deftext">"[V'NEFESH KI SECHETA V'SHAM'AH KOL ALAH,] V'HU ED O RA'AH O YADA; IM LO YAGID V'NASA AVONO"</span>- "[And if a person sins, and hears (and accepts) the demand for an oath,] and he is a witness, whether he has seen or known of it; if he does not utter it (i.e. testify), then he shall bear his iniquity" <span class="pasuksource">(Vayikra 5:1)</span>.</p>
+<p id="29" class="def"><span class="nm">29<span>)</span></span><span class="ln">[line 4]</span><span class="defheb">"[וּ]בַאֲבוֹד רְשָׁעִים רִנָּה"</span><span class="hack"></span><span class="deftext">"[U']VA'AVOD RESHA'IM RINAH"</span>- "... and with the destruction of the wicked, there is joyous song" <span class="pasuksource">(Mishlei 11:10)</span>.</p>
+<p id="30" class="def"><span class="nm">30<span>)</span></span><span class="ln">[line 6]</span><span class="defheb">לחורבה</span><span class="hack"></span><span class="deftext">CHURVAH</span>- a ruined building</p>
+<p id="31" class="def"><span class="nm">31<span>)</span></span><span class="ln">[line 7]</span><span class="defheb">סייף</span><span class="hack"></span><span class="deftext">SAYIF</span>- a sword</p>
+<p id="32" class="def"><span class="nm">32<span>)</span></span><span class="ln">[line 7]</span><span class="defheb">ודמו מטפטף</span><span class="hack"></span><span class="deftext">DAMO METEFTEF</span>- his blood was dripping</p>
+<p id="33" class="def"><span class="nm">33<span>)</span></span><span class="ln">[line 8]</span><span class="defheb">והרוג מפרפר</span><span class="hack"></span><span class="deftext">HARUG MEFARPER</span>- the murdered was convulsing</p>
+<p id="34" class="def"><span class="nm">34<span>)</span></span><span class="ln">[line 10]</span><span class="defheb">אראה בנחמה</span><span class="hack"></span><span class="deftext">ER'EH BA'NECHAMAH...</span>- (a) "I will see the [day that Benei Yisrael will be in a state of] comfort (and will be redeemed from Galus)" (<B>BEREISHIS RABAH</B> 65:12, see <B>MAHARSHA</B> to Pesachim 54b). This phrase is a euphemism meaning, "I will <i>not</i> see the Day of Redemption (if the following is not true)" (<B>RASHI</B> to Makos 5b DH Er'eh, 1st explanation); (b) "[I take an oath that my sons shall die and] I will see [the period of mourning in which people will come to] comfort [me] (if the following is not true)" (<B>RASHI</B> to Makos 5b DH Er'eh, 2nd explanation).</p>
+<p id="35" class="def"><span class="nm">35<span>)</span></span><span class="ln">[line 18]</span><span class="defheb">והכישו</span><span class="hack"></span><span class="deftext">HIKISHO</span>- it bit him</p>
+<p id="36" class="def"><span class="nm">36<span>)</span></span><span class="ln">[line 18]</span><span class="defheb">והאי בר נחש הוא?!</span><span class="hack"></span><span class="deftext">HAI BAR NACHASH HU?!</span>- Was this one (the presumed murderer) deserving [of being killed by] a snake?! (Being bitten by a snake is similar to the death penalty of Sereifah. Murder is punishable by the death penalty of Hereg.)</p>
+
+<p id="37" class="def inyansub"><span class="nm">37<span>)</span></span><span class="ln">[line 21]</span><span class="defheb">ארבע מיתות</span><span class="hack"></span><span class="deftext">ARBA MISOS</span> (ARBA MISOS BEIS DIN)</p>
+<p class="def inyan">Arba Misos Beis Din, the four death penalties administered by Beis Din, in their order of stringency are:</p>
+<p class="def inyan2"><span class="nm">1.</span>Sekilah (stoning, whereby the transgressor is thrust down from the height of two stories, and then (if he is still alive) a large rock is thrown down upon him). Some examples of sins for which Sekilah is administered: desecrating the Shabbos; idol worship; cursing (Chas v'Shalom) G-d; bestiality; sodomy; certain illicit relations (Sanhedrin 53a).</p>
+<p class="def inyan2"><span class="nm">2.</span>Sereifah (burning with molten lead, which is poured down the throat). Sereifah is administered for certain illicit relations (Sanhedrin 75a).</p>
+<p class="def inyan2"><span class="nm">3.</span>Hereg (killing with a sword) (Sefer ha'Chinuch #50). Hereg is administered for Avodah Zarah, when performed along with most of the inhabitants of an Ir ha'Nidachas, and for murder (Sanhedrin 76b).</p>
+<p class="def inyan2"><span class="nm">4.</span>Chenek (strangulation) (Sefer ha'Chinuch #47) - Chenek is administered for wounding one's parents; Zaken Mamrei; Navi Sheker; certain illicit relations (Sanhedrin 84b).</p>
+
+<p class="spacer"></p>
+<p id="38" class="def"><span class="nm">38<span>)</span></span><span class="ln">[line 22]</span><span class="defheb">דין ארבע מיתות לא בטלו</span><span class="hack"></span><span class="deftext">DIN ARBA MISOS LO BATLU</span>- the liability to receive the four death penalties of Beis Din has not been annulled</p>
+<p id="39" class="def"><span class="nm">39<span>)</span></span><span class="ln">[line 24]</span><span class="defheb">דורסתו</span><span class="hack"></span><span class="deftext">DORASTO</span>- tramples him to death</p>
+<p id="40" class="def"><span class="nm">40<span>)</span></span><span class="ln">[line 25]</span><span class="defheb">מכישו</span><span class="hack"></span><span class="deftext">MAKISHO</span>- bites him</p>
+<p id="41a" class="def"><span class="nm">41<span>a)</span></span><span class="ln">[line 26]</span><span class="defheb">נמסר למלכות</span><span class="hack"></span><span class="deftext">NIMSAR LA'MALCHUS</span>- he is handed over (by informers) to the ruling power</p>
+<p id="41b" class="def"><span class="nm"><span>b)</span></span><span class="ln">[line 26]</span><span class="defheb">ליסטין באין עליו</span><span class="hack"></span><span class="deftext">LISTIN BA'IN ALAV</span>- armed bandits come upon him</p>
+<p id="42" class="def"><span class="nm">42<span>)</span></span><span class="ln">[line 28]</span><span class="defheb">בסרונכי</span><span class="hack"></span><span class="deftext">SERUNCHI</span>- (O.F. bon malant) quinsy, a severe development of heat, pain, redness and swelling in the throat</p>
+<p id="43" class="def"><span class="nm">43<span>)</span></span><span class="ln">[line 33]</span><span class="defheb">האוחר</span><span class="hack"></span><span class="deftext">HA'OCHER</span>- (a) engaged in mating (<b>RASHI's</b> preferred explanation); (b) biting <b>(RASHI)</b></p>
+<p id="44" class="def"><span class="nm">44<span>)</span></span><span class="ln">[line 37]</span><span class="defheb">הוא אמר לי ש"אני חייב לו"</span><span class="hack"></span><span class="deftext">HU AMAR LI SHE'ANI CHAYAV LO</span>- [witnesses testify that] he said to me that "I owe him money"</p>
+<p id="45" class="def"><span class="nm">45<span>)</span></span><span class="ln">[line 40]</span><span class="defheb">אמרינן להו בדיני נפשות</span><span class="hack"></span><span class="deftext">AMRINAN LEHU B'DINEI NEFASHOS</span>- we say it to them (i.e. the witnesses, that certain forms of testimony, such as "Ed mi'Pi Ed," are invalid, only) in cases of Dinei Nefashos</p>
+<p id="46a" class="def"><span class="nm">46<span>a)</span></span><span class="ln">[line 42]</span><span class="defheb">חבורות</span><span class="hack"></span><span class="deftext">CHABUROS</span>- wounds</p>
+<p id="46b" class="def"><span class="nm"><span>b)</span></span><span class="ln">[line 42]</span><span class="defheb">פציעות</span><span class="hack"></span><span class="deftext">PETZI'OS</span>- stabs</p>
+<p id="47" class="def"><span class="nm">47<span>)</span></span><span class="ln">[line 45]</span><span class="defheb">"מִכְּנַף הָאָרֶץ זְמִירוֹת שָׁמַעְנוּ צְבִי לַצַּדִּיק..."</span><span class="hack"></span><span class="deftext">"MI'KENAF HA'ARETZ ZEMIROS SHAMANU TZVI LA'TZADIK..."</span>- "From the edge of the earth we heard songs: 'Glory to the righteous one'..." <span class="pasuksource">(Yeshayah 24:16)</span>.</p>
+<p id="48" class="def"><span class="nm">48<span>)</span></span><span class="ln">[line 46]</span><span class="defheb">"וַתִּפְתַּח הָאָרֶץ אֶת פִּיהָ [וַתִּבְלַע אֹתָם וְאֶת בָּתֵּיהֶם; וְאֵת כָּל הָאָדָם אֲשֶׁר לְקֹרַח וְאֵת כָּל הָרְכוּשׁ]"</span><span class="hack"></span><span class="deftext">"VA'TIFTACH HA'ARETZ ES PIHAH..."</span>- "And the ground opened up its mouth [and swallowed them and their houses; and all of the men who were with Korach, and all of the property]" <span class="pasuksource">(Bamidbar 16:32)</span> - From here we see that the ground <i>did</i> open up another time, after opening up to swallow the blood of Hevel.</p>
+<p id="49" class="def"><span class="nm">49<span>)</span></span><span class="ln">[line 48]</span><span class="defheb">"[הֵן גֵּרַשְׁתָּ אֹתִי הַיּוֹם מֵעַל פְּנֵי הָאֲדָמָה וּמִפָּנֶיךָ אֶסָּתֵר;] וְהָיִיתִי נָע וָנָד בָּאָרֶץ [וְהָיָה כָל מֹצְאִי יַהַרְגֵנִי]"</span><span class="hack"></span><span class="deftext">"... V'HAYISI NA VA'NAD [BA'ARETZ...]"</span>- "... and I will be constantly wandering [the earth...]" <span class="pasuksource">(Bereishis 4:14)</span>.</p>
+<p id="50" class="def"><span class="nm">50<span>)</span></span><span class="ln">[line 48]</span><span class="defheb">"[וַיֵּצֵא קַיִן מִלִּפְנֵי ה',] וַיֵּשֶׁב בְּאֶרֶץ נוֹד [קִדְמַת עֵדֶן]"</span><span class="hack"></span><span class="deftext">"... VA'YESHEV B'ERETZ NOD..."</span>- "... and he settled in the land of Nod..." <span class="pasuksource">(Bereishis 4:16)</span>.</p>
+<p id="51" class="def"><span class="nm">51<span>)</span></span><span class="ln">[line 49]</span><span class="defheb">"הַיּוֹשֵׁב בָּעִיר הַזֹּאת יָמוּת בַּחֶרֶב [וּ]בָרָעָב וּבַדָּבֶר; וְהַיּוֹצֵא וְנָפַל [עַל] הַכַּשְׂדִּים הַצָּרִים עֲלֵיכֶם [וְחָיָה], וְהָיְתָה לּוֹ נַפְשׁוֹ לְשָׁלָל"</span><span class="hack"></span><span class="deftext">"HA'YOSHEV BA'IR HA'ZOS YAMUS BA'CHEREV UVA'RA'AV UVA'DAVER; V'HA'YOTZEI V'NAFAL AL HA'KASDIM HA'TZARIM ALEICHEM V'CHAYAH, V'HAYESAH LO NAFSHO L'SHALAL"</span>- "He who dwells in this city will die by the sword or by famine or by plague; but he who leaves and falls into the hands of the Kasdim who are besieging you will live, and his life will be his spoils" <span class="pasuksource">(Yirmeyahu 21:9)</span>.</p>
+<p id="52" class="def"><span class="nm">52<span>)</span></span><span class="ln">[line 52]</span><span class="defheb">"[כֹּה אָמַר ה',] כִּתְבוּ אֶת הָאִישׁ הַזֶּה עֲרִירִי, גֶּבֶר לֹא יִצְלַח בְּיָמָיו; כִּי לֹא יִצְלַח מִזַּרְעוֹ אִישׁ יוֹשֵׁב עַל כִּסֵּא דָוִד וּמוֹשֵׁל עוֹד בִּיהוּדָה"</span><span class="hack"></span><span class="deftext">"... KISVU ES HA'ISH HA'ZEH ARIRI, GEVER LO YITZLACH B'YAMAV; KI LO YITZLACH MI'ZAR'O ISH YOSHEV AL KISEI DAVID U'MOSHEL OD BI'YEHUDAH"</span>- "Inscribe this man as childless, a man who will not succeed in his life; for none of his offspring will succeed as a man sitting on the throne of David and a ruler over Yehudah anymore" <span class="pasuksource">(Yirmeyahu 22:30)</span>.</p>
+<p id="53" class="def"><span class="nm">53<span>)</span></span><span class="ln">[line 53]</span><span class="defheb">"וּבְנֵי יְכָנְיָה אַסִּיר שְׁאַלְתִּיאֵל בְּנוֹ"</span><span class="hack"></span><span class="deftext">"U'VNEI YECHONYAH: ASIR SHE'ALTI'EL BENO"</span>- "The sons of Yechonyah: Asir, Shealtiel, his son" <span class="pasuksource">(Divrei ha'Yamim I 3:17)</span>.</p>
+<p id="54" class="def"><span class="nm">54<span>)</span></span><span class="ln">[last line]</span><span class="defheb">שֶׁשָּׁתְלוֹ</span><span class="hack"></span><span class="deftext">SHASLO</span>- He (HaSh-m) implanted him [at the time of his conception]</p>
+
+
+   </div> <!-- End #content -->
+<!--ftr82.1-->
+    <div class="navlinks">
+<!--nextdaf1-->
+        <div class="nextdaf">
+            <p><a href="sn-in-038.htm"><img src="http://www.dafyomi.co.il/right.gif" alt="Next"></a></p>
+        </div>
+<!--nextdaf2-->
+  
+
+
+<div class="indexlink"><a href="https://dafyomi.co.il/section.php?gid=24&amp;sid=2">Background for<br class="smallbreak"> Maseches Sanhedrin</a></div>
+ 
+
+<div class="homepagelink"><a href="https://dafyomi.co.il/gemara.php?gid=24">Homepage for Maseches<br class="smallbreak"> Sanhedrin</a></div>
+ 
+     
+
+   <div class="dafhomelink"><a href="http://www.dafyomi.co.il/index.htm" target="_parent">
+            <img src="http://www.dafyomi.co.il/kih-logo-tiny.gif" alt="Dafyomi Advancement Forum homepage">
+            <br>D.A.F. Homepage</a>
+        </div>   
+    </div> <!-- End navlinks -->
+
+
+<!--HR3-->
+    <div class="horiz_rule"></div>
+
+    <div class="resources">
+
+            <h2>OTHER D.A.F. RESOURCES<br class="smallbreak"> ON THIS DAF</h2>
+
+        <ul>
+ <li><a href="../insites/sn-dt-037.htm">Insights to<br>the Daf</a>
+
+<li><a href="../review/sn-rg-037.htm">Review<br>Questions</a>
+<li><a href="../points/sn-ps-037.htm">Point by<br>Point</a>
+
+</ul>
+<ul>
+<li><a href="../halachah/sn-hl-037.htm">Halachah<br>Outlines</a>
+<li><a href="../tosfos/sn-ts-037.htm">Tosfos<br>Outlines</a>
+<!-- <li><a href="../agadah/sn-ag-037.htm">Agadah<br>Outlines</a> -->
+<li><a href="https://dafyomi.co.il/section.php?gid=24&amp;sid=5">English<br>Charts</a></li>
+<li><a href="../../memdb/revdaf.php?tid=24&amp;id=037">Revach<br>l'Daf</a>
+
+</ul>
+<ul>
+<li><a href="../quiz/sn-qz-037.htm">Review<br>Quiz</a>
+<li class="liheb"><a href="../hebcharts/sn-tl-037.htm">טבלאות<br>בעברית</a>
+<li class="liheb"><a href="https://dafyomi.co.il/sanhedrin/yosefdas/sanh-yd-037.pdf">יוסף<br>דעת</a>
+<li class="liheb"><a href="https://dafyomi.co.il/sanhedrin/chidon/sn-cd-alla.htm?daf=037#d037">חידונים<br>על הדף</a>
+
+</ul>
+<ul>
+<li class="liheb"><a href="https://dafyomi.co.il/galei_link.php?gid=24&daf=037">גלי<br>מסכתא</a>
+<li><a href="https://dafyomi.co.il/discuss_daf.php?gid=24&amp;sid=20&daf=037&n=0">Discuss<br>the Daf</a>
+<li><a href="https://dafyomi.co.il/members/shiurim/?meseches=sanhedrin">Video/Audio<br>Lectures</a></li>
+
+        </ul>
+    </div>  
+<!--HR4--> <!-- end .resources -->
+
+    <div class="horiz_rule"></div>
+    
+    <div id="footer">
+        <ul>
+            <li><a href="http://www.dafyomi.co.il/new_gemara_picker.php">Other Masechtos</a></li>
+            <li><a href="https://gem.godaddy.com/signups/92631be18f7a4611948240bd55782374/join">Join Mailing Lists</a></li>
+        </ul>
+        <ul>
+            <li><a href="http://www.dafyomi.co.il/askollel.htm">Ask the Kollel</a></li>
+            <li><a href="http://www.dafyomi.co.il/calendars/calendar.htm" target="_parent">Dafyomi Calendar</a></li>
+        </ul>
+        <ul>
+            <li><a href="http://www.dafyomi.co.il/index_heb.htm" class="chomerbivrit">חומר בעברית</a></li>
+            <li><a href="http://www.dafyomi.co.il/sponsors.htm">Donations</a></li>
+         </ul>
+        <ul>
+             <li><a href="http://www.dafyomi.co.il/fanmail.htm">Feedback</a></li>
+             <li><a href="http://www.dafyomi.co.il/central.htm">Dafyomi Links</a></li>
+        </ul>
+    </div> <!-- End #footer -->
+    
+</div>  <!-- End #wrapper -->
+</div>  
+</body>
+</html>
+
+
+
+<!--2026_06 missing the file content.html -->


### PR DESCRIPTION
## Problem (found sweeping dafim for breadth)

On many dafim the entire **Background glossary was missing** — Sanhedrin 37a surfaced 0 Background terms even though dafyomi.co.il has 62 glossary entries for it (and so the new bg-term matcher had nothing to anchor).

Root cause: the parser used a stateful girsa→glossary section flip triggered by a `girsasep` separator. Pages with **no girsa section** have no `girsasep`, so the parser stayed stuck in "girsa" mode and every `p.def` glossary entry hit the girsa branch's `continue` and was dropped.

## Fix

Classify each element by its own class (stateless): `girsaloc`/`girsa` → girsa, plain `def` → glossary — order-sensitive since girsa elements also carry the `def` class. Works regardless of whether a page has a girsa section, a glossary, or both.

- Sanhedrin 37a: **0 → 62** glossary terms
- Chullin 76 (has both): unchanged — 32 glossary + 2 girsa, ARKUVAH intact

Bumps dafyomi cache `v3 → v4` so dapim cached with empty background re-parse.

## Tests

Added a regression test parsing a real no-girsa page (Sanhedrin 37a fixture): asserts 0 girsa, >40 glossary, first term `ושלש שורות`/`SHALOSH SHUROS`. Existing Chullin test tightened to assert it still has a girsa section. Full suite 1200 passing.