### PR TITLE
Sidebar: collapse explainer sections by default

### DIFF
--- a/src/client/sidebar/primitives.tsx
+++ b/src/client/sidebar/primitives.tsx
@@ -135,23 +135,60 @@ export function SectionCard(props: {
    *  section's leaf enrichment. `leafId` is the enrichment id that produced
    *  the section (e.g. 'pesukim.tanach-context'). */
   inspect?: { instanceKey: string; leafId: string };
+  /** When set, the body is collapsible behind the label. `true` starts
+   *  collapsed (the "dig deeper" default for explainer cards), `false` starts
+   *  open but still toggleable. Omitted → the original always-open card. */
+  collapsed?: boolean;
 }): JSX.Element {
+  // Signal-driven (not native <details>) so the inspect 'i' — which lives in the
+  // label row and stops propagation — never toggles the fold.
+  const collapsible = (): boolean => props.collapsed != null;
+  const [open, setOpen] = createSignal(props.collapsed !== true);
+  const labelRow = (): JSX.Element => (
+    <div style={{
+      ...SECTION_LABEL,
+      'margin-bottom': open() ? (props.spacing === 'loose' ? '0.5rem' : '0.4rem') : 0,
+      display: 'flex', 'align-items': 'center', gap: '0.4rem',
+    }}>
+      <Show when={collapsible()}>
+        <span style={{ color: '#bbb', 'font-size': '0.7rem', width: '0.7rem', display: 'inline-block', transform: open() ? 'rotate(90deg)' : 'none', transition: 'transform 0.12s' }}>▸</span>
+      </Show>
+      <span>{t(props.label)}</span>
+      <Show when={props.inspect}>
+        {(ins) => <InspectDot instanceKey={ins().instanceKey} leafId={ins().leafId} style={{ 'margin-left': 'auto' }} />}
+      </Show>
+    </div>
+  );
+  const body = (): JSX.Element => (
+    <Show when={props.text != null} fallback={props.children}>
+      <div style={SECTION_PROSE}>
+        <HebraizedWithRabbis text={props.text!} />
+      </div>
+    </Show>
+  );
   return (
     <div style={SECTION_BOX}>
-      <div style={{
-        ...SECTION_LABEL,
-        'margin-bottom': props.spacing === 'loose' ? '0.5rem' : '0.4rem',
-        display: 'flex', 'align-items': 'center', gap: '0.4rem',
-      }}>
-        <span>{t(props.label)}</span>
-        <Show when={props.inspect}>
-          {(ins) => <InspectDot instanceKey={ins().instanceKey} leafId={ins().leafId} style={{ 'margin-left': 'auto' }} />}
-        </Show>
-      </div>
-      <Show when={props.text != null} fallback={props.children}>
-        <div style={SECTION_PROSE}>
-          <HebraizedWithRabbis text={props.text!} />
+      <Show
+        when={collapsible()}
+        fallback={<>{labelRow()}{body()}</>}
+      >
+        {/* clickable label toggles; the inspect 'i' inside stops propagation */}
+        <div
+          onClick={() => setOpen((v) => !v)}
+          role="button"
+          tabindex={0}
+          aria-expanded={open()}
+          onKeyDown={(e) => {
+            // Only the wrapper itself toggles — a keydown bubbled up from the
+            // focused inspect 'i' button must not also flip the fold.
+            if (e.currentTarget !== e.target) return;
+            if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setOpen((v) => !v); }
+          }}
+          style={{ cursor: 'pointer', 'user-select': 'none' }}
+        >
+          {labelRow()}
         </div>
+        <Show when={open()}>{body()}</Show>
       </Show>
     </div>
   );
@@ -338,8 +375,10 @@ export type SectionSpec =
   | { type: 'prose'; field: string }
   /** The synthesis card for the recipe's mark; feeds the shared `deps`. */
   | { type: 'synthesis' }
-  /** A labeled prose box rendering one dependent enrichment's `textField`. */
-  | { type: 'explainer'; dep: string; textField: string; labelKey: CatalogKey }
+  /** A labeled prose box rendering one dependent enrichment's `textField`.
+   *  Collapsed by default (the "dig deeper" layer under the synthesis); set
+   *  `defaultOpen` to lead with it expanded. */
+  | { type: 'explainer'; dep: string; textField: string; labelKey: CatalogKey; defaultOpen?: boolean }
   /** The follow-up Q&A affordance. */
   | { type: 'qa' }
   /** A genuinely-custom block, looked up by name in the card's `specialBlocks`.
@@ -486,7 +525,7 @@ export function SidebarCardFromHint(props: {
         };
         return (
           <Show when={text()}>
-            <SectionCard label={s.labelKey} text={text()} inspect={{ instanceKey: props.instanceKey, leafId: s.dep }} />
+            <SectionCard label={s.labelKey} text={text()} inspect={{ instanceKey: props.instanceKey, leafId: s.dep }} collapsed={!s.defaultOpen} />
           </Show>
         );
       }

--- a/tests/client/primitives.test.tsx
+++ b/tests/client/primitives.test.tsx
@@ -102,6 +102,31 @@ describe('Panel', () => {
   });
 });
 
+describe('SectionCard collapse', () => {
+  it('omitting `collapsed` keeps the body always rendered (no toggle)', () => {
+    const { container } = render(() => <SectionCard label="aggadata.background" text="body-text" />);
+    expect(container.textContent).toContain('body-text');
+    expect(container.querySelector('[role="button"]')).toBeNull();
+  });
+
+  it('`collapsed` hides the body until the label is clicked', () => {
+    const { container } = render(() => <SectionCard label="aggadata.background" text="hidden-body" collapsed />);
+    expect(container.textContent).not.toContain('hidden-body');
+    const toggle = container.querySelector('[role="button"]') as HTMLElement;
+    expect(toggle).toBeTruthy();
+    toggle.click();
+    expect(container.textContent).toContain('hidden-body');
+  });
+
+  it('`collapsed={false}` starts open but stays toggleable', () => {
+    const { container } = render(() => <SectionCard label="aggadata.background" text="shown-body" collapsed={false} />);
+    expect(container.textContent).toContain('shown-body');
+    const toggle = container.querySelector('[role="button"]') as HTMLElement;
+    toggle.click();
+    expect(container.textContent).not.toContain('shown-body');
+  });
+});
+
 describe('kindLabelKey / ACCENTS', () => {
   it('maps every kind to a real catalog key', () => {
     for (const kind of Object.keys(ACCENTS) as Array<keyof typeof ACCENTS>) {


### PR DESCRIPTION
Makes the synthesis the lead of a card and folds the supporting **explainer** cards (background / interpretation) underneath as a "dig deeper" layer, instead of stacking every paragraph open.

- `SectionCard` gains **`collapsed?: boolean`**: `true` starts folded · `false` starts open but toggleable · **omitted = the original always-open card** (DOM-identical, existing tests untouched).
- The fold is **signal-driven** (not native `<details>`) so the inspect **"i"** — which sits in the label row and `stopPropagation`s its click — never toggles the card. A keyboard guard (`currentTarget === target`) stops `Enter`/`Space` on the focused "i" from bubbling into a toggle. `role` / `tabindex` / `aria-expanded` for a11y.
- Recipe `explainer` sections are **collapsed by default**; the spec gains `defaultOpen?` to lead with one expanded when wanted.

So the Aggadata card now reads: theme · summary · **synthesis** (open) · ▸ Background · ▸ Interpretation · parallels · Q&A.

`pnpm typecheck` clean · `pnpm test` 1530/1530 · 3 new collapse tests. Codex-reviewed (both points fixed).