### PR TITLE
Live-refresh enrichment cards on stale-while-revalidate

### DIFF
--- a/src/client/MarkEnrichmentCards.tsx
+++ b/src/client/MarkEnrichmentCards.tsx
@@ -370,6 +370,47 @@ export default function MarkEnrichmentCards(props: Props) {
   // prefetch, but they don't starve the primary synthesis or another anchor
   // the user opens next).
   const cardPriority = props.markId === 'argument-move' ? QUEUE_PRIORITY.normal : QUEUE_PRIORITY.high;
+
+  // Stale-while-revalidate follow-up. The server serves the PREVIOUS
+  // cache_version (tagged `refreshing`) on a version-bump miss while the new one
+  // recomputes in the enrichment-jobs queue. We show that stale value
+  // immediately, then re-fetch on a short backoff to swap in the fresh version
+  // the moment it lands — no reload needed. Bounded attempts: if the recompute
+  // never lands (budget paused → server keeps serving stale), we stop and leave
+  // the stale value shown; a later reload or re-warm fills it. Timers are tied
+  // to the effect's AbortController so a daf/anchor change cancels them.
+  const REFRESH_BACKOFF_MS = [4000, 8000, 16000];
+  const scheduleRefresh = (
+    d: EnrichmentDef, s: string, curLang: string, controller: AbortController, attempt: number,
+  ) => {
+    if (attempt >= REFRESH_BACKOFF_MS.length) return;
+    if (controller.signal.aborted || stamp() !== s) return;
+    let timer: ReturnType<typeof setTimeout>;
+    const onAbort = () => clearTimeout(timer);
+    timer = setTimeout(() => {
+      controller.signal.removeEventListener('abort', onAbort);
+      if (controller.signal.aborted || stamp() !== s) return;
+      const { id: actId, label: actLabel } = enrichmentActivityKey(
+        d.id, props.tractate, props.page, props.instance, props.instanceKey,
+      );
+      void enrichmentQueue.enqueue(actId, actLabel, (sig) =>
+        runEnrichment(d.id, props.tractate, props.page, props.instance, props.instanceKey, sig),
+        controller.signal,
+        cardPriority,
+      ).then(
+        (result) => {
+          if (stamp() !== s) return;
+          if (result.refreshing) { scheduleRefresh(d, s, curLang, controller, attempt + 1); return; }
+          runResultCache.set(runCacheKey(d.id, props.tractate, props.page, props.instanceKey, curLang), result);
+          applyResult(d, s, result);
+        },
+        // Aborted / superseded / transient error — keep the stale value visible.
+        () => {},
+      );
+    }, REFRESH_BACKOFF_MS[attempt]);
+    controller.signal.addEventListener('abort', onAbort, { once: true });
+  };
+
   createEffect(() => {
     const list = matching();
     if (list.length === 0) return;
@@ -396,6 +437,14 @@ export default function MarkEnrichmentCards(props: Props) {
           cardPriority,
         ).then(
           (result) => {
+            // A `refreshing` result is the stale previous version (SWR). Show it,
+            // but don't persist it (it would pin the stale value in the run
+            // cache); instead re-fetch shortly to pick up the fresh version.
+            if (result.refreshing) {
+              applyResult(d, s, result);
+              scheduleRefresh(d, s, curLang, controller, 0);
+              return;
+            }
             runResultCache.set(runCacheKey(d.id, props.tractate, props.page, props.instanceKey, curLang), result);
             applyResult(d, s, result);
           },
@@ -461,7 +510,10 @@ export default function MarkEnrichmentCards(props: Props) {
       QUEUE_PRIORITY.high,
     ).then(
       (result) => {
-        runResultCache.set(runCacheKey(id, props.tractate, props.page, props.instanceKey, curLang), result);
+        // Don't pin a stale SWR value in the cache (see the auto-fire path).
+        if (!result.refreshing) {
+          runResultCache.set(runCacheKey(id, props.tractate, props.page, props.instanceKey, curLang), result);
+        }
         if (stamp() === s) setRun(id, { kind: 'ok', stamp: s, result });
       },
       (err) => { if (!isAbort(err) && stamp() === s) { /* keep synthetic content; inspection just lacks prompts */ } },
@@ -615,6 +667,23 @@ export default function MarkEnrichmentCards(props: Props) {
         padding: '0.85rem 1rem',
       }}>
         {renderCardBody()}
+        <Show when={(() => { const r = primaryRun(); return r.kind === 'ok' && r.result.refreshing; })()}>
+          {/* Stale-while-revalidate: the value above is the previous version,
+              served while the new one recomputes. scheduleRefresh swaps it in. */}
+          <div style={{
+            display: 'flex', 'align-items': 'center', gap: '0.4rem',
+            'margin-top': '0.5rem', color: '#a16207', 'font-size': '0.72rem',
+            'font-style': 'italic',
+          }}>
+            <span style={{
+              display: 'inline-block', width: '0.6rem', height: '0.6rem',
+              'border-radius': '50%',
+              border: '2px solid #e7d9b0', 'border-top-color': '#a16207',
+              animation: 'daf-spin 0.8s linear infinite', 'flex-shrink': 0,
+            }} />
+            {t('enrichment.updating')}
+          </div>
+        </Show>
         <Show when={devModeActive()}>
           <button
             onClick={openInspector}

--- a/src/client/enrichmentQueue.ts
+++ b/src/client/enrichmentQueue.ts
@@ -30,6 +30,14 @@ export interface RunResult {
    *  → instances list under the 'rabbi' key). Same fetch as deps_resolved;
    *  surfaced so a sidebar can render mark-specific UI without re-fetching. */
   anchors_resolved?: Record<string, unknown>;
+  /** Stale-while-revalidate (server, /api/studio/run): this value is the
+   *  PREVIOUS cache_version served while the new one recomputes after a bump.
+   *  When `refreshing`, the client shows it with an "updating" marker, does NOT
+   *  persist it in the long-lived run cache (it would pin the stale value), and
+   *  re-fetches shortly to swap in the fresh version. See src/worker/index.ts. */
+  stale?: boolean;
+  refreshing?: boolean;
+  cache_hit?: boolean;
 }
 
 /** True for an AbortError (DOMException or any error whose name is set). */

--- a/src/client/i18n.ts
+++ b/src/client/i18n.ts
@@ -201,6 +201,7 @@ const CATALOG = {
   'loading.places': { en: 'Travelling…', he: 'נוסע…' },
   'loading.rishonim': { en: 'Listening to Rashi and Tosafot…', he: 'מקשיב לרש״י ולתוספות…' },
   'loading.default': { en: 'Learning…', he: 'לומד…' },
+  'enrichment.updating': { en: 'Updating…', he: 'מתעדכן…' },
 
   // — Questions (Q&A) panel —
   'qa.questions': { en: 'Questions', he: 'שאלות' },


### PR DESCRIPTION
Follow-up to #92, which added server-side stale-while-revalidate to `/api/studio/run`: on a `cache_version`-bump miss the worker serves the **previous** version's value tagged `{ stale, refreshing }` and enqueues the recompute. Until now the client ignored that flag — readers saw the stale value correct only on reload.

This makes the sidebar enrichment cards (`MarkEnrichmentCards`) observe `refreshing`:

- **Don't pin the stale value.** A `refreshing` result is shown but **not** written into the long-lived in-session `runResultCache` (which would otherwise serve it across remounts until a model/prompt invalidation). This was a latent correctness bug independent of the UX.
- **Swap in-tab.** A bounded-backoff re-fetch (4s/8s/16s) picks up the fresh version the moment the server recompute lands. If it never lands (budget paused → server keeps serving stale), it stops and leaves the stale value shown; a later reload/re-warm fills it.
- **"Updating…" badge** renders while refreshing.

Timers are tied to the effect's `AbortController` (cleared via a `{ once: true }` abort listener), so a daf/anchor/lang change cancels them. `runResultCache` is only used here, so the overview/`createResource` consumers (which re-fetch per mount) already self-heal.

Codex-reviewed: no blocking issues; the two cleanups it suggested (upfront abort guard, listener removal on fire) are applied.

`pnpm typecheck` clean; `pnpm test` 1430 passing.