### PR TITLE
Overview maps: contiguous sugya runs (fix out-of-order orphan map)

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -720,25 +720,29 @@ function OverviewSectionVoices(props: {
 // sugyot, so they don't merge sections into the same map.
 const SUGYA_BINDING_KINDS = new Set(['continues', 'resolves', 'depends-on']);
 
-/** Partition a daf's argument sections into discussion groups (sugyot): maximal
- *  connected components over the binding flow edges. Sections with no binding
- *  edge are their own singleton group. Returns groups of section indices, each
- *  ascending, ordered by first section — the daf top-to-bottom reading order. */
-function groupSectionsBySugya(sectionCount: number, connections: FlowConnection[]): number[][] {
-  const parent = Array.from({ length: sectionCount }, (_, i) => i);
-  const find = (x: number): number => { while (parent[x] !== x) { parent[x] = parent[parent[x]]; x = parent[x]; } return x; };
-  const union = (a: number, b: number) => { const ra = find(a), rb = find(b); if (ra !== rb) parent[Math.max(ra, rb)] = Math.min(ra, rb); };
-  for (const c of connections) {
-    if (!SUGYA_BINDING_KINDS.has(c.kind)) continue;
-    if (c.from < 0 || c.to < 0 || c.from >= sectionCount || c.to >= sectionCount || c.from === c.to) continue;
-    union(c.from, c.to);
+/** Partition a daf's argument sections into discussion groups (sugyot) as
+ *  CONTIGUOUS runs in daf order. The daf is linear, so a sugya is a run of
+ *  consecutive sections; a boundary falls between section b-1 and b only where
+ *  NO binding edge spans that point (a clean cut). This keeps maps in reading
+ *  order and never orphans a passed-over section (e.g. a section the flow
+ *  skipped over with a 2→4 edge stays inside the surrounding discussion).
+ *  Returns contiguous groups of section indices, top-to-bottom. */
+export function groupSectionsBySugya(sectionCount: number, connections: FlowConnection[]): number[][] {
+  if (sectionCount <= 0) return [];
+  const bindings = connections.filter(
+    (c) => SUGYA_BINDING_KINDS.has(c.kind)
+      && c.from >= 0 && c.to >= 0 && c.from < sectionCount && c.to < sectionCount && c.from !== c.to,
+  );
+  // A binding edge spans the gap before section b iff min(endpoints) < b <= max.
+  const spans = (b: number) => bindings.some((c) => Math.min(c.from, c.to) < b && b <= Math.max(c.from, c.to));
+  const groups: number[][] = [];
+  let cur = [0];
+  for (let b = 1; b < sectionCount; b++) {
+    if (spans(b)) cur.push(b);
+    else { groups.push(cur); cur = [b]; }
   }
-  const groups = new Map<number, number[]>();
-  for (let i = 0; i < sectionCount; i++) {
-    const r = find(i);
-    const g = groups.get(r); if (g) g.push(i); else groups.set(r, [i]);
-  }
-  return [...groups.values()].sort((a, b) => a[0] - b[0]);
+  groups.push(cur);
+  return groups;
 }
 
 /** Whole-daf argument overview. A one-paragraph synthesis, then the daf's

--- a/tests/sugya-grouping.test.ts
+++ b/tests/sugya-grouping.test.ts
@@ -1,0 +1,49 @@
+/**
+ * groupSectionsBySugya (ArgumentSidebar): split a daf's argument sections into
+ * CONTIGUOUS discussion maps. The key property is that maps are runs in daf
+ * order — a section the flow "skips over" (a 2->4 edge) must stay inside the
+ * surrounding discussion, never get orphaned into a trailing singleton map.
+ */
+import { describe, it, expect } from 'vitest';
+import { groupSectionsBySugya } from '../src/client/ArgumentSidebar';
+import type { FlowConnection } from '../src/client/ArgumentFlowGraph';
+
+const e = (from: number, to: number, kind: FlowConnection['kind'] = 'continues'): FlowConnection => ({ from, to, kind });
+
+describe('groupSectionsBySugya — contiguous discussion maps', () => {
+  it('a fully-bound run is one map', () => {
+    expect(groupSectionsBySugya(4, [e(0, 1), e(1, 2), e(2, 3)])).toEqual([[0, 1, 2, 3]]);
+  });
+
+  it('splits where no binding edge crosses (clean cut)', () => {
+    // 0-1 a discussion; 2-3 another; nothing crosses the 1|2 gap.
+    expect(groupSectionsBySugya(4, [e(0, 1), e(2, 3)])).toEqual([[0, 1], [2, 3]]);
+  });
+
+  it('keeps a skipped-over section inside the run (2->4 spans section 3)', () => {
+    // The Berakhot 2b case: section 3 has no edge of its own, but 2->4 spans it,
+    // so it stays in the contradiction run instead of orphaning after it.
+    const conns = [e(0, 1, 'parallels'), e(2, 4, 'depends-on'), e(4, 5), e(5, 6)];
+    // parallels doesn't bind, so 0 and 1 are their own clean cuts; 2..6 is one run.
+    expect(groupSectionsBySugya(7, conns)).toEqual([[0], [1], [2, 3, 4, 5, 6]]);
+  });
+
+  it('orphaned middle section never renders out of order', () => {
+    // Even if only 2 and 4 bind (skipping 3), the result is contiguous + ordered.
+    const groups = groupSectionsBySugya(5, [e(0, 1), e(2, 4, 'depends-on')]);
+    expect(groups).toEqual([[0, 1], [2, 3, 4]]);
+    // every group is a contiguous ascending run
+    for (const g of groups) {
+      for (let i = 1; i < g.length; i++) expect(g[i]).toBe(g[i - 1] + 1);
+    }
+  });
+
+  it('non-binding kinds do not merge sections', () => {
+    expect(groupSectionsBySugya(3, [e(0, 1, 'contrasts'), e(1, 2, 'cites')])).toEqual([[0], [1], [2]]);
+  });
+
+  it('single section / empty', () => {
+    expect(groupSectionsBySugya(1, [])).toEqual([[0]]);
+    expect(groupSectionsBySugya(0, [])).toEqual([]);
+  });
+});


### PR DESCRIPTION
On Berakhot 2b the maps rendered card 4 (Second contradiction) as its own map *after* the 3-8 map — out of order.

Cause: grouping used union-find over all binding edges, which can yield **non-contiguous** groups. When one run of the LLM flow left a middle section unbound, it became a singleton group that sorted after the group surrounding it.

Fix: group by **clean cuts** — a sugya boundary falls between two consecutive sections only where no binding edge spans that gap. Maps are always contiguous and in daf reading order; a section the flow skips over (e.g. a 2→4 edge spanning section 3) stays inside the surrounding discussion. Added unit tests (1403 total green).