### PR TITLE
Promote section typing to readers + pre-warm the narrative view

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -10,7 +10,6 @@ import { type GeographyData, type GeographyEvidence } from './RabbiGeographyCard
 import RabbiPlacesTimeline, { type LocationInference } from './RabbiPlacesTimeline';
 import ArgumentVoiceMap, { type ArgumentVoicesData } from './ArgumentVoiceMap';
 import ArgumentNarrative from './ArgumentNarrative';
-import { devModeActive } from './DevModeShelf';
 import ArgumentFlowGraph, { type FlowConnection } from './ArgumentFlowGraph';
 import { selectSectionMoves } from '../lib/argumentMoves';
 import { t, lang } from './i18n';
@@ -98,7 +97,9 @@ function useVoicesGate(tractate: () => string, page: () => string, section: () =
     return (profiles() ?? []).find((p) => p.unit.startSegIdx === s.startSegIdx && p.unit.endSegIdx === s.endSegIdx);
   };
   const suppress = (): boolean => {
-    if (!devModeActive()) return false;            // readers unaffected
+    // Promoted to readers: section typing now drives the view for everyone, not
+    // just dev mode. Safe-by-default — an unknown/uncomputed profile shows the
+    // voice graph exactly as before, so a missing profile never regresses.
     const p = profile();
     if (!p) return false;                          // unknown → show (safe default)
     return !(p.isDispute && p.primary !== 'aggadata'); // hide unless a real, non-narrative dispute

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -6563,6 +6563,34 @@ async function deepWarmDaf(
       }
     }
   }
+
+  // Section typing: pre-warm the narrative story view, but ONLY for sections
+  // that actually type as narrative (aggadata-primary). The marks are now run +
+  // cached above, so the profile composition is a cache-only read. Without this,
+  // a reader is the first to trigger argument.narrative on a story section (cold
+  // generation); with it, the story view is usually a cache hit.
+  try {
+    const narrativeDef = await loadEnrichmentDef(rc.env, 'argument.narrative');
+    if (narrativeDef) {
+      const profiles = await buildDafTypeProfiles(rc.env, tractate, page);
+      const sections = await readMarkInstances(rc.env, 'argument', tractate, page);
+      for (const prof of profiles) {
+        if (prof.primary !== 'aggadata') continue;
+        const sec = sections.find((s) => s.startSegIdx === prof.unit.startSegIdx && s.endSegIdx === prof.unit.endSegIdx);
+        if (!sec) continue;
+        const iid = await instanceIdOf(sec);
+        const key = keyForEnrichment(narrativeDef, iid, { tractate, page }, undefined, lang);
+        if (key && cache && (await cache.get(key))) { skipped++; continue; }
+        const runId = `warm:argument.narrative:${tractate}:${page}:${iid}:${lang}:${Math.floor(Date.now() / 1000)}`
+          .replace(/[^a-zA-Z0-9._:-]+/g, '_').slice(0, 200);
+        try {
+          await queue.send({ runId, enrichment_id: 'argument.narrative', tractate, page, mark_input: sec, ...(lang === 'he' ? { lang } : {}) });
+          enqueued++;
+        } catch { /* best-effort warm */ }
+      }
+    }
+  } catch { /* profile composition is best-effort; never block the deep-warm */ }
+
   return { marks, enqueued, skipped };
 }
 

--- a/src/worker/yomi-cron.ts
+++ b/src/worker/yomi-cron.ts
@@ -149,6 +149,22 @@ export async function runYomiWarmCron(env: YomiCronEnv): Promise<void> {
           console.error(`[yomi-cron] enqueue rabbi.observations ${tractate}/${page} failed:`, e);
         }),
     );
+    // Deep-warm the daf so the section-typing views are ready for the daf-yomi
+    // crowd — notably argument.narrative on story sections, which the deep-warm
+    // path pre-warms only for narrative-primary sections (cache-respecting, so
+    // the marks above are reused, not re-paid). One full deep-warm per daily daf.
+    const deepRunId = (await warmRunId('warm-deep', tractate, page)).replace(/[^a-zA-Z0-9._:-]+/g, '_').slice(0, 200);
+    jobs.push(
+      env.ENRICHMENT_QUEUE.send({ runId: deepRunId, warm_deep: true, tractate, page })
+        .then(() => {
+          // eslint-disable-next-line no-console
+          console.log(`[yomi-cron] enqueued deep-warm ${tractate}/${page} runId=${deepRunId}`);
+        })
+        .catch((e) => {
+          // eslint-disable-next-line no-console
+          console.error(`[yomi-cron] enqueue deep-warm ${tractate}/${page} failed:`, e);
+        }),
+    );
   }
   await Promise.allSettled(jobs);
   // eslint-disable-next-line no-console


### PR DESCRIPTION
#2 of the set. Promotes the section-typing views from dev-mode to all readers, and pre-warms the narrative story view so readers hit a cache, not a cold generation.

- **Promote:** drop the dev-mode gate on the view router; safe-by-default (unknown profile -> voice graph, as before, so unwarmed dapim never regress).
- **Pre-warm:** `deepWarmDaf` enqueues `argument.narrative` only for narrative-primary sections (profile composed from the marks it already ran, cache-only); `yomi-cron` deep-warms tomorrow's daf-yomi page.

1351 tests pass, typecheck clean. Reversible by restoring the gate.