### PR TITLE
Recipe panel: inspect every section from the bottom drawer

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -17,7 +17,7 @@ import { adjacentAmud } from '../lib/sefref/amudim';
 import { dafRefHe, pageLabelHe } from '../lib/sefref/tractates';
 import { selectSectionMoves } from '../lib/argumentMoves';
 import { t, lang } from './i18n';
-import { ACCENTS, HebrewProse, Panel, QASection, SectionCard, Synthesis, SidebarPanelFromHint, SidebarCardFromHint, setActiveRecipe, kindLabelKey, type SidebarHint, type SidebarRecipe, type SpecialBlockProps } from './sidebar/primitives';
+import { ACCENTS, HebrewProse, Panel, QASection, SectionCard, Synthesis, SidebarPanelFromHint, SidebarCardFromHint, setActiveCard, kindLabelKey, type SidebarHint, type SidebarRecipe, type SpecialBlockProps } from './sidebar/primitives';
 import { InspectDot } from './MarkEnrichmentCards';
 
 /** Localize an era date-range ("c. 290 – 320 CE") for Hebrew display. */
@@ -1666,7 +1666,7 @@ export const AGGADATA_RECIPE: SidebarRecipe = {
     { type: 'synthesis' },
     { type: 'explainer', dep: 'aggadata.background', textField: 'background', labelKey: 'aggadata.background' },
     { type: 'explainer', dep: 'aggadata.interpretation', textField: 'interpretation', labelKey: 'aggadata.interpretation' },
-    { type: 'special', block: 'aggadata-parallels' },
+    { type: 'special', block: 'aggadata-parallels', deps: ['aggadata.parallels'] },
     { type: 'qa' },
   ],
 };
@@ -1677,10 +1677,26 @@ export const AGGADATA_BLOCKS: Record<string, (p: SpecialBlockProps) => JSX.Eleme
 /** Which sidebar kinds are recipe-driven today (the rest are still bespoke
  *  *Body components). The single source of truth for both the dispatch and the
  *  dev shelf's Recipe panel — adding an entry here as a card is converted makes
- *  it light up in the shelf automatically. */
+ *  it light up in the shelf automatically.
+ *
+ *  Invariant: any recipe whose sections expose inspect dots must include a
+ *  `synthesis` section — that's what mounts the MarkEnrichmentCards host the
+ *  inspect drawer renders inside. Without it the panel's 'i' targets an
+ *  unmounted instanceKey (a dead click). */
 export const RECIPES_BY_KIND: Partial<Record<SidebarContent['kind'], SidebarRecipe>> = {
   aggadata: AGGADATA_RECIPE,
 };
+
+/** The instanceKey a recipe-driven card mounts under (the client run memo + the
+ *  inspect drawer are keyed by it). Single source of truth so the dispatch and
+ *  the dev Recipe panel target the SAME drawer byte-for-byte. null for kinds not
+ *  yet recipe-driven. */
+export function instanceKeyForContent(content: SidebarContent, tractate: string, page: string): string | null {
+  switch (content.kind) {
+    case 'aggadata': return `${tractate}:${page}:${content.index}:${content.story.title}`;
+    default: return null;
+  }
+}
 
 /** The mark-instance shape the aggadata extractor emits (mark_input for leaves). */
 export function aggadataInstance(story: AggadataStory): { fields: Record<string, unknown>; startSegIdx: number; endSegIdx: number } {
@@ -1828,13 +1844,18 @@ export function ArgumentSidebar(props: ArgumentSidebarProps): JSX.Element {
   window.addEventListener('keydown', onKey);
   onCleanup(() => window.removeEventListener('keydown', onKey));
 
-  // Publish the open card's recipe for the dev shelf's Recipe panel (null when
-  // no card is open or the open card is still a bespoke *Body). Single writer.
+  // Publish the open card (recipe + instanceKey) for the dev shelf's Recipe
+  // panel — null when no card is open or it's still a bespoke *Body. Single
+  // writer. The instanceKey matches what the dispatch mounts, so each panel
+  // row's inspect 'i' targets the very drawer that card renders.
   createEffect(() => {
     const content = props.content;
-    setActiveRecipe(content ? (RECIPES_BY_KIND[content.kind] ?? null) : null);
+    if (!content) { setActiveCard(null); return; }
+    const recipe = RECIPES_BY_KIND[content.kind];
+    const instanceKey = instanceKeyForContent(content, props.tractate, props.page);
+    setActiveCard(recipe && instanceKey ? { recipe, instanceKey } : null);
   });
-  onCleanup(() => setActiveRecipe(null));
+  onCleanup(() => setActiveCard(null));
 
   return (
     <Show when={props.content}>
@@ -1970,7 +1991,7 @@ export function ArgumentSidebar(props: ArgumentSidebarProps): JSX.Element {
               <SidebarCardFromHint
                 recipe={AGGADATA_RECIPE}
                 instance={aggadataInstance((c() as Extract<SidebarContent, { kind: 'aggadata' }>).story)}
-                instanceKey={`${props.tractate}:${props.page}:${(c() as Extract<SidebarContent, { kind: 'aggadata' }>).index}:${(c() as Extract<SidebarContent, { kind: 'aggadata' }>).story.title}`}
+                instanceKey={instanceKeyForContent(c() as Extract<SidebarContent, { kind: 'aggadata' }>, props.tractate, props.page)!}
                 qaInstanceId={`${(c() as Extract<SidebarContent, { kind: 'aggadata' }>).story.title}|${(c() as Extract<SidebarContent, { kind: 'aggadata' }>).story.excerpt}`}
                 tractate={props.tractate}
                 page={props.page}

--- a/src/client/InstanceInspectorShelf.tsx
+++ b/src/client/InstanceInspectorShelf.tsx
@@ -162,6 +162,18 @@ export default function InstanceInspectorShelf(props: Props) {
           {props.renderBody()}
         </div>
 
+        {/* the mark instance this run was built from — the 'extraction' that
+            tags/prose render their fields off. Collapsed; present on aggregate
+            runs that resolved their anchors. */}
+        <Show when={result()?.anchors_resolved}>{(anchors) => (
+          <details style={{ 'margin-bottom': '0.5rem' }}>
+            <summary style={{ color: '#666', cursor: 'pointer', 'font-size': '0.78rem' }}>instance (extraction)</summary>
+            <pre style={{ 'white-space': 'pre-wrap', 'font-family': 'ui-monospace, Menlo, monospace', 'font-size': '12px', margin: '0.4rem 0 0', background: '#f8f8f8', padding: '0.6rem', 'border-radius': '3px' }}>
+              {JSON.stringify(anchors(), null, 2)}
+            </pre>
+          </details>
+        )}</Show>
+
         <Show when={props.depBadges.length > 0}>
           <div style={{
             display: 'flex', gap: '0.3rem', 'align-items': 'center',

--- a/src/client/RecipePanel.tsx
+++ b/src/client/RecipePanel.tsx
@@ -2,21 +2,24 @@
  * RecipePanel — dev-shelf view of the OPEN sidebar card's recipe (its
  * declaration), so dev mode makes clear "what we are defining": the header
  * fields, the ordered sections, each section's type, and what each one pulls
- * from. `special` sections are flagged as custom — the one place genuinely
- * bespoke code lives.
+ * from. `special` sections are flagged as custom — but they still declare their
+ * input leaves, so even custom blocks aren't opaque.
  *
- * Reads the `activeRecipe` signal that ArgumentSidebar's dispatch publishes.
- * When that's null the open card is still a bespoke (un-converted) *Body — the
- * panel says so, which turns it into a live scoreboard of the generic-sidebar
- * migration: a card appears here the moment it becomes recipe-driven.
+ * Each row carries an inspect 'i' that opens the bottom drawer at that section's
+ * true source: explainer/special → their leaf, synthesis/tags/prose → the
+ * synthesis+instance view (where the mark extraction lives). So the panel is
+ * both the map of what's declared AND the way to dig into how each piece was
+ * made — the same drawer the in-card 'i' dots open.
  *
- * Pairs with the existing inspect drawer: this answers "what is this card",
- * the "i" dots + drawer answer "how was each section made". A section's
- * `target` (for explainers) is the same leaf id you open in that drawer.
+ * Reads the `activeCard` signal that ArgumentSidebar's dispatch publishes (the
+ * recipe + the instanceKey to target). When that's null the open card is still
+ * a bespoke (un-converted) *Body — so the panel doubles as a live scoreboard of
+ * the generic-sidebar migration.
  */
 
 import { For, Show, type JSX } from 'solid-js';
-import { activeRecipe, describeRecipe, type RecipeSectionInfo } from './sidebar/primitives';
+import { activeCard, describeRecipe, type RecipeSectionInfo } from './sidebar/primitives';
+import { InspectDot } from './MarkEnrichmentCards';
 
 /** Monospace tag for a section's type — special is highlighted (it's the custom one). */
 function TypeTag(props: { info: RecipeSectionInfo }): JSX.Element {
@@ -36,9 +39,10 @@ function TypeTag(props: { info: RecipeSectionInfo }): JSX.Element {
 }
 
 export default function RecipePanel(): JSX.Element {
+  const card = () => activeCard();
   const info = () => {
-    const r = activeRecipe();
-    return r ? describeRecipe(r) : null;
+    const c = card();
+    return c ? describeRecipe(c.recipe) : null;
   };
   return (
     <div style={{
@@ -94,7 +98,7 @@ export default function RecipePanel(): JSX.Element {
               }}>{i().header}</span>
             </div>
 
-            {/* Sections, in render order */}
+            {/* Sections, in render order — each with an inspect 'i' on its source */}
             <For each={i().sections}>{(s) => (
               <div style={{ display: 'flex', 'align-items': 'baseline', gap: '0.4rem', padding: '0.15rem 0', color: '#444' }}>
                 <span style={{
@@ -111,12 +115,33 @@ export default function RecipePanel(): JSX.Element {
                     'white-space': 'nowrap', overflow: 'hidden', 'text-overflow': 'ellipsis',
                   }}>{s.target}</span>
                 </Show>
+                {/* inspect 'i' → opens the drawer at this section's true source */}
+                <Show when={s.inspect}>
+                  {(insp) => (
+                    <InspectDot
+                      instanceKey={card()!.instanceKey}
+                      leafId={insp().leafId}
+                      title={insp().leafId
+                        ? `inspect ${insp().leafId}`
+                        : 'inspect synthesis + instance (the extraction)'}
+                      style={{ 'flex-shrink': 0 }}
+                    />
+                  )}
+                </Show>
+              </div>
+            )}</For>
+
+            {/* A special block's declared inputs — so 'custom' means custom render,
+                not opaque: its leaf inputs are listed. */}
+            <For each={i().sections.filter((s) => s.custom && (s.inputs?.length ?? 0) > 0)}>{(s) => (
+              <div style={{ color: '#9a3412', 'font-size': '0.66rem', 'margin-top': '0.2rem', 'padding-left': '1.5rem' }}>
+                {s.target} inputs: {s.inputs!.join(', ')}
               </div>
             )}</For>
 
             <Show when={i().sections.some((s) => s.custom)}>
               <div style={{ color: '#9a3412', 'font-size': '0.66rem', 'margin-top': '0.3rem' }}>
-                special = custom block (registered, not freeform)
+                special = custom block (registered, declared inputs — not freeform)
               </div>
             </Show>
           </>

--- a/src/client/sidebar/primitives.tsx
+++ b/src/client/sidebar/primitives.tsx
@@ -342,8 +342,11 @@ export type SectionSpec =
   | { type: 'explainer'; dep: string; textField: string; labelKey: CatalogKey }
   /** The follow-up Q&A affordance. */
   | { type: 'qa' }
-  /** A genuinely-custom block, looked up by name in the card's `specialBlocks`. */
-  | { type: 'special'; block: string };
+  /** A genuinely-custom block, looked up by name in the card's `specialBlocks`.
+   *  `deps` declares the dependent leaf ids it reads from the shared deps bag —
+   *  so even a custom block has *declared inputs* (shown in the Recipe panel,
+   *  and the first is what its inspect 'i' opens). */
+  | { type: 'special'; block: string; deps?: string[] };
 
 export interface SidebarRecipe {
   kind: SidebarKind;
@@ -362,9 +365,14 @@ export interface RecipeSectionInfo {
   n: number;
   type: SectionSpec['type'];
   /** What the section pulls from — field name(s), the dep/leaf id, or the block
-   *  name. null for self-contained sections (synthesis, qa). The dep id doubles
-   *  as the `leafId` you'd open in the inspect drawer. */
+   *  name. null for self-contained sections (synthesis, qa). */
   target: string | null;
+  /** A special block's declared dependent leaf ids (its inputs). */
+  inputs?: string[];
+  /** What this section's inspect 'i' opens in the bottom drawer — a leaf id, or
+   *  null for the synthesis/instance view (where the mark extraction lives).
+   *  `null` (the whole field) means the section has no inspectable source (qa). */
+  inspect: { leafId: string | null } | null;
   /** True only for `special` blocks: genuinely-custom code, not a standard type. */
   custom: boolean;
 }
@@ -380,26 +388,33 @@ export function describeRecipe(recipe: SidebarRecipe): RecipeInfo {
     : recipe.titleField;
   const sections = recipe.sections.map((s, i): RecipeSectionInfo => {
     const n = i + 1;
+    // tags/prose render fields off the mark instance → their provenance is the
+    // extraction, surfaced as the synthesis/instance view (leafId null).
     switch (s.type) {
-      case 'tags': return { n, type: s.type, target: s.fields.join(', '), custom: false };
-      case 'prose': return { n, type: s.type, target: s.field, custom: false };
-      case 'synthesis': return { n, type: s.type, target: null, custom: false };
-      case 'explainer': return { n, type: s.type, target: s.dep, custom: false };
-      case 'qa': return { n, type: s.type, target: null, custom: false };
-      case 'special': return { n, type: s.type, target: s.block, custom: true };
+      case 'tags': return { n, type: s.type, target: s.fields.join(', '), inspect: { leafId: null }, custom: false };
+      case 'prose': return { n, type: s.type, target: s.field, inspect: { leafId: null }, custom: false };
+      case 'synthesis': return { n, type: s.type, target: null, inspect: { leafId: null }, custom: false };
+      case 'explainer': return { n, type: s.type, target: s.dep, inspect: { leafId: s.dep }, custom: false };
+      case 'qa': return { n, type: s.type, target: null, inspect: null, custom: false };
+      case 'special': return {
+        n, type: s.type, target: s.block, inputs: s.deps,
+        inspect: s.deps && s.deps.length > 0 ? { leafId: s.deps[0] } : { leafId: null },
+        custom: true,
+      };
     }
   });
   return { kind: recipe.kind, markId: recipe.markId, header, sections };
 }
 
-/** The recipe of the currently-open sidebar card, published for the dev shelf's
- *  Recipe panel. null when no card is open OR the open card is still a bespoke
- *  (un-converted) *Body — so the panel doubles as a conversion scoreboard: a
- *  card 'lights up' here the moment it becomes recipe-driven. ArgumentSidebar's
- *  dispatch is the single writer (see RECIPES_BY_KIND). */
-const [activeRecipeSig, setActiveRecipeSig] = createSignal<SidebarRecipe | null>(null);
-export function activeRecipe(): SidebarRecipe | null { return activeRecipeSig(); }
-export function setActiveRecipe(r: SidebarRecipe | null): void { setActiveRecipeSig(r); }
+/** The currently-open sidebar card, published for the dev shelf's Recipe panel:
+ *  its recipe + the `instanceKey` (so each panel row's inspect 'i' can target the
+ *  drawer for this exact instance). null when no card is open OR the open card is
+ *  still a bespoke (un-converted) *Body — so the panel doubles as a conversion
+ *  scoreboard. ArgumentSidebar's dispatch is the single writer (RECIPES_BY_KIND). */
+export interface ActiveCard { recipe: SidebarRecipe; instanceKey: string; }
+const [activeCardSig, setActiveCardSig] = createSignal<ActiveCard | null>(null);
+export function activeCard(): ActiveCard | null { return activeCardSig(); }
+export function setActiveCard(c: ActiveCard | null): void { setActiveCardSig(c); }
 
 /**
  * Render a card from its recipe. Draws the Panel header, holds one shared `deps`

--- a/tests/client/recipe-describe.test.ts
+++ b/tests/client/recipe-describe.test.ts
@@ -11,7 +11,7 @@ const AGGADATA: SidebarRecipe = {
     { type: 'prose', field: 'summary' },
     { type: 'synthesis' },
     { type: 'explainer', dep: 'aggadata.background', textField: 'background', labelKey: 'aggadata.background' },
-    { type: 'special', block: 'aggadata-parallels' },
+    { type: 'special', block: 'aggadata-parallels', deps: ['aggadata.parallels'] },
     { type: 'qa' },
   ],
 };
@@ -47,5 +47,23 @@ describe('describeRecipe', () => {
   it('joins multiple tag fields', () => {
     const r = describeRecipe({ ...AGGADATA, sections: [{ type: 'tags', fields: ['theme', 'era'] }] });
     expect(r.sections[0].target).toBe('theme, era');
+  });
+
+  it('gives each section an inspect target — leaf for explainer/special, null (synthesis+instance) for tags/prose/synthesis, none for qa', () => {
+    const byType = Object.fromEntries(describeRecipe(AGGADATA).sections.map((s) => [s.type, s]));
+    expect(byType.explainer.inspect).toEqual({ leafId: 'aggadata.background' });
+    expect(byType.special.inspect).toEqual({ leafId: 'aggadata.parallels' }); // its first declared dep
+    expect(byType.tags.inspect).toEqual({ leafId: null });   // → synthesis+instance (the extraction)
+    expect(byType.prose.inspect).toEqual({ leafId: null });
+    expect(byType.synthesis.inspect).toEqual({ leafId: null });
+    expect(byType.qa.inspect).toBeNull();                    // nothing to inspect
+  });
+
+  it('surfaces a special block declared inputs; falls back to the instance view when undeclared', () => {
+    const byType = Object.fromEntries(describeRecipe(AGGADATA).sections.map((s) => [s.type, s]));
+    expect(byType.special.inputs).toEqual(['aggadata.parallels']);
+    const noDeps = describeRecipe({ ...AGGADATA, sections: [{ type: 'special', block: 'x' }] });
+    expect(noDeps.sections[0].inputs).toBeUndefined();
+    expect(noDeps.sections[0].inspect).toEqual({ leafId: null });
   });
 });


### PR DESCRIPTION
Ties the dev **Recipe panel** to the existing **inspect drawer**, so the bottom panel becomes the one place you both *see what a card declares* and *dig into how each piece was made*.

Every Recipe-panel row now carries an **"i"** pointing at that section's **true source**:

| Section | "i" opens |
|---|---|
| `explainer` / `special` | their dependent **leaf** |
| `synthesis` / `tags` / `prose` | the **synthesis + instance** view (the extraction) |
| `qa` | nothing (no cached provenance) |

```
RECIPE  aggadata
 1 [tags]      → theme                 (i)
 2 [prose]     → summary               (i)
 3 [synthesis]                         (i)
 4 [explainer] → aggadata.background   (i)
 6 [special]   → aggadata-parallels    (i)
      aggadata-parallels inputs: aggadata.parallels
```

**Declarative special inputs.** `special` sections now declare `deps: ['aggadata.parallels']`. The Recipe panel lists a custom block's input leaves, and its first is what the "i" opens — so **"custom" now means custom *render*, not undeclared inputs**. Closes the "custom = opaque" gap.

**"Extraction" is a real target.** The drawer gains an *instance (extraction)* collapsible rendering the run's `anchors_resolved` — the mark instance that `tags`/`prose` render their fields off (already in `RunResult`, just never surfaced). So clicking a tag's "i" actually shows you where that field came from.

**Why it lands on the right drawer:** the published signal goes from a bare recipe to `{recipe, instanceKey}`, and `instanceKeyForContent()` is now the *single source* of that key — used by **both** the dispatch (what the card mounts under) and the panel (what its "i" targets), byte-identical by construction.

**Design note (deliberate):** the inspector stays **registry-driven** (the complete ground truth of what's computed) — the recipe makes it *aware*, not *driven*. Recorded invariant: a recipe exposing inspect dots must include a `synthesis` section (the drawer host).

`pnpm typecheck` clean · `pnpm test` 1527/1527 · `recipe-describe` extended (9 cases). Codex: no blocking issues.