### PR TITLE
Section typing P1: deterministic TypeProfile composition

### DIFF
--- a/src/lib/typing/profile.ts
+++ b/src/lib/typing/profile.ts
@@ -1,0 +1,158 @@
+/**
+ * @fileoverview Section typing — P1: the deterministic TypeProfile composition.
+ *
+ * The app already extracts independent, overlapping mark layers over the same
+ * text (argument / argument-move = dialectical base; halacha / aggadata /
+ * pesukim = content overlays). What was missing is the RELATION between them.
+ * This module computes it deterministically — no LLM — by intersecting the
+ * other layers' instance ranges with a unit's range and emitting a TypeProfile.
+ *
+ * Design: docs/section-typing.md. Key idea — type is multi-label and granular,
+ * not a flat enum:
+ *   - the dialectical base (argument-move `role`) is ALWAYS present, so a unit
+ *     with no content overlay is `pure-dialectic`, a real type, not a gap;
+ *   - content overlays (halacha/aggadata/pesukim) add dimensions; one becomes
+ *     `primary` when it MATERIALLY covers the unit (coverage × confidence ×
+ *     layer-priority), else `primary` falls back to `pure-dialectic`;
+ *   - nesting is native: a small overlay inside a big unit is just a claim with
+ *     low `coverage` — it appears in `claims` but doesn't win `primary`.
+ *
+ * Pure + DOM-free + env-free → lives in src/lib and is unit-testable. Tuning
+ * constants (PRIMARY_FLOOR, LAYER_PRIORITY) are documented open questions in the
+ * design doc; they're isolated here so empirical tuning is a one-line change.
+ */
+
+export type OverlayLayer = 'halacha' | 'aggadata' | 'pesukim';
+export type LayerId = 'argument' | 'argument-move' | OverlayLayer | 'rabbi' | 'places';
+export type PrimaryType = 'pure-dialectic' | OverlayLayer;
+
+export interface UnitRange {
+  tractate: string;
+  page: string;
+  startSegIdx: number;
+  endSegIdx: number;
+}
+
+/** One mark instance, reduced to what composition needs: its layer, an id, the
+ *  segment range it spans, and an optional grounding confidence. */
+export interface LayerInstance {
+  layer: LayerId;
+  instanceId: string;
+  startSegIdx: number;
+  endSegIdx: number;
+  confidence?: number;
+}
+
+/** A layer's claim on a unit: which of the unit's segments it covers, and how
+ *  much of the unit that is. */
+export interface LayerClaim {
+  layer: LayerId;
+  instanceId: string;
+  /** The unit segments this claim covers (sorted, unique). */
+  segs: number[];
+  /** 0..1 — fraction of the unit's segments the claim covers. */
+  coverage: number;
+  confidence?: number;
+}
+
+export interface TypeProfile {
+  unit: UnitRange;
+  /** Every layer claim that touches the unit (≥1 segment), coverage-desc. */
+  claims: LayerClaim[];
+  /** Dominant content dimension, or `pure-dialectic` when no overlay clears
+   *  the floor (the always-present dialectical base). Derived, not stored. */
+  primary: PrimaryType;
+  /** True only when the argument structure over the unit has real opposing
+   *  voices (≥1 `opposes` edge). Gates dispute rendering (P2). Orthogonal to
+   *  `primary`: a כולכם dispute with no content overlay is
+   *  `primary: 'pure-dialectic'`, `isDispute: true`. */
+  isDispute: boolean;
+}
+
+/** An overlay must cover at least this fraction of the unit to win `primary`;
+ *  below it the overlay is a NESTED claim and `primary` stays the dialectical
+ *  base. (Design open question #2 — tune empirically.) */
+export const PRIMARY_FLOOR = 0.5;
+
+/** Tiebreak weight when more than one overlay clears the floor: a story
+ *  dominates a ruling dominates a bare verse citation. (Design open question
+ *  #1 — tune empirically.) */
+export const LAYER_PRIORITY: Record<OverlayLayer, number> = { aggadata: 3, halacha: 2, pesukim: 1 };
+
+const OVERLAYS: ReadonlySet<LayerId> = new Set<LayerId>(['halacha', 'aggadata', 'pesukim']);
+
+/** Inclusive [start..end] as a set of segment indices (empty if inverted). */
+function rangeSegs(start: number, end: number): number[] {
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end < start) return [];
+  const out: number[] = [];
+  for (let i = start; i <= end; i++) out.push(i);
+  return out;
+}
+
+/** A minimal voices-graph shape (argument.voices output) for the dispute test. */
+export interface VoicesGraph { edges?: { kind?: string }[] }
+
+/** True when the voices graph carries a real opposition (an `opposes` edge). */
+export function hasOpposingVoices(voices?: VoicesGraph | null): boolean {
+  return !!voices?.edges?.some((e) => e?.kind === 'opposes');
+}
+
+/**
+ * Compose a TypeProfile for `unit` from the other layers' instances. Pure +
+ * deterministic. `instances` is the flat list of every layer's instances on the
+ * daf (argument/halacha/aggadata/pesukim/…); only those overlapping the unit
+ * contribute claims. Pass the unit's `argument.voices` graph (when available) to
+ * derive `isDispute`; omit it and `isDispute` is false (unknown → not a dispute).
+ */
+export function composeTypeProfile(
+  unit: UnitRange,
+  instances: readonly LayerInstance[],
+  opts: { voices?: VoicesGraph | null } = {},
+): TypeProfile {
+  const unitSegs = rangeSegs(unit.startSegIdx, unit.endSegIdx);
+  const unitSet = new Set(unitSegs);
+  const denom = unitSegs.length || 1;
+
+  const claims: LayerClaim[] = [];
+  for (const inst of instances) {
+    const covered = rangeSegs(inst.startSegIdx, inst.endSegIdx).filter((s) => unitSet.has(s));
+    if (covered.length === 0) continue; // doesn't touch the unit
+    claims.push({
+      layer: inst.layer,
+      instanceId: inst.instanceId,
+      segs: covered,
+      coverage: covered.length / denom,
+      confidence: inst.confidence,
+    });
+  }
+  claims.sort((a, b) => b.coverage - a.coverage);
+
+  // primary: the highest-scoring overlay that materially covers the unit;
+  // otherwise the always-present dialectical base.
+  let primary: PrimaryType = 'pure-dialectic';
+  let bestScore = 0;
+  for (const c of claims) {
+    if (!OVERLAYS.has(c.layer) || c.coverage < PRIMARY_FLOOR) continue;
+    const score = c.coverage * (c.confidence ?? 1) * LAYER_PRIORITY[c.layer as OverlayLayer];
+    if (score > bestScore) { bestScore = score; primary = c.layer as OverlayLayer; }
+  }
+
+  return { unit, claims, primary, isDispute: hasOpposingVoices(opts.voices) };
+}
+
+/**
+ * P0 coverage helper: the unit segments NOT covered by any CONTENT overlay
+ * (halacha/aggadata/pesukim). These are the "pure dialectic" segments — covered
+ * by the argument base but no content dimension. Not a gap; the dialectical
+ * type. Used by the coverage audit to measure how much of a daf is bare שקלא
+ * וטריא vs. content-covered.
+ */
+export function overlayUncoveredSegs(unit: UnitRange, instances: readonly LayerInstance[]): number[] {
+  const unitSegs = rangeSegs(unit.startSegIdx, unit.endSegIdx);
+  const coveredByOverlay = new Set<number>();
+  for (const inst of instances) {
+    if (!OVERLAYS.has(inst.layer)) continue;
+    for (const s of rangeSegs(inst.startSegIdx, inst.endSegIdx)) coveredByOverlay.add(s);
+  }
+  return unitSegs.filter((s) => !coveredByOverlay.has(s));
+}

--- a/tests/typing/profile.test.ts
+++ b/tests/typing/profile.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Section typing P1 — the deterministic TypeProfile composition
+ * (src/lib/typing/profile.ts). Covers the mechanics (coverage math, claim
+ * inclusion, primary selection, nesting, tiebreaks) and the named validation
+ * cases from docs/section-typing.md (Ashmedai → aggadata, כולכם → dispute,
+ * Berakhot pure-dialectic, 67b remedies → aggadata).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  composeTypeProfile, overlayUncoveredSegs, hasOpposingVoices, PRIMARY_FLOOR,
+  type LayerInstance, type UnitRange,
+} from '../../src/lib/typing/profile';
+
+const unit = (startSegIdx: number, endSegIdx: number): UnitRange => ({ tractate: 'Gittin', page: '67b', startSegIdx, endSegIdx });
+const inst = (layer: LayerInstance['layer'], instanceId: string, s: number, e: number, confidence?: number): LayerInstance =>
+  ({ layer, instanceId, startSegIdx: s, endSegIdx: e, confidence });
+
+describe('composeTypeProfile — mechanics', () => {
+  it('computes coverage as the fraction of unit segments a claim covers', () => {
+    // unit 0..3 (4 segs); halacha covers 1..2 → 2/4 = 0.5.
+    const p = composeTypeProfile(unit(0, 3), [inst('halacha', 'h1', 1, 2)]);
+    expect(p.claims).toHaveLength(1);
+    expect(p.claims[0]).toMatchObject({ layer: 'halacha', segs: [1, 2], coverage: 0.5 });
+  });
+
+  it('excludes instances that do not touch the unit, clips those that overhang', () => {
+    const p = composeTypeProfile(unit(2, 4), [
+      inst('aggadata', 'a-out', 5, 9),   // entirely after the unit → excluded
+      inst('halacha', 'h-over', 0, 3),   // overhangs start → clipped to {2,3}
+    ]);
+    expect(p.claims.map((c) => c.instanceId)).toEqual(['h-over']);
+    expect(p.claims[0].segs).toEqual([2, 3]);
+  });
+
+  it('sorts claims by coverage descending', () => {
+    const p = composeTypeProfile(unit(0, 9), [
+      inst('pesukim', 'p', 0, 0),       // 0.1
+      inst('aggadata', 'a', 0, 7),      // 0.8
+      inst('halacha', 'h', 0, 3),       // 0.4
+    ]);
+    expect(p.claims.map((c) => c.instanceId)).toEqual(['a', 'h', 'p']);
+  });
+});
+
+describe('composeTypeProfile — primary selection', () => {
+  it('an overlay that materially covers the unit wins primary', () => {
+    const p = composeTypeProfile(unit(0, 4), [inst('aggadata', 'story', 0, 4)]);
+    expect(p.primary).toBe('aggadata');
+  });
+
+  it('falls back to pure-dialectic when no overlay clears the floor (nesting)', () => {
+    // a 1-of-6 halacha span is a NESTED claim, not the primary type.
+    const p = composeTypeProfile(unit(0, 5), [inst('halacha', 'h', 2, 2)]);
+    expect(p.claims).toHaveLength(1);            // still recorded
+    expect(p.claims[0].coverage).toBeLessThan(PRIMARY_FLOOR);
+    expect(p.primary).toBe('pure-dialectic');     // but doesn't win primary
+  });
+
+  it('layer priority breaks ties when two overlays both clear the floor', () => {
+    // both cover the whole unit; aggadata (3) outranks halacha (2).
+    const p = composeTypeProfile(unit(0, 3), [
+      inst('halacha', 'h', 0, 3),
+      inst('aggadata', 'a', 0, 3),
+    ]);
+    expect(p.primary).toBe('aggadata');
+  });
+
+  it('confidence weights the primary score', () => {
+    // halacha covers slightly less but is fully confident; aggadata barely
+    // clears the floor with low confidence → halacha wins despite lower priority.
+    const p = composeTypeProfile(unit(0, 9), [
+      inst('aggadata', 'a', 0, 4, 0.2),  // coverage .5 × .2 × 3 = 0.30
+      inst('halacha', 'h', 0, 8, 1.0),   // coverage .9 × 1 × 2 = 1.80
+    ]);
+    expect(p.primary).toBe('halacha');
+  });
+
+  it('rabbi/places entity layers never become primary', () => {
+    const p = composeTypeProfile(unit(0, 3), [inst('rabbi', 'Rava', 0, 3), inst('places', 'Bavel', 0, 3)]);
+    expect(p.primary).toBe('pure-dialectic');
+    expect(p.claims).toHaveLength(2); // recorded as claims, just not primary-eligible
+  });
+});
+
+describe('isDispute', () => {
+  it('is true when the voices graph has an opposes edge', () => {
+    expect(hasOpposingVoices({ edges: [{ kind: 'responds-to' }, { kind: 'opposes' }] })).toBe(true);
+    const p = composeTypeProfile(unit(0, 3), [], { voices: { edges: [{ kind: 'opposes' }] } });
+    expect(p.isDispute).toBe(true);
+  });
+
+  it('is false with no opposition or no voices supplied', () => {
+    expect(hasOpposingVoices({ edges: [{ kind: 'supports' }, { kind: 'responds-to' }] })).toBe(false);
+    expect(composeTypeProfile(unit(0, 3), []).isDispute).toBe(false);
+  });
+});
+
+describe('overlayUncoveredSegs (P0 coverage)', () => {
+  it('returns unit segments covered by no content overlay (pure dialectic)', () => {
+    // unit 0..5; aggadata covers 0..2 → 3,4,5 are pure-dialectic.
+    const segs = overlayUncoveredSegs(unit(0, 5), [inst('aggadata', 'a', 0, 2), inst('rabbi', 'r', 4, 4)]);
+    expect(segs).toEqual([3, 4, 5]); // rabbi is an entity layer, not content → doesn't cover
+  });
+});
+
+describe('named validation cases from the design doc', () => {
+  it('Ashmedai unit (story spanning the unit) → primary aggadata', () => {
+    const p = composeTypeProfile(
+      { tractate: 'Gittin', page: '68a', startSegIdx: 2, endSegIdx: 6 },
+      [inst('aggadata', 'ashmedai', 2, 6), inst('rabbi', 'Rav Ashi', 3, 3)],
+      { voices: { edges: [{ kind: 'responds-to' }] } }, // a story rendered with responds-to, NOT opposes
+    );
+    expect(p.primary).toBe('aggadata');
+    expect(p.isDispute).toBe(false); // the fix: a story is not a dispute
+  });
+
+  it('כולכם unit (dispute, no content overlay) → pure-dialectic primary but isDispute', () => {
+    const p = composeTypeProfile(unit(0, 2), [inst('argument', 'sec', 0, 2)], { voices: { edges: [{ kind: 'opposes' }, { kind: 'supports' }] } });
+    expect(p.primary).toBe('pure-dialectic');
+    expect(p.isDispute).toBe(true);
+  });
+
+  it('Berakhot 2a Stam Q&A segments → pure-dialectic, not untyped', () => {
+    // segments 5,6,9,10 covered by no content overlay and no opposition.
+    const p = composeTypeProfile({ tractate: 'Berakhot', page: '2a', startSegIdx: 5, endSegIdx: 6 }, []);
+    expect(p.primary).toBe('pure-dialectic');
+    expect(p.isDispute).toBe(false);
+  });
+
+  it('67b remedies unit (aggadata covers the majority) → aggadata', () => {
+    const p = composeTypeProfile(unit(10, 16), [
+      inst('aggadata', 'remedies', 10, 15),  // 6/7 ≈ 0.86
+      inst('rabbi', 'Abaye', 11, 11),
+    ]);
+    expect(p.primary).toBe('aggadata');
+  });
+});


### PR DESCRIPTION
First increment of **Track C** (docs/section-typing.md), stacked on #53. Pure, deterministic, no LLM, no render/runner wiring yet — the composition core everything else builds on.

## What it adds
`src/lib/typing/profile.ts`:
- **`composeTypeProfile(unit, instances, {voices?})`** — intersects every mark layer's instance ranges with a unit's range and returns a `TypeProfile`: the `LayerClaim`s (each with the unit segments it covers + a 0..1 `coverage`), a derived **`primary`** content dimension, and **`isDispute`**.
- **`overlayUncoveredSegs`** — the P0 coverage helper (unit segments covered by no content overlay = pure dialectic).
- **`hasOpposingVoices`** — `isDispute` from an `opposes` edge.

## Model (from the design)
Type is multi-label + granular, not a flat enum:
- the dialectical base (argument-move `role`) is always present → a unit with no overlay is **`pure-dialectic`**, a real type not a gap;
- a content overlay wins **`primary`** only when it materially covers the unit (`coverage × confidence × LAYER_PRIORITY` ≥ `PRIMARY_FLOOR`); a small overlay is a **nested** low-coverage claim that stays recorded but doesn't win;
- **`isDispute`** is orthogonal to `primary` and derived from the voices graph — the gate P2 uses to stop rendering stories (responds-to only) as debates.

Tuning constants (`PRIMARY_FLOOR`, `LAYER_PRIORITY`) are isolated for empirical tuning (design open questions #1/#2).

## Verification
`tests/typing/profile.test.ts` (15 cases): coverage math, claim inclusion/clipping, primary selection, nesting, priority + confidence tiebreaks, entity layers never primary, and the design's named validation cases (Ashmedai→aggadata, כולכם→dispute, Berakhot Stam Q&A→pure-dialectic, 67b remedies→aggadata).

62 files / 1307 tests passing, typecheck clean.

Next: P2 — wire `isDispute` to gate `argument.voices` and add the narrative/move-flow alternatives (flag-gated).