### PR TITLE
Derive voices-graph edge directions in code (fix #5)

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -10,6 +10,7 @@ import { type GeographyData, type GeographyEvidence } from './RabbiGeographyCard
 import RabbiPlacesTimeline, { type LocationInference } from './RabbiPlacesTimeline';
 import ArgumentVoiceMap, { type ArgumentVoicesData } from './ArgumentVoiceMap';
 import ArgumentNarrative from './ArgumentNarrative';
+import { deriveVoiceEdges } from '../lib/typing/voices';
 import ArgumentFlowGraph, { type FlowConnection } from './ArgumentFlowGraph';
 import { selectSectionMoves } from '../lib/argumentMoves';
 import { t, lang } from './i18n';
@@ -554,7 +555,9 @@ export function ArgumentBody(props: {
     const voices = r.deps_resolved?.['argument.voices'] as ArgumentVoicesData | undefined;
     if (voices && Array.isArray(voices.voices)) {
       // Edges may be absent on older cached entries — default to [].
-      setVoicesData({ voices: voices.voices, edges: Array.isArray(voices.edges) ? voices.edges : [] });
+      // Repair edge directions / drop malformed edges deterministically, so even
+      // already-cached graphs (pre the derive-voice-edges transform) render right.
+      setVoicesData(deriveVoiceEdges({ voices: voices.voices, edges: Array.isArray(voices.edges) ? voices.edges : [] }) as ArgumentVoicesData);
     }
   };
 
@@ -689,7 +692,7 @@ function OverviewSectionVoices(props: {
   createEffect(() => { void instanceKey(); setVoices(null); });
   const onResolved = (r: { deps_resolved?: Record<string, unknown> }) => {
     const v = r.deps_resolved?.['argument.voices'] as ArgumentVoicesData | undefined;
-    if (v && Array.isArray(v.voices)) setVoices({ voices: v.voices, edges: Array.isArray(v.edges) ? v.edges : [] });
+    if (v && Array.isArray(v.voices)) setVoices(deriveVoiceEdges({ voices: v.voices, edges: Array.isArray(v.edges) ? v.edges : [] }) as ArgumentVoicesData);
   };
   return (
     <div style={{ 'margin-top': '0.6rem', 'border-top': '1px dashed #e5e3dc', 'padding-top': '0.6rem' }}>

--- a/src/lib/check/postcheck.ts
+++ b/src/lib/check/postcheck.ts
@@ -18,6 +18,7 @@ import { lintSynthesis } from '../synthesisLint';
 import { lintHalachaParsed } from '../halachaLint';
 import { reanchorArgument, reanchorArgumentMove, reanchorPesukim, reanchorAggadata, reanchorRabbiEvidence, reanchorNarrative } from '../place/reanchor';
 import { normalizeHebrew, buildVerbatimGrid, findExcerpt } from '../place/verbatim';
+import { deriveVoiceEdges } from '../typing/voices';
 
 export type Severity = 'hard' | 'soft';
 
@@ -246,6 +247,7 @@ export const CHECKS: Record<string, PostCheck> = {
   'reanchor-aggadata': transform('reanchor-aggadata', reanchorAggadata),
   'reanchor-rabbi-evidence': transform('reanchor-rabbi-evidence', reanchorRabbiEvidence),
   'reanchor-narrative': transform('reanchor-narrative', reanchorNarrative),
+  'derive-voice-edges': { id: 'derive-voice-edges', phase: 'transform', run: (parsed) => ({ parsed: deriveVoiceEdges(parsed) }) },
   'hebrew-excerpt': hebrewExcerpt,
   'hebrew-gloss': hebrewGloss,
   'anchor-verbatim': anchorVerbatim,

--- a/src/lib/typing/voices.ts
+++ b/src/lib/typing/voices.ts
@@ -1,0 +1,53 @@
+/**
+ * @fileoverview Deterministic repair of the argument.voices edge graph.
+ *
+ * The LLM is unreliable about edge DIRECTION (the review found 26 inverted
+ * `responds-to` edges) and emits edges pointing at voices that aren't in the
+ * node list (18 of them) and the occasional self-loop. But direction is
+ * derivable in code, so we don't have to trust the model: the `voices` array is
+ * emitted in appearance order, and an argument flows forward — the voice DOING
+ * something (`from`: responding, opposing, resolving, citing) always appears at
+ * or after the voice it acts on (`to`). So:
+ *
+ *   - an edge whose `from` appears BEFORE its `to` is inverted → flip it;
+ *   - an edge referencing a non-existent voice is unrenderable → drop it;
+ *   - a self-loop is meaningless → drop it.
+ *
+ * Pure + DOM-free. Used both as a post-LLM transform check (fixes new writes) and
+ * at the client render path (fixes already-cached graphs without a re-warm).
+ */
+
+interface Voice { name?: unknown }
+interface VoiceEdge { from?: unknown; to?: unknown; kind?: unknown; [k: string]: unknown }
+interface VoicesGraph { voices?: unknown; edges?: unknown; [k: string]: unknown }
+
+/** Repair the edge directions + drop malformed edges. Mutates + returns the
+ *  graph (matches the other transform checks' contract). Non-graph input and a
+ *  missing edges array pass through untouched. */
+export function deriveVoiceEdges(parsed: unknown): unknown {
+  if (!parsed || typeof parsed !== 'object') return parsed;
+  const g = parsed as VoicesGraph;
+  if (!Array.isArray(g.edges)) return parsed;
+
+  // name -> appearance index (first occurrence wins).
+  const order = new Map<string, number>();
+  if (Array.isArray(g.voices)) {
+    g.voices.forEach((v, i) => {
+      const name = (v as Voice)?.name;
+      if (typeof name === 'string' && name && !order.has(name)) order.set(name, i);
+    });
+  }
+
+  const out: VoiceEdge[] = [];
+  for (const e of g.edges as VoiceEdge[]) {
+    const from = typeof e?.from === 'string' ? e.from : '';
+    const to = typeof e?.to === 'string' ? e.to : '';
+    if (!order.has(from) || !order.has(to)) continue; // phantom-voice edge → drop
+    if (from === to) continue;                         // self-loop → drop
+    const fi = order.get(from)!, ti = order.get(to)!;
+    // The actor (from) reacts to the target (to), so it must be the later voice.
+    out.push(fi < ti ? { ...e, from: to, to: from } : e);
+  }
+  g.edges = out;
+  return g;
+}

--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -2003,7 +2003,7 @@ CODE_ENRICHMENTS.push(
     {
       mode: 'augment-content', scope: 'local',
       dependencies: ['gemara', { mark: 'argument-move' }, { mark: 'rabbi' }],
-      checks: ['edge-integrity'],
+      checks: ['derive-voice-edges', 'edge-integrity'],
       defHash: 'argument.voices-v5', cacheVersion: '5',
       model: ARGUMENT_FLASH_MODEL,
       systemPromptHe: ARGUMENT_VOICES_SYSTEM_PROMPT_HE,

--- a/tests/check/wiring.test.ts
+++ b/tests/check/wiring.test.ts
@@ -28,7 +28,7 @@ describe('declarative check wiring', () => {
     'halacha.practical': ['hebrew-gloss'],
     'halacha.disputes': ['hebrew-gloss'],
     'halacha.synthesis': ['hebrew-gloss'],
-    'argument.voices': ['edge-integrity'],
+    'argument.voices': ['derive-voice-edges', 'edge-integrity'],
     'rabbi.relationships.evidence': ['reanchor-rabbi-evidence'],
     'rabbi.geography.evidence': ['reanchor-rabbi-evidence'],
   };

--- a/tests/typing/voices.test.ts
+++ b/tests/typing/voices.test.ts
@@ -1,0 +1,43 @@
+/**
+ * deriveVoiceEdges (src/lib/typing/voices.ts) — deterministic repair of the
+ * argument.voices edge graph: flip inverted directions (the actor must appear
+ * after the voice it reacts to), drop phantom-voice edges and self-loops.
+ */
+import { describe, it, expect } from 'vitest';
+import { deriveVoiceEdges } from '../../src/lib/typing/voices';
+
+// Voices in appearance order: Rava(0), Abaye(1), Rav Ashi(2).
+const voices = [{ name: 'Rava' }, { name: 'Abaye' }, { name: 'Rav Ashi' }];
+const run = (edges: unknown[]) => (deriveVoiceEdges({ voices, edges }) as { edges: { from: string; to: string; kind: string }[] }).edges;
+
+describe('deriveVoiceEdges', () => {
+  it('keeps a correctly-directed edge (actor after target)', () => {
+    expect(run([{ from: 'Abaye', to: 'Rava', kind: 'responds-to' }]))
+      .toEqual([{ from: 'Abaye', to: 'Rava', kind: 'responds-to' }]);
+  });
+
+  it('flips an inverted edge (actor before target)', () => {
+    // LLM emitted Rava(0) responds-to Abaye(1) — but Rava came first, so flip.
+    expect(run([{ from: 'Rava', to: 'Abaye', kind: 'responds-to' }]))
+      .toEqual([{ from: 'Abaye', to: 'Rava', kind: 'responds-to' }]);
+  });
+
+  it('flips across all reactive kinds, preserving kind + note', () => {
+    const out = run([{ from: 'Rava', to: 'Rav Ashi', kind: 'opposes', note: 'n' }]);
+    expect(out).toEqual([{ from: 'Rav Ashi', to: 'Rava', kind: 'opposes', note: 'n' }]);
+  });
+
+  it('drops edges referencing a non-existent voice', () => {
+    expect(run([{ from: 'Rava', to: 'Ghost', kind: 'cites' }, { from: 'Nobody', to: 'Abaye', kind: 'supports' }]))
+      .toEqual([]);
+  });
+
+  it('drops self-loops', () => {
+    expect(run([{ from: 'Rava', to: 'Rava', kind: 'responds-to' }])).toEqual([]);
+  });
+
+  it('passes non-graph input and missing edges through untouched', () => {
+    expect(deriveVoiceEdges({ voices })).toEqual({ voices });
+    expect(deriveVoiceEdges(null)).toBeNull();
+  });
+});


### PR DESCRIPTION
The LLM inverts edge directions (26 `responds-to` inversions) + emits phantom-voice edges (18) + self-loops — all derivable in code. The voices array is in appearance order and argument flows forward, so the actor (`from`) always appears at/after the voice it reacts to (`to`).

- **`deriveVoiceEdges`** flips inverted edges, drops phantom + self edges. Pure, unit-tested.
- Runs as the **`derive-voice-edges` transform** before `edge-integrity` on argument.voices (fixes future writes), **and at the client render path** so already-cached graphs render corrected without a re-warm.

1374 tests pass, typecheck clean.