### PR TITLE
GC orphaned cache entries (stale cache_version cruft)

### DIFF
--- a/src/worker/cache-gc.ts
+++ b/src/worker/cache-gc.ts
@@ -1,0 +1,119 @@
+/**
+ * Garbage-collect orphaned cache entries — KV entries left behind at a
+ * SUPERSEDED cache_version after a def bump.
+ *
+ * Cache keys are `mark:<id>:<version>:<rest>` / `enrich:<id>:<version>:<rest>`
+ * (see cache-keys.ts). A read always builds the key with the def's CURRENT
+ * cache_version, so any entry whose version segment differs is unreachable —
+ * dead weight that persists forever (the result cache has no TTL). Bumping a
+ * def's cache_version (the project does this often) orphans its whole previous
+ * generation. This GC deletes exactly those entries and nothing else.
+ *
+ * Safety: it only ever deletes keys whose parsed version segment is NOT the
+ * current version. The `:he` language marker is a LATER segment, so a current
+ * Hebrew entry (`<id>:<current>:he:…`) still has version === current and is
+ * kept. The version-staleness predicate is unit-tested (the one thing that
+ * must never be wrong). Dry-run by default; deletion is bounded by maxDeletes.
+ */
+
+/** Minimal KV surface this module needs (a subset of KVNamespace) — keeps it
+ *  unit-testable with a fake. */
+export interface GcKV {
+  list(opts: { prefix: string; cursor?: string; limit?: number }): Promise<{
+    keys: Array<{ name: string }>;
+    list_complete: boolean;
+    cursor?: string;
+  }>;
+  delete(name: string): Promise<void>;
+}
+
+export interface GcTarget {
+  /** Version-agnostic id prefix WITH trailing colon, e.g. `mark:argument:`. */
+  prefix: string;
+  /** The def's current cache_version (e.g. '4'). */
+  currentVersion: string;
+}
+
+export interface GcResult {
+  prefix: string;
+  scanned: number;
+  stale: number;
+  deleted: number;
+  /** A few stale keys, for a dry-run preview. */
+  sampleStaleKeys: string[];
+}
+
+/**
+ * The cache_version segment of a key under `prefix`, or null if the key isn't
+ * under that prefix. `mark:argument:` must NOT match `mark:argument-move:…` —
+ * the trailing colon in the prefix enforces that.
+ */
+export function versionSegment(keyName: string, prefix: string): string | null {
+  if (!keyName.startsWith(prefix)) return null;
+  const rest = keyName.slice(prefix.length);
+  return rest.split(':')[0] || null;
+}
+
+/** True iff the key is a SUPERSEDED-version entry under `prefix` (safe to GC). */
+export function isStaleKey(keyName: string, prefix: string, currentVersion: string): boolean {
+  const v = versionSegment(keyName, prefix);
+  return v !== null && v !== currentVersion;
+}
+
+/** Scan one id prefix; delete (unless dryRun) entries at a non-current version. */
+export async function gcPrefix(
+  cache: GcKV,
+  target: GcTarget,
+  opts: { dryRun: boolean; maxDeletes: number },
+): Promise<GcResult> {
+  const out: GcResult = { prefix: target.prefix, scanned: 0, stale: 0, deleted: 0, sampleStaleKeys: [] };
+  let cursor: string | undefined;
+  for (;;) {
+    const res = await cache.list({ prefix: target.prefix, cursor, limit: 1000 });
+    for (const k of res.keys) {
+      out.scanned++;
+      if (!isStaleKey(k.name, target.prefix, target.currentVersion)) continue;
+      out.stale++;
+      if (out.sampleStaleKeys.length < 5) out.sampleStaleKeys.push(k.name);
+      if (!opts.dryRun && out.deleted < opts.maxDeletes) {
+        await cache.delete(k.name);
+        out.deleted++;
+      }
+    }
+    if (res.list_complete || !res.cursor) break;
+    cursor = res.cursor;
+  }
+  return out;
+}
+
+export interface GcSummary {
+  dryRun: boolean;
+  results: GcResult[];
+  totalScanned: number;
+  totalStale: number;
+  totalDeleted: number;
+}
+
+/** GC every target, capping TOTAL deletions at maxDeletes (so a cron pass is a
+ *  bounded, gradual cleanup rather than one huge delete burst). */
+export async function gcStaleCache(
+  cache: GcKV,
+  targets: readonly GcTarget[],
+  opts: { dryRun?: boolean; maxDeletes?: number } = {},
+): Promise<GcSummary> {
+  const dryRun = opts.dryRun ?? true;
+  let budget = opts.maxDeletes ?? 2000;
+  const results: GcResult[] = [];
+  for (const t of targets) {
+    const r = await gcPrefix(cache, t, { dryRun, maxDeletes: budget });
+    budget -= r.deleted;
+    results.push(r);
+  }
+  return {
+    dryRun,
+    results,
+    totalScanned: results.reduce((a, r) => a + r.scanned, 0),
+    totalStale: results.reduce((a, r) => a + r.stale, 0),
+    totalDeleted: results.reduce((a, r) => a + r.deleted, 0),
+  };
+}

--- a/src/worker/cache-stats.ts
+++ b/src/worker/cache-stats.ts
@@ -25,6 +25,7 @@ import rabbiOrientationData from '../lib/data/rabbi-orientation.json';
 import { getWarmTotal } from './warm-cron';
 import { CODE_MARKS, CODE_ENRICHMENTS } from './code-marks';
 import { listMarks, listEnrichments } from './studio-registry';
+import type { GcTarget } from './cache-gc';
 
 // v5: mark/enrichment rows carry a per-cache-version breakdown (`versions` +
 // `staleCount`) + the `observations` bucket (rabbi.observations reverse index).
@@ -230,6 +231,16 @@ async function mergedEnrichments(cache: KVNamespace): Promise<Array<{
     source: 'kv', cache_version: e.cache_version,
   });
   return [...byId.values()].sort((a, b) => a.id.localeCompare(b.id));
+}
+
+/** Version-agnostic id prefixes + current versions for every mark + enrichment
+ *  (code and KV). The input to the stale-cache GC (src/worker/cache-gc.ts). */
+export async function cacheGcTargets(cache: KVNamespace): Promise<GcTarget[]> {
+  const [marks, enrich] = await Promise.all([mergedMarks(cache), mergedEnrichments(cache)]);
+  return [
+    ...marks.map((m) => ({ prefix: `mark:${m.id}:`, currentVersion: m.cache_version })),
+    ...enrich.map((e) => ({ prefix: `enrich:${e.id}:`, currentVersion: e.cache_version })),
+  ];
 }
 
 export async function computeCacheStats(cache: KVNamespace): Promise<CacheStats> {

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -39,7 +39,9 @@ import {
   readCachedCacheStats,
   writeCachedCacheStats,
   isFresh,
+  cacheGcTargets,
 } from './cache-stats';
+import { gcStaleCache } from './cache-gc';
 import { runYomiWarmCron } from './yomi-cron';
 import { GENERATION_IDS, GENERATION_BY_ID, GENERATIONS_PROMPT_REFERENCE, type GenerationId } from '../client/generations';
 import { stripEchoParens } from '../client/hebraize';
@@ -2586,6 +2588,22 @@ app.get('/api/admin/cache-stats', async (c) => {
   const stats = await computeCacheStats(cache);
   await writeCachedCacheStats(cache, stats);
   return c.json(stats);
+});
+
+// GC orphaned cache entries (those left at a superseded cache_version after a
+// def bump — unreachable, no-TTL cruft). Dry-run by default; `?apply=1` deletes
+// (gated by STUDIO_SECRET, since deletion is destructive). `maxDeletes` caps a
+// single pass so a real run is bounded. See src/worker/cache-gc.ts.
+app.post('/api/admin/cache-gc', async (c) => {
+  const cache = c.env.CACHE;
+  if (!cache) return c.json({ error: 'no cache binding' }, 503);
+  const apply = c.req.query('apply') === '1';
+  if (apply && !isTrustedRequest(c)) return c.json({ error: 'deletion requires studio auth (?apply=1)' }, 403);
+  const maxDeletes = Math.min(Number(c.req.query('maxDeletes')) || 2000, 20000);
+  const targets = await cacheGcTargets(cache);
+  const summary = await gcStaleCache(cache, targets, { dryRun: !apply, maxDeletes });
+  // Only echo prefixes that actually have stale entries — keeps the report short.
+  return c.json({ ...summary, results: summary.results.filter((r) => r.stale > 0) });
 });
 
 /**

--- a/tests/cache-gc.test.ts
+++ b/tests/cache-gc.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Stale-cache GC (src/worker/cache-gc.ts). The version-staleness predicate is
+ * safety-critical — deleting a CURRENT entry would be data loss — so it's
+ * pinned hard here: only superseded-version keys are ever stale, prefixes don't
+ * bleed (argument vs argument-move), and the `:he` marker never makes a current
+ * entry look stale.
+ */
+import { describe, it, expect } from 'vitest';
+import { versionSegment, isStaleKey, gcPrefix, type GcKV } from '../src/worker/cache-gc';
+
+const P = 'mark:argument:';
+
+describe('versionSegment / isStaleKey', () => {
+  it('parses the version segment under a prefix', () => {
+    expect(versionSegment('mark:argument:4:gittin:67b', P)).toBe('4');
+    expect(versionSegment('mark:argument:3:he:gittin:67b', P)).toBe('3');
+  });
+
+  it('does not match a sibling prefix (argument vs argument-move)', () => {
+    expect(versionSegment('mark:argument-move:9:gittin:67b', P)).toBeNull();
+    expect(isStaleKey('mark:argument-move:9:gittin:67b', P, '4')).toBe(false);
+  });
+
+  it('current version (either language) is never stale', () => {
+    expect(isStaleKey('mark:argument:4:gittin:67b', P, '4')).toBe(false);
+    expect(isStaleKey('mark:argument:4:he:gittin:67b', P, '4')).toBe(false);
+  });
+
+  it('a superseded version (either language) IS stale', () => {
+    expect(isStaleKey('mark:argument:3:gittin:67b', P, '4')).toBe(true);
+    expect(isStaleKey('mark:argument:3:he:gittin:67b', P, '4')).toBe(true);
+    expect(isStaleKey('mark:argument:llm-v2:gittin:67b', P, '4')).toBe(true);
+  });
+});
+
+/** Fake KV returning a fixed key set in one page; records deletions. */
+function fakeKV(names: string[]): GcKV & { deleted: string[] } {
+  const deleted: string[] = [];
+  return {
+    deleted,
+    async list({ prefix }) {
+      return { keys: names.filter((n) => n.startsWith(prefix)).map((name) => ({ name })), list_complete: true };
+    },
+    async delete(name: string) { deleted.push(name); names.splice(names.indexOf(name), 1); },
+  };
+}
+
+describe('gcPrefix', () => {
+  const keys = () => [
+    'mark:argument:4:gittin:67b',      // current — keep
+    'mark:argument:4:he:gittin:67b',   // current he — keep
+    'mark:argument:3:gittin:67b',      // stale — delete
+    'mark:argument:3:he:gittin:68a',   // stale he — delete
+    'mark:argument:2:berakhot:2a',     // stale — delete
+  ];
+
+  it('dry-run counts stale but deletes nothing', async () => {
+    const kv = fakeKV(keys());
+    const r = await gcPrefix(kv, { prefix: P, currentVersion: '4' }, { dryRun: true, maxDeletes: 999 });
+    expect(r.scanned).toBe(5);
+    expect(r.stale).toBe(3);
+    expect(r.deleted).toBe(0);
+    expect(kv.deleted).toEqual([]);
+  });
+
+  it('apply deletes only the superseded entries, keeping current (+he)', async () => {
+    const kv = fakeKV(keys());
+    const r = await gcPrefix(kv, { prefix: P, currentVersion: '4' }, { dryRun: false, maxDeletes: 999 });
+    expect(r.deleted).toBe(3);
+    expect(kv.deleted.sort()).toEqual([
+      'mark:argument:2:berakhot:2a',
+      'mark:argument:3:gittin:67b',
+      'mark:argument:3:he:gittin:68a',
+    ]);
+    // The two current entries survive.
+  });
+
+  it('respects maxDeletes (bounded pass)', async () => {
+    const kv = fakeKV(keys());
+    const r = await gcPrefix(kv, { prefix: P, currentVersion: '4' }, { dryRun: false, maxDeletes: 1 });
+    expect(r.stale).toBe(3);
+    expect(r.deleted).toBe(1);
+    expect(kv.deleted).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Fix #9 from the original review. Garbage-collects KV entries stranded at a superseded `cache_version` after a def bump — unreachable + no-TTL, so they accumulate forever.

- **`cache-gc.ts`** — deletes ONLY keys whose version segment != the def's current version (the `:he` marker is a later segment, so current Hebrew entries are kept). Bounded by `maxDeletes`, **dry-run by default**. The version-staleness predicate is unit-tested (prefix isolation, he keys, superseded versions).
- **`POST /api/admin/cache-gc`** — dry-run report by default; `?apply=1` deletes (gated by `STUDIO_SECRET`, since destructive).

Run dry first to preview counts, then `?apply=1`. 1366 tests pass, typecheck clean.