### PR TITLE
Assemble cross-page sugyot (sections + flow + bridges) (#2)

### DIFF
--- a/src/lib/typing/assemble.ts
+++ b/src/lib/typing/assemble.ts
@@ -1,0 +1,66 @@
+/**
+ * @fileoverview Assemble cross-page sugyot from the primitives: per-daf argument
+ * sections, the per-daf flow (argument-overview connections between sections),
+ * and the cross-daf bridges (does daf N continue into N+1). Maps it all into
+ * coord.ts coordinates + SugyaFlowEdges and runs stitchSugyot — the result is
+ * the set of sugya units, each spanning whatever dapim its thread covers.
+ *
+ * Pure: the worker loads the data for a window of dapim and calls this. The flow
+ * `from`/`to` are 0-based indices into a daf's ordered argument sections (the
+ * argument-overview.flow contract); each maps to that section's coordinate.
+ */
+
+import { coordForSeg, type AnchorCoord, type DafRef } from '../context/coord';
+import { stitchSugyot, type SugyaFlowEdge, type SugyaUnit } from './sugya';
+
+export interface DafForAssembly {
+  ref: DafRef;
+  /** Ordered argument sections of this daf. */
+  sections: Array<{ startSegIdx: number; endSegIdx: number }>;
+  /** Per-daf flow: from/to are section INDICES into `sections`. */
+  flow: Array<{ from: number; to: number; kind: string }>;
+}
+
+/** Whether dapim[i] continues into dapim[i+1] (one entry per consecutive pair). */
+export interface BridgeLink { continues: boolean }
+
+/**
+ * Build the section coordinates + edges across a window of consecutive dapim and
+ * stitch them into cross-page sugya units. `bridges[i]` links dapim[i] →
+ * dapim[i+1]; a continuing bridge adds a `continues` edge from the earlier daf's
+ * LAST section to the later daf's FIRST section.
+ */
+export function assembleSugyot(dapim: readonly DafForAssembly[], bridges: readonly BridgeLink[]): SugyaUnit[] {
+  const coords: AnchorCoord[] = [];
+  const edges: SugyaFlowEdge[] = [];
+
+  for (const d of dapim) {
+    for (const s of d.sections) coords.push(coordForSeg(d.ref, s.startSegIdx));
+    // intra-daf flow: section index → that section's coordinate.
+    for (const f of d.flow) {
+      const from = d.sections[f.from], to = d.sections[f.to];
+      if (!from || !to) continue;
+      edges.push({ from: coordForSeg(d.ref, from.startSegIdx), to: coordForSeg(d.ref, to.startSegIdx), kind: f.kind });
+    }
+  }
+
+  // cross-daf bridges: earlier daf's last section → later daf's first section.
+  for (let i = 0; i < dapim.length - 1; i++) {
+    if (!bridges[i]?.continues) continue;
+    const a = dapim[i].sections, b = dapim[i + 1].sections;
+    if (a.length === 0 || b.length === 0) continue;
+    const last = a.reduce((x, y) => (y.startSegIdx > x.startSegIdx ? y : x));
+    const first = b.reduce((x, y) => (y.startSegIdx < x.startSegIdx ? y : x));
+    edges.push({ from: coordForSeg(dapim[i].ref, last.startSegIdx), to: coordForSeg(dapim[i + 1].ref, first.startSegIdx), kind: 'continues' });
+  }
+
+  return stitchSugyot(coords, edges);
+}
+
+/** The sugya unit that contains a given (daf, seg) coordinate, or null. */
+export function sugyaContaining(units: readonly SugyaUnit[], at: AnchorCoord): SugyaUnit | null {
+  for (const u of units) {
+    if (u.span.some((c) => c.tractate === at.tractate && c.page === at.page && c.seg === at.seg)) return u;
+  }
+  return null;
+}

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -90,6 +90,8 @@ import {
 } from './output-schemas';
 import { findHadranSegments } from '../lib/typing/markers';
 import { hadranBridge, edgeOfTractateBridge, buildBridgePrompt, llmBridge, type DafBridge, type BridgeSection } from '../lib/typing/bridge';
+import { assembleSugyot, sugyaContaining, type DafForAssembly } from '../lib/typing/assemble';
+import { coordForSeg } from '../lib/context/coord';
 import type {
   MarkDefinition as SchemaMarkDefinition,
   EnrichmentDefinition as SchemaEnrichmentDefinition,
@@ -757,6 +759,68 @@ async function computeDafBridge(env: Bindings, tractate: string, page: string): 
 app.get('/api/studio/bridge/:tractate/:page', async (c) => {
   const bridge = await computeDafBridge(c.env, c.req.param('tractate'), c.req.param('page'));
   return c.json(bridge);
+});
+
+// Load a daf's cached argument-overview.flow connections (section-index edges).
+async function readFlowConnections(env: Bindings, tractate: string, page: string): Promise<Array<{ from: number; to: number; kind: string }>> {
+  const def = findCodeEnrichment('argument-overview.flow');
+  if (!def) return [];
+  const iid = await instanceIdOf({ fields: {} });
+  const hit = await readCachedResult(env, keyForEnrichment(def, iid, { tractate, page }));
+  const conns = (hit?.parsed as { connections?: unknown } | null)?.connections;
+  if (!Array.isArray(conns)) return [];
+  return (conns as Array<Record<string, unknown>>)
+    .filter((c) => typeof c.from === 'number' && typeof c.to === 'number')
+    .map((c) => ({ from: c.from as number, to: c.to as number, kind: typeof c.kind === 'string' ? c.kind : 'continues' }));
+}
+async function sectionsFor(env: Bindings, tractate: string, page: string): Promise<Array<{ startSegIdx: number; endSegIdx: number }>> {
+  return (await readMarkInstances(env, 'argument', tractate, page))
+    .filter((i) => typeof i.startSegIdx === 'number' && typeof i.endSegIdx === 'number')
+    .map((i) => ({ startSegIdx: i.startSegIdx as number, endSegIdx: i.endSegIdx as number }));
+}
+
+// Assemble the cross-page sugyot around a daf: walk the continuing bridges to a
+// bounded window of dapim, load each one's sections + flow, and stitch them
+// (intra-daf flow + cross-daf bridges) into sugya units. Returns the units and
+// the one containing the target daf's first section.
+const SUGYA_WINDOW_CAP = 5;
+app.get('/api/studio/sugya/:tractate/:page', async (c) => {
+  const env = c.env;
+  const tractate = c.req.param('tractate');
+  const page = c.req.param('page');
+
+  // Window: walk forward + backward from the target while the bridge continues.
+  const pages: string[] = [page];
+  let cur = page;
+  while (pages.length < SUGYA_WINDOW_CAP) {
+    const b = await computeDafBridge(env, tractate, cur);
+    if (!b.to || !b.continues) break;
+    pages.push(b.to.page); cur = b.to.page;
+  }
+  cur = page;
+  while (pages.length < SUGYA_WINDOW_CAP) {
+    const prev = adjacentAmud(tractate, cur, -1);
+    if (!prev) break;
+    const b = await computeDafBridge(env, tractate, prev); // prev -> cur
+    if (!b.continues) break;
+    pages.unshift(prev); cur = prev;
+  }
+
+  const dapim: DafForAssembly[] = [];
+  for (const p of pages) {
+    dapim.push({ ref: { tractate, page: p }, sections: await sectionsFor(env, tractate, p), flow: await readFlowConnections(env, tractate, p) });
+  }
+  const bridges = [];
+  for (let i = 0; i < dapim.length - 1; i++) {
+    bridges.push({ continues: (await computeDafBridge(env, tractate, dapim[i].ref.page)).continues });
+  }
+
+  const sugyot = assembleSugyot(dapim, bridges);
+  const targetSecs = dapim.find((d) => d.ref.page === page)?.sections ?? [];
+  const targetFirst = targetSecs.length ? targetSecs.reduce((a, b) => (b.startSegIdx < a.startSegIdx ? b : a)) : null;
+  const current = targetFirst ? sugyaContaining(sugyot, coordForSeg({ tractate, page }, targetFirst.startSegIdx)) : null;
+
+  return c.json({ tractate, page, window: pages, count: sugyot.length, sugyot, current });
 });
 
 app.get('/api/studio/enrichments', async (c) => {

--- a/tests/typing/assemble.test.ts
+++ b/tests/typing/assemble.test.ts
@@ -1,0 +1,49 @@
+/**
+ * assembleSugyot (src/lib/typing/assemble.ts): combine per-daf sections +
+ * per-daf flow + cross-daf bridges into cross-page sugya units.
+ */
+import { describe, it, expect } from 'vitest';
+import { assembleSugyot, sugyaContaining, type DafForAssembly } from '../../src/lib/typing/assemble';
+import { coordForSeg } from '../../src/lib/context/coord';
+
+const d125: DafForAssembly = {
+  ref: { tractate: 'Shabbat', page: '125b' },
+  sections: [{ startSegIdx: 0, endSegIdx: 3 }, { startSegIdx: 4, endSegIdx: 7 }],
+  flow: [{ from: 0, to: 1, kind: 'continues' }], // section 0 -> section 1 within the daf
+};
+const d126: DafForAssembly = {
+  ref: { tractate: 'Shabbat', page: '126a' },
+  sections: [{ startSegIdx: 0, endSegIdx: 2 }],
+  flow: [],
+};
+
+describe('assembleSugyot', () => {
+  it('a continuing bridge merges both dapim into ONE cross-page sugya', () => {
+    const units = assembleSugyot([d125, d126], [{ continues: true }]);
+    expect(units).toHaveLength(1);
+    expect(units[0].crossesDaf).toBe(true);
+    expect(units[0].dapim.map((d) => d.page)).toEqual(['125b', '126a']);
+    expect(units[0].span).toHaveLength(3);
+  });
+
+  it('a non-continuing bridge keeps the dapim as separate sugyot', () => {
+    const units = assembleSugyot([d125, d126], [{ continues: false }]);
+    // 125b's two sections are linked by flow -> one sugya; 126a's lone section -> another.
+    expect(units).toHaveLength(2);
+    expect(units.some((u) => u.crossesDaf)).toBe(false);
+  });
+
+  it('ignores flow edges that reference an out-of-range section index', () => {
+    const bad: DafForAssembly = { ref: { tractate: 'Shabbat', page: '125b' }, sections: [{ startSegIdx: 0, endSegIdx: 3 }], flow: [{ from: 0, to: 9, kind: 'continues' }] };
+    const units = assembleSugyot([bad], []);
+    expect(units).toHaveLength(1); // the single section, edge dropped
+  });
+
+  it('sugyaContaining finds the unit holding a coordinate', () => {
+    const units = assembleSugyot([d125, d126], [{ continues: true }]);
+    const u = sugyaContaining(units, coordForSeg({ tractate: 'Shabbat', page: '126a' }, 0));
+    expect(u).not.toBeNull();
+    expect(u!.dapim.map((d) => d.page)).toEqual(['125b', '126a']);
+    expect(sugyaContaining(units, coordForSeg({ tractate: 'Shabbat', page: '200a' }, 0))).toBeNull();
+  });
+});


### PR DESCRIPTION
Turns the primitives into real cross-page sugyot.

- **`assembleSugyot`** (pure): per-daf sections + flow + cross-daf bridges → coords + edges → `stitchSugyot`. A continuing bridge merges dapim into one sugya; non-continuing keeps them separate. `sugyaContaining` locates a coordinate's unit. Unit-tested.
- **`GET /api/studio/sugya/:t/:p`**: walks continuing bridges to a ≤5-daf window, loads sections + cached flow, returns the assembled sugyot + the one containing the target. Deterministic given the cached primitives.

Completes the cross-page sugya **data path** (coord → stitch → flow → bridge → assemble). Remaining for #2: the renderer. 1397 tests pass, typecheck clean.