### PR TITLE
Remove dead filterFlowConnections from the flow graph

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Principles: deterministic rules grow over time but **AI keeps final say**; conte
 4. **Generic sidebar** — render a piece's enrichments from a declared render hint (retire bespoke `*Body` components).
 5. **Entity pieces** (lift "global" rabbi/place), **link pieces** (unify flow/bridge/voice-edges/citations), **user pieces** (highlights/notes).
 6. **Tractate-continuous + commentary spines** (wire the reserved `external` anchor); **content-hash freshness + reverse-dependency index**.
-7. **Cruft + DX**: remove the orphaned sugya-assembly (`/api/studio/sugya`, `assemble.ts`, `SUGYA_WINDOW_CAP`) and test-only `filterFlowConnections`; drop the `/studio` API prefix; keep `src/worker/mcp-openapi.ts` in sync; expand `docs/framework.md` toward an SDK.
+7. **Cruft + DX**: remove the orphaned sugya-assembly (`/api/studio/sugya`, `assemble.ts`, `SUGYA_WINDOW_CAP`); drop the `/studio` API prefix; keep `src/worker/mcp-openapi.ts` in sync; expand `docs/framework.md` toward an SDK. (Done: dead `filterFlowConnections` removed — the flow graph's inline `edges()` membership filter subsumes it.)
 
 Cross-cutting always: typed piece bodies, resilient anchors, provenance/confidence, eval-gated producer promotion.
 

--- a/src/client/ArgumentFlowGraph.tsx
+++ b/src/client/ArgumentFlowGraph.tsx
@@ -55,18 +55,6 @@ const KIND_DASH: Partial<Record<FlowConnection['kind'], string>> = {
   parallels: '2 3',
 };
 
-/** Keep only connections whose endpoints are valid section indices and which
- *  aren't self-loops. Guards against the LLM emitting an out-of-range or
- *  self-referential index — those would otherwise mis-route or be dropped
- *  silently by the renderer. Pure + exported for tests. */
-export function filterFlowConnections(connections: FlowConnection[], nodeCount: number): FlowConnection[] {
-  return connections.filter(
-    (c) => c.from !== c.to
-      && Number.isInteger(c.from) && c.from >= 0 && c.from < nodeCount
-      && Number.isInteger(c.to) && c.to >= 0 && c.to < nodeCount,
-  );
-}
-
 /** Assign each connection a routing lane (0-based) so connectors that share
  *  vertical extent never sit in the same lane — interval-graph coloring, which
  *  keeps parallel runs from drawing on top of each other (the old `i % 4`
@@ -128,7 +116,10 @@ export default function ArgumentFlowGraph(props: Props): JSX.Element {
   // Map section index -> array position, so a SUBSET of the daf's sections (one
   // sugya group) lays out compactly in rows 0..k while connections still arrive
   // keyed by absolute section index. Edges with an endpoint outside this group
-  // are dropped — they belong to another map.
+  // are dropped — they belong to another map. The same membership test also
+  // guards against the LLM emitting a self-loop or an out-of-range / non-integer
+  // index: a self-loop fails `from !== to`, and a bad index isn't a real section
+  // so `pm.has` rejects it (the map is keyed by integer section indices).
   const posOf = () => new Map(props.nodes.map((n, i) => [n.index, i]));
   const edges = () => {
     const pm = posOf();

--- a/tests/argument-overview-flow.test.ts
+++ b/tests/argument-overview-flow.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { filterFlowConnections, assignLanes, type FlowConnection } from '../src/client/ArgumentFlowGraph';
+import { assignLanes, type FlowConnection } from '../src/client/ArgumentFlowGraph';
 import { tokenizeRabbiMentions } from '../src/client/rabbiLinks';
 
 const conn = (from: number, to: number): FlowConnection => ({ from, to, kind: 'continues', note: '' });
@@ -22,25 +22,6 @@ describe('assignLanes — connectors that overlap vertically get different lanes
   });
   it('empty in -> empty out', () => {
     expect(assignLanes([])).toEqual([]);
-  });
-});
-
-describe('filterFlowConnections — overview flow graph edges', () => {
-  it('keeps valid in-range connections', () => {
-    expect(filterFlowConnections([conn(0, 1), conn(1, 3)], 5)).toHaveLength(2);
-  });
-  it('drops endpoints outside the section range (LLM hallucinated an index)', () => {
-    expect(filterFlowConnections([conn(0, 9)], 5)).toHaveLength(0);
-    expect(filterFlowConnections([conn(-1, 2)], 5)).toHaveLength(0);
-  });
-  it('drops self-loops', () => {
-    expect(filterFlowConnections([conn(3, 3)], 5)).toHaveLength(0);
-  });
-  it('drops non-integer indices', () => {
-    expect(filterFlowConnections([{ from: 0.5, to: 2, kind: 'resolves', note: '' }], 5)).toHaveLength(0);
-  });
-  it('empty in -> empty out', () => {
-    expect(filterFlowConnections([], 5)).toEqual([]);
   });
 });
 


### PR DESCRIPTION
`filterFlowConnections` was an exported helper with no production caller. `ArgumentFlowGraph`'s `edges()` does its own **stronger** inline filtering — membership in the rendered-node position map (`pm.has(c.from) && pm.has(c.to)`) plus `from !== to`. That already rejects self-loops, out-of-range indices, and non-integers (a bad index isn't a real section, so `pm.has` rejects it). The exported helper existed only to be unit-tested.

Removed the helper and its 5 test cases; folded the LLM-hallucination guard rationale into the `edges()` comment so it isn't lost. `assignLanes` (live) and `tokenizeRabbiMentions` tests stay.

Part of the roadmap step-7 cruft cleanup. The backend pieces (sugya-assembly, `/studio` rename) are deliberately left to the in-flight `remove-legacy-2` / `cache-cleanup` worktrees, which are rewriting `src/worker/index.ts`.

`pnpm typecheck` clean; `pnpm test` 1425 passing.