### PR TITLE
Fix: rabbi names dropped when copying sidebar prose

### DIFF
--- a/src/client/rabbiLinks.tsx
+++ b/src/client/rabbiLinks.tsx
@@ -159,13 +159,22 @@ export function RabbiText(props: {
       // daf.
       const resolved = resolveRabbi(p.value, props.rabbis);
       const targetName = resolved ? resolved.name : p.value;
+      // Inline <span role="link">, NOT <button> — a <button>'s text is atomic
+      // and gets dropped when the user selects/copies the surrounding prose, so
+      // copying a paragraph silently lost every rabbi name. A span keeps the
+      // name in the document text flow (copyable) while staying clickable +
+      // keyboard-accessible.
       return (
-        <button
-          type="button"
+        <span
+          role="link"
+          tabindex={0}
           onClick={(e) => { e.stopPropagation(); props.onPushRabbi(targetName); }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); e.stopPropagation(); props.onPushRabbi(targetName); }
+          }}
           style={linkStyle}
           title={`Open ${targetName}`}
-        >{p.value}</button>
+        >{p.value}</span>
       );
     }}</For>
   );

--- a/tests/client/rabbi-links.test.tsx
+++ b/tests/client/rabbi-links.test.tsx
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+import { render } from '@solidjs/testing-library';
+import { describe, expect, it, vi } from 'vitest';
+import { RabbiText } from '../../src/client/rabbiLinks';
+import type { IdentifiedRabbi } from '../../src/client/dafContext';
+
+const RABBIS: IdentifiedRabbi[] = [
+  { name: 'Rabban Gamliel', nameHe: 'רבן גמליאל', mentions: [] } as unknown as IdentifiedRabbi,
+];
+
+describe('RabbiText copy-friendliness', () => {
+  it('renders a matched rabbi name as an inline copyable element (not a <button>)', () => {
+    const { container } = render(() => (
+      <RabbiText text="Rabban Gamliel ruled leniently." rabbis={RABBIS} onPushRabbi={() => {}} />
+    ));
+    // The name must be in the text flow so it survives select+copy of the prose.
+    expect(container.textContent).toContain('Rabban Gamliel');
+    // It must NOT be a <button> (atomic, dropped on copy).
+    expect(container.querySelector('button')).toBeNull();
+    const link = container.querySelector('[role="link"]') as HTMLElement;
+    expect(link).toBeTruthy();
+    expect(link.textContent).toBe('Rabban Gamliel');
+  });
+
+  it('still routes on click', () => {
+    const onPush = vi.fn();
+    const { container } = render(() => (
+      <RabbiText text="see Rabban Gamliel here" rabbis={RABBIS} onPushRabbi={onPush} />
+    ));
+    (container.querySelector('[role="link"]') as HTMLElement).click();
+    expect(onPush).toHaveBeenCalledWith('Rabban Gamliel');
+  });
+});


### PR DESCRIPTION
Rabbi mentions in card prose rendered as `<button>` elements, and browsers treat a button's text as **atomic** — it's excluded when you select + copy the surrounding paragraph. So copying the aggadata synthesis produced `"'s sons return late…"` with **"Rabban Gamliel" missing**.

Fix: render each mention as an inline **`<span role="link" tabindex=0>`** instead of a `<button>`. The name stays in the document text flow (copyable) while remaining clickable and keyboard-activatable (Enter/Space). Styling unchanged.

`pnpm typecheck` clean · `pnpm test` 1537/1537 · new `rabbi-links` test (asserts copyable text flow + not a button + still routes on click).