### PR TITLE
Drop quote-wrapped Hebrew gloss echoes; tighten the echo gate

### DIFF
--- a/src/client/hebraize.ts
+++ b/src/client/hebraize.ts
@@ -486,22 +486,31 @@ const HE = '\\u0590-\\u05FF\\uFB1D-\\uFB4F';
 // malformed/duplicated) is redundant. A genuine Hebrew clarification that adds
 // new words must be kept, so we gate the drop on word overlap below rather than
 // stripping every Hebrew paren. The paren body is restricted to Hebrew + Hebrew
-// punctuation, so digits / other scripts never match.
+// punctuation, so digits / other scripts never match. The GAP between term and
+// paren tolerates closing quotes (straight + curly) and spaces, so a quoted
+// term like 'מלא צואר' (מלא צואר) still matches; the quote is preserved.
+const GLOSS_GAP = ` '"\\u2018\\u2019\\u201C\\u201D`;
 const HE_GLOSS_PAREN_RE = new RegExp(
-  `([${HE}][${HE}\\u05BE\\u05F3\\u05F4 -]*?)\\s*\\(\\s*([${HE}][${HE}\\u05BE\\u05F3\\u05F4 ]*)\\)`,
+  `([${HE}][${HE}\\u05BE\\u05F3\\u05F4 -]*?)([${GLOSS_GAP}]*)\\(\\s*([${HE}][${HE}\\u05BE\\u05F3\\u05F4 ]*)\\)`,
   'g',
 );
 
 /** Drop an all-Hebrew parenthetical that merely restates the Hebrew term before
- *  it (a redundant/duplicated gloss). Conservative: keep the paren unless at
- *  least half its words already appear in the preceding term. */
+ *  it (a redundant/duplicated gloss). Conservative: drop only when EVERY word in
+ *  the paren already appears in the preceding term — i.e. it adds no new
+ *  information (the observed failures are exact or padded repetitions like
+ *  "מלא צואר (מלא צואר וחוץ לצואר)"). A paren that introduces even one new word
+ *  is a real clarification and is kept. Any closing quote in the gap is kept (it
+ *  belongs to the term); only the paren and the whitespace that separated it
+ *  are dropped. */
 function dropHebrewGlossEchoes(text: string): string {
-  return text.replace(HE_GLOSS_PAREN_RE, (m: string, term: string, paren: string) => {
+  return text.replace(HE_GLOSS_PAREN_RE, (m: string, term: string, gap: string, paren: string) => {
     const termWords = new Set(term.trim().split(/\s+/).filter(Boolean));
     const parenWords = paren.trim().split(/\s+/).filter(Boolean);
     if (parenWords.length === 0) return m;
-    const shared = parenWords.filter((w: string) => termWords.has(w)).length;
-    return shared >= Math.ceil(parenWords.length / 2) ? term : m;
+    const addsNewWord = parenWords.some((w: string) => !termWords.has(w));
+    if (addsNewWord) return m;
+    return term + gap.replace(/\s+/g, '');
   });
 }
 

--- a/tests/prose-bidi.test.ts
+++ b/tests/prose-bidi.test.ts
@@ -24,4 +24,15 @@ describe('stripEchoParens — drop redundant all-Hebrew gloss parentheticals', (
   it('keeps a Hebrew paren with a digit/other script (only Hebrew bodies match)', () => {
     expect(stripEchoParens('the daf דף (דף 2) here')).toBe('the daf דף (דף 2) here');
   });
+  it('KEEPS a quoted paren that adds a new word (not a pure repetition)', () => {
+    // Shares words with the term but introduces 'מבחוץ' — a real clarification.
+    expect(stripEchoParens("a knife 'מלא צואר' (מלא צואר מבחוץ) here"))
+      .toBe("a knife 'מלא צואר' (מלא צואר מבחוץ) here");
+  });
+  it('drops a quote-wrapped echo, keeping the closing quote (the production case)', () => {
+    // A closing quote sits between the term and the paren; the echo must still
+    // be dropped, and the quote that wraps the term must be preserved.
+    expect(stripEchoParens("says the knife must be 'מלא צואר וחוץ לצואר' (מלא צואר וחוץ לצואר). The Gemara"))
+      .toBe("says the knife must be 'מלא צואר וחוץ לצואר'. The Gemara");
+  });
 });


### PR DESCRIPTION
Follow-up to #93. A redundant all-Hebrew gloss was still surviving in production when the Hebrew term was **quote-wrapped**: `'מלא צואר וחוץ לצואר' (מלא צואר וחוץ לצואר)`. The closing `'` between the term and the `(` broke the match (the gap previously allowed whitespace only).

- **Quote-tolerant gap:** the separator between term and paren now also matches closing quotes (straight `'` `"` and curly), and the quote is **preserved** (re-emitted) while the redundant paren + its separating whitespace are dropped.
- **Stricter gate:** changed the drop condition from "≥ half the paren's words overlap the term" to "**every** paren word is already in the term." The real failures are exact/padded repetitions; this keeps any paren that adds a genuinely new word (a real clarification — Codex flagged the old threshold as a false-positive risk).

Codex-reviewed. `pnpm typecheck` clean; `pnpm test` 1427 passing (8 in `tests/prose-bidi.test.ts`, incl. the production case and a "keeps a paren that adds a new word" guard).