### PR TITLE
Cross-daf sugya bridge — the boundary-finder (#2)

### DIFF
--- a/src/lib/typing/bridge.ts
+++ b/src/lib/typing/bridge.ts
@@ -1,0 +1,75 @@
+/**
+ * @fileoverview Cross-daf sugya bridge — does the discussion at the END of one
+ * daf continue into the START of the next? This is the boundary-finder the
+ * cross-page sugya map needs: combined with the per-daf flow (argument-overview)
+ * and stitchSugyot, a `continues` bridge chains two dapim's sections into one
+ * sugya that spans the page break (Shabbat 125b–126b).
+ *
+ * Two-tier, cheap-first:
+ *   - DETERMINISTIC: a Hadran ("הדרן עלך …") at the end of the from-daf means the
+ *     perek closed there, so the sugya cannot continue — no LLM (hadranBridge).
+ *   - LLM: otherwise, judge the boundary from the two sections' summaries +
+ *     verbatim closing/opening text. The prompt is built here (pure, testable);
+ *     the call itself is in the worker.
+ *
+ * Pure + DOM-free.
+ */
+
+import type { DafRef } from '../context/coord';
+
+export type BridgeKind = 'continues' | 'perek-boundary' | 'new-topic';
+
+export interface DafBridge {
+  from: DafRef;
+  /** The next amud, or null at the end of the tractate. */
+  to: DafRef | null;
+  /** Does the from-daf's closing discussion carry into the to-daf? */
+  continues: boolean;
+  kind: BridgeKind;
+  via: 'hadran' | 'llm' | 'edge-of-tractate' | 'no-data';
+  note?: string;
+}
+
+export interface BridgeSection { title?: string; summary?: string; excerpt?: string }
+
+/** No next daf (tractate end) → no bridge. */
+export function edgeOfTractateBridge(from: DafRef): DafBridge {
+  return { from, to: null, continues: false, kind: 'new-topic', via: 'edge-of-tractate' };
+}
+
+/** Deterministic short-circuit: a Hadran ending the from-daf closes the perek,
+ *  so the sugya does NOT continue — skip the LLM. Returns null when there's no
+ *  Hadran (caller falls through to the LLM judgement). */
+export function hadranBridge(from: DafRef, to: DafRef, fromEndsWithHadran: boolean): DafBridge | null {
+  if (!fromEndsWithHadran) return null;
+  return { from, to, continues: false, kind: 'perek-boundary', via: 'hadran', note: 'Hadran — perek boundary' };
+}
+
+/** The LLM prompt judging whether the boundary continues. Pure string assembly
+ *  so it's unit-testable; the worker runs it through runLLM. */
+export function buildBridgePrompt(prev: BridgeSection, next: BridgeSection): string {
+  return [
+    'Two consecutive dapim of Talmud. Decide whether the discussion at the END of the first daf continues directly into the START of the second, or the second begins a new topic.',
+    '',
+    `END of daf 1 — section "${prev.title ?? ''}":`,
+    prev.summary ?? '',
+    `closing text: ${prev.excerpt ?? ''}`,
+    '',
+    `START of daf 2 — section "${next.title ?? ''}":`,
+    next.summary ?? '',
+    `opening text: ${next.excerpt ?? ''}`,
+    '',
+    'Set continues=true ONLY if daf 2 directly carries forward daf 1\'s same discussion / sugya thread (not merely the same tractate or a loosely related theme). Answer per the schema.',
+  ].join('\n');
+}
+
+/** Build a DafBridge from the LLM verdict. */
+export function llmBridge(from: DafRef, to: DafRef, verdict: { continues?: unknown; note?: unknown }): DafBridge {
+  const continues = verdict?.continues === true;
+  return {
+    from, to, continues,
+    kind: continues ? 'continues' : 'new-topic',
+    via: 'llm',
+    note: typeof verdict?.note === 'string' ? verdict.note : undefined,
+  };
+}

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -86,7 +86,10 @@ import { CODE_MARKS, CODE_ENRICHMENTS, findCodeMark, findCodeEnrichment } from '
 import {
   ENRICH_JSON_SCHEMA,
   TRANSLATE_BIO_JSON_SCHEMA,
+  ARGUMENT_BRIDGE_OUTPUT_SCHEMA,
 } from './output-schemas';
+import { findHadranSegments } from '../lib/typing/markers';
+import { hadranBridge, edgeOfTractateBridge, buildBridgePrompt, llmBridge, type DafBridge, type BridgeSection } from '../lib/typing/bridge';
 import type {
   MarkDefinition as SchemaMarkDefinition,
   EnrichmentDefinition as SchemaEnrichmentDefinition,
@@ -694,6 +697,66 @@ app.get('/api/studio/type-profiles/:tractate/:page', async (c) => {
   const slice = await getGemaraSlice(c.env, tractate, page, false);
   const markers = findMarkers(slice.segments_he);
   return c.json({ tractate, page, count: profiles.length, profiles, markers });
+});
+
+// Cross-daf bridge (sugya map): does this daf's closing discussion continue into
+// the next amud? Deterministic Hadran short-circuit (perek boundary → no), else
+// a cheap Flash judgement over the two boundary sections. Cached by daf.
+const bridgeKey = (t: string, p: string) =>
+  `bridge:v1:${t.toLowerCase().replace(/[^a-z0-9.-]+/g, '_')}:${p.toLowerCase().replace(/[^a-z0-9.-]+/g, '_')}`;
+async function computeDafBridge(env: Bindings, tractate: string, page: string): Promise<DafBridge> {
+  const from = { tractate, page };
+  const nextPage = adjacentAmud(tractate, page, 1);
+  if (!nextPage) return edgeOfTractateBridge(from);
+  const to = { tractate, page: nextPage };
+  const cache = env.CACHE;
+  const key = bridgeKey(tractate, page);
+  if (cache) { const c = await cache.get(key); if (c) { try { return JSON.parse(c) as DafBridge; } catch { /* recompute */ } } }
+
+  // Deterministic: a Hadran in the daf's final segment(s) closes the perek.
+  const slice = await getGemaraSlice(env, tractate, page, false);
+  const hadran = findHadranSegments(slice.segments_he);
+  const endsWithHadran = hadran.length > 0 && hadran[hadran.length - 1] >= slice.segments_he.length - 2;
+  let bridge = hadranBridge(from, to, endsWithHadran);
+
+  if (!bridge) {
+    const str = (v: unknown): string => (typeof v === 'string' ? v : '');
+    const numSeg = (i: RawInstance) => (typeof i.startSegIdx === 'number' ? i.startSegIdx : -1);
+    const prev = (await readMarkInstances(env, 'argument', tractate, page)).filter((i) => numSeg(i) >= 0);
+    const next = (await readMarkInstances(env, 'argument', tractate, nextPage)).filter((i) => numSeg(i) >= 0);
+    const prevLast = prev.length ? prev.reduce((a, b) => (numSeg(b) > numSeg(a) ? b : a)) : null;
+    const nextFirst = next.length ? next.reduce((a, b) => (numSeg(b) < numSeg(a) ? b : a)) : null;
+    if (!prevLast || !nextFirst) {
+      bridge = { from, to, continues: false, kind: 'new-topic', via: 'no-data', note: 'argument sections not warmed for both dapim' };
+    } else {
+      const prevSec: BridgeSection = { title: str(prevLast.fields?.title), summary: str(prevLast.fields?.summary), excerpt: str(prevLast.fields?.endExcerpt) || str(prevLast.fields?.excerpt) };
+      const nextSec: BridgeSection = { title: str(nextFirst.fields?.title), summary: str(nextFirst.fields?.summary), excerpt: str(nextFirst.fields?.excerpt) };
+      try {
+        const res = await runLLM(env, {
+          model: 'openrouter/deepseek/deepseek-v4-flash' as LLMModelId,
+          messages: [
+            { role: 'system', content: 'You are a Talmud scholar judging whether a sugya continues across a daf boundary.' },
+            { role: 'user', content: buildBridgePrompt(prevSec, nextSec) },
+          ],
+          max_tokens: 1500, temperature: 0.2,
+          response_format: { type: 'json_schema', json_schema: ARGUMENT_BRIDGE_OUTPUT_SCHEMA },
+          thinking: false, tag: 'argument-overview.bridge',
+        });
+        let verdict: { continues?: unknown; note?: unknown } = {};
+        try { verdict = JSON.parse(res.content); } catch { /* fall through */ }
+        bridge = llmBridge(from, to, verdict);
+      } catch {
+        bridge = { from, to, continues: false, kind: 'new-topic', via: 'no-data', note: 'bridge LLM unavailable' };
+      }
+    }
+  }
+  // Don't pin a no-data verdict — it should retry once the dafim are warmed / budget frees.
+  if (cache && bridge.via !== 'no-data') await cache.put(key, JSON.stringify(bridge));
+  return bridge;
+}
+app.get('/api/studio/bridge/:tractate/:page', async (c) => {
+  const bridge = await computeDafBridge(c.env, c.req.param('tractate'), c.req.param('page'));
+  return c.json(bridge);
 });
 
 app.get('/api/studio/enrichments', async (c) => {

--- a/src/worker/output-schemas.ts
+++ b/src/worker/output-schemas.ts
@@ -133,6 +133,11 @@ export const ARGUMENT_NARRATIVE_OUTPUT_SCHEMA = responseFormat('argument_narrati
     excerpt: z.string(),
   })),
 }));
+// Cross-daf bridge verdict (sugya map): does the boundary continue into the next daf?
+export const ARGUMENT_BRIDGE_OUTPUT_SCHEMA = responseFormat('argument_bridge', z.object({
+  continues: z.boolean(),
+  note: z.string(),
+}));
 export const ARGUMENT_BACKGROUND_OUTPUT_SCHEMA = responseFormat('argument_background', single('background'));
 export const ARGUMENT_SYNTHESIS_OUTPUT_SCHEMA = responseFormat('argument_synthesis', single('synthesis'));
 

--- a/tests/typing/bridge.test.ts
+++ b/tests/typing/bridge.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Cross-daf bridge pure logic (src/lib/typing/bridge.ts): the deterministic
+ * Hadran short-circuit, the tractate-edge case, the prompt assembly, and the
+ * LLM-verdict → DafBridge mapping. (The LLM call + cross-daf loading live in the
+ * worker; here we pin the pieces that must be exact.)
+ */
+import { describe, it, expect } from 'vitest';
+import { hadranBridge, edgeOfTractateBridge, buildBridgePrompt, llmBridge } from '../../src/lib/typing/bridge';
+
+const from = { tractate: 'Shabbat', page: '125b' };
+const to = { tractate: 'Shabbat', page: '126a' };
+
+describe('hadranBridge', () => {
+  it('blocks continuation when the daf ends with a Hadran (no LLM)', () => {
+    expect(hadranBridge(from, to, true)).toEqual({
+      from, to, continues: false, kind: 'perek-boundary', via: 'hadran', note: 'Hadran — perek boundary',
+    });
+  });
+  it('returns null (fall through to LLM) when there is no Hadran', () => {
+    expect(hadranBridge(from, to, false)).toBeNull();
+  });
+});
+
+describe('edgeOfTractateBridge', () => {
+  it('no next daf → no bridge', () => {
+    expect(edgeOfTractateBridge(from)).toMatchObject({ to: null, continues: false, via: 'edge-of-tractate' });
+  });
+});
+
+describe('buildBridgePrompt', () => {
+  it('includes both sections\' titles, summaries and boundary text', () => {
+    const p = buildBridgePrompt(
+      { title: 'Carrying out', summary: 'ends mid-dispute', excerpt: 'סוף הסוגיא' },
+      { title: 'New case', summary: 'opens a new question', excerpt: 'מתני׳' },
+    );
+    expect(p).toContain('Carrying out');
+    expect(p).toContain('ends mid-dispute');
+    expect(p).toContain('סוף הסוגיא');
+    expect(p).toContain('New case');
+    expect(p).toContain('מתני׳');
+    expect(p.toLowerCase()).toContain('continues=true');
+  });
+});
+
+describe('llmBridge', () => {
+  it('maps a continues verdict', () => {
+    expect(llmBridge(from, to, { continues: true, note: 'same thread' }))
+      .toEqual({ from, to, continues: true, kind: 'continues', via: 'llm', note: 'same thread' });
+  });
+  it('maps a non-continues verdict (and a missing/odd continues field is false)', () => {
+    expect(llmBridge(from, to, { continues: false, note: 'new topic' }).kind).toBe('new-topic');
+    expect(llmBridge(from, to, {}).continues).toBe(false);
+    expect(llmBridge(from, to, { continues: 'yes' }).continues).toBe(false); // only strict true counts
+  });
+});


### PR DESCRIPTION
The hard core of the cross-page sugya map: does a daf's closing discussion continue into the next amud?

- **Deterministic** Hadran short-circuit (perek boundary → no continuation, no LLM) + tractate-edge case.
- **LLM** otherwise — a cheap Flash judgement over the two boundary sections' summaries + verbatim closing/opening text.
- `src/lib/typing/bridge.ts` = pure pieces (decisions/prompt/verdict, unit-tested); `computeDafBridge` (worker) = cross-daf load + LLM + cache (`bridge:v1:<daf>`); `GET /api/studio/bridge/:t/:p` exposes it. Returns `via:'no-data'` (retryable, unpinned) when a daf's sections aren't warmed yet.

Next: chain bridges + per-daf flow through `stitchSugyot` → full cross-page sugya spans + renderer. 1393 tests pass, typecheck clean.