### PR TITLE
Add /api/links: the unified link layer of a daf (first Link consumer)

### DIFF
--- a/src/lib/context/dafLinks.ts
+++ b/src/lib/context/dafLinks.ts
@@ -1,0 +1,67 @@
+/**
+ * dafLinks — assemble EVERY link on a daf into one list, all expressed through
+ * the shared Link vocabulary (src/lib/context/link.ts). The three edge kinds the
+ * system produces converge here:
+ *   - 'continues' — the tractate-continuity bridge (this daf → the next)
+ *   - 'cites'     — a study-aid/context note's external references
+ *   - the flow relations (resolves / depends-on / parallels / …) — the
+ *                   argument-overview flow graph between this daf's sections
+ *
+ * Pure: the worker gathers the inputs (bridge verdict, context pool, cached flow
+ * edges, section ranges) and calls this. The first real CONSUMER of the link
+ * layer — `GET /api/links/:tractate/:page` returns `dafLinks(...)`.
+ */
+
+import { coordForSeg, dafCoord, type AnchorCoord, type DafRef } from './coord.ts';
+import { citationLink, continuationLink, flowLinks, type FlowEdge, type LinkRelation } from './link.ts';
+import type { ContextItem } from './types.ts';
+
+/** A link on a daf: where it lives (`source`), the `relation`, and what it
+ *  points at (`targets`). `via` records which producer it came from, for
+ *  display + debugging. */
+export interface DafLink {
+  via: 'bridge' | 'context' | 'flow';
+  source: AnchorCoord;
+  relation: LinkRelation;
+  targets: AnchorCoord[];
+  note?: string;
+}
+
+export interface DafLinkInputs {
+  /** The next daf this sugya continues into, or null. From the cross-daf bridge. */
+  continuesTo: DafRef | null;
+  /** Context items (study-aids) on this daf — each item's `refs` becomes a
+   *  'cites' link sourced at where the item sits. */
+  items: ContextItem[];
+  /** The argument-overview flow graph edges (section index → section index). */
+  flowEdges: readonly FlowEdge[];
+  /** startSegIdx of each argument section, in flow-index order, so a flow edge's
+   *  section index resolves to a coordinate. */
+  sectionStartSegs: readonly number[];
+}
+
+export function dafLinks(daf: DafRef, input: DafLinkInputs): DafLink[] {
+  const out: DafLink[] = [];
+
+  // 1) Tractate-continuity: the cross-daf bridge.
+  const cont = continuationLink(input.continuesTo);
+  if (cont) out.push({ via: 'bridge', source: dafCoord(daf), relation: cont.relation, targets: cont.targets });
+
+  // 2) Citations: each context item's external refs, sourced where the item sits
+  //    (its first placed segment, else whole-daf).
+  for (const it of input.items) {
+    const cite = citationLink(it.refs);
+    if (!cite) continue;
+    const source = it.segs.length ? coordForSeg(daf, it.segs[0]) : dafCoord(daf);
+    out.push({ via: 'context', source, relation: cite.relation, targets: cite.targets, note: it.sourceLabel });
+  }
+
+  // 3) Argument flow: section→section edges, resolved to coordinates.
+  const coordOf = (i: number): AnchorCoord | null =>
+    i >= 0 && i < input.sectionStartSegs.length ? coordForSeg(daf, input.sectionStartSegs[i]) : null;
+  for (const fl of flowLinks(input.flowEdges, coordOf)) {
+    out.push({ via: 'flow', source: fl.source, relation: fl.link.relation, targets: fl.link.targets });
+  }
+
+  return out;
+}

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -11,7 +11,8 @@ import { getDafyomiMasechet } from '../lib/sefref/dafyomi/masechtos';
 import { collectContext } from './context-providers';
 import { placeRevachWithAi } from './revach-ai-place';
 import { formatContextForPrompt, contextForAnchor, segsFromMarkInput } from '../lib/context/select';
-import { continuationLink } from '../lib/context/link';
+import { continuationLink, type FlowEdge } from '../lib/context/link';
+import { dafLinks } from '../lib/context/dafLinks';
 import { aiMatchToSegments } from './context-match';
 import type { MatchInput } from '../lib/context/anchor/ai-prompt';
 import {
@@ -774,6 +775,59 @@ app.get('/api/bridge/:tractate/:page', async (c) => {
   // Computed (not stored on the cached DafBridge), so it needs no cache bump.
   const link = bridge.continues ? continuationLink(bridge.to) : null;
   return c.json({ ...bridge, link });
+});
+
+// Read the cached argument-overview.flow connections (section-index edges).
+// Empty when the daf hasn't been warmed — best-effort, never throws.
+async function readFlowConnections(env: Bindings, tractate: string, page: string): Promise<FlowEdge[]> {
+  try {
+    const def = await loadEnrichmentDef(env, 'argument-overview.flow');
+    if (!def) return [];
+    const iid = await instanceIdOf({ fields: {} });
+    const hit = await readCachedResult(env, keyForEnrichment(def, iid, { tractate, page }));
+    const conns = (hit?.parsed as { connections?: unknown } | null)?.connections;
+    if (!Array.isArray(conns)) return [];
+    return (conns as Array<Record<string, unknown>>)
+      .filter((c) => typeof c.from === 'number' && typeof c.to === 'number' && typeof c.kind === 'string')
+      .map((c) => ({ from: c.from as number, to: c.to as number, kind: c.kind as string }));
+  } catch { return []; }
+}
+
+// The unified link layer for a daf: tractate-continuity (bridge), citations
+// (context refs), and the argument flow graph, all in one Link vocabulary. The
+// first real CONSUMER of src/lib/context/link.ts — assembled by the pure
+// `dafLinks`. Best-effort per source: a cold/failed source contributes nothing
+// rather than failing the whole response.
+app.get('/api/links/:tractate/:page', async (c) => {
+  const tractate = c.req.param('tractate');
+  const page = c.req.param('page');
+  const daf = { tractate, page };
+
+  // Argument sections, read once: their ranges place Revach refs (so 'cites'
+  // links get a real segment source, not whole-daf), and their startSegIdx (in
+  // reading order) resolves a flow edge's section index to a coordinate.
+  const sectionInstances = await readMarkInstances(c.env, 'argument', tractate, page).catch(() => []);
+  const sections = sectionInstances
+    .filter((i) => typeof i.startSegIdx === 'number' && typeof i.endSegIdx === 'number')
+    .map((i) => ({
+      startSegIdx: i.startSegIdx as number,
+      endSegIdx: i.endSegIdx as number,
+      title: typeof i.fields?.title === 'string' ? i.fields.title : undefined,
+      summary: typeof i.fields?.summary === 'string' ? i.fields.summary : undefined,
+    }));
+  const sectionStartSegs = sections.map((s) => s.startSegIdx).sort((a, b) => a - b);
+
+  const bridge = await computeDafBridge(c.env, tractate, page).catch(() => null);
+  const items = await collectContext(c.env, tractate, page, { sections }).catch(() => []);
+  const flowEdges = await readFlowConnections(c.env, tractate, page);
+
+  const links = dafLinks(daf, {
+    continuesTo: bridge?.continues ? bridge.to : null,
+    items,
+    flowEdges,
+    sectionStartSegs,
+  });
+  return c.json({ tractate, page, count: links.length, links });
 });
 
 app.get('/api/enrichments', async (c) => {

--- a/tests/daf-links.test.ts
+++ b/tests/daf-links.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { dafLinks } from '../src/lib/context/dafLinks';
+import { dafCoord, coordForSeg } from '../src/lib/context/coord';
+import type { ContextItem } from '../src/lib/context/types';
+
+const DAF = { tractate: 'Shabbat', page: '125b' };
+const item = (over: Partial<ContextItem>): ContextItem => ({
+  source: 'dafyomi:revach', sourceLabel: "Revach l'Daf", kind: 'revach', key: 'k', segs: [], ...over,
+});
+
+describe('dafLinks — the unified link layer of a daf', () => {
+  it('is empty when there is nothing to link', () => {
+    expect(dafLinks(DAF, { continuesTo: null, items: [], flowEdges: [], sectionStartSegs: [] })).toEqual([]);
+  });
+
+  it('emits a bridge link (continues) sourced at the whole daf', () => {
+    const out = dafLinks(DAF, { continuesTo: { tractate: 'Shabbat', page: '126a' }, items: [], flowEdges: [], sectionStartSegs: [] });
+    expect(out).toEqual([
+      { via: 'bridge', source: dafCoord(DAF), relation: 'continues', targets: [dafCoord({ tractate: 'Shabbat', page: '126a' })] },
+    ]);
+  });
+
+  it('emits a cites link per context item with refs, sourced at its first seg (else whole-daf)', () => {
+    const placed = item({ key: 'a', segs: [7, 3], refs: [dafCoord({ tractate: 'Pesachim', page: '50a' })] });
+    const unplaced = item({ key: 'b', segs: [], refs: [dafCoord({ tractate: 'Gittin', page: '6a' })] });
+    const noRefs = item({ key: 'c', segs: [2] });
+    const out = dafLinks(DAF, { continuesTo: null, items: [placed, unplaced, noRefs], flowEdges: [], sectionStartSegs: [] });
+    expect(out).toEqual([
+      { via: 'context', source: coordForSeg(DAF, 7), relation: 'cites', targets: [dafCoord({ tractate: 'Pesachim', page: '50a' })], note: "Revach l'Daf" },
+      { via: 'context', source: dafCoord(DAF), relation: 'cites', targets: [dafCoord({ tractate: 'Gittin', page: '6a' })], note: "Revach l'Daf" },
+    ]);
+  });
+
+  it('emits flow links by resolving section indices through sectionStartSegs', () => {
+    // sections 0,1,2 start at segs 0, 5, 9. Edge 0->2 (depends-on), 1->2 (resolves).
+    const out = dafLinks(DAF, {
+      continuesTo: null, items: [],
+      flowEdges: [{ from: 0, to: 2, kind: 'depends-on' }, { from: 1, to: 2, kind: 'resolves' }],
+      sectionStartSegs: [0, 5, 9],
+    });
+    expect(out).toEqual([
+      { via: 'flow', source: coordForSeg(DAF, 0), relation: 'depends-on', targets: [coordForSeg(DAF, 9)] },
+      { via: 'flow', source: coordForSeg(DAF, 5), relation: 'resolves', targets: [coordForSeg(DAF, 9)] },
+    ]);
+  });
+
+  it('combines all three sources in order: bridge, then cites, then flow', () => {
+    const out = dafLinks(DAF, {
+      continuesTo: { tractate: 'Shabbat', page: '126a' },
+      items: [item({ segs: [4], refs: [dafCoord({ tractate: 'Pesachim', page: '50a' })] })],
+      flowEdges: [{ from: 0, to: 1, kind: 'continues' }],
+      sectionStartSegs: [4, 8],
+    });
+    expect(out.map((l) => l.via)).toEqual(['bridge', 'context', 'flow']);
+  });
+});


### PR DESCRIPTION
The **first real consumer** of `src/lib/context/link.ts` — making the link-unification work (`cites` #100, `continues` #108, `flowLinks` #110) render end-to-end.

`GET /api/links/:tractate/:page` returns a daf's entire link graph, assembled from three sources into one Link vocabulary:
- **`continues`** — the cross-daf bridge (`continuationLink`)
- **`cites`** — context items' external refs (`citationLink`), sourced at the item's placed segment
- **flow edges** — the `argument-overview` flow graph (`flowLinks`), section indices resolved to coordinates

```
GET /api/links/Shabbat/125b ->
{ tractate, page, count, links: [
  { via: 'bridge',  source, relation: 'continues',  targets: [...] },
  { via: 'context', source, relation: 'cites',      targets: [...], note: "Revach l'Daf" },
  { via: 'flow',    source, relation: 'resolves',   targets: [...] },
] }
```

The assembly is a **pure** function — `src/lib/context/dafLinks.ts` (unit-tested) — so the route just gathers inputs **best-effort** (each source falls back to empty; a cold/failed source never 500s the response) and calls it. Argument sections are read once: their ranges place Revach refs (so `cites` gets a real segment source, not whole-daf — addressing a Codex note) and their `startSegIdx` resolves flow section indices. Re-introduces `readFlowConnections` (deleted in #98) now that it has a consumer.

This is the framework thesis end-to-end: **one model and one assembler** for citations, tractate-continuity, and argument-flow edges alike. A UI renders it next.

Codex-reviewed (dafLinks pure + correct; flow-index assumption sound; no 500 path; the segment-source improvement applied). `pnpm typecheck` clean; `pnpm test` 1467 passing (+5 `tests/daf-links.test.ts`). MCP unchanged (sibling read endpoints `/api/bridge`/`/api/checks` aren't documented there either).