### PR TITLE
Aggadata card: summary as synthesis placeholder + Questions/Answers labels

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -1662,7 +1662,7 @@ export const AGGADATA_RECIPE: SidebarRecipe = {
   titleHeField: 'titleHe',
   sections: [
     { type: 'tags', fields: ['theme'] },
-    { type: 'prose', field: 'summary' },
+    { type: 'prose', field: 'summary', untilSynthesis: true },
     { type: 'synthesis' },
     { type: 'explainer', dep: 'aggadata.background', textField: 'background', labelKey: 'aggadata.background' },
     { type: 'explainer', dep: 'aggadata.interpretation', textField: 'interpretation', labelKey: 'aggadata.interpretation' },

--- a/src/client/QAPanel.tsx
+++ b/src/client/QAPanel.tsx
@@ -120,7 +120,7 @@ async function fetchSuggested(mark: string, tractate: string, page: string, inst
   const enrichmentId = `${mark}.suggested-questions`;
   const result = await trackAI(
     `${enrichmentId}:${tractate}:${page}:${instanceId}`,
-    `Suggested questions · ${instanceId}`,
+    `Questions · ${instanceId}`,
     () => runEnrichmentDirect(enrichmentId, tractate, page, instance),
   );
   const parsed = result.parsed as SuggestedQuestionsPayload | null;

--- a/src/client/i18n.ts
+++ b/src/client/i18n.ts
@@ -223,7 +223,7 @@ const CATALOG = {
 
   // — Questions (Q&A) panel —
   'qa.questions': { en: 'Questions', he: 'שאלות' },
-  'qa.empty': { en: 'No suggested questions yet. Ask your own below.', he: 'אין עדיין שאלות מוצעות. שאלו את שלכם למטה.' },
+  'qa.empty': { en: 'No questions yet. Ask your own below.', he: 'אין עדיין שאלות. שאלו את שלכם למטה.' },
   'qa.placeholder': { en: 'Ask your own question about this move…', he: 'שאלו שאלה משלכם על המהלך…' },
   'qa.submit': { en: 'Submit', he: 'שליחה' },
   'qa.cancel': { en: 'Cancel', he: 'ביטול' },

--- a/src/client/sidebar/primitives.tsx
+++ b/src/client/sidebar/primitives.tsx
@@ -371,8 +371,11 @@ export type SpecialBlock = (props: SpecialBlockProps) => JSX.Element;
 export type SectionSpec =
   /** Accent-tinted chips from instance fields (e.g. an aggadata theme). */
   | { type: 'tags'; fields: string[] }
-  /** A paragraph of an instance field, rabbi-linked + Hebraized (e.g. a summary). */
-  | { type: 'prose'; field: string }
+  /** A paragraph of an instance field, rabbi-linked + Hebraized (e.g. a summary).
+   *  `untilSynthesis` makes it a placeholder: shown only until the synthesis
+   *  section resolves, then replaced by it (the instant field fills the slot
+   *  while the richer paragraph computes). */
+  | { type: 'prose'; field: string; untilSynthesis?: boolean }
   /** The synthesis card for the recipe's mark; feeds the shared `deps`. */
   | { type: 'synthesis' }
   /** A labeled prose box rendering one dependent enrichment's `textField`.
@@ -476,9 +479,14 @@ export function SidebarCardFromHint(props: {
   const fields = (): Record<string, unknown> => props.instance.fields;
   const accent = (): string => ACCENTS[props.recipe.kind];
   const [deps, setDeps] = createSignal<Record<string, unknown>>({});
-  // Reset captured leaves when the instance changes (mirrors each old body's
-  // handleResolved reset) so a new instance doesn't show the previous one's deps.
-  createEffect(() => { void props.instanceKey; setDeps({}); });
+  // True once the synthesis has resolved (cache hit or fresh). A `prose` section
+  // with `untilSynthesis` shows only until then — the instant `summary` field
+  // fills the slot, then the richer synthesis paragraph replaces it.
+  const [synthesisReady, setSynthesisReady] = createSignal(false);
+  // Reset captured leaves + the synthesis-ready flag when the instance changes
+  // (mirrors each old body's handleResolved reset) so a new instance doesn't
+  // show the previous one's deps or skip its placeholder.
+  createEffect(() => { void props.instanceKey; setDeps({}); setSynthesisReady(false); });
 
   const renderSection = (s: SectionSpec): JSX.Element => {
     switch (s.type) {
@@ -501,7 +509,7 @@ export function SidebarCardFromHint(props: {
       }
       case 'prose':
         return (
-          <Show when={str(fields()[s.field])}>
+          <Show when={str(fields()[s.field]) && !(s.untilSynthesis && synthesisReady())}>
             <p style={{ margin: '0 0 0.8rem', color: '#333', 'line-height': 1.55 }}>
               <HebraizedWithRabbis text={str(fields()[s.field])} />
             </p>
@@ -515,7 +523,7 @@ export function SidebarCardFromHint(props: {
             instanceKey={props.instanceKey}
             tractate={props.tractate}
             page={props.page}
-            onResolved={(r) => setDeps(r.deps_resolved ?? {})}
+            onResolved={(r) => { setDeps(r.deps_resolved ?? {}); setSynthesisReady(true); }}
           />
         );
       case 'explainer': {

--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -3016,7 +3016,7 @@ CODE_ENRICHMENTS.push(
   // /api/run, on demand, so we don't fan out per-move LLM calls for
   // moves nobody opens.
   makeEnrichment(
-    'argument-move', 'argument-move.suggested-questions', 'Suggested questions',
+    'argument-move', 'argument-move.suggested-questions', 'Questions',
     'Curated follow-up questions the synthesis doesn\'t answer. Powers the Explore-deeper panel.',
     ARGUMENT_MOVE_SUGGESTED_QUESTIONS_SYSTEM_PROMPT, ARGUMENT_MOVE_SUGGESTED_QUESTIONS_USER_TEMPLATE, ARGUMENT_MOVE_SUGGESTED_QUESTIONS_OUTPUT_SCHEMA,
     {
@@ -3033,7 +3033,7 @@ CODE_ENRICHMENTS.push(
     },
   ),
   makeEnrichment(
-    'argument-move', 'argument-move.qa', 'Q&A',
+    'argument-move', 'argument-move.qa', 'Answers',
     'Answer one learner-supplied question about THIS move. Cache keyed per (move, normalized question).',
     ARGUMENT_MOVE_QA_SYSTEM_PROMPT, ARGUMENT_MOVE_QA_USER_TEMPLATE, ARGUMENT_MOVE_QA_OUTPUT_SCHEMA,
     {
@@ -4595,7 +4595,7 @@ CODE_ENRICHMENTS.push(
   // Mirror of argument-move.suggested-questions / argument-move.qa: powers the
   // QAPanel "Questions" expander attached to each pasuk card.
   makeEnrichment(
-    'pesukim', 'pesukim.suggested-questions', 'Suggested questions',
+    'pesukim', 'pesukim.suggested-questions', 'Questions',
     'Curated follow-up questions the synthesis doesn\'t answer. Powers the Questions panel on each pasuk card.',
     PESUKIM_SUGGESTED_QUESTIONS_SYSTEM_PROMPT, PESUKIM_SUGGESTED_QUESTIONS_USER_TEMPLATE, PESUKIM_SUGGESTED_QUESTIONS_OUTPUT_SCHEMA,
     {
@@ -4612,7 +4612,7 @@ CODE_ENRICHMENTS.push(
     },
   ),
   makeEnrichment(
-    'pesukim', 'pesukim.qa', 'Q&A',
+    'pesukim', 'pesukim.qa', 'Answers',
     'Answer one learner-supplied question about THIS pasuk citation. Cache keyed per (verse, normalized question).',
     PESUKIM_QA_SYSTEM_PROMPT, PESUKIM_QA_USER_TEMPLATE, PESUKIM_QA_OUTPUT_SCHEMA,
     {
@@ -5124,7 +5124,7 @@ CODE_ENRICHMENTS.push(
     },
   ),
   makeEnrichment(
-    'aggadata', 'aggadata.suggested-questions', 'Suggested questions',
+    'aggadata', 'aggadata.suggested-questions', 'Questions',
     'Curated follow-up questions the synthesis doesn\'t answer. Powers the Questions panel on each aggadah card.',
     AGGADATA_SUGGESTED_QUESTIONS_SYSTEM_PROMPT, AGGADATA_SUGGESTED_QUESTIONS_USER_TEMPLATE, AGGADATA_SUGGESTED_QUESTIONS_OUTPUT_SCHEMA,
     {
@@ -5141,7 +5141,7 @@ CODE_ENRICHMENTS.push(
     },
   ),
   makeEnrichment(
-    'aggadata', 'aggadata.qa', 'Q&A',
+    'aggadata', 'aggadata.qa', 'Answers',
     'Answer one learner-supplied question about THIS aggadic story. Cache keyed per (story, normalized question).',
     AGGADATA_QA_SYSTEM_PROMPT, AGGADATA_QA_USER_TEMPLATE, AGGADATA_QA_OUTPUT_SCHEMA,
     {


### PR DESCRIPTION
Two clarity changes from reading the card together.

### 1. Summary is now the synthesis's placeholder
A `prose` section gains **`untilSynthesis`**: it shows only while the synthesis hasn't resolved, then steps aside for it.
- `summary` has **no dependencies** (it's extracted with the story), so it paints **instantly** — a meaningful skeleton while the synthesis (which needs 3 dep enrichments) computes.
- The moment the synthesis section's `onResolved` fires (cache hit **or** fresh), the summary hides and the richer paragraph takes the slot. Warmed dapim skip straight to synthesis with no flicker; cold ones show summary → synthesis.
- Resets per instance (cleared alongside `deps` on `instanceKey` change). If synthesis errors/never resolves, the summary stays (correct fallback).

### 2. "Questions" / "Answers" producer labels
The two Q&A producers were confusingly named in the dev Marks panel. Renamed the **display labels**:
- `*.suggested-questions` → **Questions** (it already covers asking your own — the reader header was already "Questions")
- `*.qa` → **Answers** (it produces the answers)

Across `argument-move` / `pesukim` / `aggadata`. **The enrichment IDs and `defHash`/`cacheVersion` are unchanged** — labels are display-only, so every cache stays valid (Codex confirmed cache keys + `recipeHash` exclude `label`). Also aligned the `qa.empty` reader string and the dev activity label.

`pnpm typecheck` clean · `pnpm test` 1530/1530. Codex: no blocking findings.