### PR TITLE
Place Revach l'Daf onto argument sections (framework step 2)

### DIFF
--- a/src/lib/context/anchor/revach.ts
+++ b/src/lib/context/anchor/revach.ts
@@ -1,0 +1,132 @@
+/**
+ * @fileoverview Revach-l'Daf → argument-section placer (deterministic, English).
+ *
+ * Revach entries are English summary prose that walks the daf in order; the
+ * daf's `argument` sections are ALSO English, ordered, and carry a segment
+ * range. So we place a Revach entry by matching it to the section it describes —
+ * English word overlap — and borrowing that section's segment range. Conservative
+ * by design: a wrong segment label is worse than "whole daf" (the LLM treats it
+ * as fact), so we place ONLY on a strong, clear-margin match with enough raw
+ * shared words, and we keep the chosen placements in reading order via a
+ * max-weight non-decreasing alignment (so one early false positive can't poison
+ * the rest). Unmatched entries are left unplaced (they stay whole-daf).
+ *
+ * Pure: the worker loads this amud's sections and applies the result via
+ * `applyMatches`. Per-amud naturally — an entry about the other amud finds no
+ * good match here; it gets placed when that amud's context is built.
+ */
+
+import type { ContextItem } from '../types.ts';
+import { segRange, type SegMatch } from '../match.ts';
+
+/** The bits of an `argument` section this matcher needs. */
+export interface SectionForMatch {
+  startSegIdx: number;
+  endSegIdx: number;
+  title?: string;
+  summary?: string;
+}
+
+// English content tokens: lowercase words of length >= 4 (so distinctive terms
+// like "shema"/"chatzos"/"terumah" and names survive and short function-words
+// drop out), minus a stoplist of common words AND structural Talmud scaffold
+// ("mishnah", "gemara", "tanna", "rabbi", "verse", "opinion"…) that appear in
+// almost every section and so don't discriminate between them.
+const STOP = new Set([
+  // generic
+  'that', 'this', 'with', 'from', 'they', 'them', 'their', 'have', 'here', 'into',
+  'which', 'when', 'where', 'while', 'until', 'after', 'before', 'about', 'would',
+  'should', 'could', 'because', 'there', 'these', 'those', 'then', 'than', 'also',
+  'both', 'each', 'such', 'only', 'other', 'same', 'more', 'most', 'some', 'must',
+  'first', 'second', 'third', 'case', 'cases', 'reason', 'order', 'time',
+  // Talmud scaffold (ubiquitous → non-discriminating)
+  'mishnah', 'mishna', 'gemara', 'gemora', 'tanna', 'tanno', 'baraisa', 'baraita',
+  'beraisa', 'rabbi', 'rebbi', 'raban', 'rabban', 'says', 'said', 'asks', 'asked',
+  'answer', 'answers', 'question', 'questions', 'verse', 'verses', 'opinion',
+  'opinions', 'holds', 'rules', 'ruling', 'teaches', 'learns', 'explains',
+  'explained', 'discusses', 'states', 'halacha', 'halachah', 'amud', 'sugya',
+]);
+
+function tokenSet(text: string): Set<string> {
+  const out = new Set<string>();
+  for (const w of (text.toLowerCase().match(/[a-z']{4,}/g) ?? [])) {
+    const t = w.replace(/'/g, '');
+    if (t.length >= 4 && !STOP.has(t)) out.add(t);
+  }
+  return out;
+}
+
+/** Jaccard similarity + the raw intersection count (so we can require real
+ *  evidence, not just a high ratio on tiny token sets). */
+function overlap(a: Set<string>, b: Set<string>): { score: number; inter: number } {
+  if (!a.size || !b.size) return { score: 0, inter: 0 };
+  let inter = 0;
+  for (const w of a) if (b.has(w)) inter++;
+  return { score: inter / (a.size + b.size - inter), inter };
+}
+
+// Tunable conservative thresholds (verified against a daf sample before rollout).
+const MIN_SCORE = 0.16;   // best section must share enough distinctive words
+const MIN_MARGIN = 0.06;  // …and clearly beat the runner-up
+const MIN_OVERLAP = 3;    // …with at least this many real shared words
+
+interface Cand { key: string; sec: number; score: number }
+
+/** Keep the max-total-score subset of candidates whose section indices are
+ *  non-decreasing in entry order (weighted longest non-decreasing subsequence).
+ *  This preserves reading order without letting one bad early match drop every
+ *  later one. O(n^2), n = matched entries (tiny). */
+function keepInOrder(cands: Cand[]): Cand[] {
+  const n = cands.length;
+  if (n <= 1) return cands;
+  const dp = cands.map((c) => c.score);
+  const prev = new Array<number>(n).fill(-1);
+  for (let i = 0; i < n; i++) {
+    for (let j = 0; j < i; j++) {
+      if (cands[j].sec <= cands[i].sec && dp[j] + cands[i].score > dp[i]) {
+        dp[i] = dp[j] + cands[i].score;
+        prev[i] = j;
+      }
+    }
+  }
+  let best = 0;
+  for (let i = 1; i < n; i++) if (dp[i] > dp[best]) best = i;
+  const out: Cand[] = [];
+  for (let i = best; i >= 0; i = prev[i]) out.push(cands[i]);
+  return out.reverse();
+}
+
+/** Place Revach items onto the argument section each one describes. Returns the
+ *  SegMatches to feed `applyMatches`; items without a confident, in-order match
+ *  are simply omitted (left unplaced → whole-daf). */
+export function matchRevach(items: ContextItem[], sections: SectionForMatch[]): SegMatch[] {
+  if (sections.length === 0) return [];
+  // Defensive: align over reading order, not cache/storage order.
+  const secs = [...sections].sort((a, b) => a.startSegIdx - b.startSegIdx);
+  const secTokens = secs.map((s) => tokenSet(`${s.title ?? ''} ${s.summary ?? ''}`));
+
+  const cands: Cand[] = [];
+  for (const item of items) {
+    if (item.source !== 'dafyomi:revach') continue;
+    const et = tokenSet(`${item.title?.en ?? ''} ${item.body?.en ?? ''}`);
+    if (et.size < 3) continue;
+    let best = -1, bestScore = 0, second = 0, bestInter = 0;
+    secs.forEach((_s, idx) => {
+      const { score, inter } = overlap(et, secTokens[idx]);
+      if (score > bestScore) { second = bestScore; bestScore = score; best = idx; bestInter = inter; }
+      else if (score > second) second = score;
+    });
+    if (best < 0 || bestScore < MIN_SCORE || bestScore - second < MIN_MARGIN || bestInter < MIN_OVERLAP) continue;
+    cands.push({ key: item.key, sec: best, score: bestScore });
+  }
+
+  return keepInOrder(cands).map((c) => {
+    const s = secs[c.sec];
+    return {
+      key: c.key,
+      segs: segRange(s.startSegIdx, s.endSegIdx),
+      via: 'revach-section',
+      confidence: Math.round(c.score * 100) / 100,
+    };
+  });
+}

--- a/src/worker/context-providers.ts
+++ b/src/worker/context-providers.ts
@@ -32,6 +32,8 @@ import {
 } from '../lib/context/fromSefaria';
 import { matchTosfos } from '../lib/context/anchor/tosfos';
 import { matchBackgroundTerms } from '../lib/context/anchor/bg-term';
+import { matchRevach, type SectionForMatch } from '../lib/context/anchor/revach';
+import { applyMatches } from '../lib/context/match';
 import type { ContextItem } from '../lib/context/types';
 
 export interface ContextEnv {
@@ -46,16 +48,25 @@ export interface ContextEnv {
  * through its existing KV-cached wrapper, so this is cheap once warm and
  * resilient — a source that fails contributes nothing rather than throwing.
  */
+export interface CollectContextOpts {
+  /** Incoming request origin, for the dev-mode ASSETS fallback. */
+  assetOrigin?: string;
+  /** This amud's argument sections (English title/summary + seg range). When
+   *  provided, Revach entries are conservatively placed onto the section each
+   *  describes; omit to skip Revach placement (e.g. the workbench). */
+  sections?: SectionForMatch[];
+}
+
 export async function collectContext(
   env: ContextEnv,
   tractate: string,
   page: string,
-  assetOrigin?: string,
+  opts: CollectContextOpts = {},
 ): Promise<ContextItem[]> {
   const cache = env.CACHE;
   const allowLive = env.DAFYOMI_LIVE !== '0';
   const [dafyomi, sefariaPage, segments, rishonim, halacha, mishna, topics] = await Promise.all([
-    getDafyomiContentCached(cache, env.ASSETS, tractate, page, { assetOrigin, allowLive }).catch(() => null),
+    getDafyomiContentCached(cache, env.ASSETS, tractate, page, { assetOrigin: opts.assetOrigin, allowLive }).catch(() => null),
     getSefariaPageCached(cache, tractate, page).catch(() => null),
     getSefariaSegmentsCached(cache, tractate, page).catch(() => null),
     getRishonimCached(cache, tractate, page).catch(() => []),
@@ -79,6 +90,9 @@ export async function collectContext(
     matchTosfos(dy, sefariaPage?.tosafot);
     // Place Background glossary/girsa terms onto the segment(s) that quote them.
     matchBackgroundTerms(dy, segments?.he);
+    // Place whole-daf Revach summaries onto the argument section each describes
+    // (conservative; unmatched entries are left whole-daf). LLM-free.
+    if (opts.sections?.length) applyMatches(dy, matchRevach(dy, opts.sections));
     items.push(...dy);
   }
   return items;

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1210,7 +1210,17 @@ async function resolveDependencies(
       // enrichment gets the context grounded to its own lines; a whole-daf one
       // (no segment location) gets the full pool. Each source that fails
       // contributes nothing rather than throwing.
-      const items = await collectContext(rc.env, tractate, page);
+      // This amud's argument sections let Revach summaries be placed per-section
+      // (English↔English alignment, conservative); a cheap cached read.
+      const sections = (await readMarkInstances(rc.env, 'argument', tractate, page))
+        .filter((i) => typeof i.startSegIdx === 'number' && typeof i.endSegIdx === 'number')
+        .map((i) => ({
+          startSegIdx: i.startSegIdx as number,
+          endSegIdx: i.endSegIdx as number,
+          title: typeof i.fields?.title === 'string' ? i.fields.title : undefined,
+          summary: typeof i.fields?.summary === 'string' ? i.fields.summary : undefined,
+        }));
+      const items = await collectContext(rc.env, tractate, page, { sections });
       const scoped = contextForAnchor(items, segsFromMarkInput(markInput));
       out.vars.context = formatContextForPrompt(scoped);
       return;
@@ -3914,7 +3924,7 @@ app.get('/api/context/:tractate/:page', async (c) => {
   const tractate = c.req.param('tractate');
   const page = c.req.param('page');
   try {
-    const items = await collectContext(c.env, tractate, page, new URL(c.req.url).origin);
+    const items = await collectContext(c.env, tractate, page, { assetOrigin: new URL(c.req.url).origin });
     return c.json({ tractate, page, items, fetchedAt: new Date().toISOString() });
   } catch (err) {
     return c.json({ error: String(err) }, 502);

--- a/tests/revach-placer.test.ts
+++ b/tests/revach-placer.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { matchRevach, type SectionForMatch } from '../src/lib/context/anchor/revach';
+import type { ContextItem } from '../src/lib/context/types';
+
+const sections: SectionForMatch[] = [
+  { startSegIdx: 0, endSegIdx: 4, title: 'Opening Mishnah: Time for Evening Shema',
+    summary: 'The Mishnah presents opinions on the time for reciting the evening Shema, until midnight and until dawn.' },
+  { startSegIdx: 5, endSegIdx: 7, title: 'Why begin with evening?',
+    summary: 'The Gemara asks why the Tanna begins with the morning prayer order, citing the verse about lying down.' },
+];
+
+const revach = (key: string, title: string, body: string): ContextItem => ({
+  source: 'dafyomi:revach', sourceLabel: "Revach l'Daf", kind: 'revach', key,
+  title: { en: title }, body: { en: body }, segs: [],
+});
+
+describe('matchRevach — conservative section placement', () => {
+  it('places a clearly-matching entry on its section segment range', () => {
+    const items = [revach('r:0',
+      'The Mishnah discusses the latest time for the nighttime Shema',
+      'Rebbi Eliezer until a third of the night; Chachamim until midnight; Raban Gamliel until dawn.')];
+    const m = matchRevach(items, sections);
+    expect(m).toHaveLength(1);
+    expect(m[0]).toMatchObject({ key: 'r:0', segs: [0, 1, 2, 3, 4], via: 'revach-section' });
+    expect(m[0].confidence).toBeGreaterThan(0);
+  });
+
+  it('leaves an entry unplaced when nothing overlaps', () => {
+    const items = [revach('r:x', 'A note about ritual purity vessels', 'Earthenware and immersion in a mikveh.')];
+    expect(matchRevach(items, sections)).toEqual([]);
+  });
+
+  it('ignores non-revach items and empty section lists', () => {
+    const notRevach: ContextItem = { ...revach('bg:0', 'x', 'y'), source: 'dafyomi:background' };
+    expect(matchRevach([notRevach], sections)).toEqual([]);
+    expect(matchRevach([revach('r:0', 'Mishnah evening Shema time', 'midnight dawn')], [])).toEqual([]);
+  });
+
+  it('places two in-order entries on their sections, preserving order', () => {
+    const items = [
+      revach('r:0', 'The latest time for the nighttime Shema, reciting in the evening', 'until midnight and dawn'),
+      revach('r:1', 'Why begin with the evening prayer before morning', 'from the verse about lying down'),
+    ];
+    const m = matchRevach(items, sections);
+    expect(m.map((x) => x.key)).toEqual(['r:0', 'r:1']);
+    expect(m[0].segs).toEqual([0, 1, 2, 3, 4]);
+    expect(m[1].segs).toEqual([5, 6, 7]);
+  });
+
+  it('always returns placements in non-decreasing segment order', () => {
+    // Out-of-order entries: a (→ section 1) before b (→ section 0). The
+    // max-weight non-decreasing alignment keeps an in-order subset, never a
+    // backwards pair.
+    const items = [
+      revach('r:a', 'Why begin with the evening prayer before morning, the verse on lying down', 'order'),
+      revach('r:b', 'The latest time for the nighttime Shema, reciting evening until midnight and dawn', 'opinions'),
+    ];
+    const m = matchRevach(items, sections);
+    const starts = m.map((x) => x.segs[0]);
+    expect([...starts]).toEqual([...starts].sort((p, q) => p - q)); // non-decreasing
+    expect(m.length).toBeLessThanOrEqual(1); // the two conflict → at most one kept
+  });
+});


### PR DESCRIPTION
Step 2 of un-flattening Revach — the **conservative section placer** (PR1 #88 captured the citations; this pins each entry to the section it describes).

## How
Revach entries are **English summary prose that walks the daf in order**; the daf's `argument` sections are **also English, ordered, and carry a segment range**. So `matchRevach` aligns each entry to its section by English content-word overlap and borrows that section's segments. A per-section enrichment (`argument.background`) then sees the *relevant* Revach entry instead of the whole-daf blob.

**Conservative by design** (a wrong segment label is worse than `[whole daf]`):
- requires a strong score **+ clear margin** over the runner-up **+ enough raw shared words**;
- a **scaffold stoplist** drops ubiquitous words ("mishnah", "gemara", "tanna", "verse"…) that don't discriminate;
- keeps placements in reading order via a **max-weight non-decreasing alignment** (so one early false positive can't poison the rest);
- **unmatched entries stay whole-daf** — strictly no worse than before.

LLM-free; wired into `collectContext` via an options object; the worker passes this amud's argument sections (a cheap cached read).

## Gated next steps (not in this PR)
- **Verify on sample dapim** (bypass-cache): eyeball that placements are right and there are no false positives; tune `MIN_SCORE`/`MIN_MARGIN`/`MIN_OVERLAP` if needed.
- **Enrichment rollout**: bump `argument.background` (v4→5) + `argument-overview.synthesis` (v2→3), re-warm, with stale-while-revalidate. Existing outputs don't change until then.

Codex-reviewed: it flagged greedy-monotonic poisoning, low-evidence short matches, a shallow stoplist, cache-order vs startSegIdx, and the positional-arg footgun — **all addressed**. typecheck + tests green (5 new placer tests).