### PR TITLE
Narrative move layer: typed, anchored, clickable beats

### DIFF
--- a/src/client/ArgumentNarrative.tsx
+++ b/src/client/ArgumentNarrative.tsx
@@ -7,12 +7,16 @@
  * an LLM call only when a dev opens a narrative section.
  */
 
-import { createResource, For, Show, type JSX } from 'solid-js';
+import { createResource, createSignal, For, Show, type JSX } from 'solid-js';
 import { lang } from './i18n';
 
 interface Actor { name: string; role: string }
-interface Beat { n: number; actor: string; action: string }
+interface Beat { n: number; kind?: string; actor: string; action: string; excerpt?: string; startSegIdx?: number; endSegIdx?: number; tokenStart?: number; tokenEnd?: number }
 interface NarrativeData { summary: string; actors: Actor[]; beats: Beat[] }
+
+const KIND_COLOR: Record<string, string> = {
+  scene: '#0369a1', action: '#15803d', dialogue: '#7c3aed', turn: '#b45309', resolution: '#be123c',
+};
 
 const POLL_INTERVAL_MS = 1500;
 const POLL_TIMEOUT_MS = 90_000;
@@ -54,11 +58,14 @@ export default function ArgumentNarrative(props: {
   section: { startSegIdx?: number; endSegIdx?: number; title?: string };
   tractate: string;
   page: string;
+  /** Highlight a beat's span on the daf (null clears). */
+  onHighlight?: (range: { start: number; end: number; tokenStart?: number; tokenEnd?: number } | null) => void;
 }): JSX.Element {
   const [data] = createResource(
     () => `${props.tractate}|${props.page}|${props.section.startSegIdx}-${props.section.endSegIdx}`,
     () => runNarrative(props.tractate, props.page, props.section),
   );
+  const [activeBeat, setActiveBeat] = createSignal<number | null>(null);
 
   return (
     <div style={{ 'margin-top': '0.6rem' }}>
@@ -96,15 +103,43 @@ export default function ArgumentNarrative(props: {
             </Show>
 
             <Show when={d().beats?.length > 0}>
-              <ol style={{ margin: 0, padding: '0 0 0 1.2rem', display: 'flex', 'flex-direction': 'column', gap: '0.3rem' }}>
-                <For each={[...d().beats].sort((a, b) => a.n - b.n)}>{(b) => (
-                  <li style={{ 'font-size': '0.82rem', color: '#444', 'line-height': 1.5 }}>
-                    <Show when={b.actor}>
-                      <span style={{ 'font-weight': 600, color: '#222' }}>{b.actor}: </span>
-                    </Show>
-                    {b.action}
-                  </li>
-                )}</For>
+              <ol style={{ margin: 0, padding: 0, 'list-style': 'none', display: 'flex', 'flex-direction': 'column', gap: '0.3rem' }}>
+                <For each={[...d().beats].sort((a, b) => a.n - b.n)}>{(b) => {
+                  const anchored = () => typeof b.startSegIdx === 'number';
+                  const isActive = () => activeBeat() === b.n;
+                  const toggle = () => {
+                    if (!anchored() || !props.onHighlight) return;
+                    const next = isActive() ? null : b.n;
+                    setActiveBeat(next);
+                    props.onHighlight(next === null ? null : { start: b.startSegIdx!, end: b.endSegIdx ?? b.startSegIdx!, tokenStart: b.tokenStart, tokenEnd: b.tokenEnd });
+                  };
+                  return (
+                    <li
+                      onClick={toggle}
+                      title={anchored() ? 'Highlight this beat on the daf' : undefined}
+                      style={{
+                        'font-size': '0.82rem', color: '#444', 'line-height': 1.5,
+                        display: 'flex', gap: '0.4rem', 'align-items': 'baseline',
+                        padding: '0.15rem 0.3rem', 'border-radius': '4px',
+                        cursor: anchored() ? 'pointer' : 'default',
+                        background: isActive() ? '#fff7ed' : 'transparent',
+                        'box-shadow': isActive() ? 'inset 2px 0 0 #ea580c' : 'none',
+                      }}
+                    >
+                      <span style={{ 'flex-shrink': 0, color: '#bbb', 'font-variant-numeric': 'tabular-nums', 'font-size': '0.72rem' }}>{b.n}</span>
+                      <Show when={b.kind}>
+                        <span style={{
+                          'flex-shrink': 0, 'font-size': '0.6rem', 'text-transform': 'uppercase', 'letter-spacing': '0.04em',
+                          color: KIND_COLOR[b.kind ?? ''] ?? '#888',
+                        }}>{b.kind}</span>
+                      </Show>
+                      <span>
+                        <Show when={b.actor}><span style={{ 'font-weight': 600, color: '#222' }}>{b.actor}: </span></Show>
+                        {b.action}
+                      </span>
+                    </li>
+                  );
+                }}</For>
               </ol>
             </Show>
           </>

--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -325,13 +325,9 @@ function ArgumentMoveCard(props: {
   onPushRabbi: (name: string) => void;
   dafRabbis: IdentifiedRabbi[];
   generationByName: Map<string, GenerationId>;
-  /** Section typing: on a narrative-primary section the dialectical role
-   *  (question/answer/objection/…) is the wrong taxonomy, so we hide the role
-   *  chip and drop its color-coding. The story's flow is the beat list above. */
-  hideRole?: boolean;
 }): JSX.Element {
   const f = props.move.fields;
-  const roleColor = () => (props.hideRole ? '#cbd5e1' : (ROLE_COLORS[f.role] ?? '#64748b'));
+  const roleColor = () => ROLE_COLORS[f.role] ?? '#64748b';
   const isActive = () => props.highlightedMoveId === f.id;
   const toggleHighlight = () => props.onHighlightMove(isActive() ? null : props.move);
 
@@ -365,13 +361,11 @@ function ArgumentMoveCard(props: {
           display: 'flex', 'align-items': 'center', gap: '0.5rem',
           'margin-bottom': '0.3rem', 'font-size': '0.7rem',
         }}>
-          <Show when={!props.hideRole}>
-            <span style={{
-              'text-transform': 'uppercase', 'letter-spacing': '0.06em',
-              'font-weight': 600, color: roleColor(),
-            }}>{moveKindLabel(f.role)}</span>
-            <span style={{ color: '#999' }}>·</span>
-          </Show>
+          <span style={{
+            'text-transform': 'uppercase', 'letter-spacing': '0.06em',
+            'font-weight': 600, color: roleColor(),
+          }}>{moveKindLabel(f.role)}</span>
+          <span style={{ color: '#999' }}>·</span>
           <span style={{ color: '#555' }}>{f.voice}</span>
           <span style={{ color: '#bbb', 'font-size': '0.65rem', 'font-family': 'ui-monospace, Menlo, monospace' }}>
             seg {props.move.startSegIdx === props.move.endSegIdx ? props.move.startSegIdx : `${props.move.startSegIdx}–${props.move.endSegIdx}`}
@@ -577,10 +571,17 @@ export function ArgumentBody(props: {
       </Show>
       <Show when={voicesGate.suppress()}>
         <Show when={voicesGate.profile()?.primary === 'aggadata'} fallback={<VoicesSuppressedNote profile={voicesGate.profile()} />}>
-          <ArgumentNarrative section={props.section} tractate={props.tractate} page={props.page} />
+          <ArgumentNarrative
+            section={props.section}
+            tractate={props.tractate}
+            page={props.page}
+            onHighlight={(r) => props.onHighlightRange(r ? { start: r.start, end: r.end, key: `beat-${r.start}-${r.tokenStart ?? 0}`, tokenStart: r.tokenStart, tokenEnd: r.tokenEnd } : null)}
+          />
         </Show>
       </Show>
-      <Show when={sectionMoves()}>
+      {/* Dialectical move list — hidden on narrative-primary sections, where the
+          anchored beat list in the narrative view above IS the move layer. */}
+      <Show when={voicesGate.profile()?.primary !== 'aggadata' && sectionMoves()}>
         {(moves) => (
           <div style={{ 'margin-top': '1rem' }}>
             <div style={{
@@ -589,7 +590,7 @@ export function ArgumentBody(props: {
               'letter-spacing': '0.08em',
               color: '#999',
               'margin-bottom': '0.5rem',
-            }}>{voicesGate.profile()?.primary === 'aggadata' ? 'Passages' : t('argument.moves')}</div>
+            }}>{t('argument.moves')}</div>
             <For each={moves()}>{(move) => (
               <ArgumentMoveCard
                 move={move}
@@ -602,7 +603,6 @@ export function ArgumentBody(props: {
                 onPushRabbi={props.onPushRabbi}
                 dafRabbis={props.dafRabbis}
                 generationByName={props.generationByName}
-                hideRole={voicesGate.profile()?.primary === 'aggadata'}
               />
             )}</For>
           </div>

--- a/src/lib/check/postcheck.ts
+++ b/src/lib/check/postcheck.ts
@@ -16,7 +16,7 @@
 
 import { lintSynthesis } from '../synthesisLint';
 import { lintHalachaParsed } from '../halachaLint';
-import { reanchorArgument, reanchorArgumentMove, reanchorPesukim, reanchorAggadata, reanchorRabbiEvidence } from '../place/reanchor';
+import { reanchorArgument, reanchorArgumentMove, reanchorPesukim, reanchorAggadata, reanchorRabbiEvidence, reanchorNarrative } from '../place/reanchor';
 import { normalizeHebrew } from '../place/verbatim';
 
 export type Severity = 'hard' | 'soft';
@@ -222,6 +222,7 @@ export const CHECKS: Record<string, PostCheck> = {
   'reanchor-pesukim': transform('reanchor-pesukim', reanchorPesukim),
   'reanchor-aggadata': transform('reanchor-aggadata', reanchorAggadata),
   'reanchor-rabbi-evidence': transform('reanchor-rabbi-evidence', reanchorRabbiEvidence),
+  'reanchor-narrative': transform('reanchor-narrative', reanchorNarrative),
   'hebrew-excerpt': hebrewExcerpt,
   'hebrew-gloss': hebrewGloss,
   'anchor-verbatim': anchorVerbatim,

--- a/src/lib/place/reanchor.ts
+++ b/src/lib/place/reanchor.ts
@@ -318,3 +318,38 @@ export function reanchorRabbiEvidence(parsed: unknown, segmentsHe: string[]): un
   }
   return obj;
 }
+
+// ---------------------------------------------------------------------------
+// argument.narrative beats (section typing P2b — narrative move layer)
+// ---------------------------------------------------------------------------
+
+/**
+ * Anchor each narrative beat to its segment via its verbatim `excerpt`, so the
+ * story beats become the narrative section's first-class, clickable move layer
+ * (parallel to argument-move for disputes). Same single-segment, whole-daf
+ * resolution as rabbi-evidence: beats sit at the top level under `beats`, each
+ * with a verbatim `excerpt`. Beats with no match keep their text but get no
+ * seg/token fields (rendered un-clickable).
+ */
+export function reanchorNarrative(parsed: unknown, segmentsHe: string[]): unknown {
+  if (!parsed || typeof parsed !== 'object') return parsed;
+  const obj = parsed as { beats?: unknown };
+  if (!Array.isArray(obj.beats)) return parsed;
+  if (segmentsHe.length === 0) return parsed;
+  const grid = buildVerbatimGrid(segmentsHe);
+
+  type Beat = { excerpt?: string; startSegIdx?: number; endSegIdx?: number; tokenStart?: number; tokenEnd?: number; [k: string]: unknown };
+  for (const b of obj.beats as Beat[]) {
+    if (!b || typeof b !== 'object') continue;
+    const ex = typeof b.excerpt === 'string' ? b.excerpt : '';
+    if (!ex) continue;
+    const hit = findExcerpt(grid, ex, 0, segmentsHe.length - 1);
+    if (hit) {
+      b.startSegIdx = hit.seg;
+      b.endSegIdx = hit.seg;
+      b.tokenStart = hit.tok;
+      b.tokenEnd = hit.tok + hit.matchLen - 1;
+    }
+  }
+  return obj;
+}

--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -1750,14 +1750,16 @@ Output STRICT JSON only:
 {
   "summary": "1-2 sentences: what happens in this story, in plain English.",
   "actors": [{ "name": "Conventional English name of a character — a rabbi, a biblical/legendary figure, a collective ('the demons'), or 'Narrator' for the anonymous teller", "role": "protagonist | antagonist | authority | narrator | other" }],
-  "beats": [{ "n": 1, "actor": "which actor acts in this beat (MUST match a name in actors)", "action": "one sentence: what happens or is said, in narrative order" }]
+  "beats": [{ "n": 1, "kind": "scene | action | dialogue | turn | resolution", "actor": "which actor acts in this beat (MUST match a name in actors)", "action": "one sentence: what happens or is said, in narrative order", "excerpt": "3-7 Hebrew/Aramaic words copied VERBATIM from the daf where this beat begins" }]
 }
 
 Rules:
 - Order beats by their occurrence in the text (n = 1, 2, 3 …); each beat is one concrete event.
-- Actors are CHARACTERS in the story, not "voices in a dispute". Demons, kings, animals, and biblical figures are valid actors.
-- Do NOT invent opposing "sides" or legal positions — this is narrative, not שקלא וטריא.
-- Plain English; Hebrew script in parentheses for technical terms, never transliteration.
+- "kind" is a NARRATIVE role, never a dialectical one: scene (sets the setting), action (something happens), dialogue (a character speaks), turn (a reversal/twist), resolution (how it ends). NEVER use question/answer/objection — this is a story, not שקלא וטריא.
+- "excerpt" MUST be copied verbatim from the daf text (the opening words of the beat), so the beat can be located on the page. Do not paraphrase or translate it.
+- Actors are CHARACTERS in the story. Demons, kings, animals, and biblical figures are valid actors.
+- Do NOT invent opposing "sides" or legal positions.
+- Plain English for "action"; Hebrew script in parentheses for technical terms, never transliteration.
 
 ${HEBREW_GLOSS_STYLE}`;
 
@@ -2015,7 +2017,8 @@ CODE_ENRICHMENTS.push(
     {
       mode: 'augment-content', scope: 'local',
       dependencies: ['gemara', { mark: 'argument-move' }, { mark: 'rabbi' }],
-      defHash: 'argument.narrative-v1', cacheVersion: '1',
+      checks: ['reanchor-narrative'],
+      defHash: 'argument.narrative-v2', cacheVersion: '2',
       model: ARGUMENT_FLASH_MODEL,
     },
   ),

--- a/src/worker/output-schemas.ts
+++ b/src/worker/output-schemas.ts
@@ -122,10 +122,15 @@ export const ARGUMENT_NARRATIVE_OUTPUT_SCHEMA = responseFormat('argument_narrati
     name: z.string(),
     role: z.enum(['protagonist', 'antagonist', 'authority', 'narrator', 'other']),
   })),
+  // Each beat carries a NARRATIVE kind (not a dialectical role) and a verbatim
+  // Hebrew `excerpt` so the worker can anchor the beat to its segment — making
+  // the beats the narrative section's first-class, clickable move layer.
   beats: z.array(z.object({
     n: z.number().int().min(1),
+    kind: z.enum(['scene', 'action', 'dialogue', 'turn', 'resolution']),
     actor: z.string(),
     action: z.string(),
+    excerpt: z.string(),
   })),
 }));
 export const ARGUMENT_BACKGROUND_OUTPUT_SCHEMA = responseFormat('argument_background', single('background'));

--- a/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
+++ b/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
@@ -15,7 +15,7 @@ exports[`CODE_ENRICHMENTS cache identity > per-enrichment fingerprint is stable 
   "argument-overview.flow@1 mode=augment-content scope=local mark=argument-overview schema=argument_overview_flow[connections] deps=[gemara|context|m:argument|m:rabbi]",
   "argument-overview.synthesis@2 mode=aggregate scope=local mark=argument-overview schema=argument_overview_synthesis[synthesis] deps=[gemara|context|e:argument-overview.flow|m:argument|m:rabbi]",
   "argument.background@4 mode=augment-content scope=local mark=argument schema=argument_background[background] deps=[gemara|commentaries|mishna|context]",
-  "argument.narrative@1 mode=augment-content scope=local mark=argument schema=argument_narrative[summary,actors,beats] deps=[gemara|m:argument-move|m:rabbi]",
+  "argument.narrative@2 mode=augment-content scope=local mark=argument schema=argument_narrative[summary,actors,beats] deps=[gemara|m:argument-move|m:rabbi]",
   "argument.synthesis@10 mode=aggregate scope=local mark=argument schema=argument_synthesis[synthesis] deps=[gemara|commentaries|mishna|e:argument.voices|e:argument.background|m:rabbi|m:argument-move]",
   "argument.voices@5 mode=augment-content scope=local mark=argument schema=argument_voices[voices,edges] deps=[gemara|m:argument-move|m:rabbi]",
   "halacha.codification@3 mode=augment-content scope=local mark=halacha schema=halacha_codification[mishnehTorah,tur,shulchanAruch,rema,prose] deps=[gemara]",

--- a/tests/place/reanchor-narrative.test.ts
+++ b/tests/place/reanchor-narrative.test.ts
@@ -1,0 +1,46 @@
+/**
+ * reanchorNarrative — anchors argument.narrative beats to their segment via the
+ * verbatim `excerpt`, making the story beats a clickable narrative move layer.
+ * Same single-segment, whole-daf resolution as rabbi-evidence.
+ */
+import { describe, it, expect } from 'vitest';
+import { reanchorNarrative } from '../../src/lib/place/reanchor';
+
+const SEGS = [
+  'אמר רבא אמר רב נחמן',
+  'תנו רבנן המביא גט ממדינת הים',
+  'רבי יוחנן ורבי שמעון בן לקיש',
+];
+const run = (beats: unknown[]) => reanchorNarrative({ summary: 's', actors: [], beats }, SEGS) as { beats: Record<string, unknown>[] };
+
+describe('reanchorNarrative', () => {
+  it('anchors each beat to the segment of its verbatim excerpt', () => {
+    const { beats } = run([
+      { n: 1, kind: 'scene', actor: 'A', action: 'x', excerpt: 'אמר רבא' },
+      { n: 2, kind: 'dialogue', actor: 'B', action: 'y', excerpt: 'רבי יוחנן ורבי שמעון' },
+    ]);
+    expect(beats[0]).toMatchObject({ startSegIdx: 0, endSegIdx: 0, tokenStart: 0, tokenEnd: 1 });
+    expect(beats[1]).toMatchObject({ startSegIdx: 2, endSegIdx: 2, tokenStart: 0, tokenEnd: 3 });
+  });
+
+  it('ignores nikud/punctuation and a non-zero token offset', () => {
+    const { beats } = run([{ n: 1, kind: 'turn', actor: 'A', action: 'x', excerpt: 'אָמַר, רַב נַחְמָן' }]);
+    expect(beats[0]).toMatchObject({ startSegIdx: 0, tokenStart: 2 }); // "אמר רב נחמן" at words 2..4
+  });
+
+  it('leaves a beat with no/short/unmatched excerpt unanchored', () => {
+    const { beats } = run([
+      { n: 1, kind: 'scene', actor: 'A', action: 'x' },                       // no excerpt
+      { n: 2, kind: 'action', actor: 'A', action: 'y', excerpt: 'רבנן' },     // 1 word
+      { n: 3, kind: 'action', actor: 'A', action: 'z', excerpt: 'מילה שאיננה' }, // no match
+    ]);
+    for (const b of beats) expect(b.startSegIdx).toBeUndefined();
+  });
+
+  it('is a no-op without a beats array or segments', () => {
+    expect(reanchorNarrative({ foo: 1 }, SEGS)).toEqual({ foo: 1 });
+    const same = { beats: [{ excerpt: 'תנו רבנן' }] };
+    expect(reanchorNarrative(same, [])).toBe(same);
+    expect((same.beats[0] as Record<string, unknown>).startSegIdx).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Follow-up to #58/#59 — the deeper half of the review: a narrative-specific move layer so the per-move level speaks the right language on aggadic sections.

- `argument.narrative` beats now carry a **narrative kind** (`scene | action | dialogue | turn | resolution`) + a verbatim Hebrew `excerpt`. Schema + prompt updated; **cache_version → v2**.
- **`reanchorNarrative`** (new `reanchor-narrative` transform check) anchors each beat to its segment + token offsets (whole-daf resolution, same as rabbi-evidence) — beats become first-class, locatable moves.
- `ArgumentNarrative` renders each beat with its kind chip and **click-to-highlight on the daf** when anchored.
- On narrative-primary sections the **dialectical move list is hidden** (beats are the move layer); reverted #59's now-redundant `hideRole`/"Passages" stopgap.

Cost-safe (on-demand, dev-gated, not in deep-warm). 1348 tests pass (incl. `tests/place/reanchor-narrative.test.ts`), typecheck clean.