### PR TITLE
Legible sugya map + pre-warm cross-daf bridges for daf-yomi

### DIFF
--- a/src/client/SugyaMap.tsx
+++ b/src/client/SugyaMap.tsx
@@ -1,18 +1,24 @@
 /**
- * Cross-page sugya map (Track C #2). Calls GET /api/studio/sugya/:t/:p — which
- * walks the continuing bridges to a window of dapim and assembles cross-page
- * sugya units — and draws them: one row per daf, the daf's sections as cells,
- * and the sugya CONTAINING the current daf highlighted across whatever pages it
- * spans. The headline is "this discussion runs from 125b to 126a", which no
- * per-daf view can show. Reader-facing: mounted at the foot of the Overview
- * sidebar (ArgumentOverviewBody); the panel self-hides when there is no window.
+ * Cross-page sugya map (Track C #2). A sugya is one continuous discussion; it
+ * often does not begin or end on the daf you're reading. This panel answers the
+ * one question no per-daf view can: "does the discussion at the top of this daf
+ * spill across the page break?" It calls GET /api/studio/sugya/:t/:p — which
+ * walks the continuing cross-daf bridges to a window of neighbouring dapim and
+ * assembles the sugya containing this daf — and lists that sugya's sections by
+ * their titles, grouped by daf. Sections ON this daf are clickable (they paint
+ * the matching text); sections on a neighbouring daf show what you'd be reading
+ * if you kept going. Reader-facing: mounted at the foot of the Overview sidebar.
  */
 
 import { createResource, For, Show, type JSX } from 'solid-js';
 
-interface DafRow { tractate: string; page: string; segs: number[] }
+interface SectionCell { start: number; end: number; title: string }
+interface DafRow { tractate: string; page: string; segs: number[]; sections: SectionCell[] }
 interface SugyaUnit { dapim: DafRow[]; crossesDaf: boolean }
-interface SugyaResponse { tractate: string; page: string; window: string[]; count: number; sugyot: SugyaUnit[]; current: SugyaUnit | null }
+interface SugyaResponse {
+  tractate: string; page: string; window: string[]; count: number;
+  sugyot: SugyaUnit[]; current: SugyaUnit | null;
+}
 
 export default function SugyaMap(props: {
   tractate: string;
@@ -29,59 +35,55 @@ export default function SugyaMap(props: {
     },
   );
 
-  const inCurrent = (page: string, seg: number) =>
-    (data()?.current?.dapim ?? []).some((d) => d.page === page && d.segs.includes(seg));
+  const current = () => data()?.current ?? null;
+  const dapim = () => current()?.dapim ?? [];
 
   return (
-    <Show when={data() && data()!.window.length > 0}>
-      <div style={{ border: '1px solid #eee', 'border-radius': '4px', background: '#fff', padding: '0.4rem 0.55rem', 'font-size': '0.78rem' }}>
+    <Show when={current() && dapim().length > 0}>
+      <div style={{ 'margin-top': '0.6rem', border: '1px solid #ede9fe', 'border-radius': '6px', background: '#faf8ff', padding: '0.55rem 0.65rem' }}>
         <div style={{
-          'font-size': '0.65rem', 'text-transform': 'uppercase', 'letter-spacing': '0.06em', color: '#888',
-          'margin-bottom': '0.35rem', display: 'flex', 'justify-content': 'space-between',
-        }}>
-          <span>Sugya map</span>
-          <Show when={data()!.current?.crossesDaf}>
-            <span style={{ color: '#9333ea' }}>spans {data()!.current!.dapim.map((d) => d.page).join(' → ')}</span>
+          'font-size': '0.62rem', 'text-transform': 'uppercase', 'letter-spacing': '0.07em',
+          color: '#9333ea', 'font-weight': 700, 'margin-bottom': '0.3rem',
+        }}>Sugya — this discussion</div>
+
+        {/* Plain-language headline: does it cross the page break, or not? */}
+        <div style={{ 'font-size': '0.8rem', color: '#555', 'line-height': 1.45, 'margin-bottom': '0.45rem' }}>
+          <Show
+            when={current()!.crossesDaf}
+            fallback={<>The discussion that opens this daf stays on <b>{props.page}</b>.</>}
+          >
+            The discussion that opens this daf runs across{' '}
+            <b style={{ color: '#7c3aed' }}>{dapim().map((d) => d.page).join(' → ')}</b> — it doesn't begin and end here.
           </Show>
         </div>
 
-        {/* One row per daf in the window; each section a cell. The cells of the
-            sugya containing the current daf are highlighted across the pages. */}
-        <For each={data()!.window}>{(pg) => {
-          const row = () => data()!.sugyot.flatMap((s) => s.dapim).filter((d) => d.page === pg);
-          const segs = () => [...new Set(row().flatMap((d) => d.segs))].sort((a, b) => a - b);
+        {/* The sugya's sections, grouped by daf. Sections on THIS daf are
+            clickable (paint the text); neighbouring dapim are context. */}
+        <For each={dapim()}>{(d) => {
+          const here = () => d.page === props.page;
           return (
-            <div style={{ display: 'flex', 'align-items': 'center', gap: '0.4rem', padding: '0.12rem 0' }}>
-              <span style={{
-                'flex-shrink': 0, width: '2.6rem', 'font-size': '0.7rem', 'font-weight': pg === props.page ? 700 : 400,
-                color: pg === props.page ? '#111' : '#999',
-              }}>{pg}</span>
-              <div style={{ display: 'flex', 'flex-wrap': 'wrap', gap: '0.2rem' }}>
-                <For each={segs()}>{(seg) => {
-                  const active = () => inCurrent(pg, seg);
-                  return (
-                    <span
-                      onClick={() => { if (pg === props.page) props.onHighlight?.({ start: seg, end: seg }); }}
-                      title={pg === props.page ? `seg ${seg} — highlight` : `${pg} seg ${seg}`}
-                      style={{
-                        'font-size': '0.62rem', 'font-variant-numeric': 'tabular-nums',
-                        padding: '0 0.3rem', 'border-radius': '3px',
-                        cursor: pg === props.page ? 'pointer' : 'default',
-                        background: active() ? '#f3e8ff' : '#f4f4f5',
-                        color: active() ? '#7c3aed' : '#999',
-                        border: active() ? '1px solid #c4b5fd' : '1px solid transparent',
-                      }}
-                    >{seg}</span>
-                  );
-                }}</For>
-              </div>
+            <div style={{ 'margin-bottom': '0.35rem' }}>
+              <div style={{
+                'font-size': '0.66rem', 'font-weight': 700, 'text-transform': 'uppercase', 'letter-spacing': '0.04em',
+                color: here() ? '#111' : '#a78b6a', 'margin-bottom': '0.15rem',
+              }}>{d.page}{here() ? ' · this daf' : ''}</div>
+              <For each={d.sections}>{(s) => (
+                <div
+                  onClick={() => { if (here()) props.onHighlight?.({ start: s.start, end: s.end }); }}
+                  title={here() ? 'Click to highlight this section on the daf' : `On ${d.page}`}
+                  style={{
+                    'font-size': '0.78rem', 'line-height': 1.4, padding: '0.12rem 0.35rem',
+                    'border-radius': '4px', 'margin-bottom': '0.1rem',
+                    cursor: here() ? 'pointer' : 'default',
+                    color: here() ? '#333' : '#999',
+                    background: here() ? '#fff' : 'transparent',
+                    border: here() ? '1px solid #eee' : '1px solid transparent',
+                  }}
+                >{s.title || `section at segment ${s.start}`}</div>
+              )}</For>
             </div>
           );
         }}</For>
-
-        <div style={{ 'margin-top': '0.3rem', 'font-size': '0.68rem', color: '#aaa' }}>
-          {data()!.count} sugy{data()!.count === 1 ? 'a' : 'ot'} in window · purple = the sugya here
-        </div>
       </div>
     </Show>
   );

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -773,11 +773,6 @@ async function readFlowConnections(env: Bindings, tractate: string, page: string
     .filter((c) => typeof c.from === 'number' && typeof c.to === 'number')
     .map((c) => ({ from: c.from as number, to: c.to as number, kind: typeof c.kind === 'string' ? c.kind : 'continues' }));
 }
-async function sectionsFor(env: Bindings, tractate: string, page: string): Promise<Array<{ startSegIdx: number; endSegIdx: number }>> {
-  return (await readMarkInstances(env, 'argument', tractate, page))
-    .filter((i) => typeof i.startSegIdx === 'number' && typeof i.endSegIdx === 'number')
-    .map((i) => ({ startSegIdx: i.startSegIdx as number, endSegIdx: i.endSegIdx as number }));
-}
 
 // Assemble the cross-page sugyot around a daf: walk the continuing bridges to a
 // bounded window of dapim, load each one's sections + flow, and stitch them
@@ -807,8 +802,23 @@ app.get('/api/studio/sugya/:tractate/:page', async (c) => {
   }
 
   const dapim: DafForAssembly[] = [];
+  // seg -> { end, title } per daf, so the response can label each section by its
+  // human title (not a bare segment index) and highlight its full segment range.
+  const secAt = new Map<string, { end: number; title: string }>();
   for (const p of pages) {
-    dapim.push({ ref: { tractate, page: p }, sections: await sectionsFor(env, tractate, p), flow: await readFlowConnections(env, tractate, p) });
+    const insts = (await readMarkInstances(env, 'argument', tractate, p))
+      .filter((i) => typeof i.startSegIdx === 'number' && typeof i.endSegIdx === 'number');
+    for (const i of insts) {
+      secAt.set(`${p}:${i.startSegIdx}`, {
+        end: i.endSegIdx as number,
+        title: typeof i.fields?.title === 'string' ? (i.fields.title as string) : '',
+      });
+    }
+    dapim.push({
+      ref: { tractate, page: p },
+      sections: insts.map((i) => ({ startSegIdx: i.startSegIdx as number, endSegIdx: i.endSegIdx as number })),
+      flow: await readFlowConnections(env, tractate, p),
+    });
   }
   const bridges = [];
   for (let i = 0; i < dapim.length - 1; i++) {
@@ -820,7 +830,24 @@ app.get('/api/studio/sugya/:tractate/:page', async (c) => {
   const targetFirst = targetSecs.length ? targetSecs.reduce((a, b) => (b.startSegIdx < a.startSegIdx ? b : a)) : null;
   const current = targetFirst ? sugyaContaining(sugyot, coordForSeg({ tractate, page }, targetFirst.startSegIdx)) : null;
 
-  return c.json({ tractate, page, window: pages, count: sugyot.length, sugyot, current });
+  // Decorate each daf row with titled section ranges (start/end/title) so the
+  // client can render "Opening Mishnah: Time for Evening Shema" instead of "0".
+  const withTitles = (u: typeof sugyot[number]) => ({
+    ...u,
+    dapim: u.dapim.map((d) => ({
+      ...d,
+      sections: d.segs.map((seg) => {
+        const s = secAt.get(`${d.page}:${seg}`);
+        return { start: seg, end: s?.end ?? seg, title: s?.title ?? '' };
+      }),
+    })),
+  });
+
+  return c.json({
+    tractate, page, window: pages, count: sugyot.length,
+    sugyot: sugyot.map(withTitles),
+    current: current ? withTitles(current) : null,
+  });
 });
 
 app.get('/api/studio/enrichments', async (c) => {
@@ -6707,10 +6734,10 @@ async function deepWarmDaf(
   tractate: string,
   page: string,
   lang: 'en' | 'he',
-): Promise<{ marks: number; enqueued: number; skipped: number }> {
+): Promise<{ marks: number; enqueued: number; skipped: number; bridges: number }> {
   const queue = rc.env.ENRICHMENT_QUEUE;
   const cache = rc.env.CACHE;
-  if (!queue) return { marks: 0, enqueued: 0, skipped: 0 };
+  if (!queue) return { marks: 0, enqueued: 0, skipped: 0, bridges: 0 };
   let marks = 0, enqueued = 0, skipped = 0;
 
   for (const [markId, enrichmentIds] of Object.entries(DEEP_WARM_PLAN)) {
@@ -6768,7 +6795,23 @@ async function deepWarmDaf(
     }
   } catch { /* profile composition is best-effort; never block the deep-warm */ }
 
-  return { marks, enqueued, skipped };
+  // Cross-daf bridges (the reader Overview's sugya map): compute + pin this
+  // daf's forward bridge and the previous daf's bridge into this one. Both
+  // dapim's argument sections are warm (run above / globally), so the bridge
+  // verdict resolves and caches instead of leaving the first reader to pay the
+  // cold bridge LLM calls. Best-effort — a bridge failure never fails the warm.
+  let bridges = 0;
+  try {
+    const fwd = await computeDafBridge(rc.env, tractate, page);
+    if (fwd.via !== 'no-data') bridges++;
+    const prev = adjacentAmud(tractate, page, -1);
+    if (prev) {
+      const back = await computeDafBridge(rc.env, tractate, prev);
+      if (back.via !== 'no-data') bridges++;
+    }
+  } catch { /* bridges are best-effort */ }
+
+  return { marks, enqueued, skipped, bridges };
 }
 
 /**
@@ -6811,7 +6854,7 @@ async function processEnrichmentJob(env: Bindings, job: JobMessage, ctx: Executi
       const stats = await deepWarmDaf(rc, job.tractate, job.page, rc.lang);
       await writeResult({ status: 'ok', result: { kind: 'warm', ...stats, total_ms: Date.now() - t0 } });
       // eslint-disable-next-line no-console
-      console.log(`[queue] deep-warm ${job.tractate}/${job.page} lang=${rc.lang} marks=${stats.marks} enqueued=${stats.enqueued} skipped=${stats.skipped}`);
+      console.log(`[queue] deep-warm ${job.tractate}/${job.page} lang=${rc.lang} marks=${stats.marks} enqueued=${stats.enqueued} skipped=${stats.skipped} bridges=${stats.bridges}`);
       return;
     }
     if (job.mark_id) {


### PR DESCRIPTION
Follow-up to #79 (sugya map promoted to readers).

**1. The sugya map is now readable.** It previously rendered bare segment-index numbers ("2a 0 5 8 11") which meant nothing to a reader. Now:
- `/api/studio/sugya` returns each section's **title** and full segment range, not just the start index.
- `SugyaMap` leads with a plain-language headline — *"The discussion that opens this daf runs across 2a → 2b — it doesn't begin and end here"* (or *"...stays on 2a"* when it doesn't cross) — then lists the sugya's sections **by title**, grouped by daf. Sections on the current daf are clickable (highlight the text); neighbouring-daf sections show what you'd read if you kept going.

**2. daf-yomi pre-warms the bridges.** `deepWarmDaf` (the daf-yomi `warm_deep` path, also navigation pre-warm) now computes and pins this daf's forward bridge and the previous daf's bridge. Both dapim's argument sections are already warm, so the bridge verdict resolves and caches — the first reader gets an instant cross-page sugya map instead of cold bridge LLM calls.

typecheck + 1397 tests green.