### PR TITLE
Drop the /studio API prefix: /api/studio/* -> /api/*

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Principles: deterministic rules grow over time but **AI keeps final say**; conte
 4. **Generic sidebar** — render a piece's enrichments from a declared render hint (retire bespoke `*Body` components).
 5. **Entity pieces** (lift "global" rabbi/place), **link pieces** (unify flow/bridge/voice-edges/citations), **user pieces** (highlights/notes).
 6. **Tractate-continuous + commentary spines** (wire the reserved `external` anchor); **content-hash freshness + reverse-dependency index**.
-7. **Cruft + DX**: drop the `/studio` API prefix; keep `src/worker/mcp-openapi.ts` in sync; expand `docs/framework.md` toward an SDK ✅. (Done: dead `filterFlowConnections` removed — flow graph's inline `edges()` filter subsumes it; orphaned sugya-assembly removed — `/api/studio/sugya` route + `SUGYA_WINDOW_CAP` + `typing/assemble.ts` + `typing/sugya.ts` + `readFlowConnections`, all dead once the route went; `docs/framework.md` SDK-grade rewrite.)
+7. ✅ **Cruft + DX** — DONE. dead `filterFlowConnections` removed (flow graph's inline `edges()` filter subsumes it); orphaned sugya-assembly removed (`/api/studio/sugya` route + `SUGYA_WINDOW_CAP` + `typing/assemble.ts` + `typing/sugya.ts` + `readFlowConnections`); `docs/framework.md` SDK-grade rewrite; **`/api/studio/*` prefix dropped to `/api/*`** (run, run-status, marks, enrichments, checks, bridge, type-profiles), `mcp-openapi.ts` kept in sync. Internal `studio` tokens kept on purpose: the `x-studio-secret` header, `studio-schema.ts`/`studio-registry.ts` filenames, and the `studio-mark`/`studio-enrichment` usage-telemetry labels (a stored taxonomy, not the URL).
 
 Cross-cutting always: typed piece bodies, resilient anchors, provenance/confidence, eval-gated producer promotion.
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -51,7 +51,7 @@ it can't be done blind). After that it's Track B (render/DX) and Track C
 ### Environment gotchas (will bite you)
 
 - **node_modules**: the worktree symlinks the main tree's `node_modules` (`ln -s <repo>/node_modules ./node_modules`). It predates PR #32, so `@hono/mcp`, `@cloudflare/codemode`, `@modelcontextprotocol/sdk` are **missing** → `tsc` reports 3-4 "Cannot find module" errors in `src/worker/mcp.ts` + `index.ts:~460`. **These are pre-existing and unrelated — ignore them.** Filter with `npx tsc --noEmit 2>&1 | grep -v "@hono/mcp\|@cloudflare/codemode\|@modelcontextprotocol"`.
-- **Live API**: production `POST /api/studio/run` (cache hits → 200, else 202 + poll `/api/studio/run-status/{runId}?k=`) is open/read. **It blocks the default Python `urllib` user-agent (403)** — set a browser `User-Agent` header. `bypass_cache`/`model_override` need the `x-studio-secret` header (we don't have it). A budget guard ($10/hr, $300/day) caps spend at the `runLLM` chokepoint.
+- **Live API**: production `POST /api/run` (cache hits → 200, else 202 + poll `/api/run-status/{runId}?k=`) is open/read. **It blocks the default Python `urllib` user-agent (403)** — set a browser `User-Agent` header. `bypass_cache`/`model_override` need the `x-studio-secret` header (we don't have it). A budget guard ($10/hr, $300/day) caps spend at the `runLLM` chokepoint.
 - **Sandbox**: throwaway scripts go in `/Users/shaunie/Documents/Code/Sandbox/` (not in-repo). The capture/regen scripts used for A0 are there: `capture_golden_anchors.py`, `regen_stale_aggadata.ts` (run with `npx tsx`).
 
 ## The pipeline (just enough to orient)

--- a/docs/framework.md
+++ b/docs/framework.md
@@ -182,15 +182,15 @@ prompt:
 - `global` — same regardless of daf (a rabbi's bio). Keyed by instance only.
 - `local` — computed in light of *this* daf (a synthesis). Keyed by instance + daf.
 
-### Run lifecycle — `/api/studio/run`
+### Run lifecycle — `/api/run`
 
 One endpoint runs any producer for a `(tractate, page, mark_input)`. It is async:
 
 ```
-POST /api/studio/run  →  { status: 'ok', result }                  // cache hit, immediate
+POST /api/run  →  { status: 'ok', result }                  // cache hit, immediate
                       →  { status: 'pending', runId, cacheKey? }   // enqueued (202); poll
                       →  { status: 'error', error }
-GET  /api/studio/run-status/:runId  →  same shape; poll until 'ok'
+GET  /api/run-status/:runId  →  same shape; poll until 'ok'
 ```
 
 The cold path enqueues a `JobMessage` onto the `enrichment-jobs` Cloudflare
@@ -214,7 +214,7 @@ foreground click outranks background prefetch) and an in-session
   `{ enrichment }` dependency — otherwise the dependent cache-hits and readers
   never see the change.
 - **Stale-while-revalidate (shipped).** `previousVersionKey(key, id, version)`
-  returns the prior version's key. On a version-bump miss `/api/studio/run`
+  returns the prior version's key. On a version-bump miss `/api/run`
   serves the previous value tagged `{ stale: true, refreshing: true }` and
   enqueues the recompute, so a bump never makes a reader wait. The client
   (`MarkEnrichmentCards`) shows it with an "Updating…" badge, does **not** pin it
@@ -294,7 +294,7 @@ This is the template every later linked source follows: parse → map → place
    `scope`, `cache_version`). Cache keys derive automatically — never hand-build.
 2. If it depends on another enrichment, remember the **cascade**: bumping the
    dependency must bump this one too.
-3. It runs through `/api/studio/run` for free; the client queue + `runResultCache`
+3. It runs through `/api/run` for free; the client queue + `runResultCache`
    + SWR apply automatically.
 4. Keep `src/worker/mcp-openapi.ts` in sync if you add/rename an endpoint.
 
@@ -312,7 +312,7 @@ This is the template every later linked source follows: parse → map → place
 | Select + format for prompt | `src/lib/context/select.ts` |
 | Producer schema | `src/worker/studio-schema.ts` |
 | Producer registry | `src/worker/code-marks.ts` |
-| Run endpoint + SWR | `src/worker/index.ts` (`/api/studio/run`) |
+| Run endpoint + SWR | `src/worker/index.ts` (`/api/run`) |
 | Cache keys + versioning | `src/worker/cache-keys.ts` |
 | Budget gate | `src/worker/budget.ts` |
 | Client queue + result cache | `src/client/enrichmentQueue.ts` |

--- a/docs/section-typing.md
+++ b/docs/section-typing.md
@@ -66,7 +66,7 @@ a story. They are parallel overlays that merely happen to share segment indices.
 
 ## Coverage findings — what "no category" actually means
 
-Measured against the live API (`POST /api/studio/run`, all cache hits, zero
+Measured against the live API (`POST /api/run`, all cache hits, zero
 cost) by overlaying the content layers on every segment:
 
 | Daf | content-covered | uncovered segs | what the gaps are |
@@ -300,7 +300,7 @@ The whole-daf "Argument map" / flow graph is still experimental and the
 sugya-spanning version is not built. **Section typing does not depend on it.** It
 rides the per-daf `argument` + `argument-move` marks, which work today and are
 cached (verified: all four content marks for Gittin 67b are 200 cache hits via
-`/api/studio/run`). So we deliver typing now on the working per-daf structure and
+`/api/run`). So we deliver typing now on the working per-daf structure and
 fold it into the diagram later, not the other way round.
 
 Phases — each shippable, flag-gated, reversible:

--- a/scripts/warm-anchors-shas.mjs
+++ b/scripts/warm-anchors-shas.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * Fire-and-forget anchors warmer. For every (tractate, page, mark) tuple,
- * POSTs to /api/studio/run and moves on without polling — cache hits return
+ * POSTs to /api/run and moves on without polling — cache hits return
  * 200 immediately, cold ones return 202 with a runId and get processed by the
  * worker queue at its own pace (max_concurrency=10 per wrangler.toml).
  *
@@ -105,7 +105,7 @@ async function enqueueOne(job) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
   try {
-    const r = await fetch(`${WORKER}/api/studio/run`, {
+    const r = await fetch(`${WORKER}/api/run`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ mark_id: job.mark, tractate: job.tractate, page: job.page }),

--- a/scripts/warm-pages.mjs
+++ b/scripts/warm-pages.mjs
@@ -84,7 +84,7 @@ async function postRun(body) {
   // status code only after exhausting retries.
   for (let attempt = 0; attempt < 4; attempt++) {
     try {
-      const r = await fetch(`${WORKER}/api/studio/run`, {
+      const r = await fetch(`${WORKER}/api/run`, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify(body),
@@ -108,7 +108,7 @@ async function pollUntilDone(runId, timeoutS) {
   while (Date.now() - start < timeoutS * 1000) {
     await sleep(1500);
     try {
-      const r = await fetch(`${WORKER}/api/studio/run-status/${encodeURIComponent(runId)}`);
+      const r = await fetch(`${WORKER}/api/run-status/${encodeURIComponent(runId)}`);
       let j = null;
       try { j = await r.json(); } catch { return null; }
       if (j && j.status === 'ok') return j;
@@ -143,7 +143,7 @@ async function runMarkSync(tractate, page, markId) {
 /** Fire an enrichment (synthesis OR suggested-questions) fire-and-forget. */
 async function fireEnrichment(tractate, page, enrichmentId, markInput) {
   try {
-    await fetch(`${WORKER}/api/studio/run`, {
+    await fetch(`${WORKER}/api/run`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ enrichment_id: enrichmentId, tractate, page, mark_input: markInput }),
@@ -153,7 +153,7 @@ async function fireEnrichment(tractate, page, enrichmentId, markInput) {
   }
 }
 
-/** Auxiliary endpoints the frontend hits beyond /api/studio/run. Each is
+/** Auxiliary endpoints the frontend hits beyond /api/run. Each is
  *  GET-cached server-side, so a single warm fetch primes the KV entry.
  *  /api/daf-context is the slowest of these (legacy rabbi-id pipeline);
  *  warming it explicitly so the rabbi sidebar's generationByName + slug

--- a/src/client/ArgumentNarrative.tsx
+++ b/src/client/ArgumentNarrative.tsx
@@ -26,7 +26,7 @@ async function pollJob(runId: string, cacheKey?: string): Promise<unknown> {
   const qs = cacheKey ? `?k=${encodeURIComponent(cacheKey)}` : '';
   while (Date.now() - start < POLL_TIMEOUT_MS) {
     await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
-    const res = await fetch(`/api/studio/run-status/${encodeURIComponent(runId)}${qs}`);
+    const res = await fetch(`/api/run-status/${encodeURIComponent(runId)}${qs}`);
     const j = await res.json() as { status?: string; result?: { parsed?: unknown }; error?: string };
     if (j.status === 'ok') return j.result?.parsed;
     if (j.status === 'error') throw new Error(j.error ?? 'narrative run failed');
@@ -35,7 +35,7 @@ async function pollJob(runId: string, cacheKey?: string): Promise<unknown> {
 }
 
 async function runNarrative(tractate: string, page: string, markInput: unknown): Promise<NarrativeData | null> {
-  const res = await fetch('/api/studio/run', {
+  const res = await fetch('/api/run', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ enrichment_id: 'argument.narrative', tractate, page, mark_input: markInput, lang: lang() }),

--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -75,7 +75,7 @@ export interface PlaceInstance {
 /** Section-typing gate for the voice-dispute map (Track C, P2). The voices
  *  graph models a מחלוקת; rendering it on a story or a one-sided Stam Q&A is the
  *  "Demons"/"Stam questioner→respondent" pathology. We compute the section's
- *  TypeProfile (deterministic, cached marks, via /api/studio/type-profiles) and
+ *  TypeProfile (deterministic, cached marks, via /api/type-profiles) and
  *  suppress the map unless the section is a real, non-narrative dispute. Gated
  *  to dev mode + reversible: readers are unaffected until this is promoted, and
  *  when the profile is unknown we default to showing (current behavior). The
@@ -87,7 +87,7 @@ function useVoicesGate(tractate: () => string, page: () => string, section: () =
     () => `${tractate()}|${page()}`,
     async (): Promise<SectionTypeProfile[]> => {
       try {
-        const r = await fetch(`/api/studio/type-profiles/${encodeURIComponent(tractate())}/${encodeURIComponent(page())}`);
+        const r = await fetch(`/api/type-profiles/${encodeURIComponent(tractate())}/${encodeURIComponent(page())}`);
         if (!r.ok) return [];
         return ((await r.json()) as { profiles?: SectionTypeProfile[] }).profiles ?? [];
       } catch { return []; }
@@ -800,7 +800,7 @@ function ArgumentOverviewBody(props: {
       const continues = async (p: string | null): Promise<boolean> => {
         if (!p) return false;
         try {
-          const r = await fetch(`/api/studio/bridge/${encodeURIComponent(props.tractate)}/${encodeURIComponent(p)}`);
+          const r = await fetch(`/api/bridge/${encodeURIComponent(props.tractate)}/${encodeURIComponent(p)}`);
           if (!r.ok) return false;
           return !!((await r.json()) as { continues?: boolean }).continues;
         } catch { return false; }

--- a/src/client/ChecksPanel.tsx
+++ b/src/client/ChecksPanel.tsx
@@ -1,6 +1,6 @@
 /**
  * Dev-panel surfacing for the post-LLM check layer. Calls
- * GET /api/studio/checks/:tractate/:page — which re-runs each daf-level mark's
+ * GET /api/checks/:tractate/:page — which re-runs each daf-level mark's
  * declared checks against its ALREADY-CACHED (anchored) output, no LLM — and
  * lists what the soft/observe-only checks (anchor-verbatim, partition-clean, …)
  * flag on the daf in view. This is the observation surface for deciding whether
@@ -20,7 +20,7 @@ export default function ChecksPanel(props: { tractate: string; page: string }): 
   const [data] = createResource(
     () => `${props.tractate}|${props.page}`,
     async (): Promise<ChecksResponse | null> => {
-      const r = await fetch(`/api/studio/checks/${encodeURIComponent(props.tractate)}/${encodeURIComponent(props.page)}`);
+      const r = await fetch(`/api/checks/${encodeURIComponent(props.tractate)}/${encodeURIComponent(props.page)}`);
       if (!r.ok) return null;
       return (await r.json()) as ChecksResponse;
     },

--- a/src/client/MarkEnrichmentCards.tsx
+++ b/src/client/MarkEnrichmentCards.tsx
@@ -2,13 +2,13 @@
  * MarkEnrichmentCards — generic, mark-agnostic component that renders all
  * registered enrichments for a given mark instance.
  *
- * Architecture: pulls /api/studio/enrichments, filters to entries whose
+ * Architecture: pulls /api/enrichments, filters to entries whose
  * `mark` field matches the props.markId, then for each promoted enrichment
- * fires /api/studio/run with `{ enrichment_id, tractate, page, mark_input
+ * fires /api/run with `{ enrichment_id, tractate, page, mark_input
  * = props.instance }` and renders the parsed JSON output.
  *
  * Adding a new enrichment for a mark = drop a row into CODE_ENRICHMENTS
- * (worker/code-marks.ts) or save one via PUT /api/studio/enrichments. The
+ * (worker/code-marks.ts) or save one via PUT /api/enrichments. The
  * sidebar picks it up automatically. No UI code changes per new
  * enrichment.
  *
@@ -96,7 +96,7 @@ type RunState =
   | { kind: 'error'; stamp: string; error: string };
 
 async function fetchEnrichments(): Promise<EnrichmentDef[]> {
-  const r = await fetch('/api/studio/enrichments');
+  const r = await fetch('/api/enrichments');
   if (!r.ok) return [];
   const j = await r.json() as { enrichments: EnrichmentDef[] };
   return j.enrichments;
@@ -131,7 +131,7 @@ async function runEnrichmentImpl(
   markInput: unknown,
   signal?: AbortSignal,
 ): Promise<RunResult> {
-  const r = await fetch('/api/studio/run', {
+  const r = await fetch('/api/run', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ enrichment_id: enrichmentId, tractate, page, mark_input: markInput, lang: lang() }),
@@ -206,7 +206,7 @@ async function pollJob(runId: string, cacheKey?: string, signal?: AbortSignal): 
   while (Date.now() - start < POLL_TIMEOUT_MS) {
     await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
     if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
-    const r = await fetch(`/api/studio/run-status/${encodeURIComponent(runId)}${qs}`, { signal });
+    const r = await fetch(`/api/run-status/${encodeURIComponent(runId)}${qs}`, { signal });
     const j = await r.json() as RunResponse | { status: 'pending' };
     if (isPausedBody(j)) throw new Error(PAUSED_ERROR);
     if ('status' in j) {
@@ -267,7 +267,7 @@ interface Props {
   /** Fired with the aggregate's `deps_resolved` + `anchors_resolved` once
    *  the synthesis run lands. Lets the parent sidebar render mark-specific
    *  UI (e.g. argument subsection pills) from the same fetch that produced
-   *  the synthesis paragraph — no duplicate `/api/studio/run` call.
+   *  the synthesis paragraph — no duplicate `/api/run` call.
    *  `deps_resolved` keys are enrichment ids; `anchors_resolved` keys are
    *  mark ids. Either may be undefined. */
   onResolved?: (resolved: {
@@ -328,7 +328,7 @@ export default function MarkEnrichmentCards(props: Props) {
     // For aggregate enrichments: server returns each dep's parsed output in
     // `deps_resolved` (enrichments) and `anchors_resolved` (marks). Populate
     // per-leaf run state so the dev dropdown can render leaves instantly
-    // without a second /api/studio/run call. Forward both maps to onResolved
+    // without a second /api/run call. Forward both maps to onResolved
     // so parent sidebars can render mark-specific UI from the same data.
     const resolved = result.deps_resolved;
     if (resolved || result.anchors_resolved) {

--- a/src/client/MarksRegistryPanel.tsx
+++ b/src/client/MarksRegistryPanel.tsx
@@ -3,7 +3,7 @@
  * inside the DafViewer's existing "Options" disclosure. Each toggle:
  *
  *   - off (default for all): nothing fetches, no daf decoration
- *   - on:  fetches /api/studio/run for the current tractate/page, stores
+ *   - on:  fetches /api/run for the current tractate/page, stores
  *          the result, exposes a status pill (loading / ok / error)
  *
  * Per-instance prompt/output inspection lives on the synthesis card (via
@@ -45,7 +45,7 @@ export interface EnrichmentDefinition {
   status?: 'draft' | 'promoted';
 }
 
-/** Worker-side mark definition (code or KV) returned by /api/studio/marks.
+/** Worker-side mark definition (code or KV) returned by /api/marks.
  *  Carries the full anchor+render+extractor schema. */
 export interface WorkerMarkDefinition {
   id: string;
@@ -189,8 +189,8 @@ function writeAppliedDefaults(tags: Iterable<string>) {
 
 async function fetchAll(): Promise<{ marks: WorkerMarkDefinition[]; enrichments: EnrichmentDefinition[] }> {
   const [m, e] = await Promise.all([
-    fetch('/api/studio/marks').then((r) => r.ok ? r.json() : { marks: [] }),
-    fetch('/api/studio/enrichments').then((r) => r.ok ? r.json() : { enrichments: [] }),
+    fetch('/api/marks').then((r) => r.ok ? r.json() : { marks: [] }),
+    fetch('/api/enrichments').then((r) => r.ok ? r.json() : { enrichments: [] }),
   ]);
   return {
     marks: ((m as { marks?: WorkerMarkDefinition[] }).marks) ?? [],
@@ -198,7 +198,7 @@ async function fetchAll(): Promise<{ marks: WorkerMarkDefinition[]; enrichments:
   };
 }
 
-// /api/studio/run is now async (queue-backed). Three response shapes:
+// /api/run is now async (queue-backed). Three response shapes:
 //   { status: 'ok', result }                            ← cache hit, immediate
 //   { status: 'pending', runId, cacheKey? } (HTTP 202)  ← enqueued, poll run-status
 //   { status: 'error', error }
@@ -212,7 +212,7 @@ type RunResponse =
 const POLL_INTERVAL_MS = 1500;
 const POLL_TIMEOUT_MS = 180_000;
 
-/** Studio secret for the privileged /api/studio/run knobs (bypass_cache here).
+/** Studio secret for the privileged /api/run knobs (bypass_cache here).
  *  The owner sets it once via
  *  `localStorage.setItem('talmud_studio_secret', '<secret>')` in the browser
  *  console; it rides along as the x-studio-secret header so the server treats
@@ -229,7 +229,7 @@ function studioHeaders(): Record<string, string> {
 }
 
 async function postAndAwait(body: unknown): Promise<RunResult> {
-  const r = await fetch('/api/studio/run', {
+  const r = await fetch('/api/run', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...studioHeaders() },
     body: JSON.stringify(body),
@@ -252,7 +252,7 @@ async function pollJob(runId: string, cacheKey?: string): Promise<RunResult> {
   const qs = cacheKey ? `?k=${encodeURIComponent(cacheKey)}` : '';
   while (Date.now() - start < POLL_TIMEOUT_MS) {
     await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
-    const r = await fetch(`/api/studio/run-status/${encodeURIComponent(runId)}${qs}`);
+    const r = await fetch(`/api/run-status/${encodeURIComponent(runId)}${qs}`);
     const j = await r.json() as RunResponse;
     if ('status' in j) {
       if (j.status === 'ok') return (j as { result: RunResult }).result;

--- a/src/client/McpPage.tsx
+++ b/src/client/McpPage.tsx
@@ -27,14 +27,14 @@ async () => {
   });
 
   let run = await codemode.request({
-    method: "POST", path: "/api/studio/run",
+    method: "POST", path: "/api/run",
     body: { tractate: "Berakhot", page: "2a", mark_id: "argument-move" },
   });
   while (run.status === "pending") {
     await new Promise((r) => setTimeout(r, 1500));
     run = await codemode.request({
       method: "GET",
-      path: \`/api/studio/run-status/\${run.runId}\`,
+      path: \`/api/run-status/\${run.runId}\`,
       query: { k: run.cacheKey },
     });
   }
@@ -139,8 +139,8 @@ export function McpPage(): JSX.Element {
       <p style={{ color: '#555', 'font-size': '0.88rem', margin: '0 0 0.2rem' }}>
         A daf page is text plus <em>marks</em> (structural extractors whose <code>excerpt</code>s are
         the anchors) and <em>enrichments</em> (LLM passes on a mark instance). Marks/enrichments run
-        through <code>POST /api/studio/run</code>, which is async — poll{' '}
-        <code>/api/studio/run-status/&#123;runId&#125;</code> until it is done:
+        through <code>POST /api/run</code>, which is async — poll{' '}
+        <code>/api/run-status/&#123;runId&#125;</code> until it is done:
       </p>
       <Code>{WORKED_EXAMPLE}</Code>
 

--- a/src/client/QAPanel.tsx
+++ b/src/client/QAPanel.tsx
@@ -7,11 +7,11 @@
  * ------------
  * 1. Renders a collapsed "Questions" button. The first time the user
  *    expands it, fetches the curated suggested-questions list (via
- *    /api/studio/run for `<mark>.suggested-questions`) AND the
+ *    /api/run for `<mark>.suggested-questions`) AND the
  *    community-asked registry (via /api/qa/registry).
  * 2. Shows the top 1-2 questions by default; "show more" reveals the rest
  *    (curated first, then community, ranked by clickCount).
- * 3. Clicking a question lazy-loads its answer via /api/studio/run for
+ * 3. Clicking a question lazy-loads its answer via /api/run for
  *    `<mark>.qa` with `user_question` set. The answer caches in shared
  *    KV so the second person to ask the same question gets it instantly.
  * 4. "+ Ask your own question" opens a textarea + submit. Submit POSTs to
@@ -23,7 +23,7 @@
  * ---------------------------------------------
  * MarkEnrichmentCards auto-fires every aggregate on mount. We need parameterized,
  * on-demand fetches keyed by question text; the existing card has no slot for
- * user-supplied `qualifier` strings. We POST to /api/studio/run directly with
+ * user-supplied `qualifier` strings. We POST to /api/run directly with
  * `user_question` in the body.
  */
 
@@ -82,7 +82,7 @@ async function runEnrichmentDirect(
     lang: lang(),
   };
   if (userQuestion) body.user_question = userQuestion;
-  const r = await fetch('/api/studio/run', {
+  const r = await fetch('/api/run', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
@@ -105,7 +105,7 @@ async function pollJob(runId: string, cacheKey?: string): Promise<RunResultLike>
   const qs = cacheKey ? `?k=${encodeURIComponent(cacheKey)}` : '';
   while (Date.now() - start < POLL_TIMEOUT_MS) {
     await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
-    const r = await fetch(`/api/studio/run-status/${encodeURIComponent(runId)}${qs}`);
+    const r = await fetch(`/api/run-status/${encodeURIComponent(runId)}${qs}`);
     const j = await r.json() as RunResponse | { status: 'pending' };
     if (isPausedBody(j)) throw new Error(PAUSED_ERROR);
     if ('status' in j) {

--- a/src/client/TypeProfilePanel.tsx
+++ b/src/client/TypeProfilePanel.tsx
@@ -1,6 +1,6 @@
 /**
  * Dev-panel view of section typing (Track C). Calls
- * GET /api/studio/type-profiles/:tractate/:page — which composes a TypeProfile
+ * GET /api/type-profiles/:tractate/:page — which composes a TypeProfile
  * per argument section from the daf's CACHED mark layers (no LLM) — and shows,
  * per section, its derived `primary` content dimension, whether it's a dispute,
  * and the overlay claims with coverage. The observation surface for validating
@@ -30,7 +30,7 @@ export default function TypeProfilePanel(props: {
   const [data] = createResource(
     () => `${props.tractate}|${props.page}`,
     async (): Promise<ProfilesResponse | null> => {
-      const r = await fetch(`/api/studio/type-profiles/${encodeURIComponent(props.tractate)}/${encodeURIComponent(props.page)}`);
+      const r = await fetch(`/api/type-profiles/${encodeURIComponent(props.tractate)}/${encodeURIComponent(props.page)}`);
       if (!r.ok) return null;
       return (await r.json()) as ProfilesResponse;
     },

--- a/src/client/aiActivity.ts
+++ b/src/client/aiActivity.ts
@@ -4,7 +4,7 @@
  * any moment, what just finished, and how long it took.
  *
  * The store is written to by every client-side runner that POSTs to
- * `/api/studio/run` — `MarkEnrichmentCards`'s queue helpers and
+ * `/api/run` — `MarkEnrichmentCards`'s queue helpers and
  * `MarksRegistryPanel`'s runMark/runEnrichment. Read by `AIActivityPanel`
  * (mounted in the dev shelf).
  *

--- a/src/client/enrichmentQueue.ts
+++ b/src/client/enrichmentQueue.ts
@@ -30,7 +30,7 @@ export interface RunResult {
    *  → instances list under the 'rabbi' key). Same fetch as deps_resolved;
    *  surfaced so a sidebar can render mark-specific UI without re-fetching. */
   anchors_resolved?: Record<string, unknown>;
-  /** Stale-while-revalidate (server, /api/studio/run): this value is the
+  /** Stale-while-revalidate (server, /api/run): this value is the
    *  PREVIOUS cache_version served while the new one recomputes after a bump.
    *  When `refreshing`, the client shows it with an "updating" marker, does NOT
    *  persist it in the long-lived run cache (it would pin the stale value), and
@@ -46,7 +46,7 @@ export function isAbort(err: unknown): boolean {
 }
 
 /** Sentinel message thrown by run helpers when the server reports a spend
- *  pause (`{ paused: true }` from /api/studio/run or run-status). The UI maps it
+ *  pause (`{ paused: true }` from /api/run or run-status). The UI maps it
  *  to a friendly localized message (t('qa.error.paused')) rather than showing a
  *  raw error string. See src/worker/budget.ts. */
 export const PAUSED_ERROR = 'BUDGET_PAUSED';
@@ -67,7 +67,7 @@ export function isPausedError(err: unknown): boolean {
 
 // Memo of completed enrichment runs, keyed by
 // enrichmentId:tractate:page:instanceKey. The server already caches in KV, but
-// every sidebar mount otherwise re-POSTs /api/studio/run and waits behind the
+// every sidebar mount otherwise re-POSTs /api/run and waits behind the
 // shared queue — so re-opening an anchor (or the second/third click on a page)
 // showed a spinner even though the result was already known. With this memo a
 // re-click renders instantly and never touches the queue at all. Within a
@@ -105,7 +105,7 @@ export const QUEUE_PRIORITY = { high: 0, normal: 1, low: 2 } as const;
 export type QueuePriority = (typeof QUEUE_PRIORITY)[keyof typeof QUEUE_PRIORITY];
 
 // Shared priority queue with bounded concurrency so opening one section that
-// mounts many move cards doesn't barrage `/api/studio/run` in parallel
+// mounts many move cards doesn't barrage `/api/run` in parallel
 // (workerd dies on the simultaneous fan-out + 30k-char prompts; see
 // 2026-05-07 incident). KV cache hits still go through the queue but resolve
 // fast, so there's no penalty once a section has been opened before.

--- a/src/client/i18n.ts
+++ b/src/client/i18n.ts
@@ -3,7 +3,7 @@
  * pages can read/set it without a shared context provider. Two things hang off
  * it:
  *
- *   1. Enrichment generation language. Every /api/studio/run (and /api/qa/ask)
+ *   1. Enrichment generation language. Every /api/run (and /api/qa/ask)
  *      caller threads lang() into the request body; the worker selects the
  *      Hebrew prompt variant and a `:he`-namespaced cache key (see
  *      src/worker/cache-keys.ts + code-marks.ts *_HE prompts).
@@ -444,9 +444,9 @@ const CATALOG = {
   'usage.unpriced': { en: 'unpriced', he: 'לא מתומחר' },
   'usage.latency.byEndpoint': { en: 'Latency by endpoint ({count} recent calls)', he: 'זמן תגובה לפי נקודת קצה ({count} קריאות אחרונות)' },
   'usage.latency.byMark': { en: 'Studio runs by mark', he: 'הרצות סטודיו לפי סימון' },
-  'usage.latency.byMark.hint': { en: 'rolled up across /api/studio/run with mark_id', he: 'מסוכם על פני /api/studio/run עם mark_id' },
+  'usage.latency.byMark.hint': { en: 'rolled up across /api/run with mark_id', he: 'מסוכם על פני /api/run עם mark_id' },
   'usage.latency.byEnrichment': { en: 'Studio runs by enrichment', he: 'הרצות סטודיו לפי העשרה' },
-  'usage.latency.byEnrichment.hint': { en: 'rolled up across /api/studio/run with enrichment_id', he: 'מסוכם על פני /api/studio/run עם enrichment_id' },
+  'usage.latency.byEnrichment.hint': { en: 'rolled up across /api/run with enrichment_id', he: 'מסוכם על פני /api/run עם enrichment_id' },
   'usage.recentErrors.title': { en: 'Recent errors', he: 'שגיאות אחרונות' },
   'usage.recentErrors.hint': { en: 'from request telemetry', he: 'מתוך טלמטריית הבקשות' },
   'usage.errorKind.other': { en: 'other', he: 'אחר' },

--- a/src/worker/budget.ts
+++ b/src/worker/budget.ts
@@ -27,7 +27,7 @@
  *
  * Enforcement lives at the single chokepoint runLLM() (src/worker/llm.ts):
  * checkBudget() before the call, recordSpend() after. Producer endpoints
- * (qa/ask, studio/run, warm-daf) pre-check too, purely for instant UI feedback
+ * (qa/ask, run, warm-daf) pre-check too, purely for instant UI feedback
  * and to avoid pointless queue churn.
  */
 import { costUsd, type TokenUsage } from './pricing';

--- a/src/worker/cache-stats.ts
+++ b/src/worker/cache-stats.ts
@@ -205,7 +205,7 @@ function pct(count: number, total: number): number {
 }
 
 /** Merge code-defined marks/enrichments with KV-defined ones. KV wins on id
- *  collision. Mirrors the precedence used by /api/studio/run. */
+ *  collision. Mirrors the precedence used by /api/run. */
 async function mergedMarks(cache: KVNamespace): Promise<Array<{ id: string; label: string; source: 'code' | 'kv'; cache_version: string }>> {
   const kv = await listMarks({ CACHE: cache });
   const byId = new Map<string, { id: string; label: string; source: 'code' | 'kv'; cache_version: string }>();

--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -1,6 +1,6 @@
 /**
  * Code-defined registry entries — the canonical "built-in" marks and
- * enrichments. Returned from /api/studio/marks and /api/studio/enrichments
+ * enrichments. Returned from /api/marks and /api/enrichments
  * alongside KV-stored entries (KV wins on id collisions, so a user can
  * override a built-in by saving a same-id KV definition).
  *
@@ -474,7 +474,7 @@ export const CODE_MARKS: MarkDefinition[] = [
   // -------------------------------------------------------------------------
   // The four segment-range marks below proxy their legacy endpoints. The
   // toggle behaviour is now uniform with rabbi (fires through
-  // /api/studio/run, shows in the loading band, surfaces in the inspect
+  // /api/run, shows in the loading band, surfaces in the inspect
   // drawer). Rendering still uses the legacy gutter+sidebar code path; a
   // bridge effect in DafViewer flips the corresponding showX signal when
   // the new mark is enabled. Future work: replace `legacy-endpoint` with a
@@ -1623,7 +1623,7 @@ export const CODE_ENRICHMENTS: EnrichmentDefinition[] = [
   // short-circuit in runEnrichmentOnce joins them by segment into per-rabbi
   // observation slices (place / opinion / story / exegesis / lineage) and
   // writes one KV slice per rabbi+daf (rabbi-obs:v1:{slug}:{tractate}:{page}).
-  // `computed` kind keeps it out of /api/studio/enrichments (that endpoint
+  // `computed` kind keeps it out of /api/enrichments (that endpoint
   // serves llm-kind only) so it never renders as a card; `draft` is belt-and-
   // suspenders. This is the COLLECT half — nothing here promotes back into the
   // canonical dataset or what users see. See src/worker/rabbi-observations.ts.
@@ -2719,7 +2719,7 @@ CODE_ENRICHMENTS.push(
   // mode='augment-content' (not 'aggregate') so MarkEnrichmentCards' auto-fire
   // for the argument-move card keeps treating argument-move.synthesis as the
   // sole primary. The Explore-deeper panel invokes these two directly via
-  // /api/studio/run, on demand, so we don't fan out per-move LLM calls for
+  // /api/run, on demand, so we don't fan out per-move LLM calls for
   // moves nobody opens.
   makeEnrichment(
     'argument-move', 'argument-move.suggested-questions', 'Suggested questions',
@@ -4870,7 +4870,7 @@ CODE_ENRICHMENTS.push(
 );
 
 // ---------------------------------------------------------------------------
-// Lookup helpers — used by /api/studio/run to resolve an id from either KV
+// Lookup helpers — used by /api/run to resolve an id from either KV
 // or code-defined sources. KV wins on collision.
 // ---------------------------------------------------------------------------
 

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -159,7 +159,7 @@ interface Bindings {
   OPENROUTER_GATEWAY_PROVIDER?: string;
   DEFAULT_LLM_MODEL?: string;
   // Enrichment job queue — see wrangler.toml + queue handler at the bottom
-  // of this file. /api/studio/run enqueues a JobMessage; the queue consumer
+  // of this file. /api/run enqueues a JobMessage; the queue consumer
   // runs the LLM chain and writes the result to KV under `job:{runId}`.
   ENRICHMENT_QUEUE?: Queue<JobMessage>;
   // When '1', the background Sefaria Shas walk also enqueues rabbi.observations
@@ -169,7 +169,7 @@ interface Bindings {
   // isolated sandbox the code-mode MCP `execute` tool runs in. Optional: when
   // unset, GET/POST /mcp returns 503 and the rest of the worker is unaffected.
   LOADER?: WorkerLoader;
-  // Shared secret gating the privileged /api/studio/run knobs (ad_hoc,
+  // Shared secret gating the privileged /api/run knobs (ad_hoc,
   // model_override, bypass_cache) and the admin mutation endpoints. Presented
   // by trusted tools as the `x-studio-secret` header. UNSET => every request is
   // treated as untrusted (fail-safe): the public app still works (it only uses
@@ -227,7 +227,7 @@ function timingSafeEqualStr(a: string, b: string): boolean {
 /**
  * True iff the request carries the STUDIO_SECRET (header `x-studio-secret`, or
  * `Authorization: Bearer <secret>`). Returns FALSE whenever the secret is unset
- * — fail-safe, so the privileged /api/studio/run knobs (ad_hoc, model_override,
+ * — fail-safe, so the privileged /api/run knobs (ad_hoc, model_override,
  * bypass_cache) and the admin mutation endpoints stay locked until the owner
  * provisions the secret. The public daf app never needs these, so locking them
  * by default doesn't degrade it.
@@ -454,7 +454,7 @@ app.get('/api/health', (c) => c.json({ ok: true }));
  * only outside access is the `request` bridge below, which re-enters our own
  * Hono app in-process for any /api/* path. The endpoint is public and gets the
  * untrusted safe subset; a trusted operator can forward an `x-studio-secret`
- * header on their MCP client to unlock the privileged /api/studio/run knobs.
+ * header on their MCP client to unlock the privileged /api/run knobs.
  */
 app.all('/mcp', async (c) => {
   if (!c.env.LOADER) {
@@ -571,12 +571,12 @@ app.get('/api/admin/llm-settings', (c) => {
  *   mark-defs:v1:{id}        — what to extract from a daf
  *   enrichment-defs:v1:{id}  — what to derive from a mark
  *
- * Ad-hoc runs (no save) hit /api/studio/run with an inline definition. Saved
+ * Ad-hoc runs (no save) hit /api/run with an inline definition. Saved
  * runs reference an id and get cached. The same registry powers Home (all
  * registered enrichments shown as toggles, off by default) and Studio
  * (per-enrichment editor + preview).
  */
-app.get('/api/studio/marks', async (c) => {
+app.get('/api/marks', async (c) => {
   // Merge KV-stored marks with code-defined seeds. KV wins on id collision
   // (a saved KV definition overrides a built-in with the same id).
   const kv = await listMarks(c.env);
@@ -587,7 +587,7 @@ app.get('/api/studio/marks', async (c) => {
   ];
   return c.json({ marks: merged });
 });
-app.get('/api/studio/marks/:id', async (c) => {
+app.get('/api/marks/:id', async (c) => {
   const id = c.req.param('id');
   const kv = await readMark(c.env, id);
   if (kv) return c.json({ mark: kv });
@@ -595,7 +595,7 @@ app.get('/api/studio/marks/:id', async (c) => {
   if (code) return c.json({ mark: code });
   return c.json({ error: 'not found' }, 404);
 });
-app.put('/api/studio/marks/:id', async (c) => {
+app.put('/api/marks/:id', async (c) => {
   let body: unknown;
   try { body = await c.req.json(); } catch { return c.json({ error: 'invalid JSON' }, 400); }
   const v = validateMark({ ...(body as object), id: c.req.param('id') });
@@ -603,7 +603,7 @@ app.put('/api/studio/marks/:id', async (c) => {
   const saved = await writeMark(c.env, v.spec);
   return c.json({ mark: saved });
 });
-app.delete('/api/studio/marks/:id', async (c) => {
+app.delete('/api/marks/:id', async (c) => {
   await deleteMark(c.env, c.req.param('id'));
   return c.json({ ok: true });
 });
@@ -615,7 +615,7 @@ app.delete('/api/studio/marks/:id', async (c) => {
 // before any of them is promoted to a hard, cache-gating check. Marks only:
 // they have one cache entry per daf; instance-scoped enrichment checks
 // (edge-integrity, rabbi-evidence) aren't enumerable without their instances.
-app.get('/api/studio/checks/:tractate/:page', async (c) => {
+app.get('/api/checks/:tractate/:page', async (c) => {
   const tractate = c.req.param('tractate');
   const page = c.req.param('page');
   const lang: 'en' | 'he' = c.req.query('lang') === 'he' ? 'he' : 'en';
@@ -689,7 +689,7 @@ async function buildDafTypeProfiles(env: Bindings, tractate: string, page: strin
   }
   return profiles;
 }
-app.get('/api/studio/type-profiles/:tractate/:page', async (c) => {
+app.get('/api/type-profiles/:tractate/:page', async (c) => {
   const tractate = c.req.param('tractate');
   const page = c.req.param('page');
   const profiles = await buildDafTypeProfiles(c.env, tractate, page);
@@ -756,12 +756,12 @@ async function computeDafBridge(env: Bindings, tractate: string, page: string): 
   if (cache && bridge.via !== 'no-data') await cache.put(key, JSON.stringify(bridge));
   return bridge;
 }
-app.get('/api/studio/bridge/:tractate/:page', async (c) => {
+app.get('/api/bridge/:tractate/:page', async (c) => {
   const bridge = await computeDafBridge(c.env, c.req.param('tractate'), c.req.param('page'));
   return c.json(bridge);
 });
 
-app.get('/api/studio/enrichments', async (c) => {
+app.get('/api/enrichments', async (c) => {
   // Merge KV + code-defined. KV wins on collision. Code-defined entries are
   // normalized to the KV-flat shape (extractor flattened, `mark` instead of
   // `target_mark`) so the client gets one consistent shape.
@@ -790,7 +790,7 @@ app.get('/api/studio/enrichments', async (c) => {
     }));
   return c.json({ enrichments: [...codeFlat, ...kv] });
 });
-app.get('/api/studio/enrichments/:id', async (c) => {
+app.get('/api/enrichments/:id', async (c) => {
   const id = c.req.param('id');
   const kv = await readEnrichment(c.env, id);
   if (kv) return c.json({ enrichment: kv });
@@ -798,7 +798,7 @@ app.get('/api/studio/enrichments/:id', async (c) => {
   if (code) return c.json({ enrichment: code });
   return c.json({ error: 'not found' }, 404);
 });
-app.put('/api/studio/enrichments/:id', async (c) => {
+app.put('/api/enrichments/:id', async (c) => {
   let body: unknown;
   try { body = await c.req.json(); } catch { return c.json({ error: 'invalid JSON' }, 400); }
   const v = validateEnrichment({ ...(body as object), id: c.req.param('id') });
@@ -806,7 +806,7 @@ app.put('/api/studio/enrichments/:id', async (c) => {
   const saved = await writeEnrichment(c.env, v.spec);
   return c.json({ enrichment: saved });
 });
-app.delete('/api/studio/enrichments/:id', async (c) => {
+app.delete('/api/enrichments/:id', async (c) => {
   await deleteEnrichment(c.env, c.req.param('id'));
   return c.json({ ok: true });
 });
@@ -1233,7 +1233,7 @@ async function writeCachedResult(env: Bindings, key: string, result: RunResult):
   // No TTL — outputs are deterministic per (def_hash, cache_version, daf
   // or instance). The canonical way to force a recache is to bump
   // cache_version on the definition (old key becomes unreachable) or
-  // call /api/studio/run with bypass_cache=true. A TTL on top of that
+  // call /api/run with bypass_cache=true. A TTL on top of that
   // just makes warmed pages silently rot — measured pain: full-shas
   // warming costs ~$1000 and ~17 days; we don't want it expiring on us.
   await env.CACHE.put(key, JSON.stringify(result));
@@ -2082,7 +2082,7 @@ async function runRabbiObservations(
 }
 
 /**
- * POST /api/studio/run — execute a mark or enrichment, return its raw output
+ * POST /api/run — execute a mark or enrichment, return its raw output
  * + telemetry. Cache-aware: results are read/written via cache-keys.ts.
  *
  * Body:
@@ -2194,21 +2194,21 @@ async function recordRecentJobError(
 }
 
 /**
- * POST /api/studio/run — async producer.
+ * POST /api/run — async producer.
  *
  * 1. Validate body.
  * 2. Compute the canonical cache key. If KV has a fresh result and the
  *    request didn't ask for bypass_cache, return 200 with the cached result
  *    immediately (this is the hot path).
  * 3. Otherwise enqueue a JobMessage and return 202 with `{ status: 'pending',
- *    runId, cacheKey }`. The client polls /api/studio/run-status/:runId.
+ *    runId, cacheKey }`. The client polls /api/run-status/:runId.
  *
  * The producer invocation is short-lived: it never holds the request open
  * while an LLM call runs. The queue consumer (queue() handler at the bottom
  * of this file) does the heavy work in its own invocation and writes the
  * result to KV under `job:{runId}` AND the canonical cache key.
  */
-app.post('/api/studio/run', async (c) => {
+app.post('/api/run', async (c) => {
   let raw: unknown;
   try { raw = await c.req.json(); }
   catch { return c.json({ error: 'invalid JSON' }, 400); }
@@ -2372,7 +2372,7 @@ app.post('/api/warm-daf', async (c) => {
 });
 
 /**
- * GET /api/studio/run-status/:runId — polling endpoint for queued jobs.
+ * GET /api/run-status/:runId — polling endpoint for queued jobs.
  * Reads `job:{runId}` from KV. While the job is still running, returns 202
  * with `{ status: 'pending' }`. When done, returns 200 with the result.
  *
@@ -2380,7 +2380,7 @@ app.post('/api/warm-daf', async (c) => {
  * to the canonical cache key. Covers the gap where the queue consumer
  * wrote canonical cache but was terminated before writing the job key.
  */
-app.get('/api/studio/run-status/:runId', async (c) => {
+app.get('/api/run-status/:runId', async (c) => {
   const runId = c.req.param('runId');
   const cache = c.env.CACHE;
   if (!cache) return c.json({ error: 'CACHE binding not available' }, 503);
@@ -2962,7 +2962,7 @@ async function tickRateLimit(env: Bindings, scope: string, who: string): Promise
  *
  * Returns the community-submitted question list for one anchor so the client
  * can render the Questions panel without enumerating KV. Curated questions
- * are fetched separately via /api/studio/run on `<mark>.suggested-questions`.
+ * are fetched separately via /api/run on `<mark>.suggested-questions`.
  *
  * `mark` defaults to 'argument-move' for back-compat with older clients.
  */
@@ -2992,7 +2992,7 @@ app.get('/api/qa/registry', async (c) => {
  * Normalizes + hashes the question, dedupes against the registry, appends
  * to community if new, and enqueues the `<mark>.qa` enrichment so the
  * answer cache fills in for everyone. The actual answer is fetched
- * separately via /api/studio/run by the client (which polls the queue) —
+ * separately via /api/run by the client (which polls the queue) —
  * this endpoint only kicks the job and records the question for other users.
  *
  * `mark` defaults to 'argument-move' for back-compat with older clients.
@@ -3065,7 +3065,7 @@ app.post('/api/qa/ask', async (c) => {
   await writeQaRegistry(c.env, scope.mark, b.tractate, b.page, scope.instanceId, reg);
 
   // Kick the enrichment job so the answer is ready by the time the client
-  // polls for it. The /api/studio/run hot-path lookup will still cache-hit
+  // polls for it. The /api/run hot-path lookup will still cache-hit
   // on the second user with the same normalized question.
   if (c.env.ENRICHMENT_QUEUE) {
     const job: JobMessage = {
@@ -3130,8 +3130,8 @@ app.post('/api/qa/click', async (c) => {
 //   'translate'           legacy /api/translate
 //   'daf-context'         legacy /api/daf-context skeleton stage
 //   'daf-context-stage2'  legacy /api/daf-context bio-enrichment stage
-//   'studio-mark'         /api/studio/run for a mark (see mark_id field)
-//   'studio-enrichment'   /api/studio/run for an enrichment (see enrichment_id)
+//   'studio-mark'         /api/run for a mark (see mark_id field)
+//   'studio-enrichment'   /api/run for an enrichment (see enrichment_id)
 //
 // New entries don't need a code change — /api/usage rolls up dynamically over
 // whatever endpoint values it sees in the ring buffer.
@@ -6829,7 +6829,7 @@ async function deepWarmDaf(
 
 /**
  * Run one queued enrichment job: replay the same logic the synchronous
- * /api/studio/run handler used to do, but write the outcome under
+ * /api/run handler used to do, but write the outcome under
  * `job:{runId}` (for client polling) AND the canonical cache key (so a
  * future direct request hits the cached result without round-tripping the
  * queue).
@@ -6958,7 +6958,7 @@ export default {
     }
   },
   // Queue consumer — wrangler.toml binds queue=enrichment-jobs to this
-  // export. Each message is one /api/studio/run job. max_concurrency=2 caps
+  // export. Each message is one /api/run job. max_concurrency=2 caps
   // simultaneous LLM workloads; max_batch_size=1 means one job per
   // invocation (no batching), which keeps memory bounded per worker.
   queue: async (batch: MessageBatch<JobMessage>, env: Bindings, ctx: ExecutionContext): Promise<void> => {

--- a/src/worker/mcp-openapi.ts
+++ b/src/worker/mcp-openapi.ts
@@ -62,16 +62,16 @@ export const TALMUD_OPENAPI: Record<string, unknown> = {
       '   `excerpt` strings ARE the anchors highlighted on the page. There is no',
       '   separate anchors endpoint. Mark ids include: rabbi, argument,',
       '   argument-move, halacha, aggadata, pesukim, places, rishonim,',
-      '   rabbi.observations. List them with GET /api/studio/marks.',
+      '   rabbi.observations. List them with GET /api/marks.',
       '3. ENRICHMENTS are LLM passes that run ON a mark instance to produce the',
       '   synthesized cards (e.g. explain an argument-move). List them with',
-      '   GET /api/studio/enrichments.',
+      '   GET /api/enrichments.',
       '',
-      'RUNNING MARKS/ENRICHMENTS (the engine): POST /api/studio/run is the single',
+      'RUNNING MARKS/ENRICHMENTS (the engine): POST /api/run is the single',
       'entry point. It is ASYNCHRONOUS:',
       '  - On a cache hit it returns 200 { status: "ok", result }.',
       '  - Otherwise it returns 202 { status: "pending", runId, cacheKey }; then',
-      '    poll GET /api/studio/run-status/{runId}?k={cacheKey} until you get',
+      '    poll GET /api/run-status/{runId}?k={cacheKey} until you get',
       '    200 { status: "ok", result } (it returns 202 { status: "pending" }',
       '    while the job is still on the queue).',
       'In code mode you can do this whole loop inside one `execute` call: run a',
@@ -186,13 +186,13 @@ export const TALMUD_OPENAPI: Record<string, unknown> = {
       },
     },
 
-    '/api/studio/marks': {
+    '/api/marks': {
       get: {
         summary: 'List all mark definitions (the structural extractors that produce anchors).',
         responses: { '200': { description: '{ marks: MarkDefinition[] }' } },
       },
     },
-    '/api/studio/marks/{id}': {
+    '/api/marks/{id}': {
       get: {
         summary: 'Get one mark definition by id.',
         parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' }, description: 'Mark id, e.g. "argument-move".' }],
@@ -200,13 +200,13 @@ export const TALMUD_OPENAPI: Record<string, unknown> = {
       },
     },
 
-    '/api/studio/enrichments': {
+    '/api/enrichments': {
       get: {
         summary: 'List all enrichment definitions (LLM passes that run on a mark instance).',
         responses: { '200': { description: '{ enrichments: EnrichmentDefinition[] }' } },
       },
     },
-    '/api/studio/enrichments/{id}': {
+    '/api/enrichments/{id}': {
       get: {
         summary: 'Get one enrichment definition by id.',
         parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
@@ -214,7 +214,7 @@ export const TALMUD_OPENAPI: Record<string, unknown> = {
       },
     },
 
-    '/api/studio/run': {
+    '/api/run': {
       post: {
         summary: 'Run a mark or enrichment for a daf. Async: cache hit => 200 result; else 202 { runId, cacheKey } to poll.',
         description:
@@ -247,12 +247,12 @@ export const TALMUD_OPENAPI: Record<string, unknown> = {
         },
       },
     },
-    '/api/studio/run-status/{runId}': {
+    '/api/run-status/{runId}': {
       get: {
         summary: 'Poll a queued run. 202 { status: "pending" } while running; 200 { status: "ok", result } when done.',
         parameters: [
-          { name: 'runId', in: 'path', required: true, schema: { type: 'string' }, description: 'runId from POST /api/studio/run.' },
-          { name: 'k', in: 'query', required: false, schema: { type: 'string' }, description: 'cacheKey fallback returned by POST /api/studio/run.' },
+          { name: 'runId', in: 'path', required: true, schema: { type: 'string' }, description: 'runId from POST /api/run.' },
+          { name: 'k', in: 'query', required: false, schema: { type: 'string' }, description: 'cacheKey fallback returned by POST /api/run.' },
         ],
         responses: { '200': { description: '{ status: "ok", result }' }, '202': { description: '{ status: "pending" }' } },
       },

--- a/src/worker/studio-schema.ts
+++ b/src/worker/studio-schema.ts
@@ -579,5 +579,5 @@ correct the ones I got wrong.
 
   14. status       — always 'draft' on creation. Promote later via UI.
 
-After fill-in, the worker computes def_hash from sha256(JSON.stringify(extractor) + JSON.stringify(render)) — NOT over `checks` (post-processing, not generation input). Save via PUT /api/studio/marks/{id}.
+After fill-in, the worker computes def_hash from sha256(JSON.stringify(extractor) + JSON.stringify(render)) — NOT over `checks` (post-processing, not generation input). Save via PUT /api/marks/{id}.
 */

--- a/src/worker/yomi-cron.ts
+++ b/src/worker/yomi-cron.ts
@@ -6,7 +6,7 @@
  * cache-keys.ts helpers and lands a KV entry the next reader hits
  * synchronously.
  *
- * NOTE: this used to POST to `https://talmud.shaunregenbaum.com/api/studio/run`
+ * NOTE: this used to POST to `https://talmud.shaunregenbaum.com/api/run`
  * — a subrequest from the Worker back to its own custom-domain route. That is
  * the classic Cloudflare worker-to-self loopback: every such POST returned
  * HTTP 522 (origin connection timeout) and nothing ever warmed. We now enqueue

--- a/tests/client/aggadata-panel.test.tsx
+++ b/tests/client/aggadata-panel.test.tsx
@@ -5,7 +5,7 @@ import type { AggadataStory } from '../../src/client/shapes';
 import { AggadataPanel } from '../../src/client/ArgumentSidebar';
 import { setLang, t } from '../../src/client/i18n';
 
-// MarkEnrichmentCards fetches /api/studio/enrichments on mount; stub it so the
+// MarkEnrichmentCards fetches /api/enrichments on mount; stub it so the
 // panel mounts cleanly and we can assert its synchronous structure (the leaf
 // SectionCards arrive later via onResolved and are covered by the SectionCard
 // unit test).

--- a/tests/integration/calque-regression.test.ts
+++ b/tests/integration/calque-regression.test.ts
@@ -47,7 +47,7 @@ async function pollJob(runId: string): Promise<unknown> {
   const start = Date.now();
   while (Date.now() - start < POLL_TIMEOUT_MS) {
     await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
-    const res = await fetch(`${BASE_URL}/api/studio/run-status/${encodeURIComponent(runId)}`);
+    const res = await fetch(`${BASE_URL}/api/run-status/${encodeURIComponent(runId)}`);
     const j = (await res.json()) as RunResponse;
     if (j.status === 'ok') return j.result.parsed;
     if (j.status === 'error') throw new Error(`run failed: ${j.error}`);
@@ -56,7 +56,7 @@ async function pollJob(runId: string): Promise<unknown> {
 }
 
 async function runMark(markId: string, bypassCache = false): Promise<unknown> {
-  const j = await postJson<RunResponse>('/api/studio/run', {
+  const j = await postJson<RunResponse>('/api/run', {
     mark_id: markId, tractate: TRACTATE, page: PAGE, bypass_cache: bypassCache,
   });
   if (j.status === 'ok') return j.result.parsed;
@@ -65,7 +65,7 @@ async function runMark(markId: string, bypassCache = false): Promise<unknown> {
 }
 
 async function runEnrichment(enrichmentId: string, markInput: unknown, bypassCache = false): Promise<unknown> {
-  const j = await postJson<RunResponse>('/api/studio/run', {
+  const j = await postJson<RunResponse>('/api/run', {
     enrichment_id: enrichmentId,
     tractate: TRACTATE,
     page: PAGE,

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -76,7 +76,7 @@ CF_ZONE_TAG = "4808b439c50e3a42494ae7e0b2fa1bec"
 # guard latches a pause at 95% of this to leave headroom for in-flight jobs);
 # HOURLY_CUSTOM_BUDGET_USD caps spend on user-submitted custom questions per
 # rolling hour. These are the code defaults made explicit/tunable here — edit +
-# redeploy to change them. The privileged /api/studio/run knobs + admin
+# redeploy to change them. The privileged /api/run knobs + admin
 # mutations are gated by the STUDIO_SECRET secret (`wrangler secret put
 # STUDIO_SECRET`); unset => everyone is treated as untrusted (fail-safe).
 DAILY_BUDGET_USD = "300"
@@ -84,9 +84,9 @@ HOURLY_CUSTOM_BUDGET_USD = "10"
 
 # Cloudflare Queue — long-running enrichment jobs run in the consumer worker
 # instead of holding the producer's request invocation. Producer (POST
-# /api/studio/run) enqueues + returns 202 with a runId; consumer processes
+# /api/run) enqueues + returns 202 with a runId; consumer processes
 # the message and writes the result to KV under `job:{runId}`. Client polls
-# /api/studio/run-status/:runId. Decouples client requests from LLM latency
+# /api/run-status/:runId. Decouples client requests from LLM latency
 # and stops workerd from dying on parallel long-fetches in dev.
 [[queues.producers]]
 queue = "enrichment-jobs"
@@ -127,7 +127,7 @@ head_sampling_rate = 1  # capture 100% of invocations
 # key to force a re-walk. See src/worker/warm-cron.ts.
 #
 # Second cron (03:00 UTC daily) pre-warms tomorrow's Daf Yomi via
-# /api/studio/run for the canonical mark set. See src/worker/yomi-cron.ts.
+# /api/run for the canonical mark set. See src/worker/yomi-cron.ts.
 [triggers]
 crons = ["*/5 * * * *", "0 3 * * *"]
 


### PR DESCRIPTION
"studio" was an internal authoring-tool name that leaked into the reader-facing routes. This renames all seven endpoints to drop it:

| old | new |
|-----|-----|
| `/api/studio/run` | `/api/run` |
| `/api/studio/run-status/:id` | `/api/run-status/:id` |
| `/api/studio/marks` | `/api/marks` |
| `/api/studio/enrichments` | `/api/enrichments` |
| `/api/studio/checks/...` | `/api/checks/...` |
| `/api/studio/bridge/...` | `/api/bridge/...` |
| `/api/studio/type-profiles/...` | `/api/type-profiles/...` |

No collisions with existing `/api/` routes (checked). Worker routes, every client `fetch`, `mcp-openapi.ts`, the `scripts/warm-*.mjs` operational scripts, comments, and docs all updated in lock step.

**Kept on purpose** (not the URL surface): the `x-studio-secret` header, the `studio-schema.ts` / `studio-registry.ts` filenames, and the `studio-mark` / `studio-enrichment` usage-telemetry endpoint labels (a stored taxonomy whose historical continuity matters).

**Breaking** for anything hard-coding the old paths. The MCP OpenAPI is served fresh, so code-mode agents pick up the new routes; an open browser tab on the old bundle will 404 its in-flight calls until reload (acceptable for this app — say the word if you'd rather I add transitional alias routes).

Codex-reviewed (caught the two warm scripts I'd missed). `pnpm typecheck` clean; `pnpm test` 1415 passing.