### PR TITLE
Sugya stitching: group sections into cross-daf discussion units (#3 foundation)

### DIFF
--- a/src/lib/typing/sugya.ts
+++ b/src/lib/typing/sugya.ts
@@ -1,0 +1,101 @@
+/**
+ * @fileoverview Sugya stitching — group argument sections into continuous
+ * discussion units (sugyot), across daf boundaries, deterministically.
+ *
+ * Section typing types each section; the argument-overview flow relates sections
+ * to each other (continues / resolves / depends-on / parallels / …). A *sugya*
+ * is a maximal run of sections joined by "same-thread" flow edges — and it can
+ * straddle dapim (Shabbat 125b–126b). This module is the deterministic core of
+ * the cross-page sugya map: given section coordinates (in cross-daf coord.ts
+ * coordinates) and flow edges, it returns the connected sugya units.
+ *
+ * It is pure graph grouping (union-find over the binding edges) — no LLM. The
+ * hard, separate problem is *producing* the cross-daf flow edges (the
+ * boundary-finder, a later pass); once those exist, the grouping is exactly
+ * this. Lives in src/lib, DOM-free, unit-testable.
+ */
+
+import { type AnchorCoord, type AnchorSpan, coordKey, normalizeSpan, spanByDaf } from '../context/coord.ts';
+
+export type SugyaFlowKind = 'continues' | 'resolves' | 'depends-on' | 'parallels' | 'contrasts' | 'generalizes' | 'cites';
+
+/** A flow relation between two sections (each a cross-daf coordinate). */
+export interface SugyaFlowEdge {
+  from: AnchorCoord;
+  to: AnchorCoord;
+  kind: SugyaFlowKind | string;
+}
+
+export interface SugyaUnit {
+  /** Every section coordinate in this sugya, normalized (deduped + ordered). */
+  span: AnchorSpan;
+  /** Per-daf section lists, ordered — the cross-page map's row model. */
+  dapim: { tractate: string; page: string; segs: number[] }[];
+  /** True when the sugya straddles more than one daf. */
+  crossesDaf: boolean;
+}
+
+/** Flow kinds that join two sections into ONE continuous sugya thread. The
+ *  others (parallels / contrasts / generalizes / cites) are cross-references
+ *  between distinct sugyot, so they don't merge. Tunable per call. */
+export const SUGYA_BINDING_KINDS: ReadonlySet<string> = new Set(['continues', 'resolves', 'depends-on']);
+
+/**
+ * Group `sections` into sugya units: maximal connected components over the
+ * binding flow edges. Sections with no binding edge are their own singleton
+ * sugya. Edges whose endpoints aren't in `sections` are ignored. Deterministic:
+ * components and their contents are returned in stable coordinate order.
+ */
+export function stitchSugyot(
+  sections: readonly AnchorCoord[],
+  edges: readonly SugyaFlowEdge[],
+  opts: { bindingKinds?: ReadonlySet<string> } = {},
+): SugyaUnit[] {
+  const binding = opts.bindingKinds ?? SUGYA_BINDING_KINDS;
+
+  // Dedupe section coords by key; keep one coord per key.
+  const coordByKey = new Map<string, AnchorCoord>();
+  for (const c of sections) {
+    const k = coordKey(c);
+    if (!coordByKey.has(k)) coordByKey.set(k, c);
+  }
+
+  // Union-find over the section keys.
+  const parent = new Map<string, string>();
+  for (const k of coordByKey.keys()) parent.set(k, k);
+  const find = (x: string): string => {
+    let r = x;
+    while (parent.get(r) !== r) r = parent.get(r)!;
+    while (parent.get(x) !== r) { const n = parent.get(x)!; parent.set(x, r); x = n; }
+    return r;
+  };
+  const union = (a: string, b: string) => {
+    const ra = find(a), rb = find(b);
+    if (ra !== rb) parent.set(ra > rb ? ra : rb, ra > rb ? rb : ra); // smaller key as root → stable
+  };
+
+  for (const e of edges) {
+    if (!binding.has(e.kind)) continue;
+    const a = coordKey(e.from), b = coordKey(e.to);
+    if (a === b || !parent.has(a) || !parent.has(b)) continue;
+    union(a, b);
+  }
+
+  // Gather components.
+  const groups = new Map<string, AnchorCoord[]>();
+  for (const k of coordByKey.keys()) {
+    const root = find(k);
+    const g = groups.get(root) ?? [];
+    g.push(coordByKey.get(k)!);
+    groups.set(root, g);
+  }
+
+  const units: SugyaUnit[] = [...groups.values()].map((coords) => {
+    const span = normalizeSpan(coords);
+    const dapim = spanByDaf(span);
+    return { span, dapim, crossesDaf: dapim.length > 1 };
+  });
+  // Stable order: by the first (normalized) coordinate of each sugya.
+  units.sort((u, v) => coordKey(u.span[0]).localeCompare(coordKey(v.span[0])));
+  return units;
+}

--- a/tests/typing/sugya.test.ts
+++ b/tests/typing/sugya.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Sugya stitching (src/lib/typing/sugya.ts): group argument sections into
+ * connected discussion units across daf boundaries, over the binding flow edges.
+ */
+import { describe, it, expect } from 'vitest';
+import { stitchSugyot, SUGYA_BINDING_KINDS, type SugyaFlowEdge } from '../../src/lib/typing/sugya';
+import { coordForSeg } from '../../src/lib/context/coord';
+
+const S125 = { tractate: 'Shabbat', page: '125b' };
+const S126 = { tractate: 'Shabbat', page: '126a' };
+
+describe('stitchSugyot', () => {
+  it('returns no units for no sections', () => {
+    expect(stitchSugyot([], [])).toEqual([]);
+  });
+
+  it('makes each section its own singleton sugya when there are no edges', () => {
+    const units = stitchSugyot([coordForSeg(S125, 0), coordForSeg(S125, 5)], []);
+    expect(units).toHaveLength(2);
+    expect(units.every((u) => !u.crossesDaf)).toBe(true);
+  });
+
+  it('joins sections across a daf boundary on a "continues" edge', () => {
+    const a = coordForSeg(S125, 0), b = coordForSeg(S125, 5), c = coordForSeg(S126, 0);
+    const units = stitchSugyot([a, b, c], [{ from: b, to: c, kind: 'continues' }]);
+    expect(units).toHaveLength(2); // {a} and {b,c}
+    const cross = units.find((u) => u.crossesDaf)!;
+    expect(cross.span).toEqual([
+      { tractate: 'Shabbat', page: '125b', seg: 5 },
+      { tractate: 'Shabbat', page: '126a', seg: 0 },
+    ]);
+    expect(cross.dapim).toEqual([
+      { tractate: 'Shabbat', page: '125b', segs: [5] },
+      { tractate: 'Shabbat', page: '126a', segs: [0] },
+    ]);
+  });
+
+  it('merges a transitive chain into one sugya', () => {
+    const a = coordForSeg(S125, 0), b = coordForSeg(S125, 3), c = coordForSeg(S126, 0);
+    const edges: SugyaFlowEdge[] = [
+      { from: a, to: b, kind: 'continues' },
+      { from: b, to: c, kind: 'resolves' },
+    ];
+    const units = stitchSugyot([a, b, c], edges);
+    expect(units).toHaveLength(1);
+    expect(units[0].span).toHaveLength(3);
+    expect(units[0].crossesDaf).toBe(true);
+  });
+
+  it('binds on resolves / depends-on but NOT on parallels / contrasts / cites', () => {
+    const a = coordForSeg(S125, 0), b = coordForSeg(S125, 5);
+    expect(stitchSugyot([a, b], [{ from: a, to: b, kind: 'depends-on' }])).toHaveLength(1);
+    expect(stitchSugyot([a, b], [{ from: a, to: b, kind: 'parallels' }])).toHaveLength(2);
+    expect(stitchSugyot([a, b], [{ from: a, to: b, kind: 'cites' }])).toHaveLength(2);
+    expect(stitchSugyot([a, b], [{ from: a, to: b, kind: 'contrasts' }])).toHaveLength(2);
+  });
+
+  it('ignores edges whose endpoints are not in the section set', () => {
+    const a = coordForSeg(S125, 0), b = coordForSeg(S125, 5);
+    const ghost = coordForSeg(S126, 9);
+    const units = stitchSugyot([a, b], [{ from: a, to: ghost, kind: 'continues' }]);
+    expect(units).toHaveLength(2); // ghost not a node → no merge
+  });
+
+  it('respects a custom binding-kinds set', () => {
+    const a = coordForSeg(S125, 0), b = coordForSeg(S125, 5);
+    const units = stitchSugyot([a, b], [{ from: a, to: b, kind: 'cites' }], { bindingKinds: new Set(['cites']) });
+    expect(units).toHaveLength(1);
+  });
+
+  it('default binding kinds are continues/resolves/depends-on', () => {
+    expect([...SUGYA_BINDING_KINDS].sort()).toEqual(['continues', 'depends-on', 'resolves']);
+  });
+});


### PR DESCRIPTION
First increment of #3 (the cross-page sugya map). Pure, deterministic, no LLM/render — the grouping core the boundary-finder + renderer build on.

`src/lib/typing/sugya.ts` — **`stitchSugyot(sections, edges)`**: union-find over the argument flow edges, grouping section coordinates (cross-daf, via `coord.ts`) into connected **sugya units** — each a normalized `AnchorSpan` + per-daf section rows + a `crossesDaf` flag. Binding kinds (continues/resolves/depends-on) join one thread; parallels/contrasts/generalizes/cites are cross-references that don't merge (tunable).

The hard, separate next step is **producing** the cross-daf flow edges (the boundary-finder pass over adjacent dapim); once those exist, grouping them into sugyot is exactly this.

`tests/typing/sugya.test.ts` (8 cases). 1359 tests pass, typecheck clean.