### PR TITLE
Surface select Acharonim in align

### DIFF
--- a/src/lib/sefref/sefaria/client.ts
+++ b/src/lib/sefref/sefaria/client.ts
@@ -169,12 +169,25 @@ const RISHONIM: ReadonlyMap<string, string> = new Map([
   ['Chidushei Agadot', 'Maharsha (Aggadah)'],
 ]);
 
+/** Select Acharonim, keyed the same way (book part of the index_title -> label).
+ *  Surfaced alongside the Rishonim in the alignment pool; kept in a separate map
+ *  so the two tiers stay distinguishable. */
+const ACHARONIM: ReadonlyMap<string, string> = new Map([
+  ['Rashash', 'Rashash'],
+  ['Gilyon HaShas', 'Gilyon HaShas'],
+  ['Penei Yehoshua', 'Penei Yehoshua'],
+  ['Ben Yehoyada', 'Ben Yehoyada'],
+  ['Chidushei Chatam Sofer', 'Chatam Sofer'],
+  ['Chiddushei Rabbi Akiva Eiger', 'Rabbi Akiva Eiger'],
+]);
+
 /** Map a Sefaria commentary index_title (e.g. "Rashba on Eruvin", "Rif Eruvin",
- *  "Beit HaBechira on Eruvin") to our Rishon label, or null if not one we keep. */
+ *  "Beit HaBechira on Eruvin") to our commentator label, or null if not one we
+ *  surface. Covers both the Rishonim and the select Acharonim above. */
 export function rishonLabel(indexTitle: string, tractate: string): string | null {
   const esc = tractate.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const book = indexTitle.replace(new RegExp(`\\s+(?:on\\s+)?${esc}\\b.*$`), '').trim();
-  return RISHONIM.get(book) ?? null;
+  return RISHONIM.get(book) ?? ACHARONIM.get(book) ?? null;
 }
 
 /** Parse the trailing segment range from a Sefaria ref like

--- a/src/worker/source-cache.ts
+++ b/src/worker/source-cache.ts
@@ -145,8 +145,10 @@ export async function getRishonimCached(
   // v2: per-comment, segment-anchored RishonComment[] (was a whole-daf blob
   // Record<label, snippet>). v3: expanded the Rishonim allowlist (Yad Ramah,
   // Ri Migash, Rabbeinu Gershom, Tosafot Rid/HaRosh, Shita Mekubetzet, Baal
-  // HaMaor, Ra'ah, Mordechai, Maharsha, …) — bump so cached dapim refetch.
-  const key = `rishonim:v3:${tractate}:${page}`;
+  // HaMaor, Ra'ah, Mordechai, Maharsha, …). v4: added select Acharonim (Rashash,
+  // Gilyon HaShas, Penei Yehoshua, Ben Yehoyada, Chatam Sofer, R' Akiva Eiger).
+  // Bump so cached dapim refetch with the new works.
+  const key = `rishonim:v4:${tractate}:${page}`;
   const hit = await readCache<RishonimBundle>(cache, key);
   if (hit) return hit;
   try {

--- a/tests/sefaria-client.test.ts
+++ b/tests/sefaria-client.test.ts
@@ -30,12 +30,20 @@ describe('rishonLabel', () => {
     expect(rishonLabel('Chidushei Halachot on Berakhot', 'Berakhot')).toBe('Maharsha');
     expect(rishonLabel('Chidushei Agadot on Sanhedrin', 'Sanhedrin')).toBe('Maharsha (Aggadah)');
   });
+  it('maps the select Acharonim now surfaced in align', () => {
+    expect(rishonLabel('Rashash on Eruvin', 'Eruvin')).toBe('Rashash');
+    expect(rishonLabel('Gilyon HaShas on Bava Batra', 'Bava Batra')).toBe('Gilyon HaShas');
+    expect(rishonLabel('Penei Yehoshua on Ketubot', 'Ketubot')).toBe('Penei Yehoshua');
+    expect(rishonLabel('Ben Yehoyada on Sanhedrin', 'Sanhedrin')).toBe('Ben Yehoyada');
+    expect(rishonLabel('Chidushei Chatam Sofer on Bava Batra', 'Bava Batra')).toBe('Chatam Sofer');
+    expect(rishonLabel('Chiddushei Rabbi Akiva Eiger on Berakhot', 'Berakhot')).toBe('Rabbi Akiva Eiger');
+  });
   it('excludes Rashi/Tosafot/Steinsaltz and unknown books', () => {
     expect(rishonLabel('Rashi on Eruvin', 'Eruvin')).toBeNull();
     expect(rishonLabel('Tosafot on Eruvin', 'Eruvin')).toBeNull();
     expect(rishonLabel('Steinsaltz on Eruvin', 'Eruvin')).toBeNull();
-    expect(rishonLabel('Rashash on Eruvin', 'Eruvin')).toBeNull(); // Acharon glosses, not kept
-    expect(rishonLabel('Penei Yehoshua on Ketubot', 'Ketubot')).toBeNull();
+    expect(rishonLabel('Reshimot Shiurim on Berakhot', 'Berakhot')).toBeNull(); // modern shiurim, not kept
+    expect(rishonLabel('Petach Einayim on Sanhedrin', 'Sanhedrin')).toBeNull();
   });
 });
 


### PR DESCRIPTION
## What

Follow-up to #47: brings the **Acharonim** into the alignment pool — Rashash, Gilyon HaShas, Penei Yehoshua, Ben Yehoyada, Chatam Sofer, and R' Akiva Eiger.

## How

A separate `ACHARONIM` map (keyed on the stripped `index_title`, verified against Sefaria link sourceRefs) looked up alongside `RISHONIM` in `rishonLabel`. Kept in its own map so the Rishon/Acharon tiers stay distinguishable in code. They flow through the same per-comment, `anchorRef`-placed discovery, so each appears as its own commentator card anchored to the exact line it comments on (no new wiring). Purely additive — a key doesn't fire on masechtos that lack the work. Bumps rishonim cache `v3 → v4`.

## Tests

`tests/sefaria-client.test.ts`: positive assertions for all 6 Acharonim; the exclusion test now uses works we still don't keep (Reshimot Shiurim, Petach Einayim). Full suite 1202 passing.