### PR TITLE
Flow enrichment: medium reasoning to stop 240s timeouts

### DIFF
--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -2155,8 +2155,12 @@ CODE_ENRICHMENTS.push(
       defHash: 'argument-overview.flow-v1', cacheVersion: '1',
       // Cross-section relationship reasoning is the part that needs real
       // thought — run deepseek-v4-pro with reasoning on (vs flash elsewhere).
+      // Reasoning is 'medium', not 'high': at 'high' the larger dapim blew past
+      // the 240s OpenRouter hard timeout and never cached (~half the Shas had no
+      // flow, so their sugya map showed every section as its own singleton).
+      // 'medium' keeps the cross-section reasoning but finishes in time.
       model: ARGUMENT_PRO_MODEL,
-      reasoningEffort: 'high',
+      reasoningEffort: 'medium',
     },
   ),
   makeSynthesis(

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -6795,6 +6795,26 @@ async function deepWarmDaf(
     }
   } catch { /* profile composition is best-effort; never block the deep-warm */ }
 
+  // Whole-daf Overview: warm argument-overview.flow (the section-to-section
+  // connections) and .synthesis (the daf summary). The flow is what the reader
+  // Overview's sugya map stitches into discussions — without it every section
+  // shows as its own singleton sugya. The one-time global sweep left gaps and
+  // never ran for new daf-yomi dapim, so warm it here. Keyed on the canonical
+  // whole-daf instance { fields: {} } to match readFlowConnections + the client.
+  for (const eid of ['argument-overview.flow', 'argument-overview.synthesis']) {
+    try {
+      const def = await loadEnrichmentDef(rc.env, eid);
+      if (!def) continue;
+      const iid = await instanceIdOf({ fields: {} });
+      const key = keyForEnrichment(def, iid, { tractate, page }, undefined, lang);
+      if (key && cache && (await cache.get(key))) { skipped++; continue; }
+      const runId = `warm:${eid}:${tractate}:${page}:${lang}:${Math.floor(Date.now() / 1000)}`
+        .replace(/[^a-zA-Z0-9._:-]+/g, '_').slice(0, 200);
+      await queue.send({ runId, enrichment_id: eid, tractate, page, mark_input: { fields: {} }, ...(lang === 'he' ? { lang } : {}) });
+      enqueued++;
+    } catch { /* best-effort warm */ }
+  }
+
   // Cross-daf bridges (the reader Overview's sugya map): compute + pin this
   // daf's forward bridge and the previous daf's bridge into this one. Both
   // dapim's argument sections are warm (run above / globally), so the bridge


### PR DESCRIPTION
Diagnosing the singleton-sugya bug on Berakhot 2b: `/api/admin/recent-errors` showed `argument-overview.flow` jobs failing with `OpenRouter body read aborted after 240000ms (hard timeout)` on the larger dapim. At `reasoningEffort: 'high'` the flow LLM call exceeded the 240s hard cap and never cached — ~50% of dapim had no flow, so their sugya map degraded to one singleton per section.

Drop reasoning `high` → `medium`: keeps the cross-section relationship reasoning but finishes in time. `cache_version` stays `'1'`, so the dapim that did cache are untouched; only the missing ones recompute (now successfully). Pairs with the deep-warm flow warming (#82) and a gap-fill pass for the dapim the original sweep dropped.

typecheck + 1397 tests green.