### PR TITLE
Commentary quote-or-omit check (fix #8)

### DIFF
--- a/src/lib/check/postcheck.ts
+++ b/src/lib/check/postcheck.ts
@@ -37,6 +37,9 @@ export interface CheckCtx {
   page: string;
   /** Segment grid for placement/anchor transforms (the gemara slice). */
   segmentsHe: string[];
+  /** The daf's Rashi/Tosafot/rishonim Hebrew text (HTML-stripped, one entry per
+   *  commentator) — for commentary-verbatim. Absent unless a check needs it. */
+  commentaryHe?: string[];
   defId: string;
   lang?: 'en' | 'he';
 }
@@ -240,6 +243,49 @@ const edgeIntegrity: PostCheck = {
   },
 };
 
+/** Maximal runs of Hebrew/Aramaic script (≥ minWords words) embedded in prose —
+ *  i.e. quoted source text, not the single-word Hebrew TERMS the gloss style
+ *  sprinkles in. English/digits break a run, so each run is one contiguous
+ *  Hebrew citation. */
+function hebrewRuns(text: string, minWords: number): string[] {
+  if (!text) return [];
+  const out: string[] = [];
+  // Hebrew block (letters + nikud/punct) with internal spaces; bounded by non-Hebrew.
+  const re = /[֑-״](?:[֑-״'"׳״־\-\s]*[֑-״])?/g;
+  for (const m of text.matchAll(re)) {
+    const run = m[0].trim();
+    if (run.split(/\s+/).filter(Boolean).length >= minWords) out.push(run);
+  }
+  return out;
+}
+
+/** commentary-verbatim — a cited Rashi/Tosafot quote must actually appear in the
+ *  daf's real commentary text (quote-or-omit; catches invented citations). For
+ *  each ≥3-word Hebrew run in the rashi/tosafot/other prose fields, verify it is
+ *  present (via the verbatim matcher) in ctx.commentaryHe. Skips when no
+ *  commentary is loaded (can't judge → no false positives). Soft (observe). */
+const commentaryVerbatim: PostCheck = {
+  id: 'commentary-verbatim',
+  phase: 'validate',
+  run: (parsed, ctx) => {
+    const issues: CheckIssue[] = [];
+    const com = ctx.commentaryHe ?? [];
+    if (com.length === 0) return { issues };
+    const grid = buildVerbatimGrid(com);
+    const p = (parsed ?? {}) as Record<string, unknown>;
+    for (const field of ['rashi', 'tosafot', 'other']) {
+      const prose = typeof p[field] === 'string' ? (p[field] as string) : '';
+      for (const run of hebrewRuns(prose, 3)) {
+        if (normalizeHebrew(run).split(' ').filter(Boolean).length < 2) continue;
+        if (!findExcerpt(grid, run, 0, com.length - 1)) {
+          issues.push({ kind: 'invented-commentary-quote', severity: 'soft', match: run, detail: field });
+        }
+      }
+    }
+    return { issues };
+  },
+};
+
 export const CHECKS: Record<string, PostCheck> = {
   'reanchor-argument': transform('reanchor-argument', reanchorArgument),
   'reanchor-argument-move': transform('reanchor-argument-move', reanchorArgumentMove),
@@ -250,6 +296,7 @@ export const CHECKS: Record<string, PostCheck> = {
   'derive-voice-edges': { id: 'derive-voice-edges', phase: 'transform', run: (parsed) => ({ parsed: deriveVoiceEdges(parsed) }) },
   'hebrew-excerpt': hebrewExcerpt,
   'hebrew-gloss': hebrewGloss,
+  'commentary-verbatim': commentaryVerbatim,
   'anchor-verbatim': anchorVerbatim,
   'partition-clean': partitionClean,
   'edge-integrity': edgeIntegrity,

--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -2694,6 +2694,7 @@ CODE_ENRICHMENTS.push(
     {
       mode: 'augment-content', scope: 'local',
       dependencies: ['gemara', 'commentaries'],
+      checks: ['commentary-verbatim'],
       defHash: 'argument-move.commentaries-v2', cacheVersion: '2',
       model: ARGUMENT_FLASH_MODEL,
       systemPromptHe: ARGUMENT_MOVE_COMMENTARIES_SYSTEM_PROMPT_HE,

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1787,8 +1787,15 @@ async function runEnrichmentOnce(
   let hardIssueCount = 0;
   if (parsed && !parse_error && def.checks && def.checks.length > 0) {
     const slice = await getGemaraSlice(rc.env, tractate, page, false);
+    // commentary-verbatim needs the daf's real Rashi/Tosafot text to verify
+    // cited quotes against — fetch it only when a check actually wants it.
+    let commentaryHe: string[] | undefined;
+    if (def.checks.includes('commentary-verbatim')) {
+      const com = await getCommentariesSlice(rc.env, tractate, page, false);
+      commentaryHe = Object.values(com.by_commentator).map((c) => stripHtmlServer(c.hebrew)).filter(Boolean);
+    }
     const checked = await runChecks(def.checks, parsed, {
-      tractate, page, segmentsHe: slice.segments_he, defId: def.id, lang: rc.lang,
+      tractate, page, segmentsHe: slice.segments_he, commentaryHe, defId: def.id, lang: rc.lang,
     });
     parsed = checked.parsed;
     if (checked.issues.length > 0) {

--- a/tests/check/commentary-verbatim.test.ts
+++ b/tests/check/commentary-verbatim.test.ts
@@ -1,0 +1,51 @@
+/**
+ * commentary-verbatim (#8): a cited Rashi/Tosafot Hebrew quote must actually
+ * appear in the daf's real commentary text — catches invented citations
+ * (quote-or-omit). Soft / observe-only.
+ */
+import { describe, it, expect } from 'vitest';
+import { runChecks, type CheckCtx, type CheckIssue } from '../../src/lib/check/postcheck';
+
+// The daf's real Rashi/Tosafot (one entry per commentator).
+const commentaryHe = [
+  'רש"י: המביא גט ממדינת הים צריך לומר בפני נכתב ובפני נחתם',
+  'תוספות: והא דאמרינן בעינן שיאמר בפני נכתב',
+];
+const ctx = (over: Partial<CheckCtx> = {}): CheckCtx =>
+  ({ tractate: 'Gittin', page: '2a', segmentsHe: [], commentaryHe, defId: 'argument-move.commentaries', ...over });
+const kinds = (i: CheckIssue[]) => i.map((x) => x.kind);
+
+describe('commentary-verbatim', () => {
+  it('passes when the cited Hebrew quote is in the real commentary', async () => {
+    const parsed = { rashi: 'Rashi explains that בפני נכתב ובפני נחתם is required.', tosafot: '', other: '' };
+    const { issues } = await runChecks(['commentary-verbatim'], parsed, ctx());
+    expect(issues).toEqual([]);
+  });
+
+  it('flags an invented Hebrew quote not present in the commentary', async () => {
+    const parsed = { rashi: 'Rashi says הדבר תלוי במחלוקת אביי ורבא about this.', tosafot: '', other: '' };
+    const { issues } = await runChecks(['commentary-verbatim'], parsed, ctx());
+    expect(kinds(issues)).toEqual(['invented-commentary-quote']);
+    expect(issues[0].severity).toBe('soft');
+    expect(issues[0].detail).toBe('rashi');
+  });
+
+  it('ignores short (1-2 word) Hebrew terms — those are glosses, not citations', async () => {
+    const parsed = { rashi: 'A point about תרומה and גט.', tosafot: '', other: '' };
+    const { issues } = await runChecks(['commentary-verbatim'], parsed, ctx());
+    expect(issues).toEqual([]);
+  });
+
+  it('checks all of rashi/tosafot/other', async () => {
+    const parsed = { rashi: '', tosafot: 'Tosafot: מילים שלא נכתבו כאן בכלל', other: '' };
+    const { issues } = await runChecks(['commentary-verbatim'], parsed, ctx());
+    expect(kinds(issues)).toEqual(['invented-commentary-quote']);
+    expect(issues[0].detail).toBe('tosafot');
+  });
+
+  it('skips when no commentary is loaded (can\'t judge → no false positives)', async () => {
+    const parsed = { rashi: 'Rashi says הדבר תלוי במחלוקת אביי ורבא.', tosafot: '', other: '' };
+    const { issues } = await runChecks(['commentary-verbatim'], parsed, ctx({ commentaryHe: [] }));
+    expect(issues).toEqual([]);
+  });
+});

--- a/tests/check/wiring.test.ts
+++ b/tests/check/wiring.test.ts
@@ -29,6 +29,7 @@ describe('declarative check wiring', () => {
     'halacha.disputes': ['hebrew-gloss'],
     'halacha.synthesis': ['hebrew-gloss'],
     'argument.voices': ['derive-voice-edges', 'edge-integrity'],
+    'argument-move.commentaries': ['commentary-verbatim'],
     'rabbi.relationships.evidence': ['reanchor-rabbi-evidence'],
     'rabbi.geography.evidence': ['reanchor-rabbi-evidence'],
   };


### PR DESCRIPTION
A cited Hebrew quote in argument-move.commentaries must actually appear in the daf's real Rashi/Tosafot — else it's invented.

- **`commentary-verbatim`** validate check: extracts >=3-word Hebrew runs (citations, not 1-2 word gloss terms) from rashi/tosafot/other and verifies each against the real commentary text via the verbatim matcher. Flags misses; **skips when no commentary loaded** (no false positives). Soft / observe-first.
- `CheckCtx` gains `commentaryHe`; `runEnrichmentOnce` loads the commentary slice only when a check needs it.

1379 tests pass, typecheck clean.