### PR TITLE
Section typing: surface TypeProfiles on real marks (validation + dev panel)

### DIFF
--- a/src/client/DafViewer.tsx
+++ b/src/client/DafViewer.tsx
@@ -34,6 +34,7 @@ import { recordStage } from './rendererActivity';
 import { applyMarkRenderers } from './renderers/dispatch';
 import DevModeShelf, { readDevMode, setDevModeActive } from './DevModeShelf';
 import ChecksPanel from './ChecksPanel';
+import TypeProfilePanel from './TypeProfilePanel';
 import type { GenerationId } from './generations';
 import { GENERATION_BY_ID } from './generations';
 import { resolveVoiceGroup, voiceGroupNames } from './voiceGroups';
@@ -2866,6 +2867,7 @@ export default function DafViewer(): JSX.Element {
       </Show>
       <DevModeShelf open={devOpen()} onClose={() => { setDevOpen(false); setDevModeActive(false); }}>
         <ChecksPanel tractate={tractate()} page={page()} />
+        <TypeProfilePanel tractate={tractate()} page={page()} />
         <MarksRegistryPanel
           tractate={tractate()}
           page={page()}

--- a/src/client/TypeProfilePanel.tsx
+++ b/src/client/TypeProfilePanel.tsx
@@ -1,0 +1,62 @@
+/**
+ * Dev-panel view of section typing (Track C). Calls
+ * GET /api/studio/type-profiles/:tractate/:page — which composes a TypeProfile
+ * per argument section from the daf's CACHED mark layers (no LLM) — and shows,
+ * per section, its derived `primary` content dimension, whether it's a dispute,
+ * and the overlay claims with coverage. The observation surface for validating
+ * the deterministic composition (and, later, the profile-driven gating) on real
+ * content. Dev mode only (mounted in DevModeShelf).
+ */
+
+import { createResource, For, Show, type JSX } from 'solid-js';
+
+interface Claim { layer: string; coverage: number }
+interface Profile { unit: { startSegIdx: number; endSegIdx: number }; claims: Claim[]; primary: string; isDispute: boolean; title?: string }
+interface ProfilesResponse { tractate: string; page: string; count: number; profiles: Profile[] }
+
+const PRIMARY_COLOR: Record<string, string> = {
+  'pure-dialectic': '#6b7280', aggadata: '#7c3aed', halacha: '#0369a1', pesukim: '#a16207',
+};
+
+export default function TypeProfilePanel(props: { tractate: string; page: string }): JSX.Element {
+  const [data] = createResource(
+    () => `${props.tractate}|${props.page}`,
+    async (): Promise<ProfilesResponse | null> => {
+      const r = await fetch(`/api/studio/type-profiles/${encodeURIComponent(props.tractate)}/${encodeURIComponent(props.page)}`);
+      if (!r.ok) return null;
+      return (await r.json()) as ProfilesResponse;
+    },
+  );
+
+  return (
+    <Show when={data() && data()!.count > 0}>
+      <div style={{
+        border: '1px solid #eee', 'border-radius': '4px', background: '#fff',
+        padding: '0.4rem 0.55rem', 'font-size': '0.78rem', 'line-height': 1.45,
+      }}>
+        <div style={{
+          'font-size': '0.65rem', 'text-transform': 'uppercase', 'letter-spacing': '0.06em',
+          color: '#888', 'margin-bottom': '0.3rem',
+        }}>Section types · {data()!.count}</div>
+
+        <For each={data()!.profiles}>{(p) => (
+          <div style={{ display: 'flex', gap: '0.4rem', padding: '0.12rem 0', 'align-items': 'baseline' }}>
+            <span style={{ 'flex-shrink': 0, color: '#bbb', 'font-size': '0.68rem', 'font-variant-numeric': 'tabular-nums' }}>
+              {p.unit.startSegIdx}-{p.unit.endSegIdx}
+            </span>
+            <span style={{
+              'flex-shrink': 0, 'font-size': '0.62rem', 'border-radius': '3px', padding: '0 0.3rem',
+              background: (PRIMARY_COLOR[p.primary] ?? '#888') + '22', color: PRIMARY_COLOR[p.primary] ?? '#666',
+            }}>{p.primary}</span>
+            <Show when={p.isDispute}>
+              <span style={{ 'flex-shrink': 0, 'font-size': '0.6rem', color: '#b91c1c' }} title="argument.voices has an opposes edge">⚔</span>
+            </Show>
+            <span style={{
+              flex: 1, 'min-width': 0, 'white-space': 'nowrap', overflow: 'hidden', 'text-overflow': 'ellipsis', color: '#555',
+            }} title={p.title}>{p.title ?? ''}</span>
+          </div>
+        )}</For>
+      </div>
+    </Show>
+  );
+}

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -63,6 +63,7 @@ import { runLLM, type LLMModelId, type LLMResult, type LLMUsage } from './llm';
 import { checkBudget, isBudgetPaused, budgetStatus, clearPauses, type BudgetScope } from './budget';
 import { lookupRelationships } from './rabbi-graph';
 import { runChecks } from '../lib/check/postcheck';
+import { composeTypeProfile, type LayerId, type LayerInstance, type TypeProfile, type UnitRange } from '../lib/typing/profile';
 import { noteLintAttempt, readLintFailures, type LintFailuresSummary } from './lint-failures';
 import { partitionSections, dedupeByRange, dedupeBy, selectSectionMoves, type MoveLike } from '../lib/argumentMoves';
 import { DEFAULT_MODEL, DEFAULT_FALLBACK_CHAIN, isLLMModelId, MODEL_PRESETS } from './settings';
@@ -627,6 +628,64 @@ app.get('/api/studio/checks/:tractate/:page', async (c) => {
     results.push({ mark_id: def.id, cached: true, issues });
   }
   return c.json({ tractate, page, total_issues: total, results });
+});
+
+// --- Section typing (P1/P2): deterministic TypeProfile composition ----------
+// Read-only over CACHED marks (no LLM, no cache write). For each argument
+// section on the daf, intersect the content overlays (halacha/aggadata/pesukim)
+// + the dialectical base (argument-move) and emit a TypeProfile: which layers
+// claim the section, the dominant `primary` content dimension (pure-dialectic
+// when no overlay materially covers it), and `isDispute` (from the section's
+// cached argument.voices graph). This is the observation/validation surface for
+// section typing — it shows, on real content, that e.g. the Ashmedai story is
+// narrative-primary (not a voice dispute). Gating + new enrichments build on it.
+type RawInstance = { startSegIdx?: unknown; endSegIdx?: unknown; fields?: Record<string, unknown> };
+async function readMarkInstances(env: Bindings, markId: string, tractate: string, page: string): Promise<RawInstance[]> {
+  const def = findCodeMark(markId);
+  if (!def) return [];
+  const hit = await readCachedResult(env, keyForMark(def, tractate, page, 'en'));
+  const parsed = hit?.parsed as { instances?: unknown } | null;
+  return Array.isArray(parsed?.instances) ? (parsed!.instances as RawInstance[]) : [];
+}
+function toLayerInstances(layer: LayerId, insts: RawInstance[]): LayerInstance[] {
+  const out: LayerInstance[] = [];
+  insts.forEach((i, idx) => {
+    if (typeof i.startSegIdx !== 'number' || typeof i.endSegIdx !== 'number') return;
+    const f = i.fields ?? {};
+    const id = (typeof f.title === 'string' && f.title) || (typeof f.topic === 'string' && f.topic)
+      || (typeof f.theme === 'string' && f.theme) || (typeof f.excerpt === 'string' && f.excerpt) || String(idx);
+    out.push({ layer, instanceId: id, startSegIdx: i.startSegIdx, endSegIdx: i.endSegIdx });
+  });
+  return out;
+}
+async function buildDafTypeProfiles(env: Bindings, tractate: string, page: string): Promise<(TypeProfile & { title?: string })[]> {
+  const sections = await readMarkInstances(env, 'argument', tractate, page);
+  const overlays: LayerInstance[] = [
+    ...toLayerInstances('aggadata', await readMarkInstances(env, 'aggadata', tractate, page)),
+    ...toLayerInstances('halacha', await readMarkInstances(env, 'halacha', tractate, page)),
+    ...toLayerInstances('pesukim', await readMarkInstances(env, 'pesukim', tractate, page)),
+    ...toLayerInstances('argument-move', await readMarkInstances(env, 'argument-move', tractate, page)),
+  ];
+  const voicesDef = findCodeEnrichment('argument.voices');
+  const profiles: (TypeProfile & { title?: string })[] = [];
+  for (const sec of sections) {
+    if (typeof sec.startSegIdx !== 'number' || typeof sec.endSegIdx !== 'number') continue;
+    const unit: UnitRange = { tractate, page, startSegIdx: sec.startSegIdx, endSegIdx: sec.endSegIdx };
+    let voices: { edges?: { kind?: string }[] } | null = null;
+    if (voicesDef) {
+      const iid = await instanceIdOf(sec);
+      const vhit = await readCachedResult(env, keyForEnrichment(voicesDef, iid, { tractate, page }));
+      voices = (vhit?.parsed as { edges?: { kind?: string }[] }) ?? null;
+    }
+    profiles.push({ ...composeTypeProfile(unit, overlays, { voices }), title: typeof sec.fields?.title === 'string' ? sec.fields.title : undefined });
+  }
+  return profiles;
+}
+app.get('/api/studio/type-profiles/:tractate/:page', async (c) => {
+  const tractate = c.req.param('tractate');
+  const page = c.req.param('page');
+  const profiles = await buildDafTypeProfiles(c.env, tractate, page);
+  return c.json({ tractate, page, count: profiles.length, profiles });
 });
 
 app.get('/api/studio/enrichments', async (c) => {


### PR DESCRIPTION
Stacked on #54 (P1). Validates the deterministic composition on real content and makes it observable — the foundation P2 gating builds on. Read-only, no LLM, no render change for readers.

## What it adds
- **GET /api/studio/type-profiles/:tractate/:page** — composes a `TypeProfile` per argument section from the daf's CACHED marks (overlays halacha/aggadata/pesukim + base argument-move) and the section's cached `argument.voices` graph, via P1's `composeTypeProfile`.
- **TypeProfilePanel** (DevModeShelf, dev mode only) — per section: segment range, `primary` (color-coded), a ⚔ dispute marker, and the title.

## Validated on the four scanned dapim — matches the design
- **Gittin 68a (Ashmedai):** all sections `primary=aggadata` — the story that currently produces a "Demons" voice node is correctly narrative.
- **Berakhot 2a Stam Q&A** (5-7, 8-10): `primary=pure-dialectic`, not untyped.
- **Gittin 67b:** counting/כולכם disputes flagged; remedy stories [17-21] → aggadata.

## Finding that shapes P2
`isDispute` (derived from voices) is **noisy** — stories carry stray `opposes` edges, so Ashmedai [0-3] shows `dispute=Y` while being aggadata. The reliable router is **`primary`**, with the deterministic composition overriding the voices signal — exactly the design's "deterministic qualifier reconciles what a third LLM would do worse." So P2 should gate on `primary` (narrative-primary → narrative view; otherwise → voices), not raw `isDispute`.

62 files / 1307 tests, typecheck clean.