### PR TITLE
Hadran / perek-boundary detection + marker rendering (#7)

### DIFF
--- a/src/client/TypeProfilePanel.tsx
+++ b/src/client/TypeProfilePanel.tsx
@@ -12,7 +12,8 @@ import { createResource, For, Show, type JSX } from 'solid-js';
 
 interface Claim { layer: string; coverage: number }
 interface Profile { unit: { startSegIdx: number; endSegIdx: number }; claims: Claim[]; primary: string; isDispute: boolean; title?: string }
-interface ProfilesResponse { tractate: string; page: string; count: number; profiles: Profile[] }
+interface Marker { startSegIdx: number; endSegIdx: number; kind: string }
+interface ProfilesResponse { tractate: string; page: string; count: number; profiles: Profile[]; markers?: Marker[] }
 
 const PRIMARY_COLOR: Record<string, string> = {
   'pure-dialectic': '#6b7280', aggadata: '#7c3aed', halacha: '#0369a1', pesukim: '#a16207',
@@ -45,6 +46,19 @@ export default function TypeProfilePanel(props: {
           'font-size': '0.65rem', 'text-transform': 'uppercase', 'letter-spacing': '0.06em',
           color: '#888', 'margin-bottom': '0.3rem',
         }}>Section types · {data()!.count}</div>
+
+        <Show when={(data()!.markers ?? []).length > 0}>
+          <For each={data()!.markers}>{(m) => (
+            <div style={{
+              display: 'flex', 'align-items': 'center', gap: '0.4rem', margin: '0.1rem 0 0.25rem',
+              color: '#9a3412', 'font-size': '0.68rem', 'text-transform': 'uppercase', 'letter-spacing': '0.05em',
+            }}>
+              <span style={{ flex: 1, 'border-top': '1px dashed #fdba74' }} />
+              <span>⎯ {m.kind} · perek boundary · seg {m.startSegIdx}</span>
+              <span style={{ flex: 1, 'border-top': '1px dashed #fdba74' }} />
+            </div>
+          )}</For>
+        </Show>
 
         <For each={data()!.profiles}>{(p) => {
           const isActive = () => props.active?.start === p.unit.startSegIdx && props.active?.end === p.unit.endSegIdx;

--- a/src/lib/typing/markers.ts
+++ b/src/lib/typing/markers.ts
@@ -1,0 +1,58 @@
+/**
+ * @fileoverview Structural markers in the daf text — currently the Hadran, the
+ * formula recited at a perek (chapter) boundary ("הדרן עלך …").
+ *
+ * A daf can straddle two perakim, so a single whole-daf Overview/summary
+ * conflates them. The Hadran is a deterministic boundary signal (a fixed Hebrew
+ * formula), so we detect it in code — no LLM — and surface it: the segment is a
+ * `marker` (rendered as a divider, not a content card), and it splits the daf
+ * into perek runs that downstream summaries/overviews can respect.
+ *
+ * Pure + DOM-free + unit-testable.
+ */
+
+import { normalizeHebrew } from '../place/verbatim';
+
+/** Segment indices whose text contains the Hadran formula (perek boundaries).
+ *  Matches the distinctive opening "הדרן עלך"; falls back to the bare "הדרן"
+ *  (always part of the formula, rare elsewhere) so a lightly-varied rendering
+ *  still registers. */
+export function findHadranSegments(segmentsHe: string[]): number[] {
+  const out: number[] = [];
+  segmentsHe.forEach((s, i) => {
+    if (typeof s !== 'string') return;
+    const n = normalizeHebrew(s);
+    if (n.includes('הדרן עלך') || n.includes('הדרן')) out.push(i);
+  });
+  return out;
+}
+
+export interface DafMarker {
+  startSegIdx: number;
+  endSegIdx: number;
+  kind: 'hadran';
+}
+
+/** All structural markers on the daf, as marker spans (currently just the
+ *  Hadran). Shape mirrors a mark instance so renderers can treat it uniformly. */
+export function findMarkers(segmentsHe: string[]): DafMarker[] {
+  return findHadranSegments(segmentsHe).map((seg) => ({ startSegIdx: seg, endSegIdx: seg, kind: 'hadran' as const }));
+}
+
+/** Split a daf's segment count into perek runs at the Hadran boundaries — each
+ *  run is the [start, end] segment range of one perek's portion on this daf.
+ *  The Hadran segment itself ends a run (it's the closing formula). A daf with
+ *  no Hadran is one run covering all segments. */
+export function perekRuns(segmentsHe: string[]): Array<{ start: number; end: number }> {
+  const n = segmentsHe.length;
+  if (n === 0) return [];
+  const boundaries = findHadranSegments(segmentsHe);
+  const runs: Array<{ start: number; end: number }> = [];
+  let start = 0;
+  for (const b of boundaries) {
+    runs.push({ start, end: b }); // run ends ON the Hadran segment (the closing formula)
+    start = b + 1;
+  }
+  if (start < n) runs.push({ start, end: n - 1 });
+  return runs;
+}

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -66,6 +66,7 @@ import { checkBudget, isBudgetPaused, budgetStatus, clearPauses, type BudgetScop
 import { lookupRelationships } from './rabbi-graph';
 import { runChecks } from '../lib/check/postcheck';
 import { composeTypeProfile, type LayerId, type LayerInstance, type TypeProfile, type UnitRange } from '../lib/typing/profile';
+import { findMarkers } from '../lib/typing/markers';
 import { noteLintAttempt, readLintFailures, type LintFailuresSummary } from './lint-failures';
 import { partitionSections, dedupeByRange, dedupeBy, selectSectionMoves, type MoveLike } from '../lib/argumentMoves';
 import { DEFAULT_MODEL, DEFAULT_FALLBACK_CHAIN, isLLMModelId, MODEL_PRESETS } from './settings';
@@ -687,7 +688,12 @@ app.get('/api/studio/type-profiles/:tractate/:page', async (c) => {
   const tractate = c.req.param('tractate');
   const page = c.req.param('page');
   const profiles = await buildDafTypeProfiles(c.env, tractate, page);
-  return c.json({ tractate, page, count: profiles.length, profiles });
+  // Structural markers (Hadran / perek boundaries) — deterministic from the
+  // gemara text, so a daf straddling two perakim renders a divider + downstream
+  // summaries can split rather than conflate.
+  const slice = await getGemaraSlice(c.env, tractate, page, false);
+  const markers = findMarkers(slice.segments_he);
+  return c.json({ tractate, page, count: profiles.length, profiles, markers });
 });
 
 app.get('/api/studio/enrichments', async (c) => {

--- a/tests/typing/markers.test.ts
+++ b/tests/typing/markers.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Hadran / perek-boundary markers (src/lib/typing/markers.ts): deterministic
+ * detection of the closing formula + splitting the daf into perek runs.
+ */
+import { describe, it, expect } from 'vitest';
+import { findHadranSegments, findMarkers, perekRuns } from '../../src/lib/typing/markers';
+
+const segs = [
+  'תנו רבנן המביא גט',
+  'אמר רבא הלכה כרבי',
+  'הדרן עלך פרק קמא וסליקא לה מסכתא',   // perek boundary
+  'מתני׳ בשלמא',
+  'גמרא מאי טעמא',
+];
+
+describe('findHadranSegments', () => {
+  it('finds the segment with the Hadran formula', () => {
+    expect(findHadranSegments(segs)).toEqual([2]);
+  });
+  it('ignores nikud (normalized match)', () => {
+    expect(findHadranSegments(['הֲדַרַן עֲלָךְ פֶּרֶק'])).toEqual([0]);
+  });
+  it('returns [] when there is no Hadran', () => {
+    expect(findHadranSegments(['תנו רבנן', 'אמר רבא'])).toEqual([]);
+  });
+});
+
+describe('findMarkers', () => {
+  it('emits a hadran marker span per boundary', () => {
+    expect(findMarkers(segs)).toEqual([{ startSegIdx: 2, endSegIdx: 2, kind: 'hadran' }]);
+  });
+});
+
+describe('perekRuns', () => {
+  it('splits the daf at the Hadran (run ends on the boundary segment)', () => {
+    expect(perekRuns(segs)).toEqual([{ start: 0, end: 2 }, { start: 3, end: 4 }]);
+  });
+  it('a daf with no Hadran is one run', () => {
+    expect(perekRuns(['a', 'b', 'c'])).toEqual([{ start: 0, end: 2 }]);
+  });
+  it('handles a Hadran as the last segment (no trailing run)', () => {
+    expect(perekRuns(['a', 'b', 'הדרן עלך'])).toEqual([{ start: 0, end: 2 }]);
+  });
+  it('empty daf -> no runs', () => {
+    expect(perekRuns([])).toEqual([]);
+  });
+});


### PR DESCRIPTION
A daf straddling two perakim gets one conflated summary. The Hadran is a deterministic boundary, so detect it in code.

- **`markers.ts`**: `findHadranSegments`/`findMarkers` + `perekRuns` (split the daf at the boundary). Pure, unit-tested.
- type-profiles endpoint returns `markers`; **TypeProfilePanel renders a perek-boundary divider**.

Deterministic, no LLM. Downstream: have the reader Overview consume `markers` to split its summary (needs the renderer + a per-perek summary). 1387 tests pass, typecheck clean.