### PR TITLE
Wire the post-LLM check layer into the runners (A2)

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,0 +1,114 @@
+# Handoff — Framework standardization (anchoring + checks)
+
+You're picking up a multi-step refactor of the Talmud app's content pipeline.
+This doc is self-contained: it assumes no prior context. Read it top to bottom,
+then read the two companion docs:
+- **The full plan**: `~/.claude/plans/how-does-our-current-jazzy-globe.md` (the approved roadmap — current architecture + target + all phases).
+- **The section-typing design**: `docs/section-typing.md` (Track C, depends on this work).
+
+## TL;DR — where we are
+
+Goal: the pipeline does the same jobs (anchor content to text, post-process LLM
+output) several different ways. We're converging them onto **one anchoring
+layer** and **one post-LLM check layer**, then building section-typing on top.
+Work is split into Track A (backend, leading) → B (render/DX) → C (typing).
+
+Done & shippable: **A1** (unified verbatim placer) = **PR #45** (open, needs owner review/merge).
+In progress: **A2** (standardized check layer) — the library exists + is tested,
+but is **not yet wired into the runners**. That wiring is your immediate task.
+
+## Repo + how to work in it (IMPORTANT)
+
+- Stack: Hono on Cloudflare Workers (`src/worker`) + Solid.js client (`src/client`) + shared logic (`src/lib`). Package manager **pnpm**, TypeScript strict.
+- **Multiple agents work this repo in parallel. NEVER edit/commit the main checkout** (`/Users/shaunie/Documents/Code/talmud`). Work in a git worktree on a branch.
+- Commands: `pnpm test` (vitest), `pnpm typecheck` (`tsc --noEmit`), `pnpm ship` (build + wrangler deploy to talmud.shaunregenbaum.com).
+- Commit rules (from CLAUDE.md): **no self-reference, no `Co-Authored-By` trailer**, no "Generated with" footer in PR bodies.
+- Merge flow: PR → `gh pr merge <n> --squash --admin` is owner-authorized (GitHub blocks self-approval). **Do not self-merge**; leave PRs for the owner unless told otherwise.
+
+### Current worktree / branch state (exact)
+
+- Worktree dir: `/Users/shaunie/Documents/Code/talmud/.claude/worktrees/section-typing-design`
+  - **Note the dir name is stale**: it currently has branch **`framework-check-layer`** checked out (not `section-typing-design`). `git branch --show-current` to confirm.
+- Branch **`section-typing-design`** = `origin/master` + 1 commit `2eef12c` (A1). → **PR #45**, base `master`, OPEN.
+- Branch **`framework-check-layer`** = `2eef12c` (A1) + `11f4f6c` (A2 layer). Pushed to origin. **No PR yet.** This is where you continue A2.
+- Both branches were cut from `origin/master` (which is ahead of the stale main checkout — always branch from `origin/master`).
+
+### Environment gotchas (will bite you)
+
+- **node_modules**: the worktree symlinks the main tree's `node_modules` (`ln -s <repo>/node_modules ./node_modules`). It predates PR #32, so `@hono/mcp`, `@cloudflare/codemode`, `@modelcontextprotocol/sdk` are **missing** → `tsc` reports 3-4 "Cannot find module" errors in `src/worker/mcp.ts` + `index.ts:~460`. **These are pre-existing and unrelated — ignore them.** Filter with `npx tsc --noEmit 2>&1 | grep -v "@hono/mcp\|@cloudflare/codemode\|@modelcontextprotocol"`.
+- **Live API**: production `POST /api/studio/run` (cache hits → 200, else 202 + poll `/api/studio/run-status/{runId}?k=`) is open/read. **It blocks the default Python `urllib` user-agent (403)** — set a browser `User-Agent` header. `bypass_cache`/`model_override` need the `x-studio-secret` header (we don't have it). A budget guard ($10/hr, $300/day) caps spend at the `runLLM` chokepoint.
+- **Sandbox**: throwaway scripts go in `/Users/shaunie/Documents/Code/Sandbox/` (not in-repo). The capture/regen scripts used for A0 are there: `capture_golden_anchors.py`, `regen_stale_aggadata.ts` (run with `npx tsx`).
+
+## The pipeline (just enough to orient)
+
+Seven stages; canonical anchor coordinate = **0-based Sefaria segment index** within a `(tractate, page)`:
+SOURCE (fetch HB+Sefaria, segment) → PLACE (attach context to segments) → EXTRACT (marks) → ENRICH (LLM passes on mark instances) → CHECK (post-LLM) → SYNTHESIZE → RENDER (gutter/sidebar/maps).
+
+Key engine files in `src/worker/index.ts`:
+- `runMarkOnce` — runs a mark extractor; **had** a hardcoded `if (def.id===…)` post-process chain (now partly delegated, see below).
+- `runEnrichmentOnce` — runs an enrichment; has its own `if (def.id===…)` chain for the linters + rabbi-evidence anchor resolution, plus cache-write gating via `noteLintAttempt` / `MAX_LINT_ATTEMPTS=3` (`src/worker/lint-failures.ts`).
+- `resolveDependencies` — resolves `'gemara'|'commentaries'|'mishna'|'context'` + `{mark:id}`/`{enrichment:id}` into prompt template vars.
+- `getGemaraSlice(env, tractate, page, false)` → `{ segments_he, ... }` is THE segment grid (Sefaria segments mapped through `stripHtmlServer`). Same as the `ctx:gemara:v1:` KV key.
+- Definitions are declarative in `src/worker/code-marks.ts` (`MarkDefinition`/`EnrichmentDefinition`, shape in `src/worker/studio-schema.ts`). `def_hash = sha256(JSON.stringify(extractor) + JSON.stringify(render))` (studio-schema.ts ~line 569) — this is part of the cache key, so changing it busts the LLM cache.
+
+## What's DONE
+
+### A0 — golden fixtures (committed on `section-typing-design`/PR #45)
+`tests/fixtures/golden-anchors/`: captured `{ raw, expected }` (raw = pre-postProcess LLM output; expected = resolved/cached output) for 4 dapim (Gittin 67b, Gittin 68a, Berakhot 2a, Sanhedrin 59b) × marks (argument, argument-move, pesukim, aggadata, rabbi), plus `gemara_<t>_<p>.json` (the segment grid). All captured as cache hits (no LLM cost).
+
+### A1 — unified verbatim placer (PR #45)
+- `src/lib/place/verbatim.ts` — the ONE DOM-free matcher: `normalizeHebrew` (strip nikud/punct/bidi, collapse ws), `buildVerbatimGrid`, `prefixTries`, `findExcerpt(grid, excerpt, fromSeg, toSeg, {last?, fullMatchLen?})`. Options capture the only real differences between the old copies (matched-prefix vs full-excerpt `matchLen`; first vs last occurrence).
+- `src/lib/place/reanchor.ts` — four pure functions (`reanchorArgument/ArgumentMove/Pesukim/Aggadata`) that replicate the old `postProcessX` orchestration on top of the shared matcher. Each MUTATES + returns the parsed object. `reanchorArgument` uses `partitionSections` from `src/lib/argumentMoves.ts`.
+- `src/worker/index.ts` — the four `postProcessArgument/ArgumentMove/Pesukim/Aggadata` are now **thin delegations**: guard → `getGemaraSlice` → `reanchorX(parsed, slice.segments_he)`. ~500 lines of duplicated matcher code deleted.
+- **Proven byte-identical** to production by `tests/golden-anchors.test.ts` (16 cases). **No `cache_version` bump** (output unchanged → live caches valid).
+- Regression tests added: `tests/place/verbatim.test.ts` (matcher contract: normalization, prefix fallback, token offsets, matchLen, first/last), `tests/place/reanchor-invariants.test.ts` (idempotency + clean partition / in-bounds moves / ordered offsets).
+- **Stale-cache finding**: 2 aggadata fixtures (Gittin 68a, Sanhedrin 59b) had production cache from an OLDER `postProcessAggadata` (1-word `endExcerpt` → old fallback painted to segment end; current code paints the start excerpt). Their `expected` was regenerated from current code and marked `_regeneratedFromCurrentCode` in-file. The other 14 stay anchored to live production.
+
+### A2 — standardized check layer, INCREMENT 1 ONLY (committed on `framework-check-layer`, NOT yet PR'd)
+- `src/lib/check/postcheck.ts` — `PostCheck` registry + `runChecks(ids, parsed, ctx)`. Two phases: `transform` (mutates parsed — the re-anchorers are registered as `reanchor-argument` etc.) and `validate` (returns `CheckIssue[]` with `severity: 'hard'|'soft'` — the linters `lintSynthesis`/`lintHalachaParsed` are registered as `hebrew-excerpt`/`hebrew-gloss`). `runChecks` runs transforms (in order) then validators.
+- `tests/check/postcheck.test.ts` (8 cases) — transforms resolve anchors identically to the direct re-anchorer; validators flag a calque / English-only pasuk; phases ordered; unknown ids tolerated.
+- **This layer is additive and NOT used by the runners yet.** Nothing imports `runChecks` in `index.ts`.
+
+Current totals: 57 test files, **1253 tests passing**; typecheck clean except the unrelated MCP-module errors.
+
+## YOUR IMMEDIATE TASK — A2 increment 2: wire `runChecks` into the runners
+
+Goal: replace the two hardcoded `if (def.id===…)` post-process chains with `runChecks`, driven by a new declarative `checks?: string[]` on each definition. Must stay byte-identical (golden suite green) and **must not bump `def_hash`**.
+
+Steps:
+1. **Add `checks?: string[]`** to `MarkDefinition` and `EnrichmentDefinition` in `src/worker/studio-schema.ts`.
+2. **Exclude `checks` from `def_hash`.** Find the `def_hash` computation (sha256 over `extractor + render`, ~studio-schema.ts:569 and wherever it's computed for code/KV defs) and ensure `checks` is NOT included (checks are post-processing, not generation input). Verify a def with `checks` set produces the SAME `def_hash` as before → cache keys unchanged.
+3. **Declare checks on the code defs** in `src/worker/code-marks.ts`: `argument` → `['reanchor-argument']`, `argument-move` → `['reanchor-argument-move']`, `pesukim` → `['reanchor-pesukim']`, `aggadata` → `['reanchor-aggadata']`, `pesukim.synthesis` → `['hebrew-excerpt']`, `halacha.*` → `['hebrew-gloss']`.
+4. **Rewire `runMarkOnce`** (`src/worker/index.ts`): replace the `if (def.id==='argument') parsed = await postProcessArgument(...) else if …` chain with `const { parsed: checked, issues } = await runChecks(def.checks ?? [], parsed, { tractate, page, segmentsHe: slice.segments_he, defId: def.id, lang })`. You'll need the gemara slice available (the delegating wrappers fetch it; centralize one fetch). **Special cases that DON'T fit the segments-only transform yet:** `postProcessRabbi` (needs the daf Hebrew text, not segments — different signature) and `recordObservedPlacesFromMark` (a side effect, not a transform). Leave those as-is for now, or model them explicitly. Only the 4 verbatim re-anchorers move to `runChecks`.
+5. **Rewire `runEnrichmentOnce`**: replace its `pesukim.synthesis`/`halacha.*` lint if-chain with `runChecks(def.checks ?? [], parsed, ctx)`. Keep `postProcessRabbiEvidence` as-is for now (it's a transform but not yet ported — see A1b). Feed the `hard` issues into the EXISTING cache-gating (`noteLintAttempt` / `MAX_LINT_ATTEMPTS`): pin on no hard issues; otherwise bounded-retry. Preserve `lint_issues` on `RunResult` (or alias to `check_issues` keeping the same JSON path so `/api/usage` `readLintFailures` and the dev tray keep working).
+6. **Verify**: `pnpm test` (golden + all must stay green → proves the rewiring reproduces the if-chains exactly), filtered `tsc`. Then PR `framework-check-layer` with `--base section-typing-design` so the diff is just A2 (stacked on A1).
+
+Risk: getting the cache-gating semantics or the synthesis-text extraction subtly wrong. The golden suite + `tests/check/postcheck.test.ts` are your safety net; add a test that a `hard` issue prevents the cache write.
+
+## REMAINING ROADMAP (tasks already filed)
+
+- **A3 — new checks, soft→hard.** Add `anchor-verbatim` (resolved excerpt actually present in its claimed segment — catches hallucinations like `אריגתא` where the daf says `כשורי`), `edge-integrity` (voices-graph edges: from/to ∈ voices, ordered ranges, no contradictory `opposes`+`supports` on one pair), `partition-clean` (no gaps/overlaps/dupes — catches the duplicated Rav Amram/Yalta moves). Ship `soft` first, observe via `GET /api/usage` (`readLintFailures`), promote to `hard` per-mark — and **only that promotion warrants a per-mark `cache_version` bump, one at a time** (full-shas re-warm is ~$1000, so never bump broadly).
+- **A4 — cross-daf coordinate.** Add `src/lib/context/coord.ts` (`AnchorCoord {tractate,page,seg}`, `AnchorSpan = AnchorCoord[]`, bridge helpers); optional `coord?` on `SegMatch` (`src/lib/context/match.ts`) + `Placement` (`src/lib/context/placement.ts`); derive a `cross-daf` level. Purely additive (in-daf readers ignore it). `CrossDafAnchor` already exists unused in studio-schema.ts. Unblocks the cross-page "sugya map".
+- **A1b — converge remaining matchers.** Port `postProcessRabbiEvidence` (`index.ts`) onto `verbatim.ts` (add a rabbi-evidence golden fixture). Then `hbAlign.findExact/findFuzzy` (`src/client/hbAlign.ts`) + `rabbi-observations.resolveSegIdxs` — these use DIFFERENT normalization (final-letter folding, fuzzy/abbrev tolerance), so converge carefully behind their own golden coverage, NOT a byte-identical merge.
+- **Track B (render/DX)** and **Track C (section typing + coverage)** — see the plan file + `docs/section-typing.md`. Track C's key finding: most "uncategorized" daf segments are pure dialectic (שקלא וטריא) which no content mark models — so `argument` is the base type and halacha/aggadata/pesukim are overlays.
+
+## Verify anything
+
+```
+cd <worktree>                       # the section-typing-design worktree dir
+git branch --show-current           # expect framework-check-layer
+[ -e node_modules ] || ln -s /Users/shaunie/Documents/Code/talmud/node_modules ./node_modules
+npx vitest run                      # full suite (expect all green)
+npx vitest run tests/place tests/check tests/golden-anchors.test.ts   # this work's tests
+npx tsc --noEmit 2>&1 | grep -v "@hono/mcp\|@cloudflare/codemode\|@modelcontextprotocol"   # expect empty
+```
+
+## Key file map
+
+- `src/lib/place/verbatim.ts`, `src/lib/place/reanchor.ts` — the unified placer (A1).
+- `src/lib/check/postcheck.ts` — the check registry + `runChecks` (A2).
+- `src/worker/index.ts` — `runMarkOnce`, `runEnrichmentOnce`, `resolveDependencies`, `getGemaraSlice`, the (now-thin) `postProcessArgument/ArgumentMove/Pesukim/Aggadata`, plus `postProcessRabbi`/`postProcessRabbiEvidence`/`recordObservedPlacesFromMark` (not yet ported).
+- `src/worker/code-marks.ts` — mark/enrichment definitions (where `checks:` will be declared).
+- `src/worker/studio-schema.ts` — definition types + `def_hash` (add `checks?`, exclude from hash).
+- `src/lib/synthesisLint.ts`, `src/lib/halachaLint.ts`, `src/worker/lint-failures.ts` — the linters (wrapped) + bounded-retry gating.
+- `tests/place/*`, `tests/check/*`, `tests/golden-anchors.test.ts`, `tests/fixtures/golden-anchors/*` — the regression nets.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -14,8 +14,10 @@ layer** and **one post-LLM check layer**, then building section-typing on top.
 Work is split into Track A (backend, leading) → B (render/DX) → C (typing).
 
 Done & shippable: **A1** (unified verbatim placer) = **PR #45** (open, needs owner review/merge).
-In progress: **A2** (standardized check layer) — the library exists + is tested,
-but is **not yet wired into the runners**. That wiring is your immediate task.
+**A2** (standardized check layer) is now **fully wired into both runners** — the
+registry library (increment 1) plus the runner rewiring (increment 2) are
+committed on `framework-check-layer`. Your immediate task is **A3** (add new
+soft checks). See "YOUR IMMEDIATE TASK" below.
 
 ## Repo + how to work in it (IMPORTANT)
 
@@ -64,26 +66,48 @@ Key engine files in `src/worker/index.ts`:
 - Regression tests added: `tests/place/verbatim.test.ts` (matcher contract: normalization, prefix fallback, token offsets, matchLen, first/last), `tests/place/reanchor-invariants.test.ts` (idempotency + clean partition / in-bounds moves / ordered offsets).
 - **Stale-cache finding**: 2 aggadata fixtures (Gittin 68a, Sanhedrin 59b) had production cache from an OLDER `postProcessAggadata` (1-word `endExcerpt` → old fallback painted to segment end; current code paints the start excerpt). Their `expected` was regenerated from current code and marked `_regeneratedFromCurrentCode` in-file. The other 14 stay anchored to live production.
 
-### A2 — standardized check layer, INCREMENT 1 ONLY (committed on `framework-check-layer`, NOT yet PR'd)
+### A2 — standardized check layer (committed on `framework-check-layer`, NOT yet PR'd)
+**Increment 1 — the registry library:**
 - `src/lib/check/postcheck.ts` — `PostCheck` registry + `runChecks(ids, parsed, ctx)`. Two phases: `transform` (mutates parsed — the re-anchorers are registered as `reanchor-argument` etc.) and `validate` (returns `CheckIssue[]` with `severity: 'hard'|'soft'` — the linters `lintSynthesis`/`lintHalachaParsed` are registered as `hebrew-excerpt`/`hebrew-gloss`). `runChecks` runs transforms (in order) then validators.
 - `tests/check/postcheck.test.ts` (8 cases) — transforms resolve anchors identically to the direct re-anchorer; validators flag a calque / English-only pasuk; phases ordered; unknown ids tolerated.
-- **This layer is additive and NOT used by the runners yet.** Nothing imports `runChecks` in `index.ts`.
 
-Current totals: 57 test files, **1253 tests passing**; typecheck clean except the unrelated MCP-module errors.
+**Increment 2 — wired into the runners (commit `45317c2`):**
+- Added `checks?: string[]` to `MarkDefinition`/`EnrichmentDefinition` in BOTH `studio-schema.ts` and `studio-registry.ts` (the runner's enrichment def is the *registry* type, not the schema one — `adaptCodeEnrichment` now copies `checks` across). Excluded from `def_hash`/the cache key (cache keys use only `id`+`cache_version`; `def_hash` is a literal, never recomputed from the def — verified).
+- Declared checks on the code defs (`code-marks.ts`): argument/argument-move/pesukim/aggadata → `reanchor-*`; pesukim.synthesis → `hebrew-excerpt`; halacha.{codification,practical,disputes,synthesis} → `hebrew-gloss`. Threaded `checks` through `makeEnrichment`/`makeSynthesis`.
+- `runMarkOnce`: the `if (def.id===…)` re-anchor chain is replaced by one `runChecks(def.checks, …)` call (fetches the gemara slice once). rabbi/places stay special-cased. The 4 inline `postProcessArgument/…` wrappers are DELETED (golden tests import the pure re-anchorers directly, not the wrappers).
+- `runEnrichmentOnce`: the two lint if-blocks are replaced by `runChecks`; gating now keys on `hardIssueCount` (all current validator issues are `hard`, so identical to the old `!lint_issues`). `lint_issues` still stored on `RunResult` (now `CheckIssue[]`; `summarizeIssue` output is unchanged since `match` is always present). `postProcessRabbiEvidence` unchanged (A1b).
+- `tests/check/wiring.test.ts` (5 cases) — locks the declared checks to the registry; proves `keyForMark`/`keyForEnrichment` are invariant to `checks`.
 
-## YOUR IMMEDIATE TASK — A2 increment 2: wire `runChecks` into the runners
+Current totals: 58 test files, **1258 tests passing**; typecheck clean except the unrelated MCP-module errors. **Not yet PR'd** — PR `framework-check-layer` with `--base section-typing-design` so the diff is just A2 stacked on A1.
 
-Goal: replace the two hardcoded `if (def.id===…)` post-process chains with `runChecks`, driven by a new declarative `checks?: string[]` on each definition. Must stay byte-identical (golden suite green) and **must not bump `def_hash`**.
+## YOUR IMMEDIATE TASK — A3: add new checks, ship them `soft`
 
-Steps:
-1. **Add `checks?: string[]`** to `MarkDefinition` and `EnrichmentDefinition` in `src/worker/studio-schema.ts`.
-2. **Exclude `checks` from `def_hash`.** Find the `def_hash` computation (sha256 over `extractor + render`, ~studio-schema.ts:569 and wherever it's computed for code/KV defs) and ensure `checks` is NOT included (checks are post-processing, not generation input). Verify a def with `checks` set produces the SAME `def_hash` as before → cache keys unchanged.
-3. **Declare checks on the code defs** in `src/worker/code-marks.ts`: `argument` → `['reanchor-argument']`, `argument-move` → `['reanchor-argument-move']`, `pesukim` → `['reanchor-pesukim']`, `aggadata` → `['reanchor-aggadata']`, `pesukim.synthesis` → `['hebrew-excerpt']`, `halacha.*` → `['hebrew-gloss']`.
-4. **Rewire `runMarkOnce`** (`src/worker/index.ts`): replace the `if (def.id==='argument') parsed = await postProcessArgument(...) else if …` chain with `const { parsed: checked, issues } = await runChecks(def.checks ?? [], parsed, { tractate, page, segmentsHe: slice.segments_he, defId: def.id, lang })`. You'll need the gemara slice available (the delegating wrappers fetch it; centralize one fetch). **Special cases that DON'T fit the segments-only transform yet:** `postProcessRabbi` (needs the daf Hebrew text, not segments — different signature) and `recordObservedPlacesFromMark` (a side effect, not a transform). Leave those as-is for now, or model them explicitly. Only the 4 verbatim re-anchorers move to `runChecks`.
-5. **Rewire `runEnrichmentOnce`**: replace its `pesukim.synthesis`/`halacha.*` lint if-chain with `runChecks(def.checks ?? [], parsed, ctx)`. Keep `postProcessRabbiEvidence` as-is for now (it's a transform but not yet ported — see A1b). Feed the `hard` issues into the EXISTING cache-gating (`noteLintAttempt` / `MAX_LINT_ATTEMPTS`): pin on no hard issues; otherwise bounded-retry. Preserve `lint_issues` on `RunResult` (or alias to `check_issues` keeping the same JSON path so `/api/usage` `readLintFailures` and the dev tray keep working).
-6. **Verify**: `pnpm test` (golden + all must stay green → proves the rewiring reproduces the if-chains exactly), filtered `tsc`. Then PR `framework-check-layer` with `--base section-typing-design` so the diff is just A2 (stacked on A1).
+A2 is done (above). Now ADD net-new checks to the registry, shipped `soft` first
+so they observe-only (never gate the cache) until you've watched them on
+`GET /api/usage` (`readLintFailures`) and decided to promote per-mark.
 
-Risk: getting the cache-gating semantics or the synthesis-text extraction subtly wrong. The golden suite + `tests/check/postcheck.test.ts` are your safety net; add a test that a `hard` issue prevents the cache write.
+New checks to add in `src/lib/check/postcheck.ts` (register in `CHECKS`, declare
+on the relevant defs via `checks: []`, cover with `tests/check/`):
+- **`anchor-verbatim`** (validate) — the resolved excerpt is actually present in
+  its claimed segment. Catches hallucinations like `אריגתא` where the daf says
+  `כשורי`. Needs `ctx.segmentsHe` (already passed in `runMarkOnce`; for
+  enrichments the validator ctx currently passes `segmentsHe: []`, so if you
+  attach this to an enrichment, wire a real slice there too).
+- **`edge-integrity`** (validate) — voices-graph edges: from/to ∈ voices,
+  ordered ranges, no contradictory `opposes`+`supports` on one pair.
+- **`partition-clean`** (validate) — no gaps/overlaps/dupes in section/move
+  partitions. Catches the duplicated Rav Amram/Yalta moves.
+
+Ship all three `soft`. Promote to `hard` per-mark only after observing — and
+**only that promotion warrants a per-mark `cache_version` bump, one at a time**
+(full-shas re-warm is ~$1000; never bump broadly).
+
+Verify: `pnpm test` (all green) + filtered `tsc`. The check registry +
+`tests/check/*` are your safety net.
+
+NOTE: A2 itself is committed on `framework-check-layer` but **not yet PR'd** — if
+the owner hasn't picked it up, open it first (`gh pr create --base
+section-typing-design`, stacked on A1/PR #45) before stacking A3 on top.
 
 ## REMAINING ROADMAP (tasks already filed)
 

--- a/src/lib/check/postcheck.ts
+++ b/src/lib/check/postcheck.ts
@@ -1,0 +1,129 @@
+/**
+ * Standardized post-LLM check layer. Replaces the two hardcoded
+ * `if (def.id === …)` chains in the worker's runMarkOnce / runEnrichmentOnce
+ * (one for anchor-resolution transforms, one for the Hebrew linters) with a
+ * single registry of named checks that a definition opts into via `checks: []`.
+ *
+ * Two phases:
+ *   - transform: mutates/returns `parsed` (placement, anchor resolution).
+ *   - validate:  inspects `parsed`, returns issues. `hard` issues gate the
+ *                cache write (via the existing bounded-retry); `soft` issues
+ *                are attached as a quality signal but never block.
+ *
+ * runChecks runs all transforms (in the order listed) then all validators.
+ * DOM-free / env-free so it lives in src/lib and is unit-testable.
+ */
+
+import { lintSynthesis } from '../synthesisLint';
+import { lintHalachaParsed } from '../halachaLint';
+import { reanchorArgument, reanchorArgumentMove, reanchorPesukim, reanchorAggadata } from '../place/reanchor';
+
+export type Severity = 'hard' | 'soft';
+
+export interface CheckIssue {
+  /** Stable kind, e.g. 'missing-hebrew-excerpt' | 'calque' | 'bare-transliteration'. */
+  kind: string;
+  severity: Severity;
+  /** Optional position/diagnostic carriers (the existing lint issue shapes fit). */
+  match?: string;
+  index?: number;
+  detail?: string;
+}
+
+export interface CheckCtx {
+  tractate: string;
+  page: string;
+  /** Segment grid for placement/anchor transforms (the gemara slice). */
+  segmentsHe: string[];
+  defId: string;
+  lang?: 'en' | 'he';
+}
+
+export type CheckResult = { parsed: unknown } | { issues: CheckIssue[] };
+
+export interface PostCheck {
+  id: string;
+  phase: 'transform' | 'validate';
+  run(parsed: unknown, ctx: CheckCtx): CheckResult | Promise<CheckResult>;
+}
+
+// ---- transform checks: anchor resolution via the unified placer ----
+
+const transform = (id: string, fn: (p: unknown, segs: string[]) => unknown): PostCheck => ({
+  id,
+  phase: 'transform',
+  run: (parsed, ctx) => ({ parsed: fn(parsed, ctx.segmentsHe) }),
+});
+
+// ---- validate checks: wrap the existing deterministic linters ----
+
+/** Pull the synthesis prose out of a parsed enrichment payload, tolerating the
+ *  older 4-field shape (mirrors the extraction in runEnrichmentOnce). */
+function synthesisText(parsed: unknown): string {
+  const p = (parsed ?? {}) as Partial<Record<'synthesis' | 'tanach_context' | 'why_here' | 'mechanism' | 'landing', string>>;
+  return p.synthesis
+    ?? [p.tanach_context, p.why_here, p.mechanism, p.landing]
+      .filter((s): s is string => typeof s === 'string' && s.length > 0)
+      .join('\n\n');
+}
+
+const hebrewExcerpt: PostCheck = {
+  id: 'hebrew-excerpt',
+  phase: 'validate',
+  run: (parsed) => ({
+    issues: lintSynthesis(synthesisText(parsed)).map((i) => ({
+      kind: i.kind,
+      severity: 'hard' as const,
+      match: i.match,
+      index: i.index,
+      detail: `${i.book} ${i.chapter}:${i.verse}`,
+    })),
+  }),
+};
+
+const hebrewGloss: PostCheck = {
+  id: 'hebrew-gloss',
+  phase: 'validate',
+  run: (parsed) => ({
+    issues: lintHalachaParsed(parsed).map((i) => ({
+      kind: i.kind,
+      severity: 'hard' as const,
+      match: i.match,
+      index: i.index,
+      detail: 'hebrew' in i ? i.hebrew : undefined,
+    })),
+  }),
+};
+
+export const CHECKS: Record<string, PostCheck> = {
+  'reanchor-argument': transform('reanchor-argument', reanchorArgument),
+  'reanchor-argument-move': transform('reanchor-argument-move', reanchorArgumentMove),
+  'reanchor-pesukim': transform('reanchor-pesukim', reanchorPesukim),
+  'reanchor-aggadata': transform('reanchor-aggadata', reanchorAggadata),
+  'hebrew-excerpt': hebrewExcerpt,
+  'hebrew-gloss': hebrewGloss,
+};
+
+/** Run the named checks: transforms first (in listed order), then validators.
+ *  Unknown ids are ignored (a definition may reference a check not yet shipped). */
+export async function runChecks(
+  checkIds: readonly string[],
+  parsed: unknown,
+  ctx: CheckCtx,
+): Promise<{ parsed: unknown; issues: CheckIssue[] }> {
+  let current = parsed;
+  const issues: CheckIssue[] = [];
+  for (const id of checkIds) {
+    const c = CHECKS[id];
+    if (!c || c.phase !== 'transform') continue;
+    const r = await c.run(current, ctx);
+    if ('parsed' in r) current = r.parsed;
+  }
+  for (const id of checkIds) {
+    const c = CHECKS[id];
+    if (!c || c.phase !== 'validate') continue;
+    const r = await c.run(current, ctx);
+    if ('issues' in r) issues.push(...r.issues);
+  }
+  return { parsed: current, issues };
+}

--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -505,6 +505,7 @@ export const CODE_MARKS: MarkDefinition[] = [
       thinking_off: true,
     },
     dependencies: ['gemara'],
+    checks: ['reanchor-argument'],
     status: 'promoted',
     def_hash: 'argument-llm-v3',
     cache_version: '4',
@@ -587,6 +588,7 @@ export const CODE_MARKS: MarkDefinition[] = [
       thinking_off: true,
     },
     dependencies: ['gemara'],
+    checks: ['reanchor-aggadata'],
     status: 'promoted',
     def_hash: 'aggadata-llm-v3',
     cache_version: '4',
@@ -615,6 +617,7 @@ export const CODE_MARKS: MarkDefinition[] = [
       thinking_off: true,
     },
     dependencies: ['gemara'],
+    checks: ['reanchor-pesukim'],
     status: 'promoted',
     def_hash: 'pesukim-llm-v4',
     cache_version: '5',
@@ -1363,6 +1366,8 @@ function makeEnrichment(
     mode: 'augment-content' | 'aggregate';
     scope: EnrichmentScope;
     dependencies?: EnrichmentDependency[];
+    /** Post-LLM validators this enrichment opts into (see EnrichmentDefinition.checks). */
+    checks?: string[];
     defHash: string;
     cacheVersion: string;
     model?: LLMModelId;
@@ -1385,6 +1390,7 @@ function makeEnrichment(
     mode: opts.mode,
     scope: opts.scope,
     dependencies: opts.dependencies,
+    ...(opts.checks ? { checks: opts.checks } : {}),
     extractor: {
       kind: 'llm',
       ...(opts.model ? { model: opts.model } : {}),
@@ -1438,6 +1444,7 @@ function makeSynthesis(
   userPromptTemplate: string,
   opts: {
     dependencies: EnrichmentDependency[];
+    checks?: string[];
     defHash: string;
     cacheVersion: string;
     scope?: EnrichmentScope;
@@ -1454,6 +1461,7 @@ function makeSynthesis(
       mode: 'aggregate',
       scope: opts.scope ?? 'local',
       dependencies: opts.dependencies,
+      checks: opts.checks,
       defHash: opts.defHash,
       cacheVersion: opts.cacheVersion,
       model: opts.model,
@@ -2254,6 +2262,7 @@ CODE_MARKS.push({
     fan_out_over: 'argument',
   },
   dependencies: ['gemara', { mark: 'argument' }],
+  checks: ['reanchor-argument-move'],
   status: 'promoted',
   def_hash: 'argument-move-v9',
   cache_version: '9',
@@ -3448,6 +3457,7 @@ CODE_ENRICHMENTS.push(
     {
       mode: 'augment-content', scope: 'local',
       dependencies: ['gemara'],
+      checks: ['hebrew-gloss'],
       defHash: 'halacha.codification-v3', cacheVersion: '3',
       systemPromptHe: HALACHA_CODIFICATION_SYSTEM_PROMPT_HE,
       userPromptTemplateHe: HALACHA_LEAF_USER_TEMPLATE_HE,
@@ -3460,6 +3470,7 @@ CODE_ENRICHMENTS.push(
     {
       mode: 'augment-content', scope: 'local',
       dependencies: ['gemara'],
+      checks: ['hebrew-gloss'],
       defHash: 'halacha.practical-v4', cacheVersion: '4',
       systemPromptHe: HALACHA_PRACTICAL_SYSTEM_PROMPT_HE,
       userPromptTemplateHe: HALACHA_LEAF_USER_TEMPLATE_HE,
@@ -3472,6 +3483,7 @@ CODE_ENRICHMENTS.push(
     {
       mode: 'augment-content', scope: 'local',
       dependencies: ['gemara'],
+      checks: ['hebrew-gloss'],
       defHash: 'halacha.disputes-v3', cacheVersion: '3',
       systemPromptHe: HALACHA_DISPUTES_SYSTEM_PROMPT_HE,
       userPromptTemplateHe: HALACHA_LEAF_USER_TEMPLATE_HE,
@@ -3488,6 +3500,7 @@ CODE_ENRICHMENTS.push(
         { enrichment: 'halacha.practical' },
         { enrichment: 'halacha.disputes' },
       ],
+      checks: ['hebrew-gloss'],
       defHash: 'halacha.synthesis-v4', cacheVersion: '4',
       systemPromptHe: HALACHA_SYNTHESIS_SYSTEM_PROMPT_HE,
       userPromptTemplateHe: HALACHA_SYNTHESIS_USER_TEMPLATE_HE,
@@ -4220,6 +4233,7 @@ CODE_ENRICHMENTS.push(
         { mark: 'rabbi' },
         { mark: 'pesukim' },
       ],
+      checks: ['hebrew-excerpt'],
       defHash: 'pesukim.synthesis-v11', cacheVersion: '11',
       // Pro instead of Flash: the synthesis must follow the 3-4 sentence
       // structure and avoid the explicit banned-phrase list. Flash skims

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -62,9 +62,7 @@ import { wrapEnv, gatewayStatus, gatewayActive } from './ai-gateway';
 import { runLLM, type LLMModelId, type LLMResult, type LLMUsage } from './llm';
 import { checkBudget, isBudgetPaused, budgetStatus, clearPauses, type BudgetScope } from './budget';
 import { lookupRelationships } from './rabbi-graph';
-import { lintSynthesis } from '../lib/synthesisLint';
-import { lintHalachaParsed } from '../lib/halachaLint';
-import { reanchorArgument, reanchorArgumentMove, reanchorPesukim, reanchorAggadata } from '../lib/place/reanchor';
+import { runChecks } from '../lib/check/postcheck';
 import { noteLintAttempt, readLintFailures, type LintFailuresSummary } from './lint-failures';
 import { partitionSections, dedupeByRange, dedupeBy, selectSectionMoves, type MoveLike } from '../lib/argumentMoves';
 import { DEFAULT_MODEL, DEFAULT_FALLBACK_CHAIN, isLLMModelId, MODEL_PRESETS } from './settings';
@@ -841,6 +839,7 @@ function adaptCodeEnrichment(code: SchemaEnrichmentDefinition): EnrichmentDefini
     mark: code.target_mark,
     scope: code.scope,
     dependencies: code.dependencies,
+    checks: code.checks,
     system_prompt: llm?.system_prompt ?? '',
     user_prompt_template: llm?.user_prompt_template ?? '',
     system_prompt_he: llm?.system_prompt_he,
@@ -1367,20 +1366,26 @@ async function runMarkOnce(
     try { parsed = JSON.parse(result.content); }
     catch (err) { parse_error = String(err).slice(0, 200); }
   }
-  // Per-mark post-processing. Some extractors (notably argument-move) can't
-  // reliably emit segment indices for sub-ranges, so we re-derive them from
-  // the verbatim Hebrew excerpt the LLM IS good at copying. Also computes
-  // token (word) offsets within the matched segment so the highlight painter
-  // can paint exactly the move/citation, not the whole containing segment.
-  if (parsed && def.id === 'argument') {
-    parsed = await postProcessArgument(parsed, rc.env, tractate, page);
-  } else if (parsed && def.id === 'argument-move') {
-    parsed = await postProcessArgumentMove(parsed, rc.env, tractate, page);
-  } else if (parsed && def.id === 'pesukim') {
-    parsed = await postProcessPesukim(parsed, rc.env, tractate, page);
-  } else if (parsed && def.id === 'aggadata') {
-    parsed = await postProcessAggadata(parsed, rc.env, tractate, page);
-  } else if (parsed && def.id === 'rabbi') {
+  // Per-mark post-processing via the declarative check layer
+  // (src/lib/check/postcheck.ts). Some extractors (notably argument-move) can't
+  // reliably emit segment indices for sub-ranges, so the verbatim re-anchorers
+  // (reanchor-argument/-move/-pesukim/-aggadata) re-derive them from the Hebrew
+  // excerpt the LLM IS good at copying, and compute token (word) offsets within
+  // the matched segment so the highlight painter can paint exactly the
+  // move/citation, not the whole containing segment. A definition opts in via
+  // `checks: []` in code-marks.ts; the transforms need the segment grid, so
+  // fetch the gemara slice once when any check runs.
+  if (parsed && def.checks && def.checks.length > 0) {
+    const slice = await getGemaraSlice(rc.env, tractate, page, false);
+    const checked = await runChecks(def.checks, parsed, {
+      tractate, page, segmentsHe: slice.segments_he, defId: def.id, lang: rc.lang,
+    });
+    parsed = checked.parsed;
+  }
+  // Special cases that don't fit the segments-only transform signature yet:
+  //   - rabbi:  needs the daf Hebrew text, not the segment grid (A1b will port it).
+  //   - places: a side effect (backlog logging), not a parsed-output transform.
+  if (parsed && def.id === 'rabbi') {
     parsed = postProcessRabbi(parsed, stripHtmlServer(String(vars.hebrew ?? '')));
   } else if (parsed && def.id === 'places') {
     // Places have no global gazetteer — log every observed location to the
@@ -1411,121 +1416,6 @@ async function runMarkOnce(
   };
   if (!parse_error) await writeCachedResult(rc.env, cacheKey, out);
   return out;
-}
-
-/**
- * Post-process argument mark output: anchor section start + end to real
- * Hebrew text by matching `excerpt` and `endExcerpt` against the segmented
- * gemara. The LLM-provided startSegIdx/endSegIdx are treated as hints and
- * overwritten when the excerpts match. Sections then partition the daf
- * cleanly (each section's endSegIdx ≥ startSegIdx, and ≥ previous section's
- * endSegIdx). Without this pass, the section's endSegIdx is whatever the
- * LLM guessed and frequently overshoots into the next section's content —
- * which then shows up as a too-large pink highlight and as misaligned
- * moves (since argument-move uses these section ranges as its partition
- * bounds).
- */
-async function postProcessArgument(
-  parsed: unknown,
-  env: Bindings,
-  tractate: string,
-  page: string,
-): Promise<unknown> {
-  if (!parsed || typeof parsed !== 'object') return parsed;
-  if (!Array.isArray((parsed as { instances?: unknown }).instances)) return parsed;
-  const slice = await getGemaraSlice(env, tractate, page, false);
-  return reanchorArgument(parsed, slice.segments_he);
-}
-
-/**
- * Post-process argument-move mark output: V4-Flash reliably copies the
- * verbatim Hebrew excerpt for each move but its startSegIdx/endSegIdx are
- * frequently the WHOLE section (every move = same range, "lazy partition"
- * issue). Re-derive ranges by locating each excerpt in the gemara's
- * numbered segments and computing the next-move boundary.
- *
- * Algorithm:
- *   1. For each move, normalize the excerpt and search the segments_he
- *      array for the segment whose normalized text contains it. That seg
- *      becomes the move's startSegIdx.
- *   2. The endSegIdx is the segment right before the next move's startSegIdx
- *      (within the same parent section), or the section's endSegIdx for the
- *      last move in a section.
- *   3. If an excerpt can't be located, leave the LLM-emitted range alone
- *      (don't make things worse).
- *
- * LIMITATION (TODO: sub-segment anchoring):
- *   When Sefaria packages a section as a SINGLE segment — most commonly the
- *   opening Mishnah of a tractate, where the whole Mishnah is one block at
- *   segments_he[0] — every move inside that section resolves to the same
- *   startSegIdx. Clicking different moves all highlight the same span on
- *   the daf even though the LLM correctly identified them as distinct.
- *
- *   Fix path (separate piece of work; see legacy halacha highlight in
- *   DafViewer.tsx for the existing word-token precedent):
- *     1. Extend mark instance fields to optionally carry { tokenStart,
- *        tokenEnd } — word indices within the segment.
- *     2. Have this post-processor also walk the .daf-word stream of the
- *        matched segment to compute the excerpt's word range, not just
- *        its segment.
- *     3. Update the move-highlight painter in DafViewer.applyHighlights
- *        to paint over [seg.tokenStart .. seg.tokenEnd] when those fields
- *        are present, falling back to whole-segment when absent.
- *   Most non-Mishnah sections are split into multiple segments per move so
- *   this only bites bundled-Mishnah-style blocks.
- */
-async function postProcessArgumentMove(
-  parsed: unknown,
-  env: Bindings,
-  tractate: string,
-  page: string,
-): Promise<unknown> {
-  if (!parsed || typeof parsed !== 'object') return parsed;
-  if (!Array.isArray((parsed as { instances?: unknown }).instances)) return parsed;
-  const slice = await getGemaraSlice(env, tractate, page, false);
-  return reanchorArgumentMove(parsed, slice.segments_he);
-}
-
-/**
- * Post-process pesukim mark output: assign tokenStart/tokenEnd to each
- * citation so the click-highlight paints exactly the cited verse phrase
- * inside its segment, not the whole segment. The pasuk excerpt IS the
- * full citation text, so tokenEnd = tokenStart + wordCount - 1 cleanly.
- *
- * Same multi-prefix matcher as argument-move; same fallback if matching
- * fails (leave whatever the LLM emitted alone — the seg-range will at
- * least be inside the daf).
- */
-async function postProcessPesukim(
-  parsed: unknown,
-  env: Bindings,
-  tractate: string,
-  page: string,
-): Promise<unknown> {
-  if (!parsed || typeof parsed !== 'object') return parsed;
-  if (!Array.isArray((parsed as { instances?: unknown }).instances)) return parsed;
-  const slice = await getGemaraSlice(env, tractate, page, false);
-  return reanchorPesukim(parsed, slice.segments_he);
-}
-
-/**
- * Post-process aggadata instances. Mirrors postProcessPesukim: locates the
- * LLM's verbatim `excerpt` and `endExcerpt` in the segment grid and writes
- * startSegIdx/endSegIdx + tokenStart/tokenEnd for pixel-precise highlighting.
- * Without this, the client's highlight painter falls back to "next story or
- * end of amud" which is wildly too wide whenever there is no immediately-
- * following aggadata on the daf.
- */
-async function postProcessAggadata(
-  parsed: unknown,
-  env: Bindings,
-  tractate: string,
-  page: string,
-): Promise<unknown> {
-  if (!parsed || typeof parsed !== 'object') return parsed;
-  if (!Array.isArray((parsed as { instances?: unknown }).instances)) return parsed;
-  const slice = await getGemaraSlice(env, tractate, page, false);
-  return reanchorAggadata(parsed, slice.segments_he);
 }
 
 /**
@@ -1850,33 +1740,26 @@ async function runEnrichmentOnce(
   if (parsed && (def.id === 'rabbi.relationships.evidence' || def.id === 'rabbi.geography.evidence')) {
     parsed = await postProcessRabbiEvidence(parsed, rc.env, tractate, page);
   }
-  // Post-generation lint for pesukim.synthesis: flag outputs where the LLM
-  // cited a pasuk with English-only quotes and no Hebrew verbatim text.
-  // We attach issues to the result (visible in dev tray / cache) but do NOT
-  // reject — a false-positive lint shouldn't block the whole run. Issues
-  // ARE used to gate cache writes so bad outputs don't get pinned.
+  // Post-generation validation via the standardized check layer
+  // (src/lib/check/postcheck.ts). An enrichment opts into validators through
+  // `checks: []` in code-marks.ts: pesukim.synthesis -> 'hebrew-excerpt'
+  // (flag pesukim cited with English-only quotes and no Hebrew verbatim text);
+  // halacha.* -> 'hebrew-gloss' (flag HEBREW_GLOSS_STYLE violations — bare /
+  // parenthesized transliterations, calques — across every prose field + chip).
+  // Issues are attached to the result (visible in dev tray / cache) but never
+  // reject the run; `hard` issues gate the cache write below so a bad output
+  // isn't pinned. These validators inspect `parsed` only (no segment grid).
   let lint_issues: unknown[] | undefined;
-  if (def.id === 'pesukim.synthesis' && parsed && !parse_error) {
-    // Synthesis emits a single `synthesis` prose field. (An earlier revision
-    // emitted four labeled fields; concat them as a fallback so any older
-    // cached payloads still in flight continue to lint.)
-    const p = parsed as Partial<Record<'synthesis' | 'tanach_context' | 'why_here' | 'mechanism' | 'landing', string>>;
-    const synth = p.synthesis
-      ?? [p.tanach_context, p.why_here, p.mechanism, p.landing]
-        .filter((s): s is string => typeof s === 'string' && s.length > 0)
-        .join('\n\n');
-    const issues = lintSynthesis(synth);
-    if (issues.length > 0) lint_issues = issues;
-  }
-  // Post-generation lint for halacha enrichments: flag HEBREW_GLOSS_STYLE
-  // violations (bare / parenthesized transliterations, calques) across every
-  // prose field and chip. Same non-blocking, cache-gating posture as
-  // pesukim.synthesis above — a non-compliant output is returned (with
-  // lint_issues attached) but not pinned to cache, so a bypass_cache re-run
-  // gets a fresh shot at clean Hebrew-anchored output.
-  if (def.id.startsWith('halacha.') && parsed && !parse_error) {
-    const issues = lintHalachaParsed(parsed);
-    if (issues.length > 0) lint_issues = issues;
+  let hardIssueCount = 0;
+  if (parsed && !parse_error && def.checks && def.checks.length > 0) {
+    const checked = await runChecks(def.checks, parsed, {
+      tractate, page, segmentsHe: [], defId: def.id, lang: rc.lang,
+    });
+    parsed = checked.parsed; // honor the transform contract (validators leave it unchanged)
+    if (checked.issues.length > 0) {
+      lint_issues = checked.issues;
+      hardIssueCount = checked.issues.filter((i) => i.severity === 'hard').length;
+    }
   }
   const out: RunResultEnrichment = {
     content: result.content,
@@ -1902,18 +1785,19 @@ async function runEnrichmentOnce(
     ...(lint_issues ? { lint_issues } : {}),
     ...(sectionRange ? { section_range: sectionRange } : {}),
   };
-  // Gate cache writes on lint passing — but BOUND the retries. A clean output
-  // is pinned immediately. A lint-failing output is left uncached so the next
-  // request regenerates (the model is mildly nondeterministic, so a retry may
-  // come back clean) — UNTIL it has failed MAX_LINT_ATTEMPTS times, at which
-  // point we pin the best-effort output anyway so reads become cache hits and
-  // regeneration stops. Without this cap the warm crons re-pay for a
-  // persistently-failing card forever. Capped failures surface on /api/usage.
+  // Gate cache writes on the checks passing — but BOUND the retries. An output
+  // with no `hard` issues is pinned immediately. A hard-failing output is left
+  // uncached so the next request regenerates (the model is mildly
+  // nondeterministic, so a retry may come back clean) — UNTIL it has failed
+  // MAX_LINT_ATTEMPTS times, at which point we pin the best-effort output anyway
+  // so reads become cache hits and regeneration stops. Without this cap the warm
+  // crons re-pay for a persistently-failing card forever. (Soft issues never
+  // gate.) Capped failures surface on /api/usage.
   if (cacheKey && !parse_error) {
-    if (!lint_issues) {
+    if (hardIssueCount === 0) {
       await writeCachedResult(rc.env, cacheKey, out);
     } else if (await noteLintAttempt(rc.env, rc.ctx, cacheKey, {
-      enrichmentId: def.id, tractate, page, lang: rc.lang, issues: lint_issues,
+      enrichmentId: def.id, tractate, page, lang: rc.lang, issues: lint_issues ?? [],
     })) {
       await writeCachedResult(rc.env, cacheKey, out);
     }

--- a/src/worker/studio-registry.ts
+++ b/src/worker/studio-registry.ts
@@ -44,6 +44,9 @@ export interface MarkDefinition {
   fields_schema?: unknown;
   /** Declared inputs (gemara/commentaries/other marks). See studio-schema.ts. */
   dependencies?: MarkDependency[];
+  /** Post-LLM checks (transform/validate) this mark opts into. See
+   *  MarkDefinition.checks in studio-schema.ts. Not part of the cache key. */
+  checks?: string[];
   /** UI-only nesting hint — see MarkDefinition.parent_mark in studio-schema.ts. */
   parent_mark?: string;
   /** Experimental feature flag — dev-only visibility. See studio-schema.ts. */
@@ -66,6 +69,10 @@ export interface EnrichmentDefinition {
   /** Declared inputs (gemara/commentaries/other enrichments/other marks).
    *  The runner walks this array and exposes each entry as a template var. */
   dependencies?: EnrichmentDependency[];
+  /** Post-LLM validators (e.g. 'hebrew-excerpt', 'hebrew-gloss') this
+   *  enrichment opts into. See EnrichmentDefinition.checks in studio-schema.ts.
+   *  Feeds the cache-gating; not part of the cache key. */
+  checks?: string[];
   system_prompt: string;
   user_prompt_template: string;
   /** Hebrew-output counterparts, selected when a run is requested with

--- a/src/worker/studio-schema.ts
+++ b/src/worker/studio-schema.ts
@@ -364,6 +364,14 @@ export interface MarkDefinition {
    *  current behavior of buildDafContext. Future secondary anchors declare
    *  other marks (e.g. an Israel/Bavel map = [{mark:'rabbi'},{mark:'place'}]). */
   dependencies?: MarkDependency[];
+  /** Post-LLM checks this definition opts into, run by the worker's check
+   *  layer (src/lib/check/postcheck.ts) after the extractor produces `parsed`.
+   *  Two phases: `transform` checks (e.g. the verbatim re-anchorers
+   *  'reanchor-argument') mutate the parsed output; `validate` checks return
+   *  issues. Ordered. NOT part of def_hash / the cache key — checks are
+   *  post-processing of generated output, not generation input, so toggling
+   *  them must never bust the LLM cache. */
+  checks?: string[];
   /** UI-only nesting hint. When set, the dev panel groups this mark as a
    *  child of `parent_mark` in the toggle list. Architecturally the mark is
    *  still independent (own anchor, own cache, own extractor) — this just
@@ -418,6 +426,11 @@ export interface EnrichmentDefinition {
    *  here are run first (recursively); other marks are extracted on the same
    *  daf. Empty array means the enrichment only sees `mark_input`. */
   dependencies?: EnrichmentDependency[];
+  /** Post-LLM checks this enrichment opts into. See MarkDefinition.checks. The
+   *  validators ('hebrew-excerpt', 'hebrew-gloss') feed the bounded-retry
+   *  cache-gating (a `hard` issue leaves the output uncached until
+   *  MAX_LINT_ATTEMPTS). NOT part of def_hash / the cache key. */
+  checks?: string[];
 
   extractor: Extractor;
 
@@ -566,5 +579,5 @@ correct the ones I got wrong.
 
   14. status       — always 'draft' on creation. Promote later via UI.
 
-After fill-in, the worker computes def_hash from sha256(JSON.stringify(extractor) + JSON.stringify(render)). Save via PUT /api/studio/marks/{id}.
+After fill-in, the worker computes def_hash from sha256(JSON.stringify(extractor) + JSON.stringify(render)) — NOT over `checks` (post-processing, not generation input). Save via PUT /api/studio/marks/{id}.
 */

--- a/tests/check/postcheck.test.ts
+++ b/tests/check/postcheck.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for the standardized post-LLM check layer (src/lib/check/postcheck.ts):
+ * transform checks resolve anchors, validate checks surface lint issues, the
+ * two phases run in order, and unknown check ids are tolerated.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { runChecks, CHECKS, type CheckCtx } from '../../src/lib/check/postcheck';
+
+const FIX = join(__dirname, '..', 'fixtures', 'golden-anchors');
+const ctx = (over: Partial<CheckCtx> = {}): CheckCtx => ({ tractate: 'Gittin', page: '67b', segmentsHe: [], defId: 'x', ...over });
+
+describe('runChecks — transforms', () => {
+  it('reanchor-argument resolves anchors identically to the direct re-anchorer', async () => {
+    const fx = JSON.parse(readFileSync(join(FIX, 'gittin_67b_argument.json'), 'utf8'));
+    const segmentsHe: string[] = JSON.parse(readFileSync(join(FIX, 'gemara_gittin_67b.json'), 'utf8')).segments_he;
+    const { parsed, issues } = await runChecks(['reanchor-argument'], structuredClone(fx.raw), ctx({ segmentsHe, defId: 'argument' }));
+    expect(parsed).toEqual(fx.expected);
+    expect(issues).toEqual([]);
+  });
+
+  it('no checks = no-op', async () => {
+    const input = { instances: [{ startSegIdx: 1, fields: {} }] };
+    const { parsed, issues } = await runChecks([], structuredClone(input), ctx());
+    expect(parsed).toEqual(input);
+    expect(issues).toEqual([]);
+  });
+
+  it('ignores unknown check ids', async () => {
+    const input = { foo: 1 };
+    const { parsed, issues } = await runChecks(['does-not-exist'], structuredClone(input), ctx());
+    expect(parsed).toEqual(input);
+    expect(issues).toEqual([]);
+  });
+});
+
+describe('runChecks — validators', () => {
+  it('hebrew-gloss flags a calque', async () => {
+    const parsed = { ruling: 'The animal is a neveila if severed without most of the flesh.' };
+    const { issues } = await runChecks(['hebrew-gloss'], parsed, ctx({ defId: 'halacha.codification' }));
+    expect(issues.length).toBeGreaterThan(0);
+    expect(issues.every((i) => i.severity === 'hard')).toBe(true);
+    expect(issues.some((i) => i.kind === 'calque')).toBe(true);
+  });
+
+  it('hebrew-excerpt flags a pasuk cited in English with no Hebrew', async () => {
+    const parsed = { synthesis: 'Tehillim 119:62 states, "At midnight I will rise to give thanks to You."' };
+    const { issues } = await runChecks(['hebrew-excerpt'], parsed, ctx({ defId: 'pesukim.synthesis' }));
+    expect(issues.some((i) => i.kind === 'missing-hebrew-excerpt')).toBe(true);
+  });
+
+  it('clean prose produces no issues', async () => {
+    const parsed = { synthesis: 'The sugya (סוגיא) turns on whether counting (מנה) equals כולכם.' };
+    const { issues } = await runChecks(['hebrew-excerpt', 'hebrew-gloss'], parsed, ctx());
+    expect(issues).toEqual([]);
+  });
+});
+
+describe('runChecks — phase ordering', () => {
+  it('validators see the transformed parsed (transform runs first)', async () => {
+    // A pesukim raw with an unresolved citation; after reanchor-pesukim the
+    // instance gains token offsets. We assert the transform applied by checking
+    // the returned parsed, then that validators ran against it without error.
+    const fx = JSON.parse(readFileSync(join(FIX, 'sanhedrin_59b_pesukim.json'), 'utf8'));
+    const segmentsHe: string[] = JSON.parse(readFileSync(join(FIX, 'gemara_sanhedrin_59b.json'), 'utf8')).segments_he;
+    const { parsed } = await runChecks(['reanchor-pesukim', 'hebrew-gloss'], structuredClone(fx.raw), ctx({ tractate: 'Sanhedrin', page: '59b', segmentsHe, defId: 'pesukim' }));
+    expect(parsed).toEqual(fx.expected);
+  });
+});
+
+describe('CHECKS registry', () => {
+  it('exposes transform + validate checks with correct phases', () => {
+    expect(CHECKS['reanchor-argument'].phase).toBe('transform');
+    expect(CHECKS['hebrew-gloss'].phase).toBe('validate');
+    expect(CHECKS['hebrew-excerpt'].phase).toBe('validate');
+  });
+});

--- a/tests/check/wiring.test.ts
+++ b/tests/check/wiring.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Wiring guard for A2 increment 2 — the runners (runMarkOnce / runEnrichmentOnce
+ * in src/worker/index.ts) drive post-LLM processing off each definition's
+ * declarative `checks: []` field instead of a hardcoded `if (def.id === …)`
+ * chain. These tests pin two invariants that wiring depends on:
+ *
+ *   1. The canon marks/enrichments declare the checks the old if-chains applied,
+ *      and every declared id exists in the CHECKS registry (a typo'd or dropped
+ *      check would silently stop re-anchoring / linting in production).
+ *   2. `checks` is NOT part of any cache key — toggling it must never bust the
+ *      LLM cache (a full-shas re-warm is ~$1000).
+ */
+import { describe, it, expect } from 'vitest';
+import { CODE_MARKS, CODE_ENRICHMENTS } from '../../src/worker/code-marks';
+import { CHECKS } from '../../src/lib/check/postcheck';
+import { keyForMark, keyForEnrichment } from '../../src/worker/cache-keys';
+
+describe('declarative check wiring', () => {
+  const markChecks: Record<string, string[]> = {
+    argument: ['reanchor-argument'],
+    'argument-move': ['reanchor-argument-move'],
+    pesukim: ['reanchor-pesukim'],
+    aggadata: ['reanchor-aggadata'],
+  };
+  const enrichmentChecks: Record<string, string[]> = {
+    'pesukim.synthesis': ['hebrew-excerpt'],
+    'halacha.codification': ['hebrew-gloss'],
+    'halacha.practical': ['hebrew-gloss'],
+    'halacha.disputes': ['hebrew-gloss'],
+    'halacha.synthesis': ['hebrew-gloss'],
+  };
+
+  it('canon marks declare the expected checks', () => {
+    for (const [id, expected] of Object.entries(markChecks)) {
+      const def = CODE_MARKS.find((m) => m.id === id);
+      expect(def, `mark ${id} present`).toBeTruthy();
+      expect(def!.checks ?? [], `mark ${id} checks`).toEqual(expected);
+    }
+  });
+
+  it('lint-gated enrichments declare the expected checks', () => {
+    for (const [id, expected] of Object.entries(enrichmentChecks)) {
+      const def = CODE_ENRICHMENTS.find((e) => e.id === id);
+      expect(def, `enrichment ${id} present`).toBeTruthy();
+      expect(def!.checks ?? [], `enrichment ${id} checks`).toEqual(expected);
+    }
+  });
+
+  it('every declared check id is registered in CHECKS', () => {
+    const declared = new Set<string>();
+    for (const m of CODE_MARKS) (m.checks ?? []).forEach((c) => declared.add(c));
+    for (const e of CODE_ENRICHMENTS) (e.checks ?? []).forEach((c) => declared.add(c));
+    for (const id of declared) {
+      expect(CHECKS[id], `check '${id}' registered`).toBeTruthy();
+    }
+  });
+});
+
+describe('checks do not affect cache keys', () => {
+  it('keyForMark is identical with and without checks', () => {
+    const base = { id: 'argument', cache_version: '4' } as Parameters<typeof keyForMark>[0];
+    const withChecks = { ...base, checks: ['reanchor-argument'] } as Parameters<typeof keyForMark>[0];
+    expect(keyForMark(withChecks, 'Gittin', '67b')).toBe(keyForMark(base, 'Gittin', '67b'));
+    expect(keyForMark(withChecks, 'Gittin', '67b', 'he')).toBe(keyForMark(base, 'Gittin', '67b', 'he'));
+  });
+
+  it('keyForEnrichment is identical with and without checks', () => {
+    const base = { id: 'pesukim.synthesis', cache_version: '11', scope: 'local' } as Parameters<typeof keyForEnrichment>[0];
+    const withChecks = { ...base, checks: ['hebrew-excerpt'] } as Parameters<typeof keyForEnrichment>[0];
+    const daf = { tractate: 'Gittin', page: '67b' };
+    expect(keyForEnrichment(withChecks, 'inst', daf)).toBe(keyForEnrichment(base, 'inst', daf));
+  });
+});


### PR DESCRIPTION
Stacked on #45 (A1, the unified verbatim placer). This is **A2** of the framework-standardization work: the standardized post-LLM check layer, now wired into both runners.

## What changed
Replaces the two hardcoded `if (def.id === …)` post-process chains in `runMarkOnce` / `runEnrichmentOnce` with a declarative `checks: []` field on each definition, driven through `runChecks` (`src/lib/check/postcheck.ts`, landed in the first commit of this branch).

- **Marks**: argument / argument-move / pesukim / aggadata declare `reanchor-*`; the 4 inline `postProcessArgument/…` wrappers in the worker are deleted (the pure re-anchorers now live only in `src/lib/place/reanchor.ts`).
- **Enrichments**: pesukim.synthesis → `hebrew-excerpt`, halacha.{codification,practical,disputes,synthesis} → `hebrew-gloss`. Validator `hard` issues feed the existing bounded-retry cache-gating (`noteLintAttempt` / `MAX_LINT_ATTEMPTS`); the `lint_issues` JSON path that `/api/usage` + the dev tray read is preserved.
- **Still special-cased** (don't fit the segments-only transform signature yet): `postProcessRabbi`, `recordObservedPlacesFromMark`, `postProcessRabbiEvidence` (the last ported in A1b).

## Cache safety
`checks` is added to both the schema and KV definition types but is **excluded from `def_hash` / the cache key** (keys use only `id` + `cache_version`; `def_hash` is a literal, never recomputed from the def). No `cache_version` bump → live LLM caches stay valid. A new test proves `keyForMark`/`keyForEnrichment` are invariant to `checks`.

## Verification
- `tests/check/wiring.test.ts` (new, 5 cases): locks the declared checks to the registry; proves cache-key invariance.
- Full suite: **58 files / 1258 tests passing**. Typecheck clean (modulo the pre-existing unrelated MCP-module errors from the stale symlinked `node_modules`).
- Behavior preserved: the golden anchor suite (16 cases) stays green, proving the re-anchor rewiring reproduces the old if-chains byte-identically.

Note: base is `section-typing-design` (#45) so this diff is just A2. Merge #45 first, then this.