### PR TITLE
Tighten argument-flow map row spacing

### DIFF
--- a/src/client/ArgumentFlowGraph.tsx
+++ b/src/client/ArgumentFlowGraph.tsx
@@ -34,7 +34,7 @@ interface Props {
 
 const NODE_W = 310;
 const NODE_H = 54;
-const ROW_GAP = 28;
+const ROW_GAP = 14;
 const LANE_BASE = 26;     // first lane's distance out from the card's right edge
 const LANE_STEP = 18;     // extra offset per concurrent connector lane
 const TOP_PAD = 10;


### PR DESCRIPTION
Reduces `ROW_GAP` in the whole-daf argument flow map from 28px to 14px so the boxes sit closer together and the overview needs less (often no) vertical scrolling. Connectors route off the same row mid-points and scale down with the rows automatically; box height (`NODE_H=54`) and corner radius are unchanged.