### PR TITLE
Promote sugya map to readers; Overview cards highlight text; center chip bar

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -12,6 +12,7 @@ import ArgumentVoiceMap, { type ArgumentVoicesData } from './ArgumentVoiceMap';
 import ArgumentNarrative from './ArgumentNarrative';
 import { deriveVoiceEdges } from '../lib/typing/voices';
 import ArgumentFlowGraph, { type FlowConnection } from './ArgumentFlowGraph';
+import SugyaMap from './SugyaMap';
 import { selectSectionMoves } from '../lib/argumentMoves';
 import { t, lang } from './i18n';
 import { ACCENTS, HebrewProse, Panel, QASection, SectionCard, Synthesis, kindLabelKey } from './sidebar/primitives';
@@ -723,6 +724,7 @@ function ArgumentOverviewBody(props: {
   page: string;
   sections: Section[];
   onPushRabbi: (name: string) => void;
+  onHighlightRange?: (range: { start: number; end: number; key: string } | null) => void;
 }): JSX.Element {
   const [connections, setConnections] = createSignal<FlowConnection[]>([]);
   const [active, setActive] = createSignal<number | null>(null);
@@ -731,7 +733,22 @@ function ArgumentOverviewBody(props: {
     void `${props.tractate}/${props.page}`;
     setConnections([]);
     setActive(null);
+    props.onHighlightRange?.(null);
   });
+
+  // Clicking a section card both opens its voices and paints the section's
+  // segment range on the daf (clicking the active card again clears both).
+  const selectSection = (i: number) => {
+    const next = active() === i ? null : i;
+    setActive(next);
+    if (next === null) { props.onHighlightRange?.(null); return; }
+    const s = props.sections[i];
+    if (s && s.startSegIdx != null && s.endSegIdx != null) {
+      props.onHighlightRange?.({ start: s.startSegIdx, end: s.endSegIdx, key: `overview:${i}` });
+    } else {
+      props.onHighlightRange?.(null);
+    }
+  };
 
   const handleResolved = (r: { deps_resolved?: Record<string, unknown>; anchors_resolved?: Record<string, unknown> }) => {
     const flow = r.deps_resolved?.['argument-overview.flow'] as { connections?: FlowConnection[] } | undefined;
@@ -762,7 +779,7 @@ function ArgumentOverviewBody(props: {
           nodes={nodes()}
           connections={connections()}
           activeIndex={active()}
-          onSelect={(i) => setActive(active() === i ? null : i)}
+          onSelect={selectSection}
         />
         <Show when={active() !== null && props.sections[active()!]}>
           <OverviewSectionVoices
@@ -772,6 +789,12 @@ function ArgumentOverviewBody(props: {
             onPushRabbi={props.onPushRabbi}
           />
         </Show>
+        {/* Cross-page sugya map: how this daf's discussion spans neighbours. */}
+        <SugyaMap
+          tractate={props.tractate}
+          page={props.page}
+          onHighlight={(r) => props.onHighlightRange?.(r ? { start: r.start, end: r.end, key: 'sugya' } : null)}
+        />
       </Show>
     </Panel>
   );
@@ -1766,6 +1789,7 @@ export function ArgumentSidebar(props: ArgumentSidebarProps): JSX.Element {
                 page={props.page}
                 sections={props.dafSections ?? []}
                 onPushRabbi={props.onPushRabbi}
+                onHighlightRange={props.onHighlightRange}
               />
             </Show>
 

--- a/src/client/DafViewer.tsx
+++ b/src/client/DafViewer.tsx
@@ -35,7 +35,6 @@ import { applyMarkRenderers } from './renderers/dispatch';
 import DevModeShelf, { readDevMode, setDevModeActive } from './DevModeShelf';
 import ChecksPanel from './ChecksPanel';
 import TypeProfilePanel from './TypeProfilePanel';
-import SugyaMap from './SugyaMap';
 import type { GenerationId } from './generations';
 import { GENERATION_BY_ID } from './generations';
 import { resolveVoiceGroup, voiceGroupNames } from './voiceGroups';
@@ -2607,7 +2606,7 @@ export default function DafViewer(): JSX.Element {
       {/* Whole-daf chip marks (the Overview) — shown to all readers now that the
           per-daf overview is promoted and its flow is warmed globally. */}
       <Show when={chipMarks().length > 0}>
-        <div class="daf-chip-bar" style={{ display: 'flex', gap: '0.4rem', 'flex-wrap': 'wrap', margin: '0 0 0.6rem' }}>
+        <div class="daf-chip-bar" style={{ display: 'flex', 'justify-content': 'center', gap: '0.4rem', 'flex-wrap': 'wrap', margin: '0 0 0.6rem' }}>
           <For each={chipMarks()}>{(m) => {
             const color = (m.render as { color?: string }).color ?? '#8a2a2b';
             const label = m.id === 'argument-overview' ? t('overview.chip') : m.id;
@@ -2872,11 +2871,6 @@ export default function DafViewer(): JSX.Element {
           page={page()}
           active={(() => { const h = argumentMoveHighlight(); return h && h.key.startsWith('typeprofile') ? { start: h.start, end: h.end } : null; })()}
           onHighlight={(r) => setArgumentMoveHighlight(r ? { start: r.start, end: r.end, key: `typeprofile-${r.start}-${r.end}` } : null)}
-        />
-        <SugyaMap
-          tractate={tractate()}
-          page={page()}
-          onHighlight={(r) => setArgumentMoveHighlight(r ? { start: r.start, end: r.end, key: `sugya-${r.start}` } : null)}
         />
         <MarksRegistryPanel
           tractate={tractate()}

--- a/src/client/SugyaMap.tsx
+++ b/src/client/SugyaMap.tsx
@@ -4,8 +4,8 @@
  * sugya units — and draws them: one row per daf, the daf's sections as cells,
  * and the sugya CONTAINING the current daf highlighted across whatever pages it
  * spans. The headline is "this discussion runs from 125b to 126a", which no
- * per-daf view can show. Dev-mode only (mounted in DevModeShelf) while the
- * cross-daf flow is still warming.
+ * per-daf view can show. Reader-facing: mounted at the foot of the Overview
+ * sidebar (ArgumentOverviewBody); the panel self-hides when there is no window.
  */
 
 import { createResource, For, Show, type JSX } from 'solid-js';


### PR DESCRIPTION
Three reader-facing Overview improvements:

1. **Sugya map promoted to readers** — `SugyaMap` now mounts at the foot of the Overview sidebar (previously dev-shelf only), so every reader sees how the daf's discussion spans neighbouring dapim. Self-hides when there's no window. Bridges are cached (Hadran boundaries deterministic+free; un-warmed boundaries do one cheap Flash call, cached after).
2. **Section cards highlight the text** — clicking an Overview section card paints that section's segment range on the daf (clicking again clears), matching the argument-move card behaviour.
3. **Centered chip bar** — the whole-daf chip bar is centered, and any future chips center with it.

typecheck + 1397 tests green.