### PR TITLE
Add recipeHash: the content hash for freshness (foundation)

### DIFF
--- a/src/worker/cache-keys.ts
+++ b/src/worker/cache-keys.ts
@@ -43,6 +43,49 @@ async function shortHash(input: string): Promise<string> {
   return hex;
 }
 
+/** Stable JSON: object keys sorted recursively so field ORDER never changes the
+ *  output. Array order is preserved (it is semantic). Used to canonicalize a
+ *  producer's recipe before hashing it. */
+function canonicalJSON(value: unknown): string {
+  const sort = (v: unknown): unknown => {
+    if (Array.isArray(v)) return v.map(sort);
+    if (v && typeof v === 'object') {
+      const src = v as Record<string, unknown>;
+      const out: Record<string, unknown> = {};
+      for (const k of Object.keys(src).sort()) out[k] = sort(src[k]);
+      return out;
+    }
+    return v;
+  };
+  return JSON.stringify(sort(value));
+}
+
+/**
+ * Content hash of a producer's RECIPE — the inputs that determine its output:
+ * the `extractor` (prompt / schema / model) plus, for marks, the `render`
+ * config. This reproduces the documented `def_hash` contract — sha256 over
+ * (extractor + render) — but COMPUTED from the live spec instead of a
+ * hand-authored literal, so it cannot drift from reality the way the current
+ * `def_hash` strings have (e.g. 'rabbi-v2' never re-derives).
+ *
+ * Deliberately EXCLUDED: `checks` (post-processing, not a generation input),
+ * `dependencies` (composition — hashed via their own recipes), and the
+ * bookkeeping fields (`cache_version` / `def_hash` / `status` / `source` /
+ * `updated_at` / `id` / `label`). Field-order insensitive.
+ *
+ * Foundation for content-hash freshness: a later step stores this alongside each
+ * cached run and recomputes staleness automatically, retiring the manual
+ * `cache_version` bump. It is intentionally NOT folded into the cache key — GC
+ * sweeps by `cache_version` only, so keying on a content hash would orphan every
+ * entry permanently in the TTL-less KV.
+ */
+export async function recipeHash(def: { extractor: unknown; render?: unknown }): Promise<string> {
+  const recipe = def.render !== undefined
+    ? { extractor: def.extractor, render: def.render }
+    : { extractor: def.extractor };
+  return shortHash(canonicalJSON(recipe));
+}
+
 /** Normalize free-text input (e.g. a user-submitted question) so cosmetic
  *  variation doesn't fan the cache out: trim, lowercase, collapse internal
  *  whitespace. Used by callers that want a stable cache-key qualifier from

--- a/src/worker/studio-schema.ts
+++ b/src/worker/studio-schema.ts
@@ -26,8 +26,10 @@
  * Architecture decisions:
  *   - Phrase-anchor output carries BOTH excerpt and segIdx+tokenStart+tokenEnd;
  *     the renderer prefers indices and falls back to excerpt match.
- *   - Cache key for run output includes def_hash (sha256 over the extractor
- *     spec); editing a prompt auto-invalidates cache. See src/worker/cache-keys.ts.
+ *   - Cache key for run output uses cache_version (bumped manually). The
+ *     computed content hash of the recipe is recipeHash() in cache-keys.ts —
+ *     the foundation for automatic content-hash freshness that will retire the
+ *     manual bump. (def_hash below is a hand-authored literal, NOT in the key.)
  *   - Toggles persist globally (localStorage); promoted marks default-listed,
  *     drafts visible only when devMode is on.
  *   - Promote = flip `status: 'draft' → 'promoted'`. No codegen.
@@ -386,8 +388,10 @@ export interface MarkDefinition {
   experimental?: boolean;
 
   status: MarkStatus;
-  /** Derived from sha256(extractor + render). Bumped automatically on save.
-   *  Cache key for instances includes this — editing the prompt auto-busts. */
+  /** A hand-authored recipe marker (e.g. 'rabbi-v2'). NOTE: despite the name it
+   *  is NOT currently auto-derived, and the cache key uses cache_version, not
+   *  this. recipeHash() in cache-keys.ts is the computed sha256(extractor[+render])
+   *  successor that content-hash freshness will use. */
   def_hash: string;
   cache_version: string;
   source: 'kv' | 'code';

--- a/tests/recipe-hash.test.ts
+++ b/tests/recipe-hash.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { recipeHash } from '../src/worker/cache-keys';
+
+// A producer's "recipe" is what determines its output: the extractor
+// (prompt/schema/model) + render for marks. recipeHash captures exactly that so
+// content-hash freshness can replace manual cache_version bumps. These lock the
+// field-set contract: generation inputs move the hash; everything else doesn't.
+
+const baseMark = () => ({
+  id: 'rabbi',
+  label: 'Rabbis',
+  extractor: {
+    kind: 'llm' as const,
+    system_prompt: 'Identify rabbi names.',
+    user_prompt_template: 'Daf: {{gemara}}',
+    output_schema: { type: 'object', properties: { names: { type: 'array' } } },
+    model: 'openrouter/x',
+  },
+  render: { kind: 'inline', style: 'underline' },
+  dependencies: ['gemara'],
+  checks: ['no-empty'],
+  cache_version: '2',
+  def_hash: 'rabbi-v2',
+  status: 'promoted',
+  source: 'code',
+  updated_at: '2026-01-01',
+});
+
+describe('recipeHash — content hash of a producer recipe', () => {
+  it('is deterministic for the same def', async () => {
+    expect(await recipeHash(baseMark())).toBe(await recipeHash(baseMark()));
+  });
+
+  it('is insensitive to field ORDER within the extractor/render', async () => {
+    const a = baseMark();
+    const b = baseMark();
+    // Re-author the extractor with keys in a different order.
+    b.extractor = {
+      model: 'openrouter/x',
+      output_schema: { properties: { names: { type: 'array' } }, type: 'object' },
+      user_prompt_template: 'Daf: {{gemara}}',
+      system_prompt: 'Identify rabbi names.',
+      kind: 'llm',
+    };
+    expect(await recipeHash(b)).toBe(await recipeHash(a));
+  });
+
+  it('MOVES when the prompt changes', async () => {
+    const m = baseMark();
+    m.extractor.system_prompt = 'Identify EVERY rabbi name.';
+    expect(await recipeHash(m)).not.toBe(await recipeHash(baseMark()));
+  });
+
+  it('MOVES when the output schema changes', async () => {
+    const m = baseMark();
+    m.extractor.output_schema = { type: 'object', properties: { names: { type: 'array' }, count: { type: 'number' } } };
+    expect(await recipeHash(m)).not.toBe(await recipeHash(baseMark()));
+  });
+
+  it('MOVES when the model changes', async () => {
+    const m = baseMark();
+    m.extractor.model = 'openrouter/y';
+    expect(await recipeHash(m)).not.toBe(await recipeHash(baseMark()));
+  });
+
+  it('MOVES when a mark render config changes', async () => {
+    const m = baseMark();
+    m.render = { kind: 'inline', style: 'highlight' };
+    expect(await recipeHash(m)).not.toBe(await recipeHash(baseMark()));
+  });
+
+  it('does NOT move for checks / dependencies / version / bookkeeping changes', async () => {
+    const base = await recipeHash(baseMark());
+    const checks = baseMark(); checks.checks = ['no-empty', 'in-range'];
+    const deps = baseMark(); deps.dependencies = ['gemara', 'commentaries'];
+    const ver = baseMark(); ver.cache_version = '9'; ver.def_hash = 'rabbi-v9'; ver.updated_at = '2030-01-01';
+    expect(await recipeHash(checks)).toBe(base);
+    expect(await recipeHash(deps)).toBe(base);
+    expect(await recipeHash(ver)).toBe(base);
+  });
+
+  it('an enrichment (no render) hashes its extractor alone, and render absence != render present', async () => {
+    const enrich = { id: 'rabbi.bio', extractor: { kind: 'llm', system_prompt: 'Write a bio.' } };
+    expect(await recipeHash(enrich)).toBe(await recipeHash({ ...enrich }));
+    // Adding a render field to the same extractor must change the hash (marks vs enrichments differ).
+    expect(await recipeHash({ ...enrich, render: { kind: 'chip' } })).not.toBe(await recipeHash(enrich));
+  });
+});


### PR DESCRIPTION
First step of **content-hash freshness** (roadmap area 6) — the mechanism that will replace manual `cache_version` bumps.

`recipeHash(def)` in `cache-keys.ts` is a pure content hash over a producer's **recipe** — the generation inputs that determine its output: the `extractor` (prompt / schema / model) plus `render` (marks only). It reproduces the *documented* `def_hash` contract (sha256 over `extractor[+render]`) but **computed** from the live spec, so it can't drift the way the hand-authored `def_hash` literals have (`'rabbi-v2'` never re-derives).

- `canonicalJSON` sorts object keys recursively → **field-order insensitive**; array order preserved.
- **Excluded:** `checks` (post-processing), `dependencies` (composition, hashed via their own recipes), and bookkeeping (`cache_version`/`def_hash`/`status`/`source`/`updated_at`/`id`/`label`).
- **Intentionally NOT in the cache key** — GC sweeps by `cache_version` only, so keying on a content hash would orphan every entry permanently in the TTL-less KV (the trap the design workflow caught). A later step stores `recipeHash` alongside each cached run and recomputes staleness; this PR is the pure primitive.

Also fixes the **stale `studio-schema.ts` docs** that claimed the cache key includes `def_hash` (it uses `cache_version`; `def_hash` is a vestigial literal) — Codex flagged this.

Tests lock the contract: prompt/schema/model/render **move** the hash; checks/dependencies/version **don't**; field-order insensitive; enrichment (no render) hashes its extractor alone.

Codex-reviewed: no correctness findings. `pnpm typecheck` clean; `pnpm test` 1437 passing (+8). Pure function + doc fix — no behaviour change, no deploy.