### PR TITLE
Fix bidi scrambling and redundant Hebrew gloss in enrichment prose

### DIFF
--- a/src/client/Hebraized.tsx
+++ b/src/client/Hebraized.tsx
@@ -9,8 +9,28 @@
  * fire-and-forget — render never blocks on it; on completion the text just
  * swaps in place. On any LLM error, the dict-pass result stays.
  */
-import { createResource, createMemo, type JSX } from 'solid-js';
+import { createResource, createMemo, For, type JSX } from 'solid-js';
 import { hebraize, unresolvedParens, hebraizeLLM, capitalizeFirst, stripEchoParens } from './hebraize';
+
+// A maximal run of Hebrew/Aramaic — letters plus internal spaces, geresh/
+// gershayim, maqaf — starting and ending on a Hebrew character. We isolate each
+// such run in a <bdi> so the surrounding English punctuation (quotes, parens,
+// commas) keeps its correct left-to-right position instead of being reordered
+// by the bidi algorithm into a scrambled mix.
+// Explicit ranges (not literal chars — a composed char like יִ would silently
+// blow the range open). Geresh/gershayim (׳/״) and maqaf (־) stay
+// inside a run (Hebrew abbreviations/compounds); ASCII quotes/parens stay out so
+// they keep their English position.
+const HE_RUN = /([\u0590-\u05FF\uFB1D-\uFB4F](?:[\u0590-\u05FF\uFB1D-\uFB4F\u05BE\u05F3\u05F4 -]*[\u0590-\u05FF\uFB1D-\uFB4F\u05F3\u05F4])?)/g;
+const isHe = (s: string): boolean => /[\u0590-\u05FF\uFB1D-\uFB4F]/.test(s);
+
+/** Render mixed Hebrew/English text with each Hebrew run bidi-isolated, so the
+ *  surrounding English punctuation doesn't get reordered into a scramble. */
+export function BidiText(props: { text: string }): JSX.Element {
+  // String.split with a capturing group alternates non-match / match.
+  const parts = createMemo(() => props.text.split(HE_RUN));
+  return <For each={parts()}>{(part) => (isHe(part) ? <bdi>{part}</bdi> : <>{part}</>)}</For>;
+}
 
 export function Hebraized(props: { text: string | undefined | null; capitalize?: boolean }): JSX.Element {
   const dictPass = createMemo(() => hebraize(props.text ?? ''));
@@ -33,5 +53,5 @@ export function Hebraized(props: { text: string | undefined | null; capitalize?:
     const s = llm != null ? stripEchoParens(llm) : dictPass();
     return props.capitalize ? capitalizeFirst(s) : s;
   });
-  return <>{out()}</>;
+  return <BidiText text={out()} />;
 }

--- a/src/client/hebraize.ts
+++ b/src/client/hebraize.ts
@@ -475,13 +475,44 @@ export function stripStopwordHebrewParens(text: string): string {
  *  different scripts — never matches. Caps at 6 tokens preceding to keep
  *  the regex bounded. */
 const ECHO_PAREN_RE = /(\S+(?:\s+\S+){0,5})\s*\(\1\)/g;
+
+// Hebrew/Aramaic ranges as \u escapes - see the same note in Hebraized.tsx:
+// a literal presentation form (U+FB1D..) can decompose under normalization and
+// silently blow the range open. ־/׳/״ = maqaf/geresh/gershayim.
+const HE = '\\u0590-\\u05FF\\uFB1D-\\uFB4F';
+// A Hebrew run immediately followed by an ALL-Hebrew parenthetical. The gloss
+// convention is "Hebrew term (English meaning)", so an all-Hebrew paren here is
+// suspect - but only a near-echo (the paren restates the term, often
+// malformed/duplicated) is redundant. A genuine Hebrew clarification that adds
+// new words must be kept, so we gate the drop on word overlap below rather than
+// stripping every Hebrew paren. The paren body is restricted to Hebrew + Hebrew
+// punctuation, so digits / other scripts never match.
+const HE_GLOSS_PAREN_RE = new RegExp(
+  `([${HE}][${HE}\\u05BE\\u05F3\\u05F4 -]*?)\\s*\\(\\s*([${HE}][${HE}\\u05BE\\u05F3\\u05F4 ]*)\\)`,
+  'g',
+);
+
+/** Drop an all-Hebrew parenthetical that merely restates the Hebrew term before
+ *  it (a redundant/duplicated gloss). Conservative: keep the paren unless at
+ *  least half its words already appear in the preceding term. */
+function dropHebrewGlossEchoes(text: string): string {
+  return text.replace(HE_GLOSS_PAREN_RE, (m: string, term: string, paren: string) => {
+    const termWords = new Set(term.trim().split(/\s+/).filter(Boolean));
+    const parenWords = paren.trim().split(/\s+/).filter(Boolean);
+    if (parenWords.length === 0) return m;
+    const shared = parenWords.filter((w: string) => termWords.has(w)).length;
+    return shared >= Math.ceil(parenWords.length / 2) ? term : m;
+  });
+}
+
 export function stripEchoParens(text: string): string {
   if (!text) return text;
   let prev = text;
   // Iterate: nested echoes (rare, but possible after the LLM cascades two
   // glosses) need a second pass to fully collapse.
   for (let i = 0; i < 3; i++) {
-    const next = prev.replace(ECHO_PAREN_RE, '$1');
+    let next = prev.replace(ECHO_PAREN_RE, '$1');
+    next = dropHebrewGlossEchoes(next);
     if (next === prev) break;
     prev = next;
   }

--- a/tests/prose-bidi.test.ts
+++ b/tests/prose-bidi.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { stripEchoParens } from '../src/client/hebraize';
+
+describe('stripEchoParens — drop redundant all-Hebrew gloss parentheticals', () => {
+  it('drops an all-Hebrew paren right after a Hebrew term (the broken case)', () => {
+    // term followed by a malformed/duplicated all-Hebrew "gloss"
+    expect(stripEchoParens('a knife of מלא צואר וחוץ לצואר (מלא צואר וחוץ לצואר וחוץ לצואר) suffices'))
+      .toBe('a knife of מלא צואר וחוץ לצואר suffices');
+  });
+  it('still collapses an exact echo', () => {
+    expect(stripEchoParens('the מעשה (מעשה) here')).toBe('the מעשה here');
+  });
+  it('KEEPS a real English gloss', () => {
+    expect(stripEchoParens('valid שחיטה (ritual slaughter) requires')).toBe('valid שחיטה (ritual slaughter) requires');
+  });
+  it('keeps an all-Hebrew paren that is NOT after a Hebrew term', () => {
+    expect(stripEchoParens('the verse (בראשית) opens')).toBe('the verse (בראשית) opens');
+  });
+  it('KEEPS a genuine Hebrew clarification that adds new words (not an echo)', () => {
+    // The paren shares no words with the term, so it is a real clarification,
+    // not a redundant restatement — must survive.
+    expect(stripEchoParens('cited by רבי עקיבא (תנא) here')).toBe('cited by רבי עקיבא (תנא) here');
+  });
+  it('keeps a Hebrew paren with a digit/other script (only Hebrew bodies match)', () => {
+    expect(stripEchoParens('the daf דף (דף 2) here')).toBe('the daf דף (דף 2) here');
+  });
+});


### PR DESCRIPTION
Mixed Hebrew/English enrichment prose was rendering with quotes/parens displaced — a Hebrew term followed by a malformed all-Hebrew gloss showed as a scrambled run.

**Two causes, two fixes (client-only — no re-warm needed):**

1. **Bidi isolation.** `Hebraized` now renders each maximal Hebrew run inside `<bdi>` (new `BidiText`), so surrounding English punctuation keeps its LTR position instead of being reordered by the bidi algorithm.
2. **Redundant-gloss collapse.** `stripEchoParens` now drops an all-Hebrew parenthetical that merely restates the Hebrew term before it. The drop is gated on **word overlap** (keep unless ≥ half the paren's words already appear in the term), so a genuine Hebrew clarification like `רבי עקיבא (תנא)` survives. The paren body is restricted to Hebrew, so digits / other scripts never match.

Hebrew ranges are written as `\u` escapes — a literal presentation form (U+FB1D..) can decompose under normalization and silently widen the range.

Codex-reviewed; all three findings addressed (\u ranges, word-overlap echo gate + Hebrew-only body, ASCII quotes excluded from runs).

`pnpm typecheck` clean; `pnpm test` 1430 passing (incl. 6 `tests/prose-bidi.test.ts`).