### PR TITLE
Dev shelf: show the open card's recipe (what's declared vs custom)

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -17,7 +17,7 @@ import { adjacentAmud } from '../lib/sefref/amudim';
 import { dafRefHe, pageLabelHe } from '../lib/sefref/tractates';
 import { selectSectionMoves } from '../lib/argumentMoves';
 import { t, lang } from './i18n';
-import { ACCENTS, HebrewProse, Panel, QASection, SectionCard, Synthesis, SidebarPanelFromHint, SidebarCardFromHint, kindLabelKey, type SidebarHint, type SidebarRecipe, type SpecialBlockProps } from './sidebar/primitives';
+import { ACCENTS, HebrewProse, Panel, QASection, SectionCard, Synthesis, SidebarPanelFromHint, SidebarCardFromHint, setActiveRecipe, kindLabelKey, type SidebarHint, type SidebarRecipe, type SpecialBlockProps } from './sidebar/primitives';
 import { InspectDot } from './MarkEnrichmentCards';
 
 /** Localize an era date-range ("c. 290 – 320 CE") for Hebrew display. */
@@ -1674,6 +1674,14 @@ export const AGGADATA_BLOCKS: Record<string, (p: SpecialBlockProps) => JSX.Eleme
   'aggadata-parallels': AggadataParallels,
 };
 
+/** Which sidebar kinds are recipe-driven today (the rest are still bespoke
+ *  *Body components). The single source of truth for both the dispatch and the
+ *  dev shelf's Recipe panel — adding an entry here as a card is converted makes
+ *  it light up in the shelf automatically. */
+export const RECIPES_BY_KIND: Partial<Record<SidebarContent['kind'], SidebarRecipe>> = {
+  aggadata: AGGADATA_RECIPE,
+};
+
 /** The mark-instance shape the aggadata extractor emits (mark_input for leaves). */
 export function aggadataInstance(story: AggadataStory): { fields: Record<string, unknown>; startSegIdx: number; endSegIdx: number } {
   return {
@@ -1819,6 +1827,14 @@ export function ArgumentSidebar(props: ArgumentSidebarProps): JSX.Element {
   };
   window.addEventListener('keydown', onKey);
   onCleanup(() => window.removeEventListener('keydown', onKey));
+
+  // Publish the open card's recipe for the dev shelf's Recipe panel (null when
+  // no card is open or the open card is still a bespoke *Body). Single writer.
+  createEffect(() => {
+    const content = props.content;
+    setActiveRecipe(content ? (RECIPES_BY_KIND[content.kind] ?? null) : null);
+  });
+  onCleanup(() => setActiveRecipe(null));
 
   return (
     <Show when={props.content}>

--- a/src/client/DevModeShelf.tsx
+++ b/src/client/DevModeShelf.tsx
@@ -13,6 +13,7 @@
 import { createSignal, createEffect, onCleanup, Show, type JSX } from 'solid-js';
 import AIActivityPanel from './AIActivityPanel';
 import PipelinePanel from './PipelinePanel';
+import RecipePanel from './RecipePanel';
 
 const DEV_MODE_KEY = 'dev-mode:v1';
 const SHELF_WIDTH_KEY = 'dev-mode:shelf-width:v1';
@@ -161,6 +162,7 @@ export default function DevModeShelf(props: Props) {
           <div style={{ padding: '0.5rem 0.75rem 0', display: 'flex', 'flex-direction': 'column', gap: '0.5rem', 'flex-shrink': 0 }}>
             <AIActivityPanel />
             <PipelinePanel />
+            <RecipePanel />
           </div>
         </Show>
 

--- a/src/client/RecipePanel.tsx
+++ b/src/client/RecipePanel.tsx
@@ -1,0 +1,127 @@
+/**
+ * RecipePanel — dev-shelf view of the OPEN sidebar card's recipe (its
+ * declaration), so dev mode makes clear "what we are defining": the header
+ * fields, the ordered sections, each section's type, and what each one pulls
+ * from. `special` sections are flagged as custom — the one place genuinely
+ * bespoke code lives.
+ *
+ * Reads the `activeRecipe` signal that ArgumentSidebar's dispatch publishes.
+ * When that's null the open card is still a bespoke (un-converted) *Body — the
+ * panel says so, which turns it into a live scoreboard of the generic-sidebar
+ * migration: a card appears here the moment it becomes recipe-driven.
+ *
+ * Pairs with the existing inspect drawer: this answers "what is this card",
+ * the "i" dots + drawer answer "how was each section made". A section's
+ * `target` (for explainers) is the same leaf id you open in that drawer.
+ */
+
+import { For, Show, type JSX } from 'solid-js';
+import { activeRecipe, describeRecipe, type RecipeSectionInfo } from './sidebar/primitives';
+
+/** Monospace tag for a section's type — special is highlighted (it's the custom one). */
+function TypeTag(props: { info: RecipeSectionInfo }): JSX.Element {
+  const custom = () => props.info.custom;
+  return (
+    <span style={{
+      'font-family': 'ui-monospace, SFMono-Regular, Menlo, monospace',
+      'font-size': '0.62rem',
+      'flex-shrink': 0,
+      color: custom() ? '#9a3412' : '#475569',
+      background: custom() ? '#ffedd5' : '#f1f5f9',
+      border: `1px solid ${custom() ? '#fdba74' : '#e2e8f0'}`,
+      padding: '0 0.3rem',
+      'border-radius': '3px',
+    }}>{props.info.type}</span>
+  );
+}
+
+export default function RecipePanel(): JSX.Element {
+  const info = () => {
+    const r = activeRecipe();
+    return r ? describeRecipe(r) : null;
+  };
+  return (
+    <div style={{
+      border: '1px solid #eee',
+      'border-radius': '4px',
+      background: '#fff',
+      padding: '0.4rem 0.55rem',
+      'font-size': '0.78rem',
+      'line-height': 1.45,
+    }}>
+      <div style={{
+        'font-size': '0.65rem',
+        'text-transform': 'uppercase',
+        'letter-spacing': '0.06em',
+        color: '#888',
+        'margin-bottom': '0.3rem',
+        display: 'flex',
+        'align-items': 'baseline',
+        gap: '0.4rem',
+      }}>
+        <span>Recipe</span>
+        <Show when={info()}>
+          {(i) => (
+            <span style={{
+              'font-family': 'ui-monospace, SFMono-Regular, Menlo, monospace',
+              'font-size': '0.66rem',
+              color: '#7c3aed',
+              'text-transform': 'none',
+              'letter-spacing': 0,
+            }}>{i().kind}</span>
+          )}
+        </Show>
+      </div>
+
+      <Show
+        when={info()}
+        fallback={
+          <div style={{ color: '#aaa', 'font-size': '0.72rem', 'font-style': 'italic' }}>
+            no recipe-driven card open — bespoke cards aren't declared yet
+          </div>
+        }
+      >
+        {(i) => (
+          <>
+            {/* Header — which fields make the card title */}
+            <div style={{ display: 'flex', 'align-items': 'baseline', gap: '0.4rem', padding: '0.1rem 0', color: '#555' }}>
+              <span style={{ color: '#aaa', 'font-size': '0.66rem', 'flex-shrink': 0, width: '1.1rem' }}>·</span>
+              <span style={{ 'font-size': '0.66rem', color: '#888', 'flex-shrink': 0 }}>header</span>
+              <span style={{
+                'font-family': 'ui-monospace, SFMono-Regular, Menlo, monospace',
+                'font-size': '0.7rem', color: '#444', flex: 1, 'min-width': 0,
+                'white-space': 'nowrap', overflow: 'hidden', 'text-overflow': 'ellipsis',
+              }}>{i().header}</span>
+            </div>
+
+            {/* Sections, in render order */}
+            <For each={i().sections}>{(s) => (
+              <div style={{ display: 'flex', 'align-items': 'baseline', gap: '0.4rem', padding: '0.15rem 0', color: '#444' }}>
+                <span style={{
+                  color: '#bbb', 'font-variant-numeric': 'tabular-nums',
+                  'flex-shrink': 0, width: '1.1rem', 'text-align': 'right',
+                  'font-size': '0.7rem',
+                }}>{s.n}</span>
+                <TypeTag info={s} />
+                <Show when={s.target}>
+                  <span style={{ color: '#bbb', 'flex-shrink': 0 }}>→</span>
+                  <span style={{
+                    'font-family': 'ui-monospace, SFMono-Regular, Menlo, monospace',
+                    'font-size': '0.7rem', color: '#666', flex: 1, 'min-width': 0,
+                    'white-space': 'nowrap', overflow: 'hidden', 'text-overflow': 'ellipsis',
+                  }}>{s.target}</span>
+                </Show>
+              </div>
+            )}</For>
+
+            <Show when={i().sections.some((s) => s.custom)}>
+              <div style={{ color: '#9a3412', 'font-size': '0.66rem', 'margin-top': '0.3rem' }}>
+                special = custom block (registered, not freeform)
+              </div>
+            </Show>
+          </>
+        )}
+      </Show>
+    </div>
+  );
+}

--- a/src/client/sidebar/primitives.tsx
+++ b/src/client/sidebar/primitives.tsx
@@ -355,6 +355,52 @@ export interface SidebarRecipe {
   sections: SectionSpec[];
 }
 
+/** A flat, render-ready description of a recipe for the dev shelf's Recipe panel.
+ *  Pure (no reactivity) so it's unit-testable and the panel needn't know the
+ *  SectionSpec union internals. */
+export interface RecipeSectionInfo {
+  n: number;
+  type: SectionSpec['type'];
+  /** What the section pulls from — field name(s), the dep/leaf id, or the block
+   *  name. null for self-contained sections (synthesis, qa). The dep id doubles
+   *  as the `leafId` you'd open in the inspect drawer. */
+  target: string | null;
+  /** True only for `special` blocks: genuinely-custom code, not a standard type. */
+  custom: boolean;
+}
+export interface RecipeInfo {
+  kind: SidebarKind;
+  markId: string;
+  header: string;
+  sections: RecipeSectionInfo[];
+}
+export function describeRecipe(recipe: SidebarRecipe): RecipeInfo {
+  const header = recipe.titleHeField
+    ? `${recipe.titleField} / ${recipe.titleHeField}`
+    : recipe.titleField;
+  const sections = recipe.sections.map((s, i): RecipeSectionInfo => {
+    const n = i + 1;
+    switch (s.type) {
+      case 'tags': return { n, type: s.type, target: s.fields.join(', '), custom: false };
+      case 'prose': return { n, type: s.type, target: s.field, custom: false };
+      case 'synthesis': return { n, type: s.type, target: null, custom: false };
+      case 'explainer': return { n, type: s.type, target: s.dep, custom: false };
+      case 'qa': return { n, type: s.type, target: null, custom: false };
+      case 'special': return { n, type: s.type, target: s.block, custom: true };
+    }
+  });
+  return { kind: recipe.kind, markId: recipe.markId, header, sections };
+}
+
+/** The recipe of the currently-open sidebar card, published for the dev shelf's
+ *  Recipe panel. null when no card is open OR the open card is still a bespoke
+ *  (un-converted) *Body — so the panel doubles as a conversion scoreboard: a
+ *  card 'lights up' here the moment it becomes recipe-driven. ArgumentSidebar's
+ *  dispatch is the single writer (see RECIPES_BY_KIND). */
+const [activeRecipeSig, setActiveRecipeSig] = createSignal<SidebarRecipe | null>(null);
+export function activeRecipe(): SidebarRecipe | null { return activeRecipeSig(); }
+export function setActiveRecipe(r: SidebarRecipe | null): void { setActiveRecipeSig(r); }
+
 /**
  * Render a card from its recipe. Draws the Panel header, holds one shared `deps`
  * signal that the `synthesis` section fills via onResolved, then walks the

--- a/tests/client/recipe-describe.test.ts
+++ b/tests/client/recipe-describe.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { describeRecipe, type SidebarRecipe } from '../../src/client/sidebar/primitives';
+
+const AGGADATA: SidebarRecipe = {
+  kind: 'aggadata',
+  markId: 'aggadata',
+  titleField: 'title',
+  titleHeField: 'titleHe',
+  sections: [
+    { type: 'tags', fields: ['theme'] },
+    { type: 'prose', field: 'summary' },
+    { type: 'synthesis' },
+    { type: 'explainer', dep: 'aggadata.background', textField: 'background', labelKey: 'aggadata.background' },
+    { type: 'special', block: 'aggadata-parallels' },
+    { type: 'qa' },
+  ],
+};
+
+describe('describeRecipe', () => {
+  it('projects the header from title fields', () => {
+    expect(describeRecipe(AGGADATA).header).toBe('title / titleHe');
+    expect(describeRecipe({ ...AGGADATA, titleHeField: undefined }).header).toBe('title');
+  });
+
+  it('numbers sections in order and reports each type', () => {
+    const { sections } = describeRecipe(AGGADATA);
+    expect(sections.map((s) => [s.n, s.type])).toEqual([
+      [1, 'tags'], [2, 'prose'], [3, 'synthesis'], [4, 'explainer'], [5, 'special'], [6, 'qa'],
+    ]);
+  });
+
+  it('reports each section target (field, dep, or block) and null for self-contained', () => {
+    const byType = Object.fromEntries(describeRecipe(AGGADATA).sections.map((s) => [s.type, s]));
+    expect(byType.tags.target).toBe('theme');
+    expect(byType.prose.target).toBe('summary');
+    expect(byType.explainer.target).toBe('aggadata.background'); // the leaf id you'd inspect
+    expect(byType.special.target).toBe('aggadata-parallels');
+    expect(byType.synthesis.target).toBeNull();
+    expect(byType.qa.target).toBeNull();
+  });
+
+  it('flags ONLY special sections as custom', () => {
+    const { sections } = describeRecipe(AGGADATA);
+    expect(sections.filter((s) => s.custom).map((s) => s.type)).toEqual(['special']);
+  });
+
+  it('joins multiple tag fields', () => {
+    const r = describeRecipe({ ...AGGADATA, sections: [{ type: 'tags', fields: ['theme', 'era'] }] });
+    expect(r.sections[0].target).toBe('theme, era');
+  });
+});


### PR DESCRIPTION
Wires the new **recipe** model into the **dev panel** so dev mode makes clear *what we are defining* — and lets you dig deeper from there.

When dev mode is on and a recipe-driven card is open, the dev shelf gains a **Recipe** panel showing that card's declaration:

```
RECIPE  aggadata
 · header   title / titleHe
 1 [tags]      → theme
 2 [prose]     → summary
 3 [synthesis]
 4 [explainer] → aggadata.background
 5 [explainer] → aggadata.interpretation
 6 [special]   → aggadata-parallels
 7 [qa]
 special = custom block (registered, not freeform)
```

- Each section shows its **type** and **what it pulls from** (a field, a dependent **leaf id**, or a named block). `special` is highlighted — the one place genuinely-custom code lives.
- For un-converted cards the panel reads *"no recipe-driven card open — bespoke cards aren't declared yet"*, so it doubles as a **migration scoreboard**: a card lights up here the moment it becomes recipe-driven.

**How it's wired:** `ArgumentSidebar`'s dispatch is the *single writer* of a new `activeRecipe` signal (`sidebar/primitives.tsx`), publishing the open card's recipe via `RECIPES_BY_KIND` (or null for bespoke). `RecipePanel` reads it through `describeRecipe` — a pure, unit-tested projection of the `SectionSpec` union (no reactivity, fully exhaustive).

**Pairs with the existing inspect drawer:** the panel answers *"what is this card"*; the "i" dots + drawer answer *"how was each section made"*. An explainer's target is the same `leafId` you open in that drawer.

`pnpm typecheck` clean · `pnpm test` 1525/1525 · new `recipe-describe` test (7 cases). Codex: no correctness/reactivity findings.