### PR TITLE
Expand Rishonim allowlist + restore Maharsha

### DIFF
--- a/src/lib/sefref/sefaria/client.ts
+++ b/src/lib/sefref/sefaria/client.ts
@@ -143,11 +143,30 @@ const RISHONIM: ReadonlyMap<string, string> = new Map([
   ['Rashba', 'Rashba'],
   ['Ritva', 'Ritva'],
   ['Ramban', 'Ramban'],
+  ['Chiddushei Ramban', 'Ramban'], // Sefaria titles the BB/Sanhedrin Ramban this way
   ['Beit HaBechira', 'Meiri'],
   ['Rosh', 'Rosh'],
   ['Ran', 'Ran'],
   ['Rabbeinu Chananel', 'Rabbeinu Chananel'],
   ['Rif', 'Rif'],
+  // Additional Rishonim Sefaria carries on various masechtos (the book part of
+  // the index_title -> our label). Keys are the exact post-strip forms verified
+  // against Sefaria link index_titles; a key simply doesn't fire on masechtos
+  // that lack the work.
+  ['Ri Migash', 'Ri Migash'],
+  ['Yad Ramah', 'Yad Ramah'],
+  ['Rabbeinu Gershom', 'Rabbeinu Gershom'],
+  ['Tosafot Rid', 'Tosafot Rid'],
+  ['Tosafot HaRosh', 'Tosafot HaRosh'],
+  ['Shita Mekubetzet', 'Shita Mekubetzet'],
+  ['Mordechai', 'Mordechai'],
+  ['HaMaor HaKatan', 'Baal HaMaor'],
+  ['HaMaor HaGadol', 'Baal HaMaor'],
+  ["Chiddushei HaRa'ah", "Ra'ah"],
+  ['Maharam', 'Maharam'],
+  // Maharsha — was surfaced before the discovery refactor dropped it.
+  ['Chidushei Halachot', 'Maharsha'],
+  ['Chidushei Agadot', 'Maharsha (Aggadah)'],
 ]);
 
 /** Map a Sefaria commentary index_title (e.g. "Rashba on Eruvin", "Rif Eruvin",

--- a/src/worker/source-cache.ts
+++ b/src/worker/source-cache.ts
@@ -143,8 +143,10 @@ export async function getRishonimCached(
   page: string,
 ): Promise<RishonimBundle> {
   // v2: per-comment, segment-anchored RishonComment[] (was a whole-daf blob
-  // Record<label, snippet>). Bumping forces a refetch into the new shape.
-  const key = `rishonim:v2:${tractate}:${page}`;
+  // Record<label, snippet>). v3: expanded the Rishonim allowlist (Yad Ramah,
+  // Ri Migash, Rabbeinu Gershom, Tosafot Rid/HaRosh, Shita Mekubetzet, Baal
+  // HaMaor, Ra'ah, Mordechai, Maharsha, …) — bump so cached dapim refetch.
+  const key = `rishonim:v3:${tractate}:${page}`;
   const hit = await readCache<RishonimBundle>(cache, key);
   if (hit) return hit;
   try {

--- a/tests/sefaria-client.test.ts
+++ b/tests/sefaria-client.test.ts
@@ -16,11 +16,26 @@ describe('rishonLabel', () => {
     expect(rishonLabel('Rif Eruvin', 'Eruvin')).toBe('Rif'); // no "on"
     expect(rishonLabel('Rashba on Bava Metzia', 'Bava Metzia')).toBe('Rashba'); // spaced tractate
   });
+  it('maps the expanded Rishonim set (verified Sefaria index_titles)', () => {
+    expect(rishonLabel('Yad Ramah on Sanhedrin', 'Sanhedrin')).toBe('Yad Ramah');
+    expect(rishonLabel('Ri Migash on Bava Batra', 'Bava Batra')).toBe('Ri Migash');
+    expect(rishonLabel('Rabbeinu Gershom on Bava Batra', 'Bava Batra')).toBe('Rabbeinu Gershom');
+    expect(rishonLabel('Tosafot Rid on Bava Batra', 'Bava Batra')).toBe('Tosafot Rid');
+    expect(rishonLabel('Tosafot HaRosh on Berakhot', 'Berakhot')).toBe('Tosafot HaRosh');
+    expect(rishonLabel('Shita Mekubetzet on Bava Batra', 'Bava Batra')).toBe('Shita Mekubetzet');
+    expect(rishonLabel('Mordechai on Bava Batra', 'Bava Batra')).toBe('Mordechai');
+    expect(rishonLabel('HaMaor HaKatan on Berakhot', 'Berakhot')).toBe('Baal HaMaor');
+    expect(rishonLabel("Chiddushei HaRa'ah on Berakhot", 'Berakhot')).toBe("Ra'ah");
+    expect(rishonLabel('Chiddushei Ramban on Bava Batra', 'Bava Batra')).toBe('Ramban');
+    expect(rishonLabel('Chidushei Halachot on Berakhot', 'Berakhot')).toBe('Maharsha');
+    expect(rishonLabel('Chidushei Agadot on Sanhedrin', 'Sanhedrin')).toBe('Maharsha (Aggadah)');
+  });
   it('excludes Rashi/Tosafot/Steinsaltz and unknown books', () => {
     expect(rishonLabel('Rashi on Eruvin', 'Eruvin')).toBeNull();
     expect(rishonLabel('Tosafot on Eruvin', 'Eruvin')).toBeNull();
     expect(rishonLabel('Steinsaltz on Eruvin', 'Eruvin')).toBeNull();
-    expect(rishonLabel('Tosafot Rid on Eruvin Second Recension', 'Eruvin')).toBeNull();
+    expect(rishonLabel('Rashash on Eruvin', 'Eruvin')).toBeNull(); // Acharon glosses, not kept
+    expect(rishonLabel('Penei Yehoshua on Ketubot', 'Ketubot')).toBeNull();
   });
 });
 


### PR DESCRIPTION
## What

Answers "are there other Rishonim we could bring in?" — yes, lots. The alignment pool surfaced only 8 commentators; Sefaria carries many more on most masechtos. Adds the verified mappings:

- **Rishonim**: Ri Migash, Yad Ramah, Rabbeinu Gershom, Tosafot Rid, Tosafot HaRosh, Shita Mekubetzet, Mordechai, Baal HaMaor (`HaMaor HaKatan`/`HaGadol`), Ra'ah (`Chiddushei HaRa'ah`), Maharam
- **Maharsha** (`Chidushei Halachot` + `Chidushei Agadot`) — was surfaced before the discovery refactor silently dropped it
- **`Chiddushei Ramban` → Ramban** — the form Sefaria uses on Bava Batra / Sanhedrin, previously missed (so Ramban wasn't showing on those masechtos)

## How

Keys are the exact post-strip `index_title` forms (`rishonLabel` strips ` on <Tractate>`), confirmed against Sefaria link/sourceRef data via the live API — e.g. `Yad Ramah on Sanhedrin` → `Yad Ramah`, `HaMaor HaKatan on Berakhot` → `Baal HaMaor`. A key simply doesn't fire on masechtos that lack the work, so this is purely additive. Bumps the rishonim cache `v2 → v3` so already-cached dapim refetch.

## Tests

`tests/sefaria-client.test.ts`: positive assertions for all 12 new mappings; the exclusion test now uses genuine Acharonim (Rashash, Penei Yehoshua) that stay null. Full suite 1201 passing.

Acharonim (Rashash, Gilyon HaShas, R' Akiva Eiger, Penei Yehoshua, Chatam Sofer, Ben Yehoyada…) are available on Sefaria too but intentionally left out as a separate tier — easy to add later if wanted.