### PR TITLE
Add a cross-daf anchor coordinate (A4)

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -13,11 +13,24 @@ output) several different ways. We're converging them onto **one anchoring
 layer** and **one post-LLM check layer**, then building section-typing on top.
 Work is split into Track A (backend, leading) → B (render/DX) → C (typing).
 
-Done & shippable: **A1** (unified verbatim placer) = **PR #45** (open, needs owner review/merge).
-**A2** (standardized check layer) is now **fully wired into both runners** — the
-registry library (increment 1) plus the runner rewiring (increment 2) are
-committed on `framework-check-layer`. Your immediate task is **A3** (add new
-soft checks). See "YOUR IMMEDIATE TASK" below.
+**Track A (backend) is functionally complete** — A1, A2, A3, A1b, A4 are all
+done and live as a stacked PR chain (none merged yet; owner admin-merges
+top-to-bottom):
+
+| PR  | Increment | Base |
+|-----|-----------|------|
+| #45 | A1 — unified verbatim placer | master |
+| #49 | A2 — check layer wired into the runners | #45 |
+| #50 | A3 — soft integrity checks (anchor-verbatim / partition-clean / edge-integrity) | #49 |
+| #51 | A1b — rabbi-evidence anchoring onto the placer | #50 |
+| #52 | A4 — cross-daf anchor coordinate | #51 |
+
+Totals on the tip branch (`framework-crossdaf-coord`): **61 test files, 1292
+tests passing**; typecheck clean. **Your immediate task is to merge the stack**
+(owner) — then the only Track A work left is *promoting* a soft A3 check to
+`hard` once you've watched it on real traffic (needs observation data first, so
+it can't be done blind). After that it's Track B (render/DX) and Track C
+(section typing). See "YOUR IMMEDIATE TASK" + "REMAINING ROADMAP".
 
 ## Repo + how to work in it (IMPORTANT)
 
@@ -78,42 +91,31 @@ Key engine files in `src/worker/index.ts`:
 - `runEnrichmentOnce`: the two lint if-blocks are replaced by `runChecks`; gating now keys on `hardIssueCount` (all current validator issues are `hard`, so identical to the old `!lint_issues`). `lint_issues` still stored on `RunResult` (now `CheckIssue[]`; `summarizeIssue` output is unchanged since `match` is always present). `postProcessRabbiEvidence` unchanged (A1b).
 - `tests/check/wiring.test.ts` (5 cases) — locks the declared checks to the registry; proves `keyForMark`/`keyForEnrichment` are invariant to `checks`.
 
-Current totals: 58 test files, **1258 tests passing**; typecheck clean except the unrelated MCP-module errors. **Not yet PR'd** — PR `framework-check-layer` with `--base section-typing-design` so the diff is just A2 stacked on A1.
+Current totals: 58 test files, **1258 tests passing** (A2 tip).
 
-## YOUR IMMEDIATE TASK — A3: add new checks, ship them `soft`
+### A3 — soft integrity checks (PR #50, on `framework-checks-a3`)
+Three observe-only validators in `src/lib/check/postcheck.ts`, all `severity: 'soft'` (never gate, no `cache_version` bump):
+- `anchor-verbatim` — resolved excerpt literally present (normalized) in its anchored segment. On argument/argument-move/pesukim/aggadata.
+- `partition-clean` — inverted ranges, exact-duplicate instances, and (argument only) overlapping section ranges. On argument/argument-move.
+- `edge-integrity` — argument.voices graph: edges to unknown voices, self-loops, opposes+supports on one pair. On argument.voices.
+Surfaced via a new `check_issues` field on `RunResult` (marks attach all; enrichments split `hard`→`lint_issues`/gating, full set→`check_issues`). Tests: `tests/check/soft-checks.test.ts`.
 
-A2 is done (above). Now ADD net-new checks to the registry, shipped `soft` first
-so they observe-only (never gate the cache) until you've watched them on
-`GET /api/usage` (`readLintFailures`) and decided to promote per-mark.
+### A1b — rabbi-evidence onto the placer (PR #51, on `framework-rabbi-evidence`)
+`reanchorRabbiEvidence` in `src/lib/place/reanchor.ts` (excerpt at the entry top level, whole-daf search) registered as the `reanchor-rabbi-evidence` transform; the two evidence enrichments opt in; `runEnrichmentOnce` drops the `postProcessRabbiEvidence` special-case and feeds `runChecks` the real gemara slice (so enrichment transforms get the segment grid); the inline fn is deleted. Byte-identical (`findExcerpt` ≡ the old loop). Tests: `tests/place/reanchor-rabbi-evidence.test.ts`. (Remaining A1b: the fuzzier `hbAlign.findExact/findFuzzy` + `rabbi-observations.resolveSegIdxs` — DIFFERENT normalization, converge behind their own coverage, NOT a byte-identical merge.)
 
-New checks to add in `src/lib/check/postcheck.ts` (register in `CHECKS`, declare
-on the relevant defs via `checks: []`, cover with `tests/check/`):
-- **`anchor-verbatim`** (validate) — the resolved excerpt is actually present in
-  its claimed segment. Catches hallucinations like `אריגתא` where the daf says
-  `כשורי`. Needs `ctx.segmentsHe` (already passed in `runMarkOnce`; for
-  enrichments the validator ctx currently passes `segmentsHe: []`, so if you
-  attach this to an enrichment, wire a real slice there too).
-- **`edge-integrity`** (validate) — voices-graph edges: from/to ∈ voices,
-  ordered ranges, no contradictory `opposes`+`supports` on one pair.
-- **`partition-clean`** (validate) — no gaps/overlaps/dupes in section/move
-  partitions. Catches the duplicated Rav Amram/Yalta moves.
+### A4 — cross-daf coordinate (PR #52, on `framework-crossdaf-coord`)
+`src/lib/context/coord.ts`: `AnchorCoord {tractate,page,seg}` + `AnchorSpan` + helpers (`coordForSeg`, `localSeg`, `sameDaf`/`isCrossDaf`, `normalizeSpan`, `spanByDaf`, `coordFromTarget` bridging the unused `CrossDafAnchor`). Optional `coord?` added to `SegMatch`/`ContextItem`/`Placement`; `placementOf(it, currentDaf?)` derives a `cross-daf` level only when a daf is supplied AND the coord is off it (single-arg callers unchanged). `applyMatches` carries the coord. Purely additive, no cache bump. Tests: `tests/context-coord.test.ts`. Unblocks the cross-page sugya map.
 
-Ship all three `soft`. Promote to `hard` per-mark only after observing — and
-**only that promotion warrants a per-mark `cache_version` bump, one at a time**
-(full-shas re-warm is ~$1000; never bump broadly).
+## YOUR IMMEDIATE TASK — merge the Track A stack, then promote a check
 
-Verify: `pnpm test` (all green) + filtered `tsc`. The check registry +
-`tests/check/*` are your safety net.
+1. **Merge the stack** (owner admin-merge, top-to-bottom): #45 → #49 → #50 → #51 → #52. Each becomes mergeable once its base lands. Then `pnpm ship` from a worktree to deploy (all of it is byte-identical / additive — no cache bump, so deploy is safe).
+2. **Promote one A3 soft check to `hard`** — but only AFTER watching it on real traffic. The soft issues ride in `RunResult.check_issues`; you need a way to observe their rate (extend `/api/usage` to roll up `check_issues`, or sample cached outputs) BEFORE flipping a check to `hard`. Promotion = change that check's `severity` to `'hard'` for one mark and bump THAT mark's `cache_version` once (full-shas re-warm ≈ $1000 — never bump broadly).
 
-NOTE: A2 itself is committed on `framework-check-layer` but **not yet PR'd** — if
-the owner hasn't picked it up, open it first (`gh pr create --base
-section-typing-design`, stacked on A1/PR #45) before stacking A3 on top.
+## REMAINING ROADMAP
 
-## REMAINING ROADMAP (tasks already filed)
-
-- **A3 — new checks, soft→hard.** Add `anchor-verbatim` (resolved excerpt actually present in its claimed segment — catches hallucinations like `אריגתא` where the daf says `כשורי`), `edge-integrity` (voices-graph edges: from/to ∈ voices, ordered ranges, no contradictory `opposes`+`supports` on one pair), `partition-clean` (no gaps/overlaps/dupes — catches the duplicated Rav Amram/Yalta moves). Ship `soft` first, observe via `GET /api/usage` (`readLintFailures`), promote to `hard` per-mark — and **only that promotion warrants a per-mark `cache_version` bump, one at a time** (full-shas re-warm is ~$1000, so never bump broadly).
-- **A4 — cross-daf coordinate.** Add `src/lib/context/coord.ts` (`AnchorCoord {tractate,page,seg}`, `AnchorSpan = AnchorCoord[]`, bridge helpers); optional `coord?` on `SegMatch` (`src/lib/context/match.ts`) + `Placement` (`src/lib/context/placement.ts`); derive a `cross-daf` level. Purely additive (in-daf readers ignore it). `CrossDafAnchor` already exists unused in studio-schema.ts. Unblocks the cross-page "sugya map".
-- **A1b — converge remaining matchers.** Port `postProcessRabbiEvidence` (`index.ts`) onto `verbatim.ts` (add a rabbi-evidence golden fixture). Then `hbAlign.findExact/findFuzzy` (`src/client/hbAlign.ts`) + `rabbi-observations.resolveSegIdxs` — these use DIFFERENT normalization (final-letter folding, fuzzy/abbrev tolerance), so converge carefully behind their own golden coverage, NOT a byte-identical merge.
+- **Observe → promote soft checks** (see immediate task #2). Blocked on an observation surface for `check_issues`.
+- **A1b leftovers** — converge `hbAlign.findExact/findFuzzy` (`src/client/hbAlign.ts`) + `rabbi-observations.resolveSegIdxs`. These use DIFFERENT normalization (final-letter folding, fuzzy/abbrev tolerance), so converge carefully behind their own golden coverage, NOT a byte-identical merge.
+- **Use A4** — build the cross-page sugya map on `coord.ts` (`spanByDaf` is the consumer shape); have a matcher/citation resolver populate `SegMatch.coord`.
 - **Track B (render/DX)** and **Track C (section typing + coverage)** — see the plan file + `docs/section-typing.md`. Track C's key finding: most "uncategorized" daf segments are pure dialectic (שקלא וטריא) which no content mark models — so `argument` is the base type and halacha/aggadata/pesukim are overlays.
 
 ## Verify anything

--- a/src/lib/context/coord.ts
+++ b/src/lib/context/coord.ts
@@ -1,0 +1,104 @@
+/**
+ * @fileoverview Cross-daf anchor coordinate — a (tractate, page, seg) triple
+ * that names a single segment ANYWHERE in Shas, not just on the daf currently
+ * in view.
+ *
+ * The rest of the grounding layer (placement.ts, match.ts) speaks in bare
+ * segment indices, which are only meaningful relative to one daf. That's the
+ * right model for in-daf reading, but it can't express "this note's real home
+ * is Gittin 67b seg 4" while you're looking at 68a, which is what a cross-page
+ * sugya map needs. An `AnchorCoord` carries the daf with the segment so a span
+ * can straddle pages.
+ *
+ * This module is PURELY ADDITIVE: in-daf readers ignore `coord` and keep using
+ * `segs`. Producers that know an off-daf target (a parallel-sugya matcher, a
+ * citation resolver, the existing CrossDafAnchor output) populate it; the
+ * helpers here normalize, group, and bridge it. Nothing here reads the network
+ * or the DOM, so it lives in src/lib and is unit-testable.
+ */
+
+/** One segment anywhere in Shas. `seg` is the 0-based Sefaria segment index
+ *  within (tractate, page) — the same canonical coordinate the in-daf layer
+ *  uses, just carried together with its daf. */
+export interface AnchorCoord {
+  tractate: string;
+  page: string;
+  seg: number;
+}
+
+/** An ordered set of coordinates that may straddle multiple dapim. */
+export type AnchorSpan = AnchorCoord[];
+
+/** A daf reference (the (tractate, page) half of a coordinate). */
+export type DafRef = { tractate: string; page: string };
+
+/** Stable string id for a coordinate — safe as a Map/Set key. */
+export function coordKey(c: AnchorCoord): string {
+  return `${c.tractate}:${c.page}:${c.seg}`;
+}
+
+/** Whether two daf references name the same page. */
+export function sameDaf(a: DafRef, b: DafRef): boolean {
+  return a.tractate === b.tractate && a.page === b.page;
+}
+
+/** A coordinate for a local segment index on a given daf. */
+export function coordForSeg(daf: DafRef, seg: number): AnchorCoord {
+  return { tractate: daf.tractate, page: daf.page, seg };
+}
+
+/** Coordinates for a list of local segment indices on a given daf. */
+export function coordsForSegs(daf: DafRef, segs: number[]): AnchorSpan {
+  return segs.map((seg) => coordForSeg(daf, seg));
+}
+
+/** The local segment index if `c` sits on `daf`, else null. The inverse of
+ *  coordForSeg — used to fold a cross-daf span back to in-daf segments for the
+ *  page currently in view. */
+export function localSeg(c: AnchorCoord, daf: DafRef): number | null {
+  return sameDaf(c, daf) ? c.seg : null;
+}
+
+/** Whether a coordinate points off the given daf (i.e. is genuinely cross-daf
+ *  relative to the page in view). */
+export function isCrossDaf(c: AnchorCoord, currentDaf: DafRef): boolean {
+  return !sameDaf(c, currentDaf);
+}
+
+/** Dedupe + order a span by (tractate, page, seg). Stable across processes so
+ *  the same span always serializes identically (cache-key friendly). */
+export function normalizeSpan(span: AnchorSpan): AnchorSpan {
+  const seen = new Set<string>();
+  const out: AnchorCoord[] = [];
+  for (const c of span) {
+    const k = coordKey(c);
+    if (!seen.has(k)) { seen.add(k); out.push(c); }
+  }
+  return out.sort(
+    (a, b) =>
+      a.tractate.localeCompare(b.tractate) ||
+      a.page.localeCompare(b.page) ||
+      a.seg - b.seg,
+  );
+}
+
+/** Group a span into per-daf segment lists (normalized: deduped + ordered).
+ *  The shape a cross-page sugya map consumes — one entry per daf, each with the
+ *  local segments it touches. */
+export function spanByDaf(span: AnchorSpan): { tractate: string; page: string; segs: number[] }[] {
+  const groups = new Map<string, { tractate: string; page: string; segs: number[] }>();
+  for (const c of normalizeSpan(span)) {
+    const dk = `${c.tractate}:${c.page}`;
+    const g = groups.get(dk) ?? { tractate: c.tractate, page: c.page, segs: [] };
+    g.segs.push(c.seg);
+    groups.set(dk, g);
+  }
+  return [...groups.values()];
+}
+
+/** Bridge from the existing CrossDafAnchor target shape
+ *  ({ tractate, page, segIdx? }) to an AnchorCoord. A missing segIdx means the
+ *  target is the whole daf; we anchor it to seg 0 so it still has a coordinate. */
+export function coordFromTarget(target: { tractate: string; page: string; segIdx?: number }): AnchorCoord {
+  return { tractate: target.tractate, page: target.page, seg: target.segIdx ?? 0 };
+}

--- a/src/lib/context/match.ts
+++ b/src/lib/context/match.ts
@@ -8,6 +8,7 @@
  */
 
 import type { ContextItem } from './types.ts';
+import type { AnchorCoord } from './coord.ts';
 
 export interface SegMatch {
   /** ContextItem.key this placement applies to. */
@@ -15,6 +16,11 @@ export interface SegMatch {
   /** Segments the item maps to. Empty = leave unplaced (no-op) UNLESS
    *  `wholeDaf` is set, which is a deliberate daf-level placement. */
   segs: number[];
+  /** Cross-daf anchor: set by a matcher when the item's true home is a segment
+   *  on ANOTHER daf (parallel sugya, citation target). Additive — in-daf
+   *  matchers leave it undefined and only fill `segs`. When present, the match
+   *  counts as a placement even if `segs` is empty. */
+  coord?: AnchorCoord;
   /** Matcher id, e.g. 'tosfos-dh' | 'ai' | 'pieceKeys'. */
   via: string;
   /** 0..1 confidence (AI matchers set this; deterministic ones may omit). */
@@ -35,10 +41,11 @@ export function applyMatches(items: ContextItem[], matches: SegMatch[]): number 
   for (const item of items) {
     const m = byKey.get(item.key);
     if (!m) continue;
-    if (!m.wholeDaf && m.segs.length === 0) continue; // unplaced no-op
+    if (!m.wholeDaf && m.segs.length === 0 && !m.coord) continue; // unplaced no-op
     item.segs = m.wholeDaf ? [] : dedupeSorted(m.segs);
     item.via = m.via; // a whole-daf AI placement is `via:'ai'` + `segs:[]`
     item.confidence = m.confidence;
+    if (m.coord) item.coord = m.coord; // cross-daf target (additive)
     changed++;
   }
   return changed;

--- a/src/lib/context/placement.ts
+++ b/src/lib/context/placement.ts
@@ -21,11 +21,17 @@
  */
 
 import type { ContextItem } from './types.ts';
+import { type AnchorCoord, type DafRef, isCrossDaf } from './coord.ts';
 
-export type PlacementLevel = 'words' | 'segment' | 'amud' | 'daf';
+/** `cross-daf` is orthogonal to the in-daf granularities: the item's home is a
+ *  segment on ANOTHER page, so relative to the daf in view it is the least
+ *  "here" — hence it ranks below `daf`. Only derived when `placementOf` is
+ *  given the current daf AND the item carries an off-daf `coord`. */
+export type PlacementLevel = 'cross-daf' | 'words' | 'segment' | 'amud' | 'daf';
 
-/** Coarsest→finest, for ranking "most specific grounding wins". */
-export const LEVEL_RANK: Record<PlacementLevel, number> = { daf: 0, amud: 1, segment: 2, words: 3 };
+/** Coarsest→finest, for ranking "most specific grounding wins". `cross-daf`
+ *  sits below everything on-daf (it isn't on this page at all). */
+export const LEVEL_RANK: Record<PlacementLevel, number> = { 'cross-daf': -1, daf: 0, amud: 1, segment: 2, words: 3 };
 
 export interface Placement {
   /** The finest granularity this grounding reached. */
@@ -36,6 +42,8 @@ export interface Placement {
   words?: number[];
   /** Side of the daf, when known (set for 'amud', carried for finer levels). */
   amud?: 'a' | 'b';
+  /** Off-daf target (set only for 'cross-daf'). */
+  coord?: AnchorCoord;
   /** How it was placed: 'tosfos-dh' | 'pieceKeys' | 'mishnah' | 'ai' |
    *  'phrase'|'phrase-in-seg'|'phrase-fuzzy' | 'ai-phrase'|'ai-segment'|'ai-daf' | … */
   via?: string;
@@ -50,9 +58,16 @@ const WORD_VIAS = new Set(['phrase', 'phrase-in-seg', 'phrase-fuzzy', 'ai-phrase
  * Normalize an item's grounding into a `Placement`, or `null` if it isn't
  * grounded at all (no words, no segments, no amud, no whole-daf decision).
  */
-export function placementOf(it: ContextItem): Placement | null {
+export function placementOf(it: ContextItem, currentDaf?: DafRef): Placement | null {
   const via = it.hbVia ?? it.via;
   const confidence = it.hbConfidence ?? it.confidence;
+
+  // Cross-daf: the item's true home is a segment on another page. Only derived
+  // when the caller supplies the daf in view AND the item's coord points off it
+  // — so existing single-arg callers see unchanged behavior.
+  if (it.coord && currentDaf && isCrossDaf(it.coord, currentDaf)) {
+    return { level: 'cross-daf', segs: [], coord: it.coord, via, confidence };
+  }
 
   // Whole-daf: a deliberate daf-level grounding (the AI placer's null segStart),
   // but only when nothing finer is known. `ai-daf` is the client-resolved

--- a/src/lib/context/types.ts
+++ b/src/lib/context/types.ts
@@ -9,6 +9,7 @@
  */
 
 import type { DafyomiContentType, DafyomiText } from '../sefref/dafyomi/schema.ts';
+import type { AnchorCoord } from './coord.ts';
 
 export type ContextSource =
   | 'sefaria-rashi'
@@ -41,6 +42,11 @@ export interface ContextItem {
   via?: string;
   /** Matcher confidence 0..1 (AI matches carry this). */
   confidence?: number;
+  /** Cross-daf anchor: the item's true home is a segment on ANOTHER daf
+   *  (parallel sugya, citation target). Additive and orthogonal to `segs` —
+   *  the in-daf reader ignores it; the cross-page sugya map reads it. See
+   *  src/lib/context/coord.ts. */
+  coord?: AnchorCoord;
 
   /** Tosfos-DH matcher input: niqqud-stripped DH opening words. Only set on
    *  dafyomi Tosfos items; lets the matcher place them via Sefaria pieceKeys. */

--- a/tests/context-coord.test.ts
+++ b/tests/context-coord.test.ts
@@ -1,0 +1,110 @@
+/**
+ * A4 — the cross-daf anchor coordinate (src/lib/context/coord.ts) and its
+ * additive wiring into the grounding layer (placement `cross-daf` level,
+ * applyMatches carrying `coord`). The in-daf behavior must be unchanged: every
+ * existing single-arg placementOf call still resolves exactly as before.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  coordKey, sameDaf, coordForSeg, coordsForSegs, localSeg, isCrossDaf,
+  normalizeSpan, spanByDaf, coordFromTarget,
+} from '../src/lib/context/coord.ts';
+import { placementOf } from '../src/lib/context/placement.ts';
+import { applyMatches, type SegMatch } from '../src/lib/context/match.ts';
+import type { ContextItem } from '../src/lib/context/types.ts';
+
+const G68 = { tractate: 'Gittin', page: '68a' };
+const G67 = { tractate: 'Gittin', page: '67b' };
+
+describe('coord helpers', () => {
+  it('coordKey / sameDaf / coordForSeg round-trip', () => {
+    const c = coordForSeg(G68, 4);
+    expect(c).toEqual({ tractate: 'Gittin', page: '68a', seg: 4 });
+    expect(coordKey(c)).toBe('Gittin:68a:4');
+    expect(sameDaf(c, G68)).toBe(true);
+    expect(sameDaf(c, G67)).toBe(false);
+  });
+
+  it('localSeg returns the seg only on its own daf', () => {
+    const c = coordForSeg(G67, 9);
+    expect(localSeg(c, G67)).toBe(9);
+    expect(localSeg(c, G68)).toBeNull();
+    expect(isCrossDaf(c, G68)).toBe(true);
+    expect(isCrossDaf(c, G67)).toBe(false);
+  });
+
+  it('coordsForSegs maps a local range to coordinates', () => {
+    expect(coordsForSegs(G68, [1, 2])).toEqual([
+      { tractate: 'Gittin', page: '68a', seg: 1 },
+      { tractate: 'Gittin', page: '68a', seg: 2 },
+    ]);
+  });
+
+  it('normalizeSpan dedupes and orders by (tractate, page, seg)', () => {
+    const span = [coordForSeg(G68, 3), coordForSeg(G67, 5), coordForSeg(G68, 1), coordForSeg(G68, 3)];
+    expect(normalizeSpan(span)).toEqual([
+      { tractate: 'Gittin', page: '67b', seg: 5 },
+      { tractate: 'Gittin', page: '68a', seg: 1 },
+      { tractate: 'Gittin', page: '68a', seg: 3 },
+    ]);
+  });
+
+  it('spanByDaf groups normalized coords into per-daf segment lists', () => {
+    const span = [coordForSeg(G68, 3), coordForSeg(G67, 5), coordForSeg(G68, 1)];
+    expect(spanByDaf(span)).toEqual([
+      { tractate: 'Gittin', page: '67b', segs: [5] },
+      { tractate: 'Gittin', page: '68a', segs: [1, 3] },
+    ]);
+  });
+
+  it('coordFromTarget bridges the CrossDafAnchor target shape (segIdx default 0)', () => {
+    expect(coordFromTarget({ tractate: 'Bava Metzia', page: '59b', segIdx: 2 })).toEqual({ tractate: 'Bava Metzia', page: '59b', seg: 2 });
+    expect(coordFromTarget({ tractate: 'Bava Metzia', page: '59b' })).toEqual({ tractate: 'Bava Metzia', page: '59b', seg: 0 });
+  });
+});
+
+const item = (over: Partial<ContextItem>): ContextItem => ({
+  source: 'sefaria-rashi', sourceLabel: 'Rashi', kind: 'rishon', key: 'k', segs: [], ...over,
+});
+
+describe('placementOf cross-daf derivation', () => {
+  it('derives cross-daf only when a current daf is supplied and the coord is off it', () => {
+    const it = item({ segs: [], coord: coordForSeg(G67, 4), via: 'parallel-sugya', confidence: 0.9 });
+    const p = placementOf(it, G68);
+    expect(p).toEqual({ level: 'cross-daf', segs: [], coord: coordForSeg(G67, 4), via: 'parallel-sugya', confidence: 0.9 });
+  });
+
+  it('does not derive cross-daf without a current daf (existing single-arg callers unchanged)', () => {
+    const it = item({ segs: [2], coord: coordForSeg(G67, 4) });
+    expect(placementOf(it)?.level).toBe('segment');
+  });
+
+  it('a coord on the current daf is not cross-daf (falls through to in-daf levels)', () => {
+    const it = item({ segs: [2], coord: coordForSeg(G68, 2) });
+    expect(placementOf(it, G68)?.level).toBe('segment');
+  });
+
+  it('an item with no coord is unaffected by passing a current daf', () => {
+    const it = item({ segs: [], amud: 'a' });
+    expect(placementOf(it, G68)?.level).toBe('amud');
+  });
+});
+
+describe('applyMatches carries a cross-daf coord', () => {
+  it('places an item with an empty local segs but a coord (no longer a no-op)', () => {
+    const items = [item({ key: 'x', segs: [] })];
+    const matches: SegMatch[] = [{ key: 'x', segs: [], via: 'parallel-sugya', coord: coordForSeg(G67, 4) }];
+    const changed = applyMatches(items, matches);
+    expect(changed).toBe(1);
+    expect(items[0].coord).toEqual(coordForSeg(G67, 4));
+    expect(items[0].segs).toEqual([]);
+  });
+
+  it('still treats an empty match with no coord as a no-op', () => {
+    const items = [item({ key: 'y', segs: [7], via: 'ai' })];
+    const changed = applyMatches(items, [{ key: 'y', segs: [], via: 'ai' }]);
+    expect(changed).toBe(0);
+    expect(items[0].coord).toBeUndefined();
+    expect(items[0].segs).toEqual([7]);
+  });
+});


### PR DESCRIPTION
Stacked on #51 (A1b). **A4**: a cross-daf coordinate so a span can name segments on more than one page — the coordinate the cross-page sugya map needs. Purely additive; nothing changes for in-daf reading.

## What's new
- **`src/lib/context/coord.ts`** — `AnchorCoord {tractate, page, seg}` + `AnchorSpan`, with helpers: `coordForSeg`/`coordsForSegs`, `localSeg` (fold a span back to in-daf segs for the page in view), `sameDaf`/`isCrossDaf`, `normalizeSpan` (dedupe + stable order), `spanByDaf` (per-daf segment lists — the sugya-map shape), and `coordFromTarget` (bridges the existing unused `CrossDafAnchor.target`).

## Additive wiring
- `SegMatch` + `ContextItem` gain optional `coord?: AnchorCoord`. `applyMatches` now treats a match with a `coord` but empty local `segs` as a placement (was a no-op) and carries the coord onto the item.
- `Placement` gains a `cross-daf` level (ranked **below** `daf` — it isn't on the page in view) and an optional `coord`. `placementOf` takes an optional `currentDaf`; it only derives `cross-daf` when given the daf in view **and** the item's coord points off it — so **every existing single-arg `placementOf` call is unchanged**.

## Safety
No `cache_version` bump; in-daf readers ignore `coord`. The existing `placement.test.ts` / `context-match.test.ts` stay green, proving in-daf behavior is untouched.

## Verification
- `tests/context-coord.test.ts` (new) covers the helpers, the cross-daf derivation incl. the single-arg no-change path and the on-daf-coord fall-through, and `applyMatches` carrying a coord.
- Full suite: **61 files / 1292 tests passing**. Typecheck clean.

Merge order: #45 → #49 → #50 → #51 → this.