### PR TITLE
Promote anchor-verbatim to hard on pesukim + aggadata

### DIFF
--- a/src/lib/check/postcheck.ts
+++ b/src/lib/check/postcheck.ts
@@ -125,11 +125,20 @@ function instancesOf(parsed: unknown): RangeInstance[] {
  *  was ~40% false positives (correct anchors whose phrase merely isn't
  *  contiguous). Skips instances with no excerpt or a <2-word excerpt (findExcerpt
  *  itself rejects <2-word needles as too ambiguous). */
+/** Marks where anchor-verbatim is promoted to `hard` (gates the cache write).
+ *  Chosen from real-traffic observation: pesukim + aggadata anchor reliably
+ *  (zero flags sampled across 23 dapim post the placer-mirroring refinement), so
+ *  a flag there is a genuine hallucination worth blocking. argument /
+ *  argument-move still flag occasionally (boundary-spanning excerpts), so they
+ *  stay `soft` (observe-only) pending more data. */
+const ANCHOR_VERBATIM_HARD_MARKS: ReadonlySet<string> = new Set(['pesukim', 'aggadata']);
+
 const anchorVerbatim: PostCheck = {
   id: 'anchor-verbatim',
   phase: 'validate',
   run: (parsed, ctx) => {
     const issues: CheckIssue[] = [];
+    const severity: Severity = ANCHOR_VERBATIM_HARD_MARKS.has(ctx.defId) ? 'hard' : 'soft';
     const segs = ctx.segmentsHe;
     const grid = buildVerbatimGrid(segs);
     for (const inst of instancesOf(parsed)) {
@@ -138,13 +147,13 @@ const anchorVerbatim: PostCheck = {
       if (normalizeHebrew(excerpt).split(' ').filter(Boolean).length < 2) continue;
       const seg = inst.startSegIdx;
       if (typeof seg !== 'number' || seg < 0 || seg >= segs.length) {
-        issues.push({ kind: 'anchor-out-of-range', severity: 'soft', match: excerpt, index: typeof seg === 'number' ? seg : -1 });
+        issues.push({ kind: 'anchor-out-of-range', severity, match: excerpt, index: typeof seg === 'number' ? seg : -1 });
         continue;
       }
       // Confine the search to the single anchored segment: a hit there is the
       // same prefix the placer would have matched to land on this segment.
       if (!findExcerpt(grid, excerpt, seg, seg)) {
-        issues.push({ kind: 'excerpt-not-in-segment', severity: 'soft', match: excerpt, index: seg });
+        issues.push({ kind: 'excerpt-not-in-segment', severity, match: excerpt, index: seg });
       }
     }
     return { issues };

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1472,15 +1472,20 @@ async function runMarkOnce(
   // `checks: []` in code-marks.ts; the transforms need the segment grid, so
   // fetch the gemara slice once when any check runs.
   let markCheckIssues: unknown[] | undefined;
+  let markHardIssues: unknown[] | undefined;
   if (parsed && def.checks && def.checks.length > 0) {
     const slice = await getGemaraSlice(rc.env, tractate, page, false);
     const checked = await runChecks(def.checks, parsed, {
       tractate, page, segmentsHe: slice.segments_he, defId: def.id, lang: rc.lang,
     });
     parsed = checked.parsed;
-    // Mark validators (anchor-verbatim / partition-clean) are all `soft` — they
-    // never gate the mark's cache write; attach them for quality observation.
-    if (checked.issues.length > 0) markCheckIssues = checked.issues;
+    // Attach all issues for observation; `hard` ones (e.g. anchor-verbatim on
+    // pesukim/aggadata, where it's promoted) gate the cache write below.
+    if (checked.issues.length > 0) {
+      markCheckIssues = checked.issues;
+      const hard = checked.issues.filter((i) => i.severity === 'hard');
+      if (hard.length > 0) markHardIssues = hard;
+    }
   }
   // Special cases that don't fit the segments-only transform signature yet:
   //   - rabbi:  needs the daf Hebrew text, not the segment grid (A1b will port it).
@@ -1514,8 +1519,22 @@ async function runMarkOnce(
     },
     cache_hit: false,
     ...(markCheckIssues ? { check_issues: markCheckIssues } : {}),
+    ...(markHardIssues ? { lint_issues: markHardIssues } : {}),
   };
-  if (!parse_error) await writeCachedResult(rc.env, cacheKey, out);
+  // Gate on hard check issues, BOUNDED — same posture as runEnrichmentOnce. A
+  // clean output (or one with only soft issues) is pinned; a hard-failing one
+  // (e.g. a hallucinated pesukim/aggadata anchor) is left uncached so the next
+  // request regenerates — until MAX_LINT_ATTEMPTS, then pinned anyway so a
+  // persistently-failing card stops re-paying. Capped failures surface on /api/usage.
+  if (!parse_error) {
+    if (!markHardIssues) {
+      await writeCachedResult(rc.env, cacheKey, out);
+    } else if (await noteLintAttempt(rc.env, rc.ctx, cacheKey, {
+      enrichmentId: def.id, tractate, page, lang: rc.lang, issues: markHardIssues,
+    })) {
+      await writeCachedResult(rc.env, cacheKey, out);
+    }
+  }
   return out;
 }
 

--- a/tests/check/anchor-verbatim-hard.test.ts
+++ b/tests/check/anchor-verbatim-hard.test.ts
@@ -1,0 +1,32 @@
+/**
+ * anchor-verbatim severity is promoted to `hard` on the marks where it's proven
+ * reliable (pesukim, aggadata — zero flags sampled across 23 dapim), so a flag
+ * there gates the cache write (a genuine hallucination). It stays `soft` on
+ * argument / argument-move, which still flag occasionally (boundary-spanning
+ * excerpts) — observe-only there.
+ */
+import { describe, it, expect } from 'vitest';
+import { runChecks, type CheckCtx } from '../../src/lib/check/postcheck';
+
+// seg 0 has the text; the instance claims its excerpt is in seg 1 (it isn't) → flagged.
+const segs = ['תנו רבנן המביא גט', 'אמר רבא הלכה כרבי'];
+const flagged = { instances: [{ startSegIdx: 0, fields: { excerpt: 'מילים שאינן שם' } }] };
+const ctx = (defId: string): CheckCtx => ({ tractate: 'Gittin', page: '67b', segmentsHe: segs, defId });
+
+describe('anchor-verbatim per-mark severity', () => {
+  it('is HARD on pesukim and aggadata', async () => {
+    for (const defId of ['pesukim', 'aggadata']) {
+      const { issues } = await runChecks(['anchor-verbatim'], structuredClone(flagged), ctx(defId));
+      expect(issues).toHaveLength(1);
+      expect(issues[0].severity).toBe('hard');
+    }
+  });
+
+  it('stays SOFT on argument and argument-move', async () => {
+    for (const defId of ['argument', 'argument-move']) {
+      const { issues } = await runChecks(['anchor-verbatim'], structuredClone(flagged), ctx(defId));
+      expect(issues).toHaveLength(1);
+      expect(issues[0].severity).toBe('soft');
+    }
+  });
+});


### PR DESCRIPTION
Completes the hallucination-catch half of #3. Real-traffic sampling (23 dapim) showed anchor-verbatim fires only on argument/argument-move and **zero** on pesukim/aggadata, so a flag there is a genuine hallucination — promote it to **hard** (gates the cache write) on those two marks; argument/argument-move stay soft.

`runMarkOnce` gains the same bounded-retry cache-gating `runEnrichmentOnce` has. **No cache_version bump** (zero current flags → existing cache is clean; the gate only catches future hallucinations). 1368 tests pass, typecheck clean.