### PR TITLE
Overview map: pull connectors in tight to the cards

### DIFF
--- a/src/client/ArgumentFlowGraph.tsx
+++ b/src/client/ArgumentFlowGraph.tsx
@@ -38,8 +38,8 @@ interface Props {
 const NODE_W = 310;
 const NODE_H = 44;
 const ROW_GAP = 10;
-const LANE_BASE = 26;     // first lane's distance out from the card's right edge
-const LANE_STEP = 18;     // extra offset per concurrent connector lane
+const LANE_BASE = 12;     // first lane's distance out from the card's right edge
+const LANE_STEP = 11;     // extra offset per concurrent connector lane
 const TOP_PAD = 10;
 const LEFT_PAD = 10;
 const CORNER_R = 18;      // rounded-corner radius on the connector's two turns


### PR DESCRIPTION
The argument-overview flow connectors bowed far out into a wide right gutter, sprawling the map horizontally. Pull them in close to the cards: `LANE_BASE` 26->12 (first lane's distance from the card edge) and `LANE_STEP` 18->11 (spacing between stacked lanes). The connector corner radius already clamps to the available leg, so the tighter bow stays smooth; the gutter (and thus overall map width) shrinks with it.