### PR TITLE
Surface the post-LLM checks in the dev panel (A3 observation)

### DIFF
--- a/src/client/AIActivityPanel.tsx
+++ b/src/client/AIActivityPanel.tsx
@@ -29,6 +29,11 @@ export default function AIActivityPanel(): JSX.Element {
   onCleanup(() => clearInterval(interval));
 
   const [showQueued, setShowQueued] = createSignal(false);
+  const [showRunning, setShowRunning] = createSignal(false);
+  const [showDone, setShowDone] = createSignal(false);
+  // Cap how many running rows render at once; the rest collapse behind a
+  // "+N more running" toggle so a burst of parallel jobs doesn't flood the panel.
+  const MAX_RUNNING = 5;
 
   // Partition into loading (active) / queued (waiting on a slot) / terminal
   // (recently finished, still lingering). Order top-to-bottom by lifecycle:
@@ -129,8 +134,25 @@ export default function AIActivityPanel(): JSX.Element {
           'margin-bottom': '0.3rem',
         }}>AI activity</div>
 
-        {/* Active work first */}
-        <For each={groups().loading}>{(entry) => renderEntry(entry)}</For>
+        {/* Active work first — capped at MAX_RUNNING, the rest collapsed. */}
+        <For each={showRunning() ? groups().loading : groups().loading.slice(0, MAX_RUNNING)}>{(entry) => renderEntry(entry)}</For>
+        <Show when={groups().loading.length > MAX_RUNNING}>
+          <div
+            onClick={() => setShowRunning((v) => !v)}
+            title={showRunning() ? 'Show fewer running' : 'Show all running'}
+            style={{ display: 'flex', 'align-items': 'center', gap: '0.4rem', padding: '0.15rem 0', cursor: 'pointer', color: '#8a2a2b' }}
+          >
+            <span style={{
+              display: 'inline-block', width: '0.7rem', height: '0.7rem', 'border-radius': '50%',
+              border: '2px solid #d6d3d1', 'border-top-color': '#8a2a2b',
+              animation: 'daf-spin 0.8s linear infinite', 'flex-shrink': 0,
+            }} />
+            <span style={{ flex: 1, 'min-width': 0 }}>
+              {showRunning() ? 'show fewer' : `+${groups().loading.length - MAX_RUNNING} more running`}
+              <span style={{ color: '#888', 'font-size': '0.7rem' }}> {showRunning() ? '▾' : '▸'}</span>
+            </span>
+          </div>
+        </Show>
 
         {/* Queued — collapsed to a single count by default. */}
         <Show when={groups().queued.length > 0}>
@@ -155,8 +177,23 @@ export default function AIActivityPanel(): JSX.Element {
           </Show>
         </Show>
 
-        {/* Recently finished */}
-        <For each={groups().terminal}>{(entry) => renderEntry(entry)}</For>
+        {/* Recently finished — collapsed to a single count by default. */}
+        <Show when={groups().terminal.length > 0}>
+          <div
+            onClick={() => setShowDone((v) => !v)}
+            title={showDone() ? 'Hide finished' : 'Show finished'}
+            style={{ display: 'flex', 'align-items': 'center', gap: '0.4rem', padding: '0.15rem 0', cursor: 'pointer', color: '#15803d' }}
+          >
+            <span style={{ 'flex-shrink': 0 }}>✓</span>
+            <span style={{ flex: 1, 'min-width': 0 }}>
+              {groups().terminal.length} finished
+              <span style={{ color: '#888', 'font-size': '0.7rem' }}> {showDone() ? '▾' : '▸'}</span>
+            </span>
+          </div>
+          <Show when={showDone()}>
+            <For each={groups().terminal}>{(entry) => renderEntry(entry)}</For>
+          </Show>
+        </Show>
       </div>
     </Show>
   );

--- a/src/client/ChecksPanel.tsx
+++ b/src/client/ChecksPanel.tsx
@@ -1,0 +1,80 @@
+/**
+ * Dev-panel surfacing for the post-LLM check layer. Calls
+ * GET /api/studio/checks/:tractate/:page — which re-runs each daf-level mark's
+ * declared checks against its ALREADY-CACHED (anchored) output, no LLM — and
+ * lists what the soft/observe-only checks (anchor-verbatim, partition-clean, …)
+ * flag on the daf in view. This is the observation surface for deciding whether
+ * a soft check is trustworthy enough to promote to a hard, cache-gating one.
+ *
+ * Mounted in DevModeShelf (dev mode only), so the read only happens for dev
+ * users and never on a reader's page load.
+ */
+
+import { createResource, For, Show, type JSX } from 'solid-js';
+
+interface CheckIssue { kind: string; severity?: string; match?: string; index?: number; detail?: string }
+interface MarkResult { mark_id: string; cached: boolean; issues: CheckIssue[] }
+interface ChecksResponse { tractate: string; page: string; total_issues: number; results: MarkResult[] }
+
+export default function ChecksPanel(props: { tractate: string; page: string }): JSX.Element {
+  const [data] = createResource(
+    () => `${props.tractate}|${props.page}`,
+    async (): Promise<ChecksResponse | null> => {
+      const r = await fetch(`/api/studio/checks/${encodeURIComponent(props.tractate)}/${encodeURIComponent(props.page)}`);
+      if (!r.ok) return null;
+      return (await r.json()) as ChecksResponse;
+    },
+  );
+  const flagged = () => (data()?.results ?? []).filter((m) => m.issues.length > 0);
+
+  return (
+    <Show when={data()}>
+      <div style={{
+        border: '1px solid #eee', 'border-radius': '4px', background: '#fff',
+        padding: '0.4rem 0.55rem', 'font-size': '0.78rem', 'line-height': 1.45,
+      }}>
+        <div style={{
+          'font-size': '0.65rem', 'text-transform': 'uppercase', 'letter-spacing': '0.06em',
+          color: '#888', 'margin-bottom': '0.3rem', display: 'flex', 'justify-content': 'space-between',
+        }}>
+          <span>Checks (soft)</span>
+          <span style={{ color: data()!.total_issues > 0 ? '#a16207' : '#15803d' }}>
+            {data()!.total_issues} flag{data()!.total_issues === 1 ? '' : 's'}
+          </span>
+        </div>
+
+        <Show when={flagged().length === 0}>
+          <div style={{ color: '#15803d', 'font-size': '0.72rem' }}>· all clear on this daf</div>
+        </Show>
+
+        <For each={flagged()}>{(m) => (
+          <div style={{ 'margin-bottom': '0.35rem' }}>
+            <div style={{ 'font-weight': 600, color: '#444', 'margin-bottom': '0.1rem' }}>
+              {m.mark_id} <span style={{ color: '#a16207', 'font-weight': 400 }}>· {m.issues.length}</span>
+            </div>
+            <For each={m.issues.slice(0, 12)}>{(i) => (
+              <div style={{ display: 'flex', gap: '0.4rem', padding: '0.1rem 0', color: '#666', 'align-items': 'baseline' }}>
+                <span style={{
+                  'flex-shrink': 0, 'font-size': '0.62rem', 'border-radius': '3px', padding: '0 0.3rem',
+                  background: i.severity === 'hard' ? '#fee2e2' : '#fef3c7',
+                  color: i.severity === 'hard' ? '#b91c1c' : '#a16207',
+                }}>{i.kind}</span>
+                <Show when={typeof i.index === 'number' && i.index >= 0}>
+                  <span style={{ 'flex-shrink': 0, color: '#999', 'font-size': '0.68rem' }}>seg {i.index}</span>
+                </Show>
+                <Show when={i.match}>
+                  <span dir="rtl" style={{ 'font-size': '0.72rem', color: '#333', overflow: 'hidden', 'text-overflow': 'ellipsis', 'white-space': 'nowrap' }}>
+                    {i.match!.slice(0, 48)}
+                  </span>
+                </Show>
+              </div>
+            )}</For>
+            <Show when={m.issues.length > 12}>
+              <div style={{ color: '#999', 'font-size': '0.68rem' }}>+{m.issues.length - 12} more</div>
+            </Show>
+          </div>
+        )}</For>
+      </div>
+    </Show>
+  );
+}

--- a/src/client/DafViewer.tsx
+++ b/src/client/DafViewer.tsx
@@ -33,6 +33,7 @@ import { fetchCommentaryAnchorIndex, type CommentaryAnchorIndex } from './commen
 import { recordStage } from './rendererActivity';
 import { applyMarkRenderers } from './renderers/dispatch';
 import DevModeShelf, { readDevMode, setDevModeActive } from './DevModeShelf';
+import ChecksPanel from './ChecksPanel';
 import type { GenerationId } from './generations';
 import { GENERATION_BY_ID } from './generations';
 import { resolveVoiceGroup, voiceGroupNames } from './voiceGroups';
@@ -2864,6 +2865,7 @@ export default function DafViewer(): JSX.Element {
         />
       </Show>
       <DevModeShelf open={devOpen()} onClose={() => { setDevOpen(false); setDevModeActive(false); }}>
+        <ChecksPanel tractate={tractate()} page={page()} />
         <MarksRegistryPanel
           tractate={tractate()}
           page={page()}

--- a/src/client/MarksRegistryPanel.tsx
+++ b/src/client/MarksRegistryPanel.tsx
@@ -667,14 +667,20 @@ export default function MarksRegistryPanel(props: Props) {
                       'line-height': 1,
                     }}
                   >{isOn() ? '●' : '○'}</button>
-                  <span style={{ 'font-weight': nested ? 400 : 500, 'font-size': nested ? '0.8rem' : '0.85rem' }}>
+                  <span style={{
+                    'font-weight': nested ? 400 : 500, 'font-size': nested ? '0.8rem' : '0.85rem',
+                    // Truncate on one line instead of wrapping: a long label that
+                    // wraps flips between 1 and 2 lines as the status badge's width
+                    // changes (spinner → "✓ 1234ms"), which reads as row jitter.
+                    flex: 1, 'min-width': 0, 'white-space': 'nowrap', overflow: 'hidden', 'text-overflow': 'ellipsis',
+                  }} title={label()}>
                     {label()}
                   </span>
-                  <span title={`anchored on ${anchor()} · rendered ${render()}`} style={{ color: '#aaa', 'font-size': '0.7rem', 'font-family': 'monospace' }}>
+                  <span title={`anchored on ${anchor()} · rendered ${render()}`} style={{ color: '#aaa', 'font-size': '0.7rem', 'font-family': 'monospace', 'flex-shrink': 0 }}>
                     {anchor()[0]}/{String(render())[0]}
                   </span>
                   <Show when={row.source !== 'seed' && isOn()}>
-                    <span style={{ 'font-size': '0.7rem', display: 'inline-flex', 'align-items': 'center', gap: '0.3rem', color: state().kind === 'error' ? '#c00' : state().kind === 'loading' ? '#888' : state().kind === 'ok' ? '#15803d' : '#aaa' }}>
+                    <span style={{ 'font-size': '0.7rem', display: 'inline-flex', 'align-items': 'center', gap: '0.3rem', 'flex-shrink': 0, color: state().kind === 'error' ? '#c00' : state().kind === 'loading' ? '#888' : state().kind === 'ok' ? '#15803d' : '#aaa' }}>
                       <Show when={state().kind === 'loading'}>
                         <span style={{
                           display: 'inline-block', width: '0.65rem', height: '0.65rem',
@@ -702,7 +708,7 @@ export default function MarksRegistryPanel(props: Props) {
                   </Show>
                   {/* Summary badge on collapsed mark rows showing enrichment progress */}
                   <Show when={row.source === 'mark' && !isExpanded() && childCount() > 0}>
-                    <span style={{ 'font-size': '0.68rem', color: '#aaa', 'margin-left': '0.1rem' }}>
+                    <span style={{ 'font-size': '0.68rem', color: '#aaa', 'margin-left': '0.1rem', 'flex-shrink': 0, 'white-space': 'nowrap' }}>
                       {childCount()} enrich{childCount() === 1 ? '' : 'ments'}
                       <Show when={summary()!.loading > 0}> · {summary()!.loading}…</Show>
                       <Show when={summary()!.ok > 0}> · {summary()!.ok} done</Show>

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -599,6 +599,36 @@ app.delete('/api/studio/marks/:id', async (c) => {
   return c.json({ ok: true });
 });
 
+// Observation surface for the post-LLM check layer. Re-runs each daf-level
+// mark's declared checks against its ALREADY-CACHED (anchored) output — no LLM
+// call, no cache write — so the dev panel can show which soft/observe-only
+// checks (anchor-verbatim, partition-clean, …) are firing on real content
+// before any of them is promoted to a hard, cache-gating check. Marks only:
+// they have one cache entry per daf; instance-scoped enrichment checks
+// (edge-integrity, rabbi-evidence) aren't enumerable without their instances.
+app.get('/api/studio/checks/:tractate/:page', async (c) => {
+  const tractate = c.req.param('tractate');
+  const page = c.req.param('page');
+  const lang: 'en' | 'he' = c.req.query('lang') === 'he' ? 'he' : 'en';
+  const marks = CODE_MARKS.filter((m) => (m.checks?.length ?? 0) > 0);
+  if (marks.length === 0) return c.json({ tractate, page, results: [], total_issues: 0 });
+
+  const slice = await getGemaraSlice(c.env, tractate, page, false);
+  const results: { mark_id: string; cached: boolean; issues: unknown[] }[] = [];
+  let total = 0;
+  for (const def of marks) {
+    const hit = await readCachedResult(c.env, keyForMark(def, tractate, page, lang));
+    if (!hit || hit.parsed == null) { results.push({ mark_id: def.id, cached: false, issues: [] }); continue; }
+    // Clone so the idempotent transform re-runs don't mutate the cached object.
+    const { issues } = await runChecks(def.checks ?? [], structuredClone(hit.parsed), {
+      tractate, page, segmentsHe: slice.segments_he, defId: def.id, lang,
+    });
+    total += issues.length;
+    results.push({ mark_id: def.id, cached: true, issues });
+  }
+  return c.json({ tractate, page, total_issues: total, results });
+});
+
 app.get('/api/studio/enrichments', async (c) => {
   // Merge KV + code-defined. KV wins on collision. Code-defined entries are
   // normalized to the KV-flat shape (extractor flattened, `mark` instead of


### PR DESCRIPTION
Stacked on #52 (A4). The observation surface for the A3 soft checks.

- **GET /api/studio/checks/:tractate/:page** — re-runs each daf-level mark's declared checks against its ALREADY-CACHED (anchored) output (no LLM, no cache write) and returns the issues.
- **ChecksPanel** (in DevModeShelf, dev mode only) calls it for the daf in view and lists what fires, severity-colored, with segment + excerpt.

Lets us watch which soft checks fire on real content before promoting any to hard/cache-gating. Observed on warmed dapim: argument-move `excerpt-not-in-segment` clusters on dialogue-heavy pages (Gittin 68a: 5, Sanhedrin 59b: 3) where the short-prefix fallback lands a move on a common opener; Berakhot 2a clean. Marks only (one cache entry per daf).

61 files / 1292 tests, typecheck clean.