### PR TITLE
Fix Hebrew overview/voices glitch + Hebraize daf reference labels

### DIFF
--- a/src/client/ArgumentFlowGraph.tsx
+++ b/src/client/ArgumentFlowGraph.tsx
@@ -242,7 +242,13 @@ export default function ArgumentFlowGraph(props: Props): JSX.Element {
                   <text
                     x={titleX}
                     y={cy() + (li() - (lines().length - 1) / 2) * LINE_H}
-                    text-anchor="start" dominant-baseline="central"
+                    // Left-align the title block at titleX in BOTH languages. SVG
+                    // text-anchor is direction-relative: with direction=rtl,
+                    // anchor="start" pins the text's RIGHT edge to titleX so the
+                    // title flows left over the number badge and clips at the card
+                    // edge. anchor="end" pins the LEFT edge to titleX instead, so
+                    // Hebrew sits to the right of the badge like the English does.
+                    text-anchor={lang() === 'he' ? 'end' : 'start'} dominant-baseline="central"
                     font-size="12" font-weight="600"
                     font-family="system-ui, -apple-system, sans-serif"
                     fill="#2a2723"

--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -14,6 +14,7 @@ import { deriveVoiceEdges } from '../lib/typing/voices';
 import ArgumentFlowGraph, { type FlowConnection } from './ArgumentFlowGraph';
 import { orderBackgroundGroups, type BackgroundGroup } from './backgroundGroups';
 import { adjacentAmud } from '../lib/sefref/amudim';
+import { dafRefHe, pageLabelHe } from '../lib/sefref/tractates';
 import { selectSectionMoves } from '../lib/argumentMoves';
 import { t, lang } from './i18n';
 import { ACCENTS, HebrewProse, Panel, QASection, SectionCard, Synthesis, SidebarPanelFromHint, kindLabelKey, type SidebarHint } from './sidebar/primitives';
@@ -813,6 +814,10 @@ function ArgumentOverviewBody(props: {
     },
   );
 
+  // Adjacent-amud page label for the continuation caption: Hebrew daf form
+  // ('ב.') in he mode, the raw '2a' slug in en.
+  const pageRef = (p: string | null): string => (p ? (lang() === 'he' ? pageLabelHe(p) : p) : '');
+
   // Cross-page continuation hint: a muted caption, not a chip. Subtle on
   // purpose — it's an aside, not a heading (no fill, no border, no bold).
   const crossLabel = (text: string): JSX.Element => (
@@ -851,7 +856,7 @@ function ArgumentOverviewBody(props: {
           return (
             <div style={{ 'margin-bottom': '0.7rem' }}>
               <Show when={hasFirst && bridge()?.fromPrev}>
-                {crossLabel(`↑ continues from ${bridge()!.prev}`)}
+                {crossLabel(t('overview.continuesFrom', { page: pageRef(bridge()!.prev) }))}
               </Show>
               <ArgumentFlowGraph
                 nodes={grpNodes}
@@ -860,7 +865,7 @@ function ArgumentOverviewBody(props: {
                 onSelect={selectSection}
               />
               <Show when={hasLast && bridge()?.toNext}>
-                {crossLabel(`continues onto ${bridge()!.next} ↓`)}
+                {crossLabel(t('overview.continuesOnto', { page: pageRef(bridge()!.next) }))}
               </Show>
               <Show when={activeInGroup() && props.sections[active()!]}>
                 <OverviewSectionVoices
@@ -1865,7 +1870,7 @@ export function ArgumentSidebar(props: ArgumentSidebarProps): JSX.Element {
               <span style={{ 'font-size': '0.7rem', color: '#999', 'text-transform': 'uppercase', 'letter-spacing': '0.08em' }}>
                 {t(kindLabelKey(c().kind))}
                 {' · '}
-                {props.tractate} {props.page}
+                {lang() === 'he' ? dafRefHe(props.tractate, props.page) : `${props.tractate} ${props.page}`}
               </span>
               <button
                 onClick={props.onClose}

--- a/src/client/ArgumentVoiceMap.tsx
+++ b/src/client/ArgumentVoiceMap.tsx
@@ -437,10 +437,15 @@ export default function ArgumentVoiceMap(props: Props): JSX.Element {
                   {/* Side-colour badge (replaces the old left accent bar, which
                       overlapped the rounded border and read as a blob). */}
                   <circle cx={n.x + 19} cy={n.y + NODE_H / 2} r={9} fill={n.color} />
+                  {/* Left-align both lines at n.x+36 (right of the badge) in BOTH
+                      languages. text-anchor is direction-relative: with
+                      direction=rtl, anchor="start" pins the text's RIGHT edge to
+                      n.x+36 so the Hebrew name flows left over the colour badge.
+                      anchor="end" pins the LEFT edge there instead. */}
                   <text
                     x={n.x + 36}
                     y={n.y + NODE_H / 2 - 6}
-                    text-anchor="start"
+                    text-anchor={lang() === 'he' ? 'end' : 'start'}
                     dominant-baseline="central"
                     font-size="11.5"
                     font-weight="600"
@@ -452,11 +457,12 @@ export default function ArgumentVoiceMap(props: Props): JSX.Element {
                   <text
                     x={n.x + 36}
                     y={n.y + NODE_H / 2 + 10}
-                    text-anchor="start"
+                    text-anchor={lang() === 'he' ? 'end' : 'start'}
                     dominant-baseline="central"
                     font-size="9.5"
                     font-family="system-ui, -apple-system, sans-serif"
                     fill="#8a857c"
+                    direction={lang() === 'he' ? 'rtl' : 'ltr'}
                   >{roleLabel(n.role)}</text>
                 </g>
               );

--- a/src/client/DafViewer.tsx
+++ b/src/client/DafViewer.tsx
@@ -1,6 +1,6 @@
 import { createResource, createSignal, createEffect, createMemo, onMount, onCleanup, For, Show, type JSX } from 'solid-js';
 import type { TalmudPageData } from '../lib/sefref';
-import { TRACTATE_OPTIONS } from '../lib/sefref';
+import { TRACTATE_OPTIONS, dafRefHe } from '../lib/sefref';
 import { DafRenderer } from '../lib/daf-render';
 import { tokenizeHebrewHtml } from './tokenize';
 import { TranslationPopup } from './TranslationPopup';
@@ -2562,7 +2562,7 @@ export default function DafViewer(): JSX.Element {
         </div>
 
         <span class="tb-hint">
-          {tractate()} {page()} · {t('header.nav.hint')}
+          {lang() === 'he' ? dafRefHe(tractate(), page()) : `${tractate()} ${page()}`} · {t('header.nav.hint')}
         </span>
       </header>
 

--- a/src/client/i18n.ts
+++ b/src/client/i18n.ts
@@ -181,6 +181,10 @@ const CATALOG = {
     en: 'No argument sections on this daf yet — open it with Arguments enabled so they load.',
     he: 'אין עדיין מקטעי טיעון בדף זה.',
   },
+  // Cross-daf continuation captions on the overview maps. {page} is the
+  // adjacent amud, already localized (Hebrew daf form in he mode).
+  'overview.continuesFrom': { en: '↑ continues from {page}', he: '↑ המשך מדף {page}' },
+  'overview.continuesOnto': { en: 'continues onto {page} ↓', he: 'ממשיך לדף {page} ↓' },
 
   // — Whole-daf background (terms/concepts a reader needs) —
   'background.chip': { en: 'Background', he: 'רקע' },

--- a/src/lib/sefref/tractates.ts
+++ b/src/lib/sefref/tractates.ts
@@ -73,3 +73,61 @@ export const HEBREW_NUMBERS: Record<number, string> = {
 export function getHebrewPageNumber(num: number): string {
 	return HEBREW_NUMBERS[num] || num.toString();
 }
+
+/**
+ * Convert a positive integer to its Hebrew-numeral (gematria) form, e.g.
+ * 2 -> 'ב', 15 -> 'טו', 127 -> 'קכז'. Covers the full daf range of Shas (the
+ * HEBREW_NUMBERS table above stops at 76, which leaves Latin digits leaking
+ * onto deeper dafim). 15 and 16 use טו/טז to avoid spelling the divine name.
+ * Non-positive / non-finite input falls back to the decimal string.
+ */
+export function toHebrewNumeral(num: number): string {
+	if (!Number.isInteger(num) || num <= 0) return String(num);
+	const HUNDREDS = ['', 'ק', 'ר', 'ש', 'ת'];
+	const TENS = ['', 'י', 'כ', 'ל', 'מ', 'נ', 'ס', 'ע', 'פ', 'צ'];
+	const ONES = ['', 'א', 'ב', 'ג', 'ד', 'ה', 'ו', 'ז', 'ח', 'ט'];
+	let out = '';
+	let n = num;
+	// Hundreds beyond 400 stack ת's (e.g. 500 = תק), matching the gematria
+	// convention; daf numbers never reach this, but it keeps the fn total.
+	while (n >= 400) { out += 'ת'; n -= 400; }
+	out += HUNDREDS[Math.floor(n / 100)];
+	n %= 100;
+	if (n === 15) return out + 'טו';
+	if (n === 16) return out + 'טז';
+	out += TENS[Math.floor(n / 10)];
+	out += ONES[n % 10];
+	return out;
+}
+
+/** English-slug -> Hebrew-label lookup, built once from TRACTATE_OPTIONS. */
+const HE_LABEL_BY_VALUE = new Map(TRACTATE_OPTIONS.map((o) => [o.value, o.label]));
+
+/**
+ * Hebrew name for a tractate's English slug (e.g. 'Berakhot' -> 'ברכות').
+ * Falls back to the input unchanged when the slug is unknown, so a caller
+ * never renders a blank tractate.
+ */
+export function tractateLabelHe(value: string): string {
+	return HE_LABEL_BY_VALUE.get(value) ?? value;
+}
+
+/**
+ * Hebrew daf form for an 'Na' / 'Nb' page string: '2a' -> 'ב.', '2b' -> 'ב:'
+ * — the standard amud-alef '.' / amud-bet ':' citation marks. Anything that
+ * doesn't match the page pattern is returned unchanged.
+ */
+export function pageLabelHe(page: string): string {
+	const m = /^(\d+)([ab])$/.exec(page.trim());
+	if (!m) return page;
+	return `${toHebrewNumeral(parseInt(m[1], 10))}${m[2] === 'a' ? '.' : ':'}`;
+}
+
+/**
+ * Full Hebrew daf reference, e.g. dafRefHe('Berakhot', '2b') -> 'ברכות ב:'.
+ * Used wherever the UI shows a tractate+page label in Hebrew mode (the English
+ * slug would otherwise leak as transliterated Latin, e.g. "BERAKHOT 2B").
+ */
+export function dafRefHe(tractate: string, page: string): string {
+	return `${tractateLabelHe(tractate)} ${pageLabelHe(page)}`;
+}

--- a/tests/client/argument-svg-rtl.test.tsx
+++ b/tests/client/argument-svg-rtl.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+//
+// Regression guard for the Hebrew SVG-diagram glitch: section/voice labels were
+// drawn with text-anchor="start" + direction="rtl", which (text-anchor being
+// direction-relative) pinned the text's RIGHT edge to the label x. Hebrew then
+// flowed leftward over the number/colour badge and clipped at the card edge. The
+// fix flips the anchor to "end" in he mode so the LEFT edge is pinned instead.
+import { render } from '@solidjs/testing-library';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import ArgumentFlowGraph from '../../src/client/ArgumentFlowGraph';
+import ArgumentVoiceMap from '../../src/client/ArgumentVoiceMap';
+import { setLang } from '../../src/client/i18n';
+
+beforeEach(() => setLang('en'));
+afterEach(() => setLang('en'));
+
+/** The <text> nodes whose content matches a string (ignoring the badge/number). */
+function textsWithContent(container: HTMLElement, needle: string): SVGTextElement[] {
+  return Array.from(container.querySelectorAll('text')).filter((t) =>
+    (t.textContent ?? '').includes(needle),
+  ) as unknown as SVGTextElement[];
+}
+
+describe('ArgumentFlowGraph — Hebrew section titles align off the badge', () => {
+  const title = 'קושיית הגמרא';
+  const props = {
+    nodes: [{ index: 0, title }],
+    connections: [],
+    activeIndex: null,
+    onSelect: () => {},
+  };
+
+  it('he mode: title text-anchor is "end" with direction rtl (left-edge pinned)', () => {
+    setLang('he');
+    const { container } = render(() => <ArgumentFlowGraph {...props} />);
+    const titleTexts = textsWithContent(container, 'קושיית');
+    expect(titleTexts.length).toBeGreaterThan(0);
+    for (const t of titleTexts) {
+      expect(t.getAttribute('text-anchor')).toBe('end');
+      expect(t.getAttribute('direction')).toBe('rtl');
+    }
+  });
+
+  it('en mode: title text-anchor stays "start"', () => {
+    setLang('en');
+    const { container } = render(() => (
+      <ArgumentFlowGraph {...props} nodes={[{ index: 0, title: 'The Gemara asks' }]} />
+    ));
+    const titleTexts = textsWithContent(container, 'Gemara');
+    expect(titleTexts.length).toBeGreaterThan(0);
+    for (const t of titleTexts) expect(t.getAttribute('text-anchor')).toBe('start');
+  });
+});
+
+describe('ArgumentVoiceMap — Hebrew voice names align off the colour badge', () => {
+  const data = {
+    voices: [{ name: 'Rav Meir', nameHe: 'רב מאיר', role: 'originator', side: 'a', stance: '' }],
+    edges: [],
+  };
+
+  it('he mode: name text-anchor is "end" with direction rtl', () => {
+    setLang('he');
+    const { container } = render(() => <ArgumentVoiceMap data={data} />);
+    const nameTexts = textsWithContent(container, 'מאיר');
+    expect(nameTexts.length).toBeGreaterThan(0);
+    for (const t of nameTexts) {
+      expect(t.getAttribute('text-anchor')).toBe('end');
+      expect(t.getAttribute('direction')).toBe('rtl');
+    }
+  });
+
+  it('en mode: name text-anchor stays "start"', () => {
+    setLang('en');
+    const { container } = render(() => <ArgumentVoiceMap data={data} />);
+    const nameTexts = textsWithContent(container, 'Meir');
+    expect(nameTexts.length).toBeGreaterThan(0);
+    for (const t of nameTexts) expect(t.getAttribute('text-anchor')).toBe('start');
+  });
+});

--- a/tests/tractate-he.test.ts
+++ b/tests/tractate-he.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { tractateLabelHe, pageLabelHe, dafRefHe, toHebrewNumeral } from '../src/lib/sefref/tractates';
+
+describe('toHebrewNumeral — gematria across the daf range', () => {
+  it('ones, tens, and the טו/טז exceptions', () => {
+    expect(toHebrewNumeral(2)).toBe('ב');
+    expect(toHebrewNumeral(10)).toBe('י');
+    expect(toHebrewNumeral(15)).toBe('טו');
+    expect(toHebrewNumeral(16)).toBe('טז');
+    expect(toHebrewNumeral(17)).toBe('יז');
+  });
+  it('hundreds (deep tractates like Bava Batra ~176)', () => {
+    expect(toHebrewNumeral(100)).toBe('ק');
+    expect(toHebrewNumeral(127)).toBe('קכז');
+    expect(toHebrewNumeral(176)).toBe('קעו');
+    expect(toHebrewNumeral(115)).toBe('קטו');
+  });
+  it('falls back to decimal for non-positive / non-integer', () => {
+    expect(toHebrewNumeral(0)).toBe('0');
+    expect(toHebrewNumeral(-3)).toBe('-3');
+  });
+});
+
+describe('tractateLabelHe — English slug -> Hebrew name', () => {
+  it('maps known tractates to their Hebrew label', () => {
+    expect(tractateLabelHe('Berakhot')).toBe('ברכות');
+    expect(tractateLabelHe('Bava Metzia')).toBe('בבא מציעא');
+    expect(tractateLabelHe('Niddah')).toBe('נידה');
+  });
+  it('falls back to the input for an unknown slug (never blank)', () => {
+    expect(tractateLabelHe('Nonexistent')).toBe('Nonexistent');
+  });
+});
+
+describe('pageLabelHe — Na/Nb -> Hebrew daf form', () => {
+  it('uses amud-alef "." and amud-bet ":"', () => {
+    expect(pageLabelHe('2a')).toBe('ב.');
+    expect(pageLabelHe('2b')).toBe('ב:');
+  });
+  it('converts multi-digit pages via the Hebrew numeral table', () => {
+    expect(pageLabelHe('15a')).toBe('טו.');
+    expect(pageLabelHe('21b')).toBe('כא:');
+  });
+  it('tolerates surrounding whitespace', () => {
+    expect(pageLabelHe(' 2b ')).toBe('ב:');
+  });
+  it('returns unparseable input unchanged', () => {
+    expect(pageLabelHe('')).toBe('');
+    expect(pageLabelHe('cover')).toBe('cover');
+    expect(pageLabelHe('2')).toBe('2');
+  });
+});
+
+describe('dafRefHe — full Hebrew reference (the BERAKHOT-2B leak guard)', () => {
+  it('renders tractate + daf entirely in Hebrew', () => {
+    expect(dafRefHe('Berakhot', '2b')).toBe('ברכות ב:');
+    expect(dafRefHe('Shabbat', '127a')).toBe('שבת קכז.');
+    expect(dafRefHe('Bava Batra', '176b')).toBe('בבא בתרא קעו:');
+  });
+  it('never emits Latin letters for a known tractate', () => {
+    expect(/[A-Za-z]/.test(dafRefHe('Berakhot', '2b'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Three Hebrew-mode rendering bugs in the argument sidebar (reported with screenshots):

1. **Overview flow-graph titles** clipped and overlapping the number badge.
2. **Voice-map names** clipped and overlapping the colour badge — same root cause.
3. **`BERAKHOT 2B`** showing the English tractate slug instead of `ברכות ב:` in Hebrew mode (plus a hardcoded-English `continues from 2a` caption).

## Root cause (1 & 2)

SVG `text-anchor` is *direction-relative*. The labels used `text-anchor="start"` + `direction="rtl"`, which pins the text's **right** edge to the label x — so Hebrew flowed leftward over the badge and clipped at the card edge. The fix flips the anchor to `"end"` in `he` mode (pins the **left** edge instead). English is unchanged.

Verified the SVG behavior in a browser (broken `start+rtl` vs fixed `end+rtl`): the fixed card shows the full title right of a visible badge, no overlap/clip.

## Root cause (3)

The headers rendered the raw English tractate slug, and the cross-daf caption was hardcoded English. Added `tractateLabelHe` / `pageLabelHe` / `dafRefHe` (+ a full-daf-range gematria `toHebrewNumeral`, since the old `HEBREW_NUMBERS` table stopped at 76) and localized the headers + caption.

## Tests

- `tests/tractate-he.test.ts` — the Hebrew helpers + gematria (ones/tens/hundreds, the טו/טז exceptions, the Latin-leak guard).
- `tests/client/argument-svg-rtl.test.tsx` — renders both diagrams in `he`/`en` and asserts the title/name `text-anchor` (the regression guard).

`pnpm typecheck`, full `pnpm test` (1471 + 15 new), and `vite build` all pass.