### PR TITLE
Drop dialectical move roles on narrative sections

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -325,9 +325,13 @@ function ArgumentMoveCard(props: {
   onPushRabbi: (name: string) => void;
   dafRabbis: IdentifiedRabbi[];
   generationByName: Map<string, GenerationId>;
+  /** Section typing: on a narrative-primary section the dialectical role
+   *  (question/answer/objection/…) is the wrong taxonomy, so we hide the role
+   *  chip and drop its color-coding. The story's flow is the beat list above. */
+  hideRole?: boolean;
 }): JSX.Element {
   const f = props.move.fields;
-  const roleColor = () => ROLE_COLORS[f.role] ?? '#64748b';
+  const roleColor = () => (props.hideRole ? '#cbd5e1' : (ROLE_COLORS[f.role] ?? '#64748b'));
   const isActive = () => props.highlightedMoveId === f.id;
   const toggleHighlight = () => props.onHighlightMove(isActive() ? null : props.move);
 
@@ -361,11 +365,13 @@ function ArgumentMoveCard(props: {
           display: 'flex', 'align-items': 'center', gap: '0.5rem',
           'margin-bottom': '0.3rem', 'font-size': '0.7rem',
         }}>
-          <span style={{
-            'text-transform': 'uppercase', 'letter-spacing': '0.06em',
-            'font-weight': 600, color: roleColor(),
-          }}>{moveKindLabel(f.role)}</span>
-          <span style={{ color: '#999' }}>·</span>
+          <Show when={!props.hideRole}>
+            <span style={{
+              'text-transform': 'uppercase', 'letter-spacing': '0.06em',
+              'font-weight': 600, color: roleColor(),
+            }}>{moveKindLabel(f.role)}</span>
+            <span style={{ color: '#999' }}>·</span>
+          </Show>
           <span style={{ color: '#555' }}>{f.voice}</span>
           <span style={{ color: '#bbb', 'font-size': '0.65rem', 'font-family': 'ui-monospace, Menlo, monospace' }}>
             seg {props.move.startSegIdx === props.move.endSegIdx ? props.move.startSegIdx : `${props.move.startSegIdx}–${props.move.endSegIdx}`}
@@ -583,7 +589,7 @@ export function ArgumentBody(props: {
               'letter-spacing': '0.08em',
               color: '#999',
               'margin-bottom': '0.5rem',
-            }}>{t('argument.moves')}</div>
+            }}>{voicesGate.profile()?.primary === 'aggadata' ? 'Passages' : t('argument.moves')}</div>
             <For each={moves()}>{(move) => (
               <ArgumentMoveCard
                 move={move}
@@ -596,6 +602,7 @@ export function ArgumentBody(props: {
                 onPushRabbi={props.onPushRabbi}
                 dafRabbis={props.dafRabbis}
                 generationByName={props.generationByName}
+                hideRole={voicesGate.profile()?.primary === 'aggadata'}
               />
             )}</For>
           </div>


### PR DESCRIPTION
Follow-up to P2b (#58). Addresses the second half of the review: the argument-move role enum (question/answer/objection/…) is dialectical and mislabels narrative beats as "questions"/"objections" on aggadic sections.

On narrative-primary sections (same type profile that gates the voices map):
- move cards **hide the role chip** and drop its color-coding (neutral left border);
- the section header reads **"Passages"** instead of "Moves".

The narrative view's ordered beat list above is the story's flow; the move cards remain as clickable, anchored text spans. Dispute/dialectical sections are unchanged. Dev-mode gated. 1344 tests pass, typecheck clean.

(Longer-term, a narrative-specific move role enum — scene/action/dialogue/turn — would let even the per-move layer speak the right language per type; deferred.)