### PR TITLE
Make anchor-verbatim check mirror the placer's prefix matcher

### DIFF
--- a/src/lib/check/postcheck.ts
+++ b/src/lib/check/postcheck.ts
@@ -17,7 +17,7 @@
 import { lintSynthesis } from '../synthesisLint';
 import { lintHalachaParsed } from '../halachaLint';
 import { reanchorArgument, reanchorArgumentMove, reanchorPesukim, reanchorAggadata, reanchorRabbiEvidence } from '../place/reanchor';
-import { normalizeHebrew } from '../place/verbatim';
+import { normalizeHebrew, buildVerbatimGrid, findExcerpt } from '../place/verbatim';
 
 export type Severity = 'hard' | 'soft';
 
@@ -108,28 +108,42 @@ function instancesOf(parsed: unknown): RangeInstance[] {
   return Array.isArray(arr) ? (arr as RangeInstance[]) : [];
 }
 
-/** anchor-verbatim — the instance's verbatim `excerpt` is actually present
- *  (as a normalized substring) in the segment it was anchored to. Catches
- *  hallucinations and prefix-only fallbacks where the re-anchorer landed on a
- *  segment that doesn't literally contain the claimed text. Skips instances
- *  with no excerpt or a <2-word excerpt (too short to verify meaningfully). */
+/** anchor-verbatim — the instance's `excerpt` can actually be located in the
+ *  segment it was anchored to, USING THE SAME MATCHER THAT PLACED IT. The
+ *  re-anchorers (reanchorArgumentMove / -Pesukim / -Aggadata) call findExcerpt,
+ *  which anchors on the longest matching prefix of the excerpt (full → 4 → 3 →
+ *  2 words) — so a lightly-paraphrased tail, or a quote that spills into the
+ *  next segment, still legitimately anchors on its opening words. Re-running
+ *  findExcerpt against the single anchored segment reproduces that decision:
+ *  a hit means the placer had a real reason to land here; a miss means the
+ *  excerpt reached this segment only via the fallback bump (prevMatchSeg+1 /
+ *  section start), i.e. it is genuinely mis-anchored (or hallucinated).
+ *
+ *  This deliberately mirrors the placer instead of demanding a full contiguous
+ *  substring: the old `segNorm.includes(fullExcerpt)` test flagged every
+ *  prefix-anchored placement as `excerpt-not-in-segment`, which on real dapim
+ *  was ~40% false positives (correct anchors whose phrase merely isn't
+ *  contiguous). Skips instances with no excerpt or a <2-word excerpt (findExcerpt
+ *  itself rejects <2-word needles as too ambiguous). */
 const anchorVerbatim: PostCheck = {
   id: 'anchor-verbatim',
   phase: 'validate',
   run: (parsed, ctx) => {
     const issues: CheckIssue[] = [];
     const segs = ctx.segmentsHe;
+    const grid = buildVerbatimGrid(segs);
     for (const inst of instancesOf(parsed)) {
       const excerpt = inst.fields?.excerpt;
       if (typeof excerpt !== 'string' || !excerpt) continue;
-      const normEx = normalizeHebrew(excerpt);
-      if (normEx.split(' ').filter(Boolean).length < 2) continue;
+      if (normalizeHebrew(excerpt).split(' ').filter(Boolean).length < 2) continue;
       const seg = inst.startSegIdx;
       if (typeof seg !== 'number' || seg < 0 || seg >= segs.length) {
         issues.push({ kind: 'anchor-out-of-range', severity: 'soft', match: excerpt, index: typeof seg === 'number' ? seg : -1 });
         continue;
       }
-      if (!normalizeHebrew(segs[seg]).includes(normEx)) {
+      // Confine the search to the single anchored segment: a hit there is the
+      // same prefix the placer would have matched to land on this segment.
+      if (!findExcerpt(grid, excerpt, seg, seg)) {
         issues.push({ kind: 'excerpt-not-in-segment', severity: 'soft', match: excerpt, index: seg });
       }
     }

--- a/tests/check/soft-checks.test.ts
+++ b/tests/check/soft-checks.test.ts
@@ -47,6 +47,39 @@ describe('anchor-verbatim', () => {
     const { issues } = await runChecks(['anchor-verbatim'], parsed, ctx({ segmentsHe: segs, defId: 'argument' }));
     expect(issues).toEqual([]);
   });
+
+  // The check must mirror the placer (findExcerpt), which anchors on the
+  // longest matching PREFIX of the excerpt (full -> 4 -> 3 -> 2 words). A
+  // lightly-paraphrased tail or a quote spilling past the segment still
+  // anchors correctly on its opening words, so it must NOT be flagged — that
+  // was ~40% of the old check's flags on real dapim (false positives).
+  it('does NOT flag when the excerpt opening (>=2-word prefix) is present but the full phrase is not contiguous', async () => {
+    // seg1 is "תנו רבנן המביא גט"; the excerpt opens on it but its tail
+    // ("בידו פסול") spills past the segment / is paraphrased.
+    const parsed = { instances: [{ startSegIdx: 1, fields: { excerpt: 'תנו רבנן המביא גט בידו פסול' } }] };
+    const { issues } = await runChecks(['anchor-verbatim'], parsed, ctx({ segmentsHe: segs, defId: 'argument-move' }));
+    expect(issues).toEqual([]);
+  });
+
+  it('still flags when not even a 2-word opening prefix is present (fallback-bumped / hallucinated)', async () => {
+    // Opening words absent from seg2 -> the placer could only have reached
+    // seg2 via the fallback bump. This is the real Pesachim-60b pile-up shape:
+    // moves clamped onto the section start whose text lives further down.
+    const parsed = { instances: [{ startSegIdx: 2, fields: { excerpt: 'תנו רבנן המביא גט' } }] };
+    const { issues } = await runChecks(['anchor-verbatim'], parsed, ctx({ segmentsHe: segs, defId: 'argument-move' }));
+    expect(kinds(issues)).toEqual(['excerpt-not-in-segment']);
+    expect(issues[0].index).toBe(2);
+    expect(allSoft(issues)).toBe(true);
+  });
+
+  it('does not leak a prefix match from a neighbouring segment (search confined to the anchored segment)', async () => {
+    // "אמר רבא" lives in seg2, NOT seg1. Anchoring it to seg1 must still flag,
+    // even though a different segment contains the prefix.
+    const parsed = { instances: [{ startSegIdx: 1, fields: { excerpt: 'אמר רבא הלכה' } }] };
+    const { issues } = await runChecks(['anchor-verbatim'], parsed, ctx({ segmentsHe: segs, defId: 'argument-move' }));
+    expect(kinds(issues)).toEqual(['excerpt-not-in-segment']);
+    expect(issues[0].index).toBe(1);
+  });
 });
 
 describe('partition-clean', () => {


### PR DESCRIPTION
## What

The soft `anchor-verbatim` check flagged `excerpt-not-in-segment` whenever the **full** normalized excerpt was not a contiguous substring of `seg[startSegIdx]`. But the re-anchorers that placed those instances (`reanchorArgumentMove` / `-Pesukim` / `-Aggadata` via `findExcerpt`) anchor on the **longest matching prefix** of the excerpt (full → 4 → 3 → 2 words). So a lightly-paraphrased tail, or a quote that spills into the next segment, still legitimately anchors on its opening words — yet the full-substring test flagged it.

## Why it matters

Auditing the prod `/api/studio/checks` endpoint across 216 warmed dapim: of 334 `excerpt-not-in-segment` flags, ~37% were false positives of exactly this kind (correct placements whose phrase merely isn't contiguous, e.g. the `אֲמַר לֵיהּ: …` colon forms). That noise is what kept this check from being promotable to a hard, cache-gating check.

## Fix

Re-run `findExcerpt` against the single anchored segment. A hit means the placer had a real reason to land here; a miss means the excerpt reached the segment only via the fallback bump (`prevMatchSeg+1` / section start) and is genuinely mis-anchored (or hallucinated).

## Validation

Ran the new code over 40 cached dapim (old full-substring vs new prefix-aware):
- **95 → 76 flags**, **0 added** — NEW is a strict subset of OLD (invariant: a full-substring match implies a prefix match).
- Every one of the 19 removed flags confirmed to have a valid ≥2-word opening prefix in its segment (correct removal).
- Real misses still flagged (e.g. Berakhot 30b section drifts; the Pesachim 60b doubled-partition pile-up where 6 moves clamp onto seg2 while their text spans seg3–8).

## Tests

Extended `tests/check/soft-checks.test.ts`: prefix-present-but-not-contiguous now passes; no-prefix (fallback-bumped) still flags; prefix in a *neighbouring* segment does not leak (search confined to the anchored segment).

## Note (separate, not fixed here)

The retained Pesachim-60b pile-up is a real upstream bug — the `argument` mark emits a doubled partition (a bogus 1-segment section `[2,2]` alongside the correct fine sections), and `reanchorArgumentMove` clamps the orphaned moves onto the section start. Worth a follow-up; this PR just makes the check trustworthy enough to surface it cleanly.