### PR TITLE
Promote the daf Overview to readers (rename from Argument map)

### DIFF
--- a/src/client/DafViewer.tsx
+++ b/src/client/DafViewer.tsx
@@ -588,16 +588,15 @@ export default function DafViewer(): JSX.Element {
     if (relevant.length === 0) return;             // no marks enabled / loaded yet
     if (relevant.some((s) => s.kind === 'loading')) return; // anchors not done
     const runs = markRunsByMarkId();
-    // The argument-overview warm only fires in dev mode (the chip is dev-only),
-    // so dev state is part of the signature — opening dev re-runs and warms it.
-    const dev = devOpen();
-    const sig = `${t}:${p}:${dev ? 'ov' : ''}|` + Object.entries(runs)
+    // The Overview is promoted to readers, so warm its flow on every daf load
+    // (cache-respecting — a hit on already-warmed dapim costs nothing).
+    const sig = `${t}:${p}:ov|` + Object.entries(runs)
       .map(([m, r]) => `${m}=${(r?.parsed as { instances?: unknown[] } | undefined)?.instances?.length ?? 0}`)
       .sort()
       .join(',');
     if (sig === lastPrefetchSig) return;
     lastPrefetchSig = sig;
-    prefetchDaf(t, p, runs, { overview: dev });
+    prefetchDaf(t, p, runs, { overview: true });
   });
 
   // Comprehensively pre-warm the adjacent dapim on idle so navigating either
@@ -2604,9 +2603,9 @@ export default function DafViewer(): JSX.Element {
           above the daf as the reader scrolls. */}
       <DafLoadProgress />
 
-      {/* Whole-daf chip marks (argument map) are experimental — shown only when
-          dev mode is open. */}
-      <Show when={devOpen() && chipMarks().length > 0}>
+      {/* Whole-daf chip marks (the Overview) — shown to all readers now that the
+          per-daf overview is promoted and its flow is warmed globally. */}
+      <Show when={chipMarks().length > 0}>
         <div class="daf-chip-bar" style={{ display: 'flex', gap: '0.4rem', 'flex-wrap': 'wrap', margin: '0 0 0.6rem' }}>
           <For each={chipMarks()}>{(m) => {
             const color = (m.render as { color?: string }).color ?? '#8a2a2b';

--- a/src/client/MobileShelf.tsx
+++ b/src/client/MobileShelf.tsx
@@ -167,6 +167,6 @@ function labelForSidebar(s: SidebarContent | null): string {
     case 'place': return 'Place';
     case 'voice-group': return 'Voice';
     case 'rishonim': return 'Rishonim';
-    case 'argument-overview': return 'Argument map';
+    case 'argument-overview': return 'Overview';
   }
 }

--- a/src/client/i18n.ts
+++ b/src/client/i18n.ts
@@ -171,11 +171,11 @@ const CATALOG = {
   'sidebar.kind.rishonim': { en: 'Rishonim', he: 'ראשונים' },
   'sidebar.kind.voice-group': { en: 'Voice', he: 'קול' },
   'sidebar.kind.rabbi': { en: 'Rabbi', he: 'חכם' },
-  'sidebar.kind.argument-overview': { en: 'Argument map', he: 'מפת הטיעון' },
+  'sidebar.kind.argument-overview': { en: 'Overview', he: 'סקירה' },
 
   // — Whole-daf argument overview —
-  'overview.chip': { en: 'Argument map', he: 'מפת הטיעון' },
-  'overview.title': { en: 'Whole-daf argument map', he: 'מפת הטיעון של הדף' },
+  'overview.chip': { en: 'Overview', he: 'סקירה' },
+  'overview.title': { en: 'Daf overview', he: 'סקירת הדף' },
   'overview.empty': {
     en: 'No argument sections on this daf yet — open it with Arguments enabled so they load.',
     he: 'אין עדיין מקטעי טיעון בדף זה.',
@@ -646,7 +646,7 @@ const CATALOG = {
   'dafLoad.family.halachot': { en: 'halachot', he: 'הלכות' },
   'dafLoad.family.rabbis': { en: 'rabbis', he: 'חכמים' },
   'dafLoad.family.rishonim': { en: 'rishonim', he: 'ראשונים' },
-  'dafLoad.family.argumentOverview': { en: 'argument map', he: 'מפת הטיעון' },
+  'dafLoad.family.argumentOverview': { en: 'overview', he: 'סקירה' },
 
   // — Gutter icon tooltips —
   'gutter.argument': { en: 'Argument structure & rabbis', he: 'מבנה הסוגיה וחכמים' },

--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -515,12 +515,12 @@ export const CODE_MARKS: MarkDefinition[] = [
   },
   {
     id: 'argument-overview',
-    label: 'Argument map',
-    description: 'Whole-daf argument flowchart (one button → sidebar voice map for the entire page), grounded on dafyomi.co.il study context.',
-    category: 'experimental',
-    // Dev-only for now: the whole-daf diagram is still being shaped (sugya-
-    // spanning ranges, cross-daf boundaries). Hidden from readers until promoted.
-    experimental: true,
+    label: 'Overview',
+    description: 'Whole-daf overview: the page\'s argument sections and how they relate (continues / resolves / depends-on / …), grounded on dafyomi.co.il study context.',
+    category: 'canon',
+    // Promoted to readers. The per-daf overview (sections + their flow) is solid
+    // and warmed globally; cross-daf / sugya-spanning ranges are a later layer
+    // (the sugya map) that builds on this, not a blocker for the per-daf view.
     anchor: 'whole-daf',
     render: {
       kind: 'chip',


### PR DESCRIPTION
Per request: take the whole-daf map out of experimental/dev-only and rename it **Overview**.

- `argument-overview` mark: drop `experimental`, category → `canon`.
- Ungate the header chip (was `devOpen()`-gated) + warm the overview flow on every daf load (cache-respecting; the global flow warm pre-empts cold loads).
- "Argument map" → "Overview" across chip/sidebar/mobile/i18n (HE: סקירה). Id stays `argument-overview` — no cache bust.

Pairs with the in-flight global flow warm. 1368 tests pass, typecheck clean.