### PR TITLE
Section typing P2b: narrative story view + fix overview drill-in formatting

### DIFF
--- a/src/client/ArgumentNarrative.tsx
+++ b/src/client/ArgumentNarrative.tsx
@@ -1,0 +1,115 @@
+/**
+ * Story view for narrative-primary argument sections (section typing P2b). When
+ * a section types as a narrative (e.g. the Ashmedai/Solomon aggadah), the
+ * dispute-oriented voice graph is the wrong model, so the sidebar shows this
+ * instead: the actors (characters) and the ordered beats of the story, from the
+ * argument.narrative enrichment. Fetched on demand (dev mode only), so it costs
+ * an LLM call only when a dev opens a narrative section.
+ */
+
+import { createResource, For, Show, type JSX } from 'solid-js';
+import { lang } from './i18n';
+
+interface Actor { name: string; role: string }
+interface Beat { n: number; actor: string; action: string }
+interface NarrativeData { summary: string; actors: Actor[]; beats: Beat[] }
+
+const POLL_INTERVAL_MS = 1500;
+const POLL_TIMEOUT_MS = 90_000;
+
+async function pollJob(runId: string, cacheKey?: string): Promise<unknown> {
+  const start = Date.now();
+  const qs = cacheKey ? `?k=${encodeURIComponent(cacheKey)}` : '';
+  while (Date.now() - start < POLL_TIMEOUT_MS) {
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+    const res = await fetch(`/api/studio/run-status/${encodeURIComponent(runId)}${qs}`);
+    const j = await res.json() as { status?: string; result?: { parsed?: unknown }; error?: string };
+    if (j.status === 'ok') return j.result?.parsed;
+    if (j.status === 'error') throw new Error(j.error ?? 'narrative run failed');
+  }
+  throw new Error('narrative run timed out');
+}
+
+async function runNarrative(tractate: string, page: string, markInput: unknown): Promise<NarrativeData | null> {
+  const res = await fetch('/api/studio/run', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ enrichment_id: 'argument.narrative', tractate, page, mark_input: markInput, lang: lang() }),
+  });
+  const j = await res.json() as { status?: string; runId?: string; cacheKey?: string; result?: { parsed?: unknown }; error?: string };
+  let parsed: unknown;
+  if (j.status === 'ok') parsed = j.result?.parsed;
+  else if (j.status === 'pending' && j.runId) parsed = await pollJob(j.runId, j.cacheKey);
+  else if (j.status === 'error') throw new Error(j.error ?? 'narrative run failed');
+  else parsed = j.result?.parsed;
+  const p = parsed as NarrativeData | undefined;
+  return p && Array.isArray(p.beats) ? p : null;
+}
+
+const ROLE_COLOR: Record<string, string> = {
+  protagonist: '#0369a1', antagonist: '#b91c1c', authority: '#7c3aed', narrator: '#6b7280', other: '#6b7280',
+};
+
+export default function ArgumentNarrative(props: {
+  section: { startSegIdx?: number; endSegIdx?: number; title?: string };
+  tractate: string;
+  page: string;
+}): JSX.Element {
+  const [data] = createResource(
+    () => `${props.tractate}|${props.page}|${props.section.startSegIdx}-${props.section.endSegIdx}`,
+    () => runNarrative(props.tractate, props.page, props.section),
+  );
+
+  return (
+    <div style={{ 'margin-top': '0.6rem' }}>
+      <div style={{
+        'font-size': '0.7rem', 'text-transform': 'uppercase', 'letter-spacing': '0.08em',
+        color: '#999', 'margin-bottom': '0.4rem', display: 'flex', 'align-items': 'center', gap: '0.4rem',
+      }}>
+        Story
+        <span style={{ 'font-size': '0.6rem', color: '#7c3aed', background: '#f3e8ff', padding: '0 0.3rem', 'border-radius': '3px', 'text-transform': 'none', 'letter-spacing': 0 }}>narrative</span>
+      </div>
+
+      <Show when={data.loading}>
+        <div style={{ color: '#999', 'font-size': '0.8rem' }}>Composing the story…</div>
+      </Show>
+      <Show when={data.error}>
+        <div style={{ color: '#b45309', 'font-size': '0.78rem' }}>Couldn't load the narrative view.</div>
+      </Show>
+
+      <Show when={data()}>
+        {(d) => (
+          <>
+            <Show when={d().summary}>
+              <div style={{ 'font-size': '0.86rem', color: '#333', 'line-height': 1.6, 'margin-bottom': '0.6rem' }}>{d().summary}</div>
+            </Show>
+
+            <Show when={d().actors?.length > 0}>
+              <div style={{ display: 'flex', 'flex-wrap': 'wrap', gap: '0.35rem', 'margin-bottom': '0.7rem' }}>
+                <For each={d().actors}>{(a) => (
+                  <span style={{
+                    'font-size': '0.72rem', padding: '0.1rem 0.45rem', 'border-radius': '999px',
+                    border: `1px solid ${ROLE_COLOR[a.role] ?? '#ccc'}`, color: ROLE_COLOR[a.role] ?? '#666',
+                  }} title={a.role}>{a.name}</span>
+                )}</For>
+              </div>
+            </Show>
+
+            <Show when={d().beats?.length > 0}>
+              <ol style={{ margin: 0, padding: '0 0 0 1.2rem', display: 'flex', 'flex-direction': 'column', gap: '0.3rem' }}>
+                <For each={[...d().beats].sort((a, b) => a.n - b.n)}>{(b) => (
+                  <li style={{ 'font-size': '0.82rem', color: '#444', 'line-height': 1.5 }}>
+                    <Show when={b.actor}>
+                      <span style={{ 'font-weight': 600, color: '#222' }}>{b.actor}: </span>
+                    </Show>
+                    {b.action}
+                  </li>
+                )}</For>
+              </ol>
+            </Show>
+          </>
+        )}
+      </Show>
+    </div>
+  );
+}

--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -9,6 +9,7 @@ import RabbiLineageTree, { type RelationshipsData, type RelationshipsEvidence } 
 import { type GeographyData, type GeographyEvidence } from './RabbiGeographyCard';
 import RabbiPlacesTimeline, { type LocationInference } from './RabbiPlacesTimeline';
 import ArgumentVoiceMap, { type ArgumentVoicesData } from './ArgumentVoiceMap';
+import ArgumentNarrative from './ArgumentNarrative';
 import { devModeActive } from './DevModeShelf';
 import ArgumentFlowGraph, { type FlowConnection } from './ArgumentFlowGraph';
 import { selectSectionMoves } from '../lib/argumentMoves';
@@ -568,8 +569,10 @@ export function ArgumentBody(props: {
           </div>
         )}
       </Show>
-      <Show when={voicesData() && voicesGate.suppress()}>
-        <VoicesSuppressedNote profile={voicesGate.profile()} />
+      <Show when={voicesGate.suppress()}>
+        <Show when={voicesGate.profile()?.primary === 'aggadata'} fallback={<VoicesSuppressedNote profile={voicesGate.profile()} />}>
+          <ArgumentNarrative section={props.section} tractate={props.tractate} page={props.page} />
+        </Show>
       </Show>
       <Show when={sectionMoves()}>
         {(moves) => (
@@ -622,9 +625,10 @@ function OverviewSectionVoices(props: {
   };
   return (
     <div style={{ 'margin-top': '0.6rem', 'border-top': '1px dashed #e5e3dc', 'padding-top': '0.6rem' }}>
-      <Show when={props.section.summary}>
-        <HebrewProse size="0.85rem" color="#444" margin="0 0 0.5rem">{props.section.summary}</HebrewProse>
-      </Show>
+      {/* The section summary was rendered here via HebrewProse (RTL/centered),
+          which mis-styles the English summary AND duplicates the synthesis prose
+          below. Dropped — the Synthesis card is the single prose source, matching
+          the main section panel. */}
       <Synthesis
         markId="argument"
         instance={{
@@ -645,8 +649,10 @@ function OverviewSectionVoices(props: {
       <Show when={!voicesGate.suppress() && voices()}>
         {(data) => <ArgumentVoiceMap data={data()} onClickVoice={props.onPushRabbi} />}
       </Show>
-      <Show when={voices() && voicesGate.suppress()}>
-        <VoicesSuppressedNote profile={voicesGate.profile()} />
+      <Show when={voicesGate.suppress()}>
+        <Show when={voicesGate.profile()?.primary === 'aggadata'} fallback={<VoicesSuppressedNote profile={voicesGate.profile()} />}>
+          <ArgumentNarrative section={props.section} tractate={props.tractate} page={props.page} />
+        </Show>
       </Show>
     </div>
   );

--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -45,6 +45,7 @@ import {
   ARGUMENT_OUTPUT_SCHEMA,
   ARGUMENT_SYNTHESIS_OUTPUT_SCHEMA,
   ARGUMENT_VOICES_OUTPUT_SCHEMA,
+  ARGUMENT_NARRATIVE_OUTPUT_SCHEMA,
   ARGUMENT_OVERVIEW_FLOW_OUTPUT_SCHEMA,
   HALACHA_CODIFICATION_OUTPUT_SCHEMA,
   HALACHA_DISPUTES_OUTPUT_SCHEMA,
@@ -1737,6 +1738,43 @@ Rabbis identified on this daf (with generation):
 For each NAMED rabbi appearing in this section's moves, describe their argumentative role per the schema.`;
 
 
+// ---------------- argument.narrative (section typing P2b) ----------------
+// Story view for NARRATIVE-primary sections, where the dispute-oriented voices
+// graph is the wrong model (a maaseh/aggadah is not a מחלוקת). Actors + ordered
+// beats instead of opposing legal positions.
+
+const ARGUMENT_NARRATIVE_SYSTEM_PROMPT = `You are a Talmud scholar. This section of the daf is a NARRATIVE (a story / aggadah / מעשה), NOT a legal dispute. Retell it as a story — characters and what happens — never as opposing legal opinions.
+
+Output STRICT JSON only:
+
+{
+  "summary": "1-2 sentences: what happens in this story, in plain English.",
+  "actors": [{ "name": "Conventional English name of a character — a rabbi, a biblical/legendary figure, a collective ('the demons'), or 'Narrator' for the anonymous teller", "role": "protagonist | antagonist | authority | narrator | other" }],
+  "beats": [{ "n": 1, "actor": "which actor acts in this beat (MUST match a name in actors)", "action": "one sentence: what happens or is said, in narrative order" }]
+}
+
+Rules:
+- Order beats by their occurrence in the text (n = 1, 2, 3 …); each beat is one concrete event.
+- Actors are CHARACTERS in the story, not "voices in a dispute". Demons, kings, animals, and biblical figures are valid actors.
+- Do NOT invent opposing "sides" or legal positions — this is narrative, not שקלא וטריא.
+- Plain English; Hebrew script in parentheses for technical terms, never transliteration.
+
+${HEBREW_GLOSS_STYLE}`;
+
+const ARGUMENT_NARRATIVE_USER_TEMPLATE = `Tractate: {{tractate}}, page {{page}}.
+
+Section (a narrative):
+{{mark_input}}
+
+Moves / segments in THIS section, in order:
+{{anchors.argument-move}}
+
+Figures identified on this daf:
+{{anchors.rabbi}}
+
+Retell this section as a story per the schema: list the actors, then the ordered beats.`;
+
+
 // ---------------- argument.background (kept) ----------------
 
 const ARGUMENT_BACKGROUND_SYSTEM_PROMPT = `You are a Talmud scholar. Given one section of a daf and its Rashi/Tosafot context, write the background a reader needs to follow this section — concepts, prior sugyot, mishnaic backdrop.
@@ -1968,6 +2006,17 @@ CODE_ENRICHMENTS.push(
       model: ARGUMENT_FLASH_MODEL,
       systemPromptHe: ARGUMENT_VOICES_SYSTEM_PROMPT_HE,
       userPromptTemplateHe: ARGUMENT_VOICES_USER_TEMPLATE_HE,
+    },
+  ),
+  makeEnrichment(
+    'argument', 'argument.narrative', 'Narrative',
+    'Story view for narrative-primary sections: actors + ordered beats, instead of the dispute voice graph (section typing).',
+    ARGUMENT_NARRATIVE_SYSTEM_PROMPT, ARGUMENT_NARRATIVE_USER_TEMPLATE, ARGUMENT_NARRATIVE_OUTPUT_SCHEMA,
+    {
+      mode: 'augment-content', scope: 'local',
+      dependencies: ['gemara', { mark: 'argument-move' }, { mark: 'rabbi' }],
+      defHash: 'argument.narrative-v1', cacheVersion: '1',
+      model: ARGUMENT_FLASH_MODEL,
     },
   ),
   makeEnrichment(

--- a/src/worker/output-schemas.ts
+++ b/src/worker/output-schemas.ts
@@ -113,6 +113,21 @@ export const ARGUMENT_OVERVIEW_FLOW_OUTPUT_SCHEMA = responseFormat('argument_ove
     note: z.string(),
   })),
 }));
+// Section typing (P2b): a NARRATIVE view for story-primary sections, where the
+// dispute-oriented `voices` graph is the wrong model. Actors (characters) +
+// ordered beats (what happens, step by step) instead of opposing legal positions.
+export const ARGUMENT_NARRATIVE_OUTPUT_SCHEMA = responseFormat('argument_narrative', z.object({
+  summary: z.string(),
+  actors: z.array(z.object({
+    name: z.string(),
+    role: z.enum(['protagonist', 'antagonist', 'authority', 'narrator', 'other']),
+  })),
+  beats: z.array(z.object({
+    n: z.number().int().min(1),
+    actor: z.string(),
+    action: z.string(),
+  })),
+}));
 export const ARGUMENT_BACKGROUND_OUTPUT_SCHEMA = responseFormat('argument_background', single('background'));
 export const ARGUMENT_SYNTHESIS_OUTPUT_SCHEMA = responseFormat('argument_synthesis', single('synthesis'));
 

--- a/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
+++ b/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
@@ -15,6 +15,7 @@ exports[`CODE_ENRICHMENTS cache identity > per-enrichment fingerprint is stable 
   "argument-overview.flow@1 mode=augment-content scope=local mark=argument-overview schema=argument_overview_flow[connections] deps=[gemara|context|m:argument|m:rabbi]",
   "argument-overview.synthesis@2 mode=aggregate scope=local mark=argument-overview schema=argument_overview_synthesis[synthesis] deps=[gemara|context|e:argument-overview.flow|m:argument|m:rabbi]",
   "argument.background@4 mode=augment-content scope=local mark=argument schema=argument_background[background] deps=[gemara|commentaries|mishna|context]",
+  "argument.narrative@1 mode=augment-content scope=local mark=argument schema=argument_narrative[summary,actors,beats] deps=[gemara|m:argument-move|m:rabbi]",
   "argument.synthesis@10 mode=aggregate scope=local mark=argument schema=argument_synthesis[synthesis] deps=[gemara|commentaries|mishna|e:argument.voices|e:argument.background|m:rabbi|m:argument-move]",
   "argument.voices@5 mode=augment-content scope=local mark=argument schema=argument_voices[voices,edges] deps=[gemara|m:argument-move|m:rabbi]",
   "halacha.codification@3 mode=augment-content scope=local mark=halacha schema=halacha_codification[mishnehTorah,tur,shulchanAruch,rema,prose] deps=[gemara]",


### PR DESCRIPTION
Branched directly off the merged master (single PR, no stack). Completes the voices fix and addresses the two issues flagged on the Argument-map drill-in.

## Narrative story view (P2b)
For narrative-primary sections, the suppressed voice-dispute map is now replaced by a real **story view** instead of just a note:
- New **`argument.narrative`** enrichment (prompt + `ARGUMENT_NARRATIVE_OUTPUT_SCHEMA`): actors (character + role) and **ordered beats**, explicitly NOT framed as opposing legal positions. Deps gemara + argument-move + rabbi; Flash.
- **`ArgumentNarrative`** component fetches it on demand and renders summary + actor chips + an ordered beat list. Shown where `primary === 'aggadata'`; pure-dialectic sections keep the "not a dispute" note.

**Cost-safe:** runs only on-demand and only in dev mode (the render gate is dev-only); it's NOT in the deep-warm plan or the yomi warm set, so nothing warms it across the shas.

## Formatting fix
The experimental Argument-map drill-in (`OverviewSectionVoices`) rendered the section summary through `HebrewProse` (RTL/centered) even for English **and** duplicated the synthesis prose. Dropped — the Synthesis card is now the single prose source, matching the main section panel.

## Verification
1344 tests pass (enrichment snapshot updated), typecheck clean. Wiring verified in-browser (the Story view renders and replaces the suppression note); the live narrative output is verified post-deploy on prod's queue.