### PR TITLE
Revach l'Daf: capture cross-references as real links (framework step 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,23 @@
 
 Talmud study app: Hono on Cloudflare Workers (`src/worker`) + Solid.js/Vite client (`src/client`), shared logic in `src/lib`. Package manager is **pnpm**. TypeScript strict.
 
+## Framework direction — read `docs/framework.md` first
+
+The app is being unified onto one model: **the Talmud covered in "smart notes" (pieces) pinned to "texts" (spines).** A piece knows where it sits (an anchor), what it's built from, how it was made, and how sure we are; pieces compose; views are generated from them. External study-aids are just notes on other texts, *linked* to the right spot. This is a **unification of what already exists** (marks, enrichments, the rabbi registry, flow/bridges, Q&A, context) — adopt it **incrementally, each step retiring a bespoke behaviour**, never a speculative engine.
+
+Principles: deterministic rules grow over time but **AI keeps final say**; context sources are pluggable per piece; pick models by **benchmark** on a fixed 15–30 daf set; **precision over recall** for placement (a wrong anchor is worse than "whole daf"); **human edits/​corrections outrank AI and are never silently overwritten**; **review changes with Codex** (`codex exec --sandbox read-only`) as you go.
+
+### Migration roadmap (remaining, smallest-first; each its own PR)
+1. ✅ **Revach refs** (PR #88) — capture study-aid cross-references as real links + the `refs` contract + coord-aware rendering.
+2. **Revach section placer** — conservatively align Revach entries to the daf's `argument` sections (English↔English, ordered) → fill `anchors`; place-or-omit. Wire `select.ts`/`placement.ts` to read `anchors`.
+3. **Enrichment rollout** — bump `argument.background` (v4→5) + `argument-overview.synthesis` (v2→3), re-warm, with **stale-while-revalidate** (serve previous cached value while the new computes; label it; never clobber a human edit).
+4. **Generic sidebar** — render a piece's enrichments from a declared render hint (retire bespoke `*Body` components).
+5. **Entity pieces** (lift "global" rabbi/place), **link pieces** (unify flow/bridge/voice-edges/citations), **user pieces** (highlights/notes).
+6. **Tractate-continuous + commentary spines** (wire the reserved `external` anchor); **content-hash freshness + reverse-dependency index**.
+7. **Cruft + DX**: remove the orphaned sugya-assembly (`/api/studio/sugya`, `assemble.ts`, `SUGYA_WINDOW_CAP`) and test-only `filterFlowConnections`; drop the `/studio` API prefix; keep `src/worker/mcp-openapi.ts` in sync; expand `docs/framework.md` toward an SDK.
+
+Cross-cutting always: typed piece bodies, resilient anchors, provenance/confidence, eval-gated producer promotion.
+
 - `pnpm test` — Vitest unit suite. `pnpm test:int` — integration (hits a running worker).
 - `pnpm typecheck` — `tsc --noEmit`. Run it plus `pnpm test` before any PR.
 - `pnpm ship` — `vite build && wrangler deploy`. Production is the custom domain **talmud.shaunregenbaum.com**. wrangler is authenticated in this environment.

--- a/docs/framework.md
+++ b/docs/framework.md
@@ -1,0 +1,115 @@
+# The framework, from the code
+
+> How this app is built, in the vocabulary of the code — written so it can later
+> be extracted as an SDK. The plain-English version is "the Talmud covered in
+> smart notes"; this is the same thing with the types and file paths.
+
+## The shape
+
+Three substances:
+
+- **Spines** — continuous, addressable texts (the Gemara of a tractate, Tosafot,
+  Tanach). A "page" (amud) is a window onto a spine. Today the Gemara spine is
+  addressed per-amud; cross-spine/cross-daf coordinates already exist.
+- **Entities** — referents that appear at many spans (a rabbi, a place). Today
+  carried as "global"-scope enrichments.
+- **Pieces** — everything we author/derive. The core unit.
+
+A **piece** anchors to one or more **pointers**, is built from declared
+**inputs**, made by a **producer**, and cached with **provenance**.
+
+## Coordinates — `src/lib/context/coord.ts`
+
+```ts
+interface AnchorCoord { tractate: string; page: string; seg: number }  // one segment anywhere in Shas
+type AnchorSpan = AnchorCoord[]                                          // an ordered, cross-daf set
+type DafRef = { tractate: string; page: string }
+coordForSeg(daf, seg) · coordKey(c) · isCrossDaf(c, currentDaf) · spanByDaf(span)
+```
+
+A coordinate is *the* address. Same-daf, sibling-amud, and other-tractate are all
+just coordinates — the reader decides how to render them.
+
+## Context items — `src/lib/context/types.ts`
+
+External study material (dafyomi.co.il, Sefaria commentary, Mishnayot…) maps into
+one flat `ContextItem`. The forward-looking contract distinguishes **where a note
+sits** from **what it cites**:
+
+```ts
+interface ContextItem {
+  source; sourceLabel; kind; key; title?; body?;
+  segs: number[];          // legacy single-amud placement
+  amud?: 'a' | 'b';
+  refs?:    AnchorCoord[];  // what it CITES (e.g. "Pesachim 50a") — rendered, never placement.
+                            // daf-level refs use seg = DAF_SEG (-1).
+  confidence?; via?;
+  // anchors?: AnchorCoord[] — WHERE it attaches (cross-amud capable). Arrives in
+  //   the follow-up that fills it, together with its select.ts/placement.ts wiring.
+}
+```
+
+Rendering helpers (same file): `rangeLabel(segs, amud)` (→ `[whole daf]` when
+unplaced), `citesLabel(refs)`, `coordLabel(c)` (daf-level when `seg < 0`).
+
+## Placement = pieces on other spines + links
+
+There is no separate "context" concept: a study-aid is **pieces on its own
+spine**, and "grounding" is **links** into the Gemara. The pipeline:
+
+1. **Parse** the source into entries + refs.
+   `src/lib/sefref/dafyomi/parse/*` — e.g. `parseRevach` sets `entry.refs` via
+   `findDafRefs` (common.ts) + `resolveTractateName` (masechtos.ts).
+2. **Map** to `ContextItem`s. `src/lib/context/fromDafyomi.ts`.
+3. **Place** (a separate layer). Matchers return `SegMatch[]` applied via
+   `applyMatches` (`src/lib/context/match.ts`):
+   - `anchor/tosfos.ts` — Tosfos pieces by Sefaria pieceKey (deterministic).
+   - `anchor/bg-term.ts` — Background terms by Hebrew whole-word overlap.
+   - `anchor/ai-prompt.ts` + `src/worker/context-match.ts` — the AI placer.
+4. **Assemble**. `collectContext(env, tractate, page)` in
+   `src/worker/context-providers.ts` builds the live pool (LLM-free) and runs the
+   deterministic matchers.
+5. **Select + render** for a prompt. `src/lib/context/select.ts` —
+   `contextForAnchor(items, targetSegs)` then `formatContextForPrompt(items)` →
+   `{{context}}`.
+
+**Layering rule (important):** parsing/refs must NOT depend on placement; a placer
+takes the spine's sections in and returns anchors out; consumers choose anchored
+vs unplaced vs whole-daf. **Precision over recall** — a wrong anchor is worse than
+"whole daf"; leave unplaced when unsure.
+
+## Producers, caching, freshness — `src/worker`
+
+- A **producer** (a mark/enrichment in `code-marks.ts`) is a pipeline: gather
+  inputs → rule and/or AI → checks (`src/lib/check/postcheck.ts`). One run can
+  emit many pieces.
+- **Cache keys** (`cache-keys.ts`): `mark:<id>:<ver>…`, `enrich:<id>:<ver>…`,
+  source caches like `dafyomi:v5:<daf>`. No TTL.
+- **Invalidation today** is a manual `cache_version` bump per producer.
+  *Forward direction:* a content hash (recipe + input hashes) makes staleness
+  automatic, with a reverse-dependency index for "what to re-warm." Stale = a
+  *candidate* for recompute, never a silent overwrite of a human correction.
+
+## Worked example — un-flattening *Revach l'Daf* (PR1)
+
+*Revach l'Daf* is English summary prose that covers a whole daf and cites other
+dapim ("Pesachim 50a"). Before: every entry was fed to the LLM as `[whole daf]`
+and its citations were dropped. PR1:
+
+- `parseRevach` → `findDafRefs` captures `entry.refs` (resolved `{tractate, page}`).
+- `fromDafyomi` carries them onto `ContextItem.refs` as `AnchorCoord`s.
+- `formatContextForPrompt` renders `… (cites Pesachim 50a)`.
+- `dafyomi:v4 → v5` so entries re-parse with refs (re-parse only, no LLM).
+
+This is the first real **stand-off link with a true span**: a note carrying a
+genuine cross-spine coordinate. PR2 adds the **anchor** (placement) by aligning
+Revach entries to the daf's argument sections — conservatively, leaving unplaced
+when the match isn't strong.
+
+## Toward an SDK
+
+The reusable core is spine-agnostic: `AnchorCoord`/`AnchorSpan` (coordinates),
+`ContextItem` with `anchors`/`refs` (the note contract), the `SegMatch`/
+`applyMatches` placement sink, and `placementLabel`/`citesLabel` rendering. A new
+source = a parser + a `from<Source>` mapper + an optional placer — no engine
+changes.

--- a/src/lib/context/coord.ts
+++ b/src/lib/context/coord.ts
@@ -47,6 +47,16 @@ export function coordForSeg(daf: DafRef, seg: number): AnchorCoord {
   return { tractate: daf.tractate, page: daf.page, seg };
 }
 
+/** Sentinel `seg` meaning "the daf, no specific segment" — for daf-level
+ *  references where the exact segment is unknown (e.g. a citation "Pesachim
+ *  50a"). Negative so it never collides with a real 0-based segment index. */
+export const DAF_SEG = -1;
+
+/** A daf-level coordinate (no specific segment). See {@link DAF_SEG}. */
+export function dafCoord(daf: DafRef): AnchorCoord {
+  return { tractate: daf.tractate, page: daf.page, seg: DAF_SEG };
+}
+
 /** Coordinates for a list of local segment indices on a given daf. */
 export function coordsForSegs(daf: DafRef, segs: number[]): AnchorSpan {
   return segs.map((seg) => coordForSeg(daf, seg));

--- a/src/lib/context/fromDafyomi.ts
+++ b/src/lib/context/fromDafyomi.ts
@@ -11,6 +11,7 @@ import type {
   DafyomiDaf, DafyomiContentType, DafyomiEntry, DafyomiAmudContent,
 } from '../sefref/dafyomi/schema.ts';
 import type { ContextItem } from './types.ts';
+import { dafCoord, type AnchorCoord } from './coord.ts';
 
 const SOURCE_LABEL: Record<DafyomiContentType, string> = {
   // dafyomi "Tosfos" is the Kollel's explanation OF Tosafot, not Tosafot itself —
@@ -73,7 +74,7 @@ function collectBlock(
     case 'points':
     case 'yerushalmi':
     case 'revach':
-      b.entries.forEach((e, i) => out.push({ ...base(b.type, `${type}:${amud}:${i}`), ...entryCard(e) }));
+      b.entries.forEach((e, i) => out.push({ ...base(b.type, `${type}:${amud}:${i}`), ...entryCard(e), ...entryRefs(e) }));
       break;
     case 'hebcharts':
       b.tables.forEach((t, i) => {
@@ -94,6 +95,16 @@ function collectBlock(
       });
       break;
   }
+}
+
+/** A dafyomi entry's resolved cross-references ("Pesachim 50a") as citation
+ *  coordinates. Daf-level (DAF_SEG, no specific segment) — these are things the
+ *  note CITES, not where it sits. Only Revach populates `refs` today. */
+function entryRefs(e: DafyomiEntry): { refs?: AnchorCoord[] } {
+  const refs = (e.refs ?? [])
+    .filter((r): r is typeof r & { tractate: string; page: string } => !!r.tractate && !!r.page)
+    .map((r) => dafCoord({ tractate: r.tractate, page: r.page }));
+  return refs.length ? { refs } : {};
 }
 
 function entryCard(e: DafyomiEntry): { title?: ContextItem['title']; body?: ContextItem['body'] } {

--- a/src/lib/context/select.ts
+++ b/src/lib/context/select.ts
@@ -9,7 +9,7 @@
  */
 
 import type { ContextItem } from './types.ts';
-import { rangeLabel } from './types.ts';
+import { rangeLabel, citesLabel } from './types.ts';
 
 export interface ContextSelectOpts {
   /** Restrict to these sources. Default: all. */
@@ -76,7 +76,8 @@ export function formatContextForPrompt(items: ContextItem[], opts: FormatOpts = 
       const title = it.title?.en || it.title?.he || '';
       const body = (it.body?.en || it.body?.he || '').replace(/\s+/g, ' ').trim().slice(0, maxBody);
       const head = [`[${rangeLabel(it.segs, it.amud)}]`, title].filter(Boolean).join(' ');
-      return `- ${head}${body ? `: ${body}` : ''}`;
+      const cites = citesLabel(it.refs);
+      return `- ${head}${body ? `: ${body}` : ''}${cites ? ` (cites ${cites})` : ''}`;
     });
     blocks.push(`## ${label}\n${lines.join('\n')}`);
   }

--- a/src/lib/context/types.ts
+++ b/src/lib/context/types.ts
@@ -48,6 +48,12 @@ export interface ContextItem {
    *  src/lib/context/coord.ts. */
   coord?: AnchorCoord;
 
+  /** External coordinates this note CITES (e.g. "Pesachim 50a"). Rendered as
+   *  links; NEVER used for placement (distinct from `segs`/`coord`). Daf-level
+   *  refs use `seg = DAF_SEG`. (Placement coordinates — `anchors` — arrive with
+   *  their selection/placement wiring in the follow-up that fills them.) */
+  refs?: AnchorCoord[];
+
   /** Tosfos-DH matcher input: niqqud-stripped DH opening words. Only set on
    *  dafyomi Tosfos items; lets the matcher place them via Sefaria pieceKeys. */
   dhNormalized?: string;
@@ -78,4 +84,16 @@ export function rangeLabel(segs: number[], amud?: 'a' | 'b'): string {
   if (contiguous) return `seg ${sorted[0]}–${sorted[sorted.length - 1]}`;
   const shown = sorted.slice(0, 4).join(', ');
   return `segs ${shown}${sorted.length > 4 ? '…' : ''}`;
+}
+
+/** One coordinate as a compact citation string: "Pesachim 50a" (daf-level, i.e.
+ *  `seg < 0`) or "Pesachim 50a:7" (with a real segment, including segment 0). */
+export function coordLabel(c: AnchorCoord): string {
+  return c.seg >= 0 ? `${c.tractate} ${c.page}:${c.seg}` : `${c.tractate} ${c.page}`;
+}
+
+/** The "cites …" payload for an item's external refs, or '' when there are none. */
+export function citesLabel(refs: AnchorCoord[] | undefined): string {
+  if (!refs || !refs.length) return '';
+  return [...new Set(refs.map(coordLabel))].join(', ');
 }

--- a/src/lib/sefref/dafyomi/masechtos.ts
+++ b/src/lib/sefref/dafyomi/masechtos.ts
@@ -14,7 +14,7 @@
  * (daf 76 -> "076"); every content type for a daf uses the same number.
  */
 
-import { TRACTATE_END_AMUD } from '../amudim.ts';
+import { TRACTATE_END_AMUD, amudToNumber } from '../amudim.ts';
 
 export type DafyomiContentType =
   | 'insights'
@@ -148,6 +148,61 @@ export interface DafyomiMasechet {
 const BY_TRACTATE = new Map<string, DafyomiMasechetSeed>(
   SEED.map((s) => [s.tractate.toLowerCase(), s]),
 );
+
+/** Letters-only lowercase, for spelling-insensitive name matching. */
+const nameKey = (s: string): string => s.toLowerCase().replace(/[^a-z]/g, '');
+
+// Map a tractate name AS WRITTEN IN dafyomi.co.il English prose (e.g. "Berachos",
+// "Bava Kama", "Rosh Hashana") to the app's canonical tractate value. Seeded from
+// both the canonical value ("Berakhot") and the site dir ("berachos"), plus a few
+// prose spellings the dir abbreviates or differs from. Used to resolve in-text
+// cross-references like "Pesachim (50a)" — unknown names resolve to null (we never
+// guess a tractate).
+const NAME_TO_TRACTATE: Map<string, string> = (() => {
+  const m = new Map<string, string>();
+  for (const s of SEED) { m.set(nameKey(s.tractate), s.tractate); m.set(nameKey(s.dir), s.tractate); }
+  const aliases: Record<string, string> = {
+    bavakama: 'Bava Kamma', bavakamma: 'Bava Kamma', babakama: 'Bava Kamma',
+    bavametzia: 'Bava Metzia', babametzia: 'Bava Metzia',
+    bavabasra: 'Bava Batra', bavabatra: 'Bava Batra', bababasra: 'Bava Batra',
+    roshhashana: 'Rosh Hashanah', avodahzara: 'Avodah Zarah', avodazara: 'Avodah Zarah',
+    arachin: 'Arakhin', kesubos: 'Ketubot', berochos: 'Berakhot', makkos: 'Makkot',
+    kerisos: 'Keritot', chagiga: 'Chagigah', megila: 'Megillah', megilla: 'Megillah',
+    sukah: 'Sukkah', taanis: 'Taanit', sanhedrin: 'Sanhedrin', shevuos: 'Shevuot',
+  };
+  for (const [k, v] of Object.entries(aliases)) m.set(nameKey(k), v);
+  return m;
+})();
+
+/** Resolve a dafyomi-prose tractate name to its canonical app value, or null.
+ *  Strips leading qualifiers ("Maseches Pesachim" → "Pesachim") and retries
+ *  trailing words, so a wrapped or prefixed name still resolves. */
+export function resolveTractateName(name: string): string | null {
+  const direct = NAME_TO_TRACTATE.get(nameKey(name));
+  if (direct) return direct;
+  const words = name.trim().split(/\s+/).filter((w) => !REF_QUALIFIER.test(w));
+  for (let i = 0; i < words.length; i++) {
+    const hit = NAME_TO_TRACTATE.get(nameKey(words.slice(i).join('')));
+    if (hit) return hit;
+  }
+  return null;
+}
+
+const REF_QUALIFIER = /^(maseches|mesechta|mishnah|mishna|gemara|gemora|daf|perek|tractate|the|in|of|see|cf)$/i;
+
+/** Resolve a prose cross-reference (name + daf) to a real {tractate, page}, or
+ *  null. Rejects out-of-range dapim (e.g. "Pesachim 999a") so a resolved name
+ *  alone can't manufacture a bogus coordinate. */
+export function resolveDafRef(name: string, page: string): { tractate: string; page: string } | null {
+  const tractate = resolveTractateName(name);
+  if (!tractate) return null;
+  const p = page.toLowerCase();
+  const n = amudToNumber(p);
+  const end = TRACTATE_END_AMUD[tractate.toLowerCase()];
+  const endNum = end ? amudToNumber(end) : null;
+  if (n == null || n < 3 || (endNum != null && n > endNum)) return null; // dapim run 2a..end
+  return { tractate, page: p };
+}
 
 /** Highest daf number from amudim.ts end-amud (e.g. "142a" -> 142). */
 function lastDafOf(tractate: string): number | null {

--- a/src/lib/sefref/dafyomi/parse/common.ts
+++ b/src/lib/sefref/dafyomi/parse/common.ts
@@ -10,6 +10,7 @@
 
 import { parse, HTMLElement, type Node } from 'node-html-parser';
 import type { DafyomiRef, DafyomiText } from '../schema.ts';
+import { resolveDafRef } from '../masechtos.ts';
 
 export { HTMLElement };
 
@@ -133,6 +134,29 @@ export function extractRefs(el: HTMLElement): DafyomiRef[] {
     }
   }
   return refs;
+}
+
+// A capitalised name (1–3 words, allowing a leading qualifier like "Maseches")
+// directly followed by a daf, the daf optionally parenthesised: "Pesachim (50a)",
+// "Bava Kama 50a", "Maseches Pesachim 50a".
+const DAF_REF_RE = /\b([A-Z][a-zA-Z']+(?:\s+[A-Z][a-zA-Z']+){0,2})\s*\(?(\d{1,3}[ab])\)?/g;
+
+/** Find resolvable cross-references ("Pesachim 50a") in English prose and return
+ *  them as DafyomiRefs with `tractate`/`page` filled. CONSERVATIVE: only emits a
+ *  ref when the name resolves to a KNOWN tractate AND the daf is in range, so
+ *  "Rebbi Eliezer 2a" or "Pesachim 999a" are ignored. Deduped by (tractate, page). */
+export function findDafRefs(prose: string): DafyomiRef[] {
+  const out: DafyomiRef[] = [];
+  const seen = new Set<string>();
+  for (const m of prose.matchAll(DAF_REF_RE)) {
+    const resolved = resolveDafRef(m[1], m[2]);
+    if (!resolved) continue;
+    const key = `${resolved.tractate}:${resolved.page}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ raw: collapse(`${m[1]} ${resolved.page}`), kind: 'gemara', ...resolved });
+  }
+  return out;
 }
 
 function classifyRef(raw: string): DafyomiRef['kind'] {

--- a/src/lib/sefref/dafyomi/parse/revach.ts
+++ b/src/lib/sefref/dafyomi/parse/revach.ts
@@ -13,7 +13,7 @@
  * `<br>`-delimited line, so they don't false-trigger a new item.
  */
 
-import { parseHtml, collapse, HTMLElement } from './common.ts';
+import { parseHtml, collapse, findDafRefs, HTMLElement } from './common.ts';
 import type { DafyomiEntry } from '../schema.ts';
 
 export interface ParsedRevach {
@@ -67,11 +67,15 @@ export function parseRevach(html: string): ParsedRevach {
   for (const n of nums) {
     const head = summary.get(n);
     const detail = more.get(n);
+    // Capture in-text cross-references ("Pesachim 50a") as DafyomiRefs so they
+    // survive as real cross-spine links instead of being lost in the prose.
+    const refs = findDafRefs(`${head ?? ''} ${detail ?? ''}`);
     entries.push({
       marker: `${n}.`,
       level: 0,
       ...(head ? { title: { en: head } } : {}),
       body: detail ? { en: detail } : {},
+      ...(refs.length ? { refs } : {}),
     });
   }
   return { entries };

--- a/src/worker/cache-keys.ts
+++ b/src/worker/cache-keys.ts
@@ -133,9 +133,11 @@ export function keyForGemara(tractate: string, page: string): string {
  *  v2 -> v3: charset-sniff decode (UTF-8 vs windows-1255) — v2 entries fetched
  *  from windows-1255 pages cached mojibake'd Hebrew (U+FFFD "????").
  *  v3 -> v4: background parser fix — pages with no girsa section (no girsasep)
- *  had their entire glossary swallowed; v3 cached those as empty background. */
+ *  had their entire glossary swallowed; v3 cached those as empty background.
+ *  v4 -> v5: Revach parser now extracts in-text cross-references ("Pesachim
+ *  50a") into entry.refs; v4 entries predate it. Re-parse only (no LLM). */
 export function keyForDafyomi(tractate: string, daf: string): string {
-  return `dafyomi:v4:${slugDaf(tractate, daf)}`;
+  return `dafyomi:v5:${slugDaf(tractate, daf)}`;
 }
 export function keyForCommentaries(tractate: string, page: string): string {
   return `ctx:commentaries:v1:${slugDaf(tractate, page)}`;

--- a/tests/revach-refs.test.ts
+++ b/tests/revach-refs.test.ts
@@ -4,7 +4,9 @@ import { resolveTractateName, resolveDafRef } from '../src/lib/sefref/dafyomi/ma
 import { parseRevach } from '../src/lib/sefref/dafyomi/parse/revach';
 import { formatContextForPrompt } from '../src/lib/context/select';
 import { dafCoord } from '../src/lib/context/coord';
+import { fromDafyomi } from '../src/lib/context/fromDafyomi';
 import type { ContextItem } from '../src/lib/context/types';
+import type { DafyomiDaf } from '../src/lib/sefref/dafyomi/schema';
 
 describe('resolveTractateName — dafyomi prose spelling → canonical', () => {
   it('maps site/prose spellings (incl. tricky ones)', () => {
@@ -63,6 +65,28 @@ describe('parseRevach — populates entry.refs end-to-end', () => {
       { raw: 'Pesachim 50a', kind: 'gemara', tractate: 'Pesachim', page: '50a' },
       { raw: 'Bava Kama 12b', kind: 'gemara', tractate: 'Bava Kamma', page: '12b' },
     ]);
+  });
+});
+
+describe('fromDafyomi — carries entry.refs onto ContextItem.refs (daf-level coords)', () => {
+  it('maps resolved refs to daf-level coordinates, drops unresolved ones', () => {
+    const daf = {
+      source: { urls: {} },
+      amudim: { a: { revach: {
+        type: 'revach', amud: 'a', wholeDaf: true,
+        body: { type: 'revach', entries: [
+          { marker: '1.', level: 0, title: { en: 'cites' }, body: { en: 'see Pesachim 50a' },
+            refs: [
+              { raw: 'Pesachim 50a', kind: 'gemara', tractate: 'Pesachim', page: '50a' },
+              { raw: 'Rashi DH', kind: 'rashi' }, // no tractate/page → dropped
+            ] },
+          { marker: '2.', level: 0, title: { en: 'no refs' }, body: { en: 'plain' } },
+        ] },
+      } } },
+    } as unknown as DafyomiDaf;
+    const items = fromDafyomi(daf).filter((i) => i.source === 'dafyomi:revach');
+    expect(items[0].refs).toEqual([{ tractate: 'Pesachim', page: '50a', seg: -1 }]);
+    expect(items[1].refs).toBeUndefined();
   });
 });
 

--- a/tests/revach-refs.test.ts
+++ b/tests/revach-refs.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { findDafRefs } from '../src/lib/sefref/dafyomi/parse/common';
+import { resolveTractateName, resolveDafRef } from '../src/lib/sefref/dafyomi/masechtos';
+import { parseRevach } from '../src/lib/sefref/dafyomi/parse/revach';
+import { formatContextForPrompt } from '../src/lib/context/select';
+import { dafCoord } from '../src/lib/context/coord';
+import type { ContextItem } from '../src/lib/context/types';
+
+describe('resolveTractateName — dafyomi prose spelling → canonical', () => {
+  it('maps site/prose spellings (incl. tricky ones)', () => {
+    expect(resolveTractateName('Berachos')).toBe('Berakhot');
+    expect(resolveTractateName('Pesachim')).toBe('Pesachim');
+    expect(resolveTractateName('Chulin')).toBe('Chullin');
+    expect(resolveTractateName('Bava Kama')).toBe('Bava Kamma');
+    expect(resolveTractateName('Rosh Hashana')).toBe('Rosh Hashanah');
+    expect(resolveTractateName('Makkos')).toBe('Makkot');
+    expect(resolveTractateName('Kerisos')).toBe('Keritot');
+  });
+  it('strips qualifiers and retries trailing words', () => {
+    expect(resolveTractateName('Maseches Pesachim')).toBe('Pesachim');
+    expect(resolveTractateName('Mishnah Bava Kama')).toBe('Bava Kamma');
+  });
+  it('returns null for non-tractates', () => {
+    expect(resolveTractateName('Rebbi Eliezer')).toBeNull();
+    expect(resolveTractateName('Shema')).toBeNull();
+  });
+});
+
+describe('resolveDafRef — name + daf, with bounds', () => {
+  it('rejects out-of-range dapim', () => {
+    expect(resolveDafRef('Pesachim', '999a')).toBeNull(); // Pesachim ends at 121b
+    expect(resolveDafRef('Pesachim', '50a')).toEqual({ tractate: 'Pesachim', page: '50a' });
+  });
+});
+
+describe('findDafRefs — cross-references in English prose', () => {
+  it('captures "Tractate (daf)" and "Tractate daf", and qualified names', () => {
+    const refs = findDafRefs('As in Maseches Pesachim (50a), and see Bava Kama 12b for more.');
+    expect(refs).toEqual([
+      { raw: 'Maseches Pesachim 50a', kind: 'gemara', tractate: 'Pesachim', page: '50a' },
+      { raw: 'Bava Kama 12b', kind: 'gemara', tractate: 'Bava Kamma', page: '12b' },
+    ]);
+  });
+  it('ignores non-tractates and impossible dapim', () => {
+    expect(findDafRefs('Rebbi Eliezer says one may read until Chatzos.')).toEqual([]);
+    expect(findDafRefs('Pesachim 999a is not a real daf.')).toEqual([]);
+  });
+  it('dedupes repeated refs', () => {
+    expect(findDafRefs('Pesachim 50a ... again Pesachim (50a)')).toHaveLength(1);
+  });
+});
+
+describe('parseRevach — populates entry.refs end-to-end', () => {
+  const html = `<table><tr>
+    <td><center>SUMMARY</center>1. The Mishnah discusses the time for Shema.<br>&nbsp;<br>2. A contradiction is raised.</td>
+    <td><center>A BIT MORE</center>1. Rebbi Eliezer says until Chatzos.<br>&nbsp;<br>2. As the Gemara explains in Pesachim (50a), and compare Bava Kama 12b.</td>
+  </tr></table>`;
+  it('captures cross-refs in the matching entry, leaves others empty', () => {
+    const { entries } = parseRevach(html);
+    expect(entries).toHaveLength(2);
+    expect(entries[0].refs).toBeUndefined();
+    expect(entries[1].refs).toEqual([
+      { raw: 'Pesachim 50a', kind: 'gemara', tractate: 'Pesachim', page: '50a' },
+      { raw: 'Bava Kama 12b', kind: 'gemara', tractate: 'Bava Kamma', page: '12b' },
+    ]);
+  });
+});
+
+describe('formatContextForPrompt — renders refs as "cites", placement unchanged', () => {
+  it('appends cites for a whole-daf Revach item with daf-level refs', () => {
+    const item: ContextItem = {
+      source: 'dafyomi:revach', sourceLabel: "Revach l'Daf", kind: 'revach', key: 'revach:a:1',
+      title: { en: 'A contradiction is raised' }, body: { en: 'See the Gemara.' },
+      segs: [], refs: [dafCoord({ tractate: 'Pesachim', page: '50a' })],
+    };
+    const out = formatContextForPrompt([item]);
+    expect(out).toContain('[whole daf] A contradiction is raised');
+    expect(out).toContain('(cites Pesachim 50a)');
+  });
+});


### PR DESCRIPTION
First incremental step of adopting the **smart-notes framework** — proving the reusable *"a note carrying a true cross-spine link"* path on the smallest real case.

## What
*Revach l'Daf* (a dafyomi.co.il study-aid) is **English summary prose** that cites other dapim ("Pesachim 50a"). Those citations were lost in parsing and every entry reached the LLM labelled `[whole daf]`. This PR:
- **Parser** captures in-text cross-refs into `entry.refs` — `findDafRefs` + a robust `resolveDafRef` (strips qualifiers like "Maseches", retries trailing words, alias-rich spelling table, **rejects out-of-range dapim**).
- **Contract**: `ContextItem.refs` (citations — rendered, never placement). Daf-level refs use a `DAF_SEG = -1` sentinel so they never collide with a real segment 0.
- **Rendering**: `formatContextForPrompt` appends `(cites Pesachim 50a)`.
- **Cache**: `dafyomi:v4 → v5` so entries re-parse with refs — **re-parse only, no LLM**.
- **Docs**: `docs/framework.md` — the framework from the code angle (toward an SDK), with this as the first worked example.

## Deliberately deferred
- **Section-level placement** (the `anchors` field + a conservative Revach→argument-section placer) — the precision feature for `argument.background`. PR2.
- **Enrichment re-warm** — `argument.background` (v4) and `argument-overview.synthesis` (v2) outputs only reflect the new refs after a bump + re-warm; that's the gated rollout phase, not this PR.

## Notes
- Static corpus caveat: only `Chullin/76` is a committed static asset (pre-refs); the live-parse path covers the rest and re-parses with refs under v5. Chullin re-ingest is a follow-up.
- **Codex-reviewed (two passes)** — it caught the seg-0 overload, an unread `anchors` field, regex/spelling/bounds gaps, and the static caveat; all addressed.

typecheck + 1412 tests green (incl. new `tests/revach-refs.test.ts`).