### PR TITLE
AI fallback for Revach placement (cached, gap-fill only)

### DIFF
--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -9,6 +9,7 @@ import {
 } from '../lib/sefref';
 import { getDafyomiMasechet } from '../lib/sefref/dafyomi/masechtos';
 import { collectContext } from './context-providers';
+import { placeRevachWithAi } from './revach-ai-place';
 import { formatContextForPrompt, contextForAnchor, segsFromMarkInput } from '../lib/context/select';
 import { aiMatchToSegments } from './context-match';
 import type { MatchInput } from '../lib/context/anchor/ai-prompt';
@@ -1221,6 +1222,9 @@ async function resolveDependencies(
           summary: typeof i.fields?.summary === 'string' ? i.fields.summary : undefined,
         }));
       const items = await collectContext(rc.env, tractate, page, { sections });
+      // Back up the deterministic Revach placer with the cached AI matcher for
+      // any entries it left whole-daf (once per daf; LLM-free on cache hit).
+      await placeRevachWithAi(rc.env, tractate, page, items);
       const scoped = contextForAnchor(items, segsFromMarkInput(markInput));
       out.vars.context = formatContextForPrompt(scoped);
       return;
@@ -2688,10 +2692,11 @@ app.get('/api/admin/hb-probe', async (c) => {
   return c.json({ tractate, mode: concurrent ? 'concurrent' : 'sequential', attempted: results.length, ok, failed: results.length - ok, results });
 });
 
-// Spot-check the deterministic Revach→section placer for one daf: how each
-// whole-daf Revach entry got placed (or left whole-daf) against this amud's
-// argument sections. Read-only, LLM-free — for tuning thresholds + the AI
-// fallback decision. Needs the daf's `argument` mark + dafyomi warm.
+// Spot-check the Revach placer for one daf: how each whole-daf Revach entry got
+// placed (or left whole-daf) against this amud's argument sections, with `via`
+// (revach-section = deterministic, ai = fallback). Read-only by default
+// (LLM-free); pass ?ai=1 to also run the cached AI fallback (one LLM call + KV
+// write on a cold daf). Needs the daf's `argument` mark + dafyomi warm.
 app.get('/api/admin/revach-check/:tractate/:page', async (c) => {
   const tractate = c.req.param('tractate');
   const page = c.req.param('page');
@@ -2704,12 +2709,16 @@ app.get('/api/admin/revach-check/:tractate/:page', async (c) => {
       summary: typeof i.fields?.summary === 'string' ? i.fields.summary : undefined,
     }));
   const items = await collectContext(c.env, tractate, page, { sections });
+  // Deterministic by default (LLM-free); pass ?ai=1 to also run the cached AI
+  // fallback (may make one LLM call + write KV on a cold daf).
+  if (c.req.query('ai') === '1') await placeRevachWithAi(c.env, tractate, page, items);
   const sectionTitleForSeg = (seg: number) =>
     sections.find((s) => seg >= s.startSegIdx && seg <= s.endSegIdx)?.title ?? null;
   const revach = items.filter((it) => it.source === 'dafyomi:revach').map((it) => ({
     entry: (it.title?.en ?? it.body?.en ?? '').slice(0, 80),
     placed: it.segs.length ? `${it.segs[0]}-${it.segs[it.segs.length - 1]}` : null,
     section: it.segs.length ? sectionTitleForSeg(it.segs[0]) : null,
+    via: it.via ?? null,
     confidence: it.confidence ?? null,
     refs: (it.refs ?? []).map((r) => `${r.tractate} ${r.page}`),
   }));

--- a/src/worker/revach-ai-place.ts
+++ b/src/worker/revach-ai-place.ts
@@ -1,0 +1,104 @@
+/**
+ * @fileoverview AI fallback for Revach l'Daf placement.
+ *
+ * The deterministic placer (matchRevach) is high-precision but low-recall on
+ * Revach's English summary prose. For the entries it leaves whole-daf, this
+ * backs up to the existing AI segment-matcher — but ONCE PER DAF, CACHED, so the
+ * live context build never makes an LLM call on a cache hit: the first build for
+ * a daf computes + caches the AI placement; every later build reads it.
+ *
+ * Safety (a wrong segment is worse than "whole daf"):
+ *  - the AI only ever FILLS GAPS — it never overrides a deterministic placement;
+ *  - only matches at/above a CONFIDENCE FLOOR are applied, so the matcher's
+ *    low-confidence "couldn't localize" guesses (e.g. an opposite-amud entry
+ *    against this amud's segments) are dropped and stay whole-daf;
+ *  - all KV + LLM failures are silent — deterministic placement always stands.
+ *
+ * The cache holds matches for ALL Revach entries (not just the currently-unplaced
+ * set), so it's complete + stable regardless of how the deterministic pass went.
+ * Improve over time by feeding confident AI placements back as rule examples.
+ */
+
+import { aiMatchToSegments } from './context-match';
+import { getSefariaSegmentsCached } from './source-cache';
+import { applyMatches, type SegMatch } from '../lib/context/match';
+import type { ContextItem } from '../lib/context/types';
+import type { MatchInput } from '../lib/context/anchor/ai-prompt';
+import type { LLMEnv } from './llm';
+
+// Bump when the Revach parser output (entry order/keys), the segment text, or
+// the matcher prompt/model changes — positional keys (`revach:a:i`) mean stale
+// matches would otherwise apply to a different entry.
+const KEY = (tractate: string, page: string) => `revach-place:v2:${tractate}:${page}`;
+
+/** Drop AI matches below this confidence — the matcher reports ~0.9 when it
+ *  localizes well and ~0 when it can't, so this filters out the guesses. */
+const MIN_AI_CONF = 0.6;
+
+function revachItems(items: ContextItem[]): ContextItem[] {
+  return items.filter((i) => i.source === 'dafyomi:revach');
+}
+
+function toMatchInput(it: ContextItem): MatchInput {
+  return { key: it.key, label: "Revach l'Daf", title: it.title?.en, text: (it.body?.en ?? '').slice(0, 400) };
+}
+
+/** Apply AI matches ONLY to items the deterministic pass left unplaced, and only
+ *  above the confidence floor, so a deterministic (or strong) placement is never
+ *  overridden and weak guesses don't smear context. Pure + exported for tests. */
+export function applyAiToUnplaced(items: ContextItem[], matches: SegMatch[]): number {
+  const gaps = new Set(revachItems(items).filter((i) => i.segs.length === 0).map((i) => i.key));
+  const good = matches.filter((m) => gaps.has(m.key) && (m.confidence ?? 0) >= MIN_AI_CONF);
+  return applyMatches(items, good);
+}
+
+// In-isolate coalescing: many section enrichments for one daf build context
+// concurrently; without this each would fire its own AI compute on a cold daf.
+const inflight = new Map<string, Promise<SegMatch[] | null>>();
+
+async function getOrCompute(
+  env: LLMEnv & { CACHE?: KVNamespace },
+  tractate: string,
+  page: string,
+  all: ContextItem[],
+): Promise<SegMatch[] | null> {
+  const cache = env.CACHE;
+  const cacheKey = KEY(tractate, page);
+  if (cache) {
+    try {
+      const raw = await cache.get(cacheKey);
+      if (raw) return JSON.parse(raw) as SegMatch[];
+    } catch { /* missing / corrupt → recompute */ }
+  }
+  const existing = inflight.get(cacheKey);
+  if (existing) return existing;
+
+  const job = (async (): Promise<SegMatch[] | null> => {
+    const segs = await getSefariaSegmentsCached(cache, tractate, page).catch(() => null);
+    if (!segs?.he?.length) return null;
+    let matches: SegMatch[];
+    try {
+      matches = await aiMatchToSegments(env, segs.he, segs.en ?? [], all.map(toMatchInput));
+    } catch {
+      return null; // budget paused / LLM error → deterministic stands
+    }
+    if (cache) { try { await cache.put(cacheKey, JSON.stringify(matches)); } catch { /* best-effort */ } }
+    return matches;
+  })();
+  inflight.set(cacheKey, job);
+  try { return await job; } finally { inflight.delete(cacheKey); }
+}
+
+/** Place still-unplaced Revach items via the cached AI matcher (mutates `items`). */
+export async function placeRevachWithAi(
+  env: LLMEnv & { CACHE?: KVNamespace },
+  tractate: string,
+  page: string,
+  items: ContextItem[],
+): Promise<void> {
+  const all = revachItems(items);
+  if (all.length === 0) return;
+  if (!all.some((i) => i.segs.length === 0)) return; // nothing to fill
+  const matches = await getOrCompute(env, tractate, page, all);
+  if (matches) applyAiToUnplaced(items, matches);
+}

--- a/tests/revach-ai.test.ts
+++ b/tests/revach-ai.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { applyAiToUnplaced } from '../src/worker/revach-ai-place';
+import type { ContextItem } from '../src/lib/context/types';
+import type { SegMatch } from '../src/lib/context/match';
+
+const rev = (key: string, segs: number[], via?: string): ContextItem => ({
+  source: 'dafyomi:revach', sourceLabel: "Revach l'Daf", kind: 'revach', key,
+  title: { en: key }, body: { en: '' }, segs, ...(via ? { via } : {}),
+});
+
+describe('applyAiToUnplaced — AI fills gaps, never overrides deterministic', () => {
+  it('places only the unplaced item; leaves the deterministically-placed one alone', () => {
+    const placed = rev('r:0', [0, 1, 2, 3, 4], 'revach-section'); // deterministic
+    const gap = rev('r:1', []);                                   // unplaced
+    const items = [placed, gap];
+    const ai: SegMatch[] = [
+      { key: 'r:0', segs: [9], via: 'ai', confidence: 0.9 }, // would override — must be ignored
+      { key: 'r:1', segs: [7, 8], via: 'ai', confidence: 0.8 },
+    ];
+    const changed = applyAiToUnplaced(items, ai);
+    expect(changed).toBe(1);
+    expect(placed.segs).toEqual([0, 1, 2, 3, 4]); // untouched
+    expect(placed.via).toBe('revach-section');
+    expect(gap.segs).toEqual([7, 8]);             // filled by AI
+    expect(gap.via).toBe('ai');
+  });
+
+  it('drops low-confidence AI guesses (stay whole-daf)', () => {
+    const gap = rev('r:1', []);
+    const weak: SegMatch[] = [{ key: 'r:1', segs: [3], via: 'ai', confidence: 0.2 }];
+    expect(applyAiToUnplaced([gap], weak)).toBe(0);
+    expect(gap.segs).toEqual([]); // untouched — below the floor
+  });
+
+  it('ignores AI matches for non-revach keys and is a no-op with none', () => {
+    const gap = rev('r:1', []);
+    expect(applyAiToUnplaced([gap], [])).toBe(0);
+    expect(applyAiToUnplaced([gap], [{ key: 'other', segs: [1], via: 'ai' }])).toBe(0);
+  });
+});


### PR DESCRIPTION
The recall fix for the Revach placer (the spot-check showed deterministic placement is precise but ~13% recall). Unplaced entries now back up to the **existing AI segment-matcher** — but **once per daf, cached** (`revach-place:v2`), so the live context build makes **no LLM call on a cache hit**.

**Safety (a wrong segment is worse than whole-daf):**
- AI only **fills gaps** — never overrides a deterministic placement;
- only matches **≥ a confidence floor (0.6)** are applied, so the matcher's low-confidence "couldn't localize" guesses (e.g. an opposite-amud entry against this amud's segments) are dropped and stay whole-daf;
- all KV + LLM failures are **silent** → deterministic always stands;
- an **in-isolate promise** coalesces concurrent computes for one daf (no stampede);
- the cache holds matches for **all** entries → complete + stable.

Wired into the `context` dep resolution (has the LLM env) + the debug endpoint (now `?ai=1` opt-in). Improve over time by feeding confident AI placements back as deterministic-rule examples.

**Cost note:** since recall was ~13%, nearly every daf has gaps, so the rollout re-warm will compute one (cached) AI placement per daf — bounded + cheap on the flash matcher, but real. Codex-reviewed (5 issues, all addressed). typecheck + tests green.