### PR TITLE
Converge rabbi-evidence anchoring onto the unified placer (A1b)

### DIFF
--- a/src/lib/check/postcheck.ts
+++ b/src/lib/check/postcheck.ts
@@ -16,7 +16,7 @@
 
 import { lintSynthesis } from '../synthesisLint';
 import { lintHalachaParsed } from '../halachaLint';
-import { reanchorArgument, reanchorArgumentMove, reanchorPesukim, reanchorAggadata } from '../place/reanchor';
+import { reanchorArgument, reanchorArgumentMove, reanchorPesukim, reanchorAggadata, reanchorRabbiEvidence } from '../place/reanchor';
 import { normalizeHebrew } from '../place/verbatim';
 
 export type Severity = 'hard' | 'soft';
@@ -221,6 +221,7 @@ export const CHECKS: Record<string, PostCheck> = {
   'reanchor-argument-move': transform('reanchor-argument-move', reanchorArgumentMove),
   'reanchor-pesukim': transform('reanchor-pesukim', reanchorPesukim),
   'reanchor-aggadata': transform('reanchor-aggadata', reanchorAggadata),
+  'reanchor-rabbi-evidence': transform('reanchor-rabbi-evidence', reanchorRabbiEvidence),
   'hebrew-excerpt': hebrewExcerpt,
   'hebrew-gloss': hebrewGloss,
   'anchor-verbatim': anchorVerbatim,

--- a/src/lib/place/reanchor.ts
+++ b/src/lib/place/reanchor.ts
@@ -281,3 +281,40 @@ export function reanchorAggadata(parsed: unknown, segmentsHe: string[]): unknown
   }
   return obj;
 }
+
+// ---------------------------------------------------------------------------
+// rabbi-evidence (rabbi.relationships.evidence / rabbi.geography.evidence)
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve each evidence entry's verbatim `excerpt` to a single-segment anchor
+ * (startSegIdx === endSegIdx) plus token offsets, so the sidebar can paint a
+ * click-to-highlight range. Unlike the mark re-anchorers the excerpt sits at the
+ * TOP level of each entry (not under `fields`), and the search spans the whole
+ * daf. Entries with no match keep their note/place name but get no seg/token
+ * fields. Byte-identical to the former inline postProcessRabbiEvidence:
+ * findExcerpt over [0, last] with default opts is exactly its prefix-fallback +
+ * word-aligned/substring matcher and `matchLen = matched-prefix length`.
+ */
+export function reanchorRabbiEvidence(parsed: unknown, segmentsHe: string[]): unknown {
+  if (!parsed || typeof parsed !== 'object') return parsed;
+  const obj = parsed as { evidence?: unknown };
+  if (!Array.isArray(obj.evidence)) return parsed;
+  if (segmentsHe.length === 0) return parsed;
+  const grid = buildVerbatimGrid(segmentsHe);
+
+  type Evidence = { excerpt?: string; startSegIdx?: number; endSegIdx?: number; tokenStart?: number; tokenEnd?: number; [k: string]: unknown };
+  for (const e of obj.evidence as Evidence[]) {
+    if (!e || typeof e !== 'object') continue;
+    const ex = typeof e.excerpt === 'string' ? e.excerpt : '';
+    if (!ex) continue;
+    const hit = findExcerpt(grid, ex, 0, segmentsHe.length - 1);
+    if (hit) {
+      e.startSegIdx = hit.seg;
+      e.endSegIdx = hit.seg;
+      e.tokenStart = hit.tok;
+      e.tokenEnd = hit.tok + hit.matchLen - 1;
+    }
+  }
+  return obj;
+}

--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -1424,6 +1424,7 @@ const makeRabbiEnrichment = (
     mode: 'augment-content' | 'aggregate';
     scope: EnrichmentScope;
     dependencies?: EnrichmentDependency[];
+    checks?: string[];
     defHash: string;
     cacheVersion: string;
     systemPromptHe?: string;
@@ -1584,6 +1585,7 @@ export const CODE_ENRICHMENTS: EnrichmentDefinition[] = [
     {
       mode: 'augment-content', scope: 'local',
       dependencies: ['gemara', { enrichment: 'rabbi.relationships' }],
+      checks: ['reanchor-rabbi-evidence'],
       defHash: 'rabbi.relationships.evidence-v2', cacheVersion: '2',
       systemPromptHe: RABBI_RELATIONSHIPS_EVIDENCE_SYSTEM_PROMPT_HE,
       userPromptTemplateHe: RABBI_RELATIONSHIPS_EVIDENCE_USER_TEMPLATE_HE,
@@ -1596,6 +1598,7 @@ export const CODE_ENRICHMENTS: EnrichmentDefinition[] = [
     {
       mode: 'augment-content', scope: 'local',
       dependencies: ['gemara', { enrichment: 'rabbi.geography' }],
+      checks: ['reanchor-rabbi-evidence'],
       defHash: 'rabbi.geography.evidence-v2', cacheVersion: '2',
       systemPromptHe: RABBI_GEOGRAPHY_EVIDENCE_SYSTEM_PROMPT_HE,
       userPromptTemplateHe: RABBI_GEOGRAPHY_EVIDENCE_USER_TEMPLATE_HE,

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1428,92 +1428,6 @@ async function runMarkOnce(
   return out;
 }
 
-/**
- * Post-process the two rabbi-evidence enrichments. Each `evidence` entry
- * has a verbatim Hebrew `excerpt`; this resolves it to (startSegIdx,
- * endSegIdx, tokenStart, tokenEnd) so the sidebar can call
- * onHighlightRange with the right values when the user clicks an evidence
- * row. Entries with no match are kept (so the user still sees the note +
- * place name) but with seg/token fields absent.
- */
-async function postProcessRabbiEvidence(
-  parsed: unknown,
-  env: Bindings,
-  tractate: string,
-  page: string,
-): Promise<unknown> {
-  if (!parsed || typeof parsed !== 'object') return parsed;
-  const obj = parsed as { evidence?: unknown };
-  if (!Array.isArray(obj.evidence)) return parsed;
-
-  const slice = await getGemaraSlice(env, tractate, page, false);
-  const segs = slice.segments_he;
-  if (segs.length === 0) return parsed;
-
-  const normalize = (s: string) =>
-    s.replace(/[֑-ׇ]/g, '')
-      .replace(/[׳״"'.,:;!?\-–—()[\]{}]/g, '')
-      .replace(/[​-‏‪-‮﻿]/g, '')
-      .replace(/\s+/g, ' ')
-      .trim();
-  const segNorms = segs.map(normalize);
-  const segWords = segNorms.map((s) => s.split(' ').filter(Boolean));
-
-  type Evidence = {
-    excerpt?: string;
-    startSegIdx?: number;
-    endSegIdx?: number;
-    tokenStart?: number;
-    tokenEnd?: number;
-    [k: string]: unknown;
-  };
-  const entries = obj.evidence as Evidence[];
-  for (const e of entries) {
-    if (!e || typeof e !== 'object') continue;
-    const ex = normalize(typeof e.excerpt === 'string' ? e.excerpt : '');
-    if (!ex) continue;
-    const exWords = ex.split(' ').filter(Boolean);
-    if (exWords.length === 0) continue;
-
-    const tries: string[][] = [exWords];
-    if (exWords.length > 4) tries.push(exWords.slice(0, 4));
-    if (exWords.length > 3) tries.push(exWords.slice(0, 3));
-    if (exWords.length > 2) tries.push(exWords.slice(0, 2));
-
-    let foundSeg = -1;
-    let foundTok = -1;
-    let foundLen = 0;
-    outer: for (const needle of tries) {
-      if (needle.length < 2) continue;
-      const needleStr = needle.join(' ');
-      for (let i = 0; i < segNorms.length; i++) {
-        if (!segNorms[i].includes(needleStr)) continue;
-        const words = segWords[i];
-        for (let w = 0; w + needle.length <= words.length; w++) {
-          let ok = true;
-          for (let k = 0; k < needle.length; k++) {
-            if (words[w + k] !== needle[k]) { ok = false; break; }
-          }
-          if (ok) {
-            foundSeg = i; foundTok = w; foundLen = needle.length;
-            break outer;
-          }
-        }
-        foundSeg = i; foundTok = 0; foundLen = needle.length;
-        break outer;
-      }
-    }
-
-    if (foundSeg >= 0) {
-      e.startSegIdx = foundSeg;
-      e.endSegIdx = foundSeg;
-      e.tokenStart = foundTok;
-      e.tokenEnd = foundTok + foundLen - 1;
-    }
-  }
-  return obj;
-}
-
 /** The segment range a section-level argument enrichment is being computed for,
  *  as a `${startSegIdx}-${endSegIdx}` stamp — or null when the enrichment isn't
  *  section-anchored (so no range guard applies). Used to reject a cache hit
@@ -1743,31 +1657,30 @@ async function runEnrichmentOnce(
     try { parsed = JSON.parse(result.content); }
     catch (err) { parse_error = String(err).slice(0, 200); }
   }
-  // Per-enrichment post-processing. Evidence enrichments emit verbatim
-  // Hebrew excerpts that need to be resolved to (startSegIdx, endSegIdx,
-  // tokenStart, tokenEnd) on the server so the sidebar can paint click-
-  // to-highlight ranges without re-walking the daf on the client.
-  if (parsed && (def.id === 'rabbi.relationships.evidence' || def.id === 'rabbi.geography.evidence')) {
-    parsed = await postProcessRabbiEvidence(parsed, rc.env, tractate, page);
-  }
-  // Post-generation validation via the standardized check layer
-  // (src/lib/check/postcheck.ts). An enrichment opts into validators through
-  // `checks: []` in code-marks.ts: pesukim.synthesis -> 'hebrew-excerpt'
-  // (flag pesukim cited with English-only quotes and no Hebrew verbatim text);
-  // halacha.* -> 'hebrew-gloss' (flag HEBREW_GLOSS_STYLE violations — bare /
-  // parenthesized transliterations, calques — across every prose field + chip).
+  // Post-generation processing via the standardized check layer
+  // (src/lib/check/postcheck.ts). An enrichment opts in through `checks: []` in
+  // code-marks.ts. Transforms run first:
+  //   - rabbi.{relationships,geography}.evidence -> 'reanchor-rabbi-evidence'
+  //     resolves each evidence excerpt to (startSegIdx, endSegIdx, tokenStart,
+  //     tokenEnd) so the sidebar can paint click-to-highlight ranges.
+  // Then validators:
+  //   - pesukim.synthesis -> 'hebrew-excerpt' (pesukim cited with English-only
+  //     quotes and no Hebrew verbatim text);
+  //   - halacha.* -> 'hebrew-gloss' (HEBREW_GLOSS_STYLE violations: bare /
+  //     parenthesized transliterations, calques, across every prose field + chip);
+  //   - argument.voices -> 'edge-integrity' (soft, observe-only).
   // Issues are attached to the result (visible in dev tray / cache) but never
-  // reject the run; only `hard` issues gate the cache write below so a bad
-  // output isn't pinned. `soft` issues (e.g. edge-integrity on argument.voices)
-  // are observe-only. These validators inspect `parsed` only (no segment grid).
+  // reject the run; only `hard` issues gate the cache write below. The transforms
+  // need the segment grid, so fetch the gemara slice once when any check runs.
   let lint_issues: unknown[] | undefined;   // hard subset → gating + /api/usage path
   let check_issues: unknown[] | undefined;  // all severities → observation
   let hardIssueCount = 0;
   if (parsed && !parse_error && def.checks && def.checks.length > 0) {
+    const slice = await getGemaraSlice(rc.env, tractate, page, false);
     const checked = await runChecks(def.checks, parsed, {
-      tractate, page, segmentsHe: [], defId: def.id, lang: rc.lang,
+      tractate, page, segmentsHe: slice.segments_he, defId: def.id, lang: rc.lang,
     });
-    parsed = checked.parsed; // honor the transform contract (validators leave it unchanged)
+    parsed = checked.parsed;
     if (checked.issues.length > 0) {
       check_issues = checked.issues;
       const hard = checked.issues.filter((i) => i.severity === 'hard');

--- a/tests/check/wiring.test.ts
+++ b/tests/check/wiring.test.ts
@@ -29,6 +29,8 @@ describe('declarative check wiring', () => {
     'halacha.disputes': ['hebrew-gloss'],
     'halacha.synthesis': ['hebrew-gloss'],
     'argument.voices': ['edge-integrity'],
+    'rabbi.relationships.evidence': ['reanchor-rabbi-evidence'],
+    'rabbi.geography.evidence': ['reanchor-rabbi-evidence'],
   };
 
   it('canon marks declare the expected checks', () => {

--- a/tests/place/reanchor-rabbi-evidence.test.ts
+++ b/tests/place/reanchor-rabbi-evidence.test.ts
@@ -1,0 +1,67 @@
+/**
+ * reanchorRabbiEvidence — the A1b port of the former inline
+ * postProcessRabbiEvidence onto the unified verbatim matcher. Pins the
+ * behaviors the old inline code had: whole-daf search, word-aligned hit with
+ * token offsets, prefix fallback (matchLen = matched-prefix length), the
+ * substring-but-not-word-aligned tok=0 fallback, single-segment anchoring
+ * (start === end), 1-word excerpts left unanchored, and non-matching entries
+ * preserved untouched.
+ */
+import { describe, it, expect } from 'vitest';
+import { reanchorRabbiEvidence } from '../../src/lib/place/reanchor';
+
+const SEGS = [
+  'אמר רבא אמר רב נחמן',          // seg 0 (5 words)
+  'תנו רבנן המביא גט ממדינת הים',  // seg 1 (6 words)
+  'רבי יוחנן ורבי שמעון בן לקיש',  // seg 2 (6 words)
+];
+
+const run = (evidence: unknown[]) => reanchorRabbiEvidence({ evidence }, SEGS) as { evidence: Record<string, unknown>[] };
+
+describe('reanchorRabbiEvidence', () => {
+  it('anchors a word-aligned excerpt at the start of a segment', () => {
+    const { evidence } = run([{ name: 'A', excerpt: 'תנו רבנן' }]);
+    expect(evidence[0]).toMatchObject({ startSegIdx: 1, endSegIdx: 1, tokenStart: 0, tokenEnd: 1 });
+  });
+
+  it('anchors a word-aligned excerpt at a non-zero token offset', () => {
+    // "אמר רב נחמן" sits at words[2..4] of seg 0.
+    const { evidence } = run([{ name: 'C', excerpt: 'אמר רב נחמן' }]);
+    expect(evidence[0]).toMatchObject({ startSegIdx: 0, endSegIdx: 0, tokenStart: 2, tokenEnd: 4 });
+  });
+
+  it('falls back to a shorter prefix; matchLen is the matched prefix length', () => {
+    // Full 6 words not present, but the 4-word prefix "תנו רבנן המביא גט" is.
+    const { evidence } = run([{ name: 'F', excerpt: 'תנו רבנן המביא גט אחרת ועוד' }]);
+    expect(evidence[0]).toMatchObject({ startSegIdx: 1, endSegIdx: 1, tokenStart: 0, tokenEnd: 3 });
+  });
+
+  it('soft-falls back to tok=0 on a substring that is not word-aligned', () => {
+    // "בא אמר" is a character substring of "...רבא אמר..." in seg 0 but never
+    // word-aligned, so the matcher records the segment with tok=0.
+    const { evidence } = run([{ name: 'X', excerpt: 'בא אמר' }]);
+    expect(evidence[0]).toMatchObject({ startSegIdx: 0, endSegIdx: 0, tokenStart: 0, tokenEnd: 1 });
+  });
+
+  it('leaves a non-matching entry untouched (note/place preserved, no seg fields)', () => {
+    const { evidence } = run([{ name: 'D', note: 'student', excerpt: 'מילה שאיננה בכלל' }]);
+    expect(evidence[0]).toEqual({ name: 'D', note: 'student', excerpt: 'מילה שאיננה בכלל' });
+  });
+
+  it('does not anchor a single-word excerpt (too ambiguous)', () => {
+    const { evidence } = run([{ name: 'E', excerpt: 'רבנן' }]);
+    expect(evidence[0].startSegIdx).toBeUndefined();
+  });
+
+  it('ignores nikud/punctuation when matching', () => {
+    const { evidence } = run([{ name: 'G', excerpt: 'תְּנוּ, רַבָּנַן' }]);
+    expect(evidence[0]).toMatchObject({ startSegIdx: 1, tokenStart: 0, tokenEnd: 1 });
+  });
+
+  it('is a no-op when there is no evidence array or no segments', () => {
+    expect(reanchorRabbiEvidence({ foo: 1 }, SEGS)).toEqual({ foo: 1 });
+    const same = { evidence: [{ excerpt: 'תנו רבנן' }] };
+    expect(reanchorRabbiEvidence(same, [])).toBe(same);
+    expect((same.evidence[0] as Record<string, unknown>).startSegIdx).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Stacked on #50 (A3). **A1b**: the last verbatim re-anchorer that still lived inline in the worker is ported onto the shared placer, completing the convergence A1 started.

## What changed
- **`reanchorRabbiEvidence`** (`src/lib/place/reanchor.ts`) — resolves each evidence entry's verbatim `excerpt` to a single-segment anchor (`startSegIdx === endSegIdx`) + `tokenStart/tokenEnd` via `findExcerpt` over the whole daf. The evidence excerpt sits at the top level of each entry (not under `fields`), so this is a small dedicated function rather than a reuse of the mark re-anchorers.
- Registered as the **`reanchor-rabbi-evidence`** transform check; `rabbi.relationships.evidence` and `rabbi.geography.evidence` opt in via `checks: []`.
- `runEnrichmentOnce` drops its `postProcessRabbiEvidence` special-case and runs the transform through `runChecks` — which is now fed the **real gemara slice** (transforms need the segment grid; validators ignore it). The 75-line inline `postProcessRabbiEvidence` is deleted.

## Byte-identical, no cache bump
`findExcerpt(grid, ex, 0, last)` with default opts is line-for-line equivalent to the old inline matcher: same `normalizeHebrew`, same prefix-fallback tries (full → 4 → 3 → 2 words), same word-aligned hit + substring `tok=0` fallback, and `matchLen = matched-prefix length`. Output is unchanged, so **no `cache_version` bump**.

## Verification
- `tests/place/reanchor-rabbi-evidence.test.ts` (new) pins every branch: word-aligned, non-zero token offset, prefix fallback, substring-not-word-aligned `tok=0`, single-word skip, non-match preserved untouched, and the no-op guards.
- Full suite: **60 files / 1280 tests passing**. Typecheck clean.

Follow-up (not in this PR): a production golden fixture for an evidence instance would add an independent byte-identical check against live data; the unit test + line-level equivalence cover it for now.

Merge order: #45 → #49 → #50 → this.