### PR TITLE
Checks: fuzzy fallback for anchor-verbatim (soft path only)

### DIFF
--- a/src/lib/check/postcheck.ts
+++ b/src/lib/check/postcheck.ts
@@ -165,7 +165,74 @@ function instancesOf(parsed: unknown): RangeInstance[] {
  *  itself rejects <2-word needles as too ambiguous). Severity is per kind:
  *  anchor-out-of-range is always `hard` (an index past the daf is never a false
  *  positive); excerpt-not-in-segment is `hard` only on the pesukim/aggadata
- *  marks (see severityOf). */
+ *  marks (see severityOf).
+ *
+ *  The exact prefix match still false-positives on two shapes the matcher can't
+ *  see: malé/ḥaser spelling variants (normalizeHebrew strips nikud but NOT the
+ *  vav/yod matres — מצות vs מצוות) and a lightly-paraphrased OPENING (the tail
+ *  is already tolerated by prefixing, but a reworded first word breaks every
+ *  prefix). So when the exact match misses, fall back to a fuzzy presence test:
+ *  the excerpt is "present" if, at some start offset, ≥FUZZY_PRESENCE_FLOOR of
+ *  its content words align POSITIONALLY with consecutive segment words under an
+ *  edit-distance-1 token match. Ordered alignment (not bag-of-words) stops a
+ *  reordered/scattered set of common words from passing. The fallback relaxes
+ *  only SOFT flags — on the hard pesukim/aggadata path it stays exact, so a
+ *  genuinely mis-anchored excerpt still gates the cache — and never touches the
+ *  placer, so it cannot regress placement or the golden anchors. */
+
+/** Within `max` single-char edits (insert/delete/substitute)? Specialized for
+ *  max=1 — the common malé/ḥaser (single vav/yod) distance — with an early exit
+ *  rather than a full DP table. */
+function withinEdits(a: string, b: string, max: number): boolean {
+  if (a === b) return true;
+  const la = a.length, lb = b.length;
+  if (Math.abs(la - lb) > max) return false;
+  if (la === lb) {
+    let diff = 0;
+    for (let i = 0; i < la; i++) if (a[i] !== b[i] && ++diff > max) return false;
+    return true;
+  }
+  // lengths differ by one: is the shorter the longer with a single deletion?
+  const [short, long] = la < lb ? [a, b] : [b, a];
+  let i = 0, j = 0, skips = 0;
+  while (i < short.length && j < long.length) {
+    if (short[i] === long[j]) { i++; j++; }
+    else if (++skips > max) return false;
+    else j++;
+  }
+  return true;
+}
+
+/** Fraction of the excerpt's content words (≥2 chars) that must align under the
+ *  positional fuzzy match for the excerpt to count as present. 0.6 keeps 2-word
+ *  excerpts strict (both words required) while tolerating ~40% drift on longer
+ *  ones. */
+export const FUZZY_PRESENCE_FLOOR = 0.6;
+
+/** Ordered, contiguous fuzzy presence: is there a start offset where the
+ *  excerpt's content words line up positionally with consecutive segment words
+ *  (each within one edit) for at least FUZZY_PRESENCE_FLOOR of them? Positional
+ *  alignment — not bag-of-words — so a scattered/reordered handful of common
+ *  words can't pass. Only ever used to suppress a SOFT flag (see call site). */
+function fuzzyPresent(excerpt: string, segWords: string[]): boolean {
+  const exWords = normalizeHebrew(excerpt).split(' ').filter((w) => w.length >= 2);
+  if (exWords.length === 0) return false;
+  const need = Math.ceil(exWords.length * FUZZY_PRESENCE_FLOOR);
+  for (let start = 0; start < segWords.length; start++) {
+    let matched = 0;
+    // Out-of-range positions (a window running past the segment end) simply stop
+    // the loop — they never count as matches, so `matched` is honest. A pass at
+    // the tail therefore means the excerpt's OPENING aligns here and the rest
+    // spills into the next segment: the same boundary-spill the prefix matcher
+    // already tolerates, intentionally kept.
+    for (let k = 0; k < exWords.length && start + k < segWords.length; k++) {
+      if (withinEdits(exWords[k], segWords[start + k], 1)) matched++;
+    }
+    if (matched >= need) return true;
+  }
+  return false;
+}
+
 const anchorVerbatim: PostCheck = {
   id: 'anchor-verbatim',
   phase: 'validate',
@@ -182,10 +249,16 @@ const anchorVerbatim: PostCheck = {
         issues.push({ kind: 'anchor-out-of-range', severity: severityOf('anchor-out-of-range', ctx.defId), match: excerpt, index: typeof seg === 'number' ? seg : -1 });
         continue;
       }
-      // Confine the search to the single anchored segment: a hit there is the
-      // same prefix the placer would have matched to land on this segment.
-      if (!findExcerpt(grid, excerpt, seg, seg)) {
-        issues.push({ kind: 'excerpt-not-in-segment', severity: severityOf('excerpt-not-in-segment', ctx.defId), match: excerpt, index: seg });
+      // Confine the search to the single anchored segment: an exact prefix hit
+      // there is the same one the placer matched to land here. On a miss, the
+      // fuzzy fallback absorbs spelling/opening-paraphrase variants — but only
+      // for SOFT flags; the hard pesukim/aggadata path stays exact so a genuine
+      // mis-anchor still gates the cache.
+      const sev = severityOf('excerpt-not-in-segment', ctx.defId);
+      const present = !!findExcerpt(grid, excerpt, seg, seg)
+        || (sev === 'soft' && fuzzyPresent(excerpt, grid.segWords[seg]));
+      if (!present) {
+        issues.push({ kind: 'excerpt-not-in-segment', severity: sev, match: excerpt, index: seg });
       }
     }
     return { issues };

--- a/tests/check/soft-checks.test.ts
+++ b/tests/check/soft-checks.test.ts
@@ -84,6 +84,45 @@ describe('anchor-verbatim', () => {
     expect(kinds(issues)).toEqual(['excerpt-not-in-segment']);
     expect(issues[0].index).toBe(1);
   });
+
+  // Fuzzy fallback: an excerpt genuinely present but with a malé/ḥaser spelling
+  // variant or a reworded opening (which breaks every exact prefix) must not be
+  // flagged — the words are there.
+  it('does NOT flag a malé/ḥaser spelling variant present in the segment (fuzzy fallback)', async () => {
+    // seg0 has the full spelling "העולם"; the excerpt drops the vav ("העלם").
+    const fuzzy = ['כל העולם כולו'];
+    const parsed = { instances: [{ startSegIdx: 0, fields: { excerpt: 'כל העלם' } }] };
+    const { issues } = await runChecks(['anchor-verbatim'], parsed, ctx({ segmentsHe: fuzzy, defId: 'argument-move' }));
+    expect(issues).toEqual([]);
+  });
+
+  it('does NOT flag a reworded opening when the rest of the words are present (fuzzy fallback)', async () => {
+    // seg2 is "אמר רבא הלכה כרבי"; excerpt opens "ואמר" (extra vav) so no exact
+    // prefix matches, but 3/3 words are present within one edit.
+    const parsed = { instances: [{ startSegIdx: 2, fields: { excerpt: 'ואמר רבא הלכה' } }] };
+    const { issues } = await runChecks(['anchor-verbatim'], parsed, ctx({ segmentsHe: segs, defId: 'argument-move' }));
+    expect(issues).toEqual([]);
+  });
+
+  it('still flags when only a single common word overlaps (fuzzy fallback does not over-suppress)', async () => {
+    // seg2 "אמר רבא הלכה כרבי": the excerpt shares only "אמר"; 1/3 < floor.
+    const parsed = { instances: [{ startSegIdx: 2, fields: { excerpt: 'אמר אביי בגמרא' } }] };
+    const { issues } = await runChecks(['anchor-verbatim'], parsed, ctx({ segmentsHe: segs, defId: 'argument-move' }));
+    expect(kinds(issues)).toEqual(['excerpt-not-in-segment']);
+  });
+
+  it('does NOT apply the fuzzy fallback on the hard pesukim/aggadata path (exact-only, still gates)', async () => {
+    // 'ואמר רבא הלכה' would fuzzily match seg2 (and is suppressed on the soft
+    // path above) — but on pesukim the kind is HARD, so it stays exact and a
+    // non-verbatim excerpt must still flag to gate the cache.
+    const parsed = { instances: [{ startSegIdx: 2, fields: { excerpt: 'ואמר רבא הלכה' } }] };
+    const pesukim = await runChecks(['anchor-verbatim'], parsed, ctx({ segmentsHe: segs, defId: 'pesukim' }));
+    expect(kinds(pesukim.issues)).toEqual(['excerpt-not-in-segment']);
+    expect(pesukim.issues[0].severity).toBe('hard');
+    // Same excerpt on the soft argument-move path is suppressed by the fallback.
+    const move = await runChecks(['anchor-verbatim'], parsed, ctx({ segmentsHe: segs, defId: 'argument-move' }));
+    expect(move.issues).toEqual([]);
+  });
 });
 
 describe('partition-clean', () => {


### PR DESCRIPTION
## What

Makes the `anchor-verbatim` soft signal actually meaningful by cutting its false positives, without weakening the hard gate.

### Problem
The check verifies an LLM-quoted Hebrew excerpt is present in the segment it was anchored to, via an exact prefix match (`findExcerpt`) confined to that segment. Two shapes that are genuinely present still miss:
- **malé/ḥaser spelling variants** — `normalizeHebrew` strips nikud/cantillation but not the vav/yod matres (מצות vs מצוות);
- **a reworded opening word** — the tail is already tolerated by prefixing, but a paraphrased first word breaks every prefix.

On a soft, observe-only flag this is pure noise — which is what made the signal feel pointless.

### Change
On an exact miss, fall back to `fuzzyPresent`: at some start offset, ≥`FUZZY_PRESENCE_FLOOR` (0.6) of the excerpt's ≥2-char words align **positionally** with consecutive segment words under an **edit-distance-1** token match (`withinEdits`). Ordered/positional alignment — not bag-of-words — so a scattered or reordered handful of common words can't pass.

### Scope & safety (shaped by Codex review)
- **Soft path only.** On the hard `pesukim`/`aggadata` path the check stays exact, so a genuinely mis-anchored excerpt still gates the cache write. (Codex's first pass caught that an unordered bag-of-words fallback could mask a real hallucination on the hard path; fixed by both the ordered matcher and the soft-only gate.)
- **Never touches the placer.** `findExcerpt` and the golden anchors are unchanged; the fallback can only *suppress* a flag, never add one, so it cannot regress placement.
- **No phantom tail matches.** A window running past the segment end never inflates the match count, so a tail pass is the legitimate boundary-spill the prefix matcher already tolerated.

Severity is unchanged — promoting `excerpt-not-in-segment` to hard for argument/argument-move stays gated on a real eval over the fixed daf set (a follow-up).

## Tests
4 new cases (malé/ḥaser suppression, reworded-opening suppression, single-word-overlap still flags, hard-path stays exact). `pnpm typecheck` clean; full suite 1535 passing.