### PR TITLE
Make argument-overview.flow fast (stop 240s timeouts breaking the sugya maps)

### DIFF
--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -2101,14 +2101,8 @@ ${HEBREW_GLOSS_STYLE}`;
 
 const ARGUMENT_OVERVIEW_FLOW_USER_TEMPLATE = `Tractate: {{tractate}}, page {{page}}.
 
-Ordered argument sections on this daf (index = position in this list, starting at 0):
+Ordered argument sections on this daf (index = position in this list, starting at 0). Each section carries its title, summary, and the voices it contains — relate the sections from these:
 {{anchors.argument}}
-
-Full daf:
-{{gemara}}
-
-Study-aid context (dafyomi.co.il — point-by-point outline, halacha summary, comparison charts):
-{{context}}
 
 Emit the connections BETWEEN these sections per the schema. Reason about how each sugya relates to the others (continues / resolves / depends-on / parallels / contrasts / generalizes / cites).`;
 
@@ -2151,16 +2145,16 @@ CODE_ENRICHMENTS.push(
     ARGUMENT_OVERVIEW_FLOW_SYSTEM_PROMPT, ARGUMENT_OVERVIEW_FLOW_USER_TEMPLATE, ARGUMENT_OVERVIEW_FLOW_OUTPUT_SCHEMA,
     {
       mode: 'augment-content', scope: 'local',
-      dependencies: ['gemara', 'context', { mark: 'argument' }, { mark: 'rabbi' }],
+      // Relate sections from their OWN summaries only — not the full daf +
+      // dafyomi context. The big prompt + reasoning model timed out at the 240s
+      // OpenRouter hard cap on most dapim, so flow never cached and the sugya
+      // map collapsed to one section per map across the Shas (198 timeouts in
+      // the error buffer). The section anchors already carry title + summary +
+      // voices, which is all the relating needs. Fast model, no thinking →
+      // lands in seconds, so every daf actually gets a flow.
+      dependencies: [{ mark: 'argument' }],
       defHash: 'argument-overview.flow-v1', cacheVersion: '1',
-      // Cross-section relationship reasoning is the part that needs real
-      // thought — run deepseek-v4-pro with reasoning on (vs flash elsewhere).
-      // Reasoning is 'medium', not 'high': at 'high' the larger dapim blew past
-      // the 240s OpenRouter hard timeout and never cached (~half the Shas had no
-      // flow, so their sugya map showed every section as its own singleton).
-      // 'medium' keeps the cross-section reasoning but finishes in time.
-      model: ARGUMENT_PRO_MODEL,
-      reasoningEffort: 'medium',
+      model: ARGUMENT_FLASH_MODEL,
     },
   ),
   makeSynthesis(

--- a/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
+++ b/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
@@ -12,7 +12,7 @@ exports[`CODE_ENRICHMENTS cache identity > per-enrichment fingerprint is stable 
   "argument-move.qa@5 mode=augment-content scope=local mark=argument-move schema=argument_move_qa[answer,confidence] deps=[gemara|e:argument-move.synthesis|e:argument-move.commentaries|m:argument-move]",
   "argument-move.suggested-questions@3 mode=augment-content scope=local mark=argument-move schema=argument_move_suggested_questions[questions] deps=[gemara|m:argument-move|e:argument-move.synthesis]",
   "argument-move.synthesis@5 mode=aggregate scope=local mark=argument-move schema=argument_move_synthesis[synthesis] deps=[gemara|e:argument-move.commentaries|m:argument-move|m:rabbi]",
-  "argument-overview.flow@1 mode=augment-content scope=local mark=argument-overview schema=argument_overview_flow[connections] deps=[gemara|context|m:argument|m:rabbi]",
+  "argument-overview.flow@1 mode=augment-content scope=local mark=argument-overview schema=argument_overview_flow[connections] deps=[m:argument]",
   "argument-overview.synthesis@2 mode=aggregate scope=local mark=argument-overview schema=argument_overview_synthesis[synthesis] deps=[gemara|context|e:argument-overview.flow|m:argument|m:rabbi]",
   "argument.background@4 mode=augment-content scope=local mark=argument schema=argument_background[background] deps=[gemara|commentaries|mishna|context]",
   "argument.narrative@2 mode=augment-content scope=local mark=argument schema=argument_narrative[summary,actors,beats] deps=[gemara|m:argument-move|m:rabbi]",


### PR DESCRIPTION
While reviewing real gemaras I found the per-sugya maps are broken **Shas-wide**: `argument-overview.flow` is uncached on nearly every daf, so grouping collapses to one section per map. Cause: 198 `OpenRouter ... aborted after 240000ms` timeouts in the error buffer — the flow was fed the whole daf + all dafyomi context and run on the reasoning model, and each timing-out job held a worker for 4 minutes, backing the queue up ~30 min.

Fix: relating sections only needs their own summaries (already in the `argument` anchors). Drop `{{gemara}}` + `{{context}}` from the prompt and dependencies, switch `argument-overview.flow` to the fast model with no thinking. It now lands in seconds, so every daf actually gets a flow. `cache_version` unchanged — good cached flows survive, the failed majority succeed on retry. Snapshot updated; 1403 tests green.