### PR TITLE
Checks: rename the post-LLM pass abstraction (checks -> passes)

### DIFF
--- a/src/client/ChecksPanel.tsx
+++ b/src/client/ChecksPanel.tsx
@@ -1,7 +1,7 @@
 /**
- * Dev-panel surfacing for the post-LLM check layer. Calls
+ * Dev-panel surfacing for the post-LLM pass layer. Calls
  * GET /api/checks/:tractate/:page — which re-runs each daf-level mark's
- * declared checks against its ALREADY-CACHED (anchored) output, no LLM — and
+ * declared passes against its ALREADY-CACHED (anchored) output, no LLM — and
  * lists what the soft/observe-only checks (anchor-verbatim, partition-clean, …)
  * flag on the daf in view. This is the observation surface for deciding whether
  * a soft check is trustworthy enough to promote to a hard, cache-gating one.

--- a/src/lib/check/passes.ts
+++ b/src/lib/check/passes.ts
@@ -1,16 +1,18 @@
 /**
- * Standardized post-LLM check layer. Replaces the two hardcoded
+ * Standardized post-LLM pass layer. Replaces the two hardcoded
  * `if (def.id === …)` chains in the worker's runMarkOnce / runEnrichmentOnce
  * (one for anchor-resolution transforms, one for the Hebrew linters) with a
- * single registry of named checks that a definition opts into via `checks: []`.
+ * single registry of named passes that a definition opts into via `passes: []`.
  *
- * Two phases:
- *   - transform: mutates/returns `parsed` (placement, anchor resolution).
- *   - validate:  inspects `parsed`, returns issues. `hard` issues gate the
- *                cache write (via the existing bounded-retry); `soft` issues
+ * A pass is one of two phases — only the validate phase is a "check" (it judges
+ * the output); transform passes derive/repair it:
+ *   - transform: mutates/returns `parsed` (placement, anchor resolution, the
+ *                voice-graph derivation). Not a check — it builds, not judges.
+ *   - validate:  inspects `parsed`, returns issues (a check). `hard` issues gate
+ *                the cache write (via the existing bounded-retry); `soft` issues
  *                are attached as a quality signal but never block.
  *
- * runChecks runs all transforms (in the order listed) then all validators.
+ * runPasses runs all transforms (in the order listed) then all validators.
  * DOM-free / env-free so it lives in src/lib and is unit-testable.
  */
 
@@ -32,7 +34,7 @@ export interface CheckIssue {
   detail?: string;
 }
 
-export interface CheckCtx {
+export interface PassCtx {
   tractate: string;
   page: string;
   /** Segment grid for placement/anchor transforms (the gemara slice). */
@@ -44,17 +46,17 @@ export interface CheckCtx {
   lang?: 'en' | 'he';
 }
 
-export type CheckResult = { parsed: unknown } | { issues: CheckIssue[] };
+export type PassResult = { parsed: unknown } | { issues: CheckIssue[] };
 
-export interface PostCheck {
+export interface PostPass {
   id: string;
   phase: 'transform' | 'validate';
-  run(parsed: unknown, ctx: CheckCtx): CheckResult | Promise<CheckResult>;
+  run(parsed: unknown, ctx: PassCtx): PassResult | Promise<PassResult>;
 }
 
-// ---- transform checks: anchor resolution via the unified placer ----
+// ---- transform passes: anchor resolution via the unified placer ----
 
-const transform = (id: string, fn: (p: unknown, segs: string[]) => unknown): PostCheck => ({
+const transform = (id: string, fn: (p: unknown, segs: string[]) => unknown): PostPass => ({
   id,
   phase: 'transform',
   run: (parsed, ctx) => ({ parsed: fn(parsed, ctx.segmentsHe) }),
@@ -72,7 +74,7 @@ function synthesisText(parsed: unknown): string {
       .join('\n\n');
 }
 
-const hebrewExcerpt: PostCheck = {
+const hebrewExcerpt: PostPass = {
   id: 'hebrew-excerpt',
   phase: 'validate',
   run: (parsed) => ({
@@ -86,7 +88,7 @@ const hebrewExcerpt: PostCheck = {
   }),
 };
 
-const hebrewGloss: PostCheck = {
+const hebrewGloss: PostPass = {
   id: 'hebrew-gloss',
   phase: 'validate',
   run: (parsed) => ({
@@ -233,7 +235,7 @@ function fuzzyPresent(excerpt: string, segWords: string[]): boolean {
   return false;
 }
 
-const anchorVerbatim: PostCheck = {
+const anchorVerbatim: PostPass = {
   id: 'anchor-verbatim',
   phase: 'validate',
   run: (parsed, ctx) => {
@@ -271,7 +273,7 @@ const anchorVerbatim: PostCheck = {
  *  daf — no overlapping section ranges. Move-level overlaps are legitimate
  *  (several moves can share one segment), so overlap is only checked for
  *  `argument`. Catches the duplicated-move / overshooting-section bugs. */
-const partitionClean: PostCheck = {
+const partitionClean: PostPass = {
   id: 'partition-clean',
   phase: 'validate',
   run: (parsed, ctx) => {
@@ -314,7 +316,7 @@ const partitionClean: PostCheck = {
  *  every edge's from/to names a declared voice, no self-loops, and no single
  *  voice pair carries both an `opposes` and a `supports` edge (a contradiction
  *  the model occasionally emits when it double-labels a resolution). */
-const edgeIntegrity: PostCheck = {
+const edgeIntegrity: PostPass = {
   id: 'edge-integrity',
   phase: 'validate',
   run: (parsed, ctx) => {
@@ -373,7 +375,7 @@ function hebrewRuns(text: string, minWords: number): string[] {
  *  each ≥3-word Hebrew run in the rashi/tosafot/other prose fields, verify it is
  *  present (via the verbatim matcher) in ctx.commentaryHe. Skips when no
  *  commentary is loaded (can't judge → no false positives). Soft (observe). */
-const commentaryVerbatim: PostCheck = {
+const commentaryVerbatim: PostPass = {
   id: 'commentary-verbatim',
   phase: 'validate',
   run: (parsed, ctx) => {
@@ -395,7 +397,7 @@ const commentaryVerbatim: PostCheck = {
   },
 };
 
-export const CHECKS: Record<string, PostCheck> = {
+export const PASSES: Record<string, PostPass> = {
   'reanchor-argument': transform('reanchor-argument', reanchorArgument),
   'reanchor-argument-move': transform('reanchor-argument-move', reanchorArgumentMove),
   'reanchor-pesukim': transform('reanchor-pesukim', reanchorPesukim),
@@ -411,23 +413,23 @@ export const CHECKS: Record<string, PostCheck> = {
   'edge-integrity': edgeIntegrity,
 };
 
-/** Run the named checks: transforms first (in listed order), then validators.
- *  Unknown ids are ignored (a definition may reference a check not yet shipped). */
-export async function runChecks(
+/** Run the named passes: transforms first (in listed order), then validators.
+ *  Unknown ids are ignored (a definition may reference a pass not yet shipped). */
+export async function runPasses(
   checkIds: readonly string[],
   parsed: unknown,
-  ctx: CheckCtx,
+  ctx: PassCtx,
 ): Promise<{ parsed: unknown; issues: CheckIssue[] }> {
   let current = parsed;
   const issues: CheckIssue[] = [];
   for (const id of checkIds) {
-    const c = CHECKS[id];
+    const c = PASSES[id];
     if (!c || c.phase !== 'transform') continue;
     const r = await c.run(current, ctx);
     if ('parsed' in r) current = r.parsed;
   }
   for (const id of checkIds) {
-    const c = CHECKS[id];
+    const c = PASSES[id];
     if (!c || c.phase !== 'validate') continue;
     const r = await c.run(current, ctx);
     if ('issues' in r) issues.push(...r.issues);

--- a/src/lib/typing/voices.ts
+++ b/src/lib/typing/voices.ts
@@ -22,7 +22,7 @@ interface VoiceEdge { from?: unknown; to?: unknown; kind?: unknown; [k: string]:
 interface VoicesGraph { voices?: unknown; edges?: unknown; [k: string]: unknown }
 
 /** Repair the edge directions + drop malformed edges. Mutates + returns the
- *  graph (matches the other transform checks' contract). Non-graph input and a
+ *  graph (matches the other transform passes' contract). Non-graph input and a
  *  missing edges array pass through untouched. */
 export function deriveVoiceEdges(parsed: unknown): unknown {
   if (!parsed || typeof parsed !== 'object') return parsed;

--- a/src/worker/cache-keys.ts
+++ b/src/worker/cache-keys.ts
@@ -68,7 +68,7 @@ function canonicalJSON(value: unknown): string {
  * hand-authored literal, so it cannot drift from reality the way the current
  * `def_hash` strings have (e.g. 'rabbi-v2' never re-derives).
  *
- * Deliberately EXCLUDED: `checks` (post-processing, not a generation input),
+ * Deliberately EXCLUDED: `passes` (post-processing, not a generation input),
  * `dependencies` (composition — hashed via their own recipes), and the
  * bookkeeping fields (`cache_version` / `def_hash` / `status` / `source` /
  * `updated_at` / `id` / `label`). Field-order insensitive.

--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -507,7 +507,7 @@ export const CODE_MARKS: MarkDefinition[] = [
       thinking_off: true,
     },
     dependencies: ['gemara'],
-    checks: ['reanchor-argument', 'anchor-verbatim', 'partition-clean'],
+    passes: ['reanchor-argument', 'anchor-verbatim', 'partition-clean'],
     status: 'promoted',
     def_hash: 'argument-llm-v3',
     cache_version: '4',
@@ -614,7 +614,7 @@ export const CODE_MARKS: MarkDefinition[] = [
       thinking_off: true,
     },
     dependencies: ['gemara'],
-    checks: ['reanchor-aggadata', 'anchor-verbatim'],
+    passes: ['reanchor-aggadata', 'anchor-verbatim'],
     status: 'promoted',
     def_hash: 'aggadata-llm-v3',
     cache_version: '4',
@@ -643,7 +643,7 @@ export const CODE_MARKS: MarkDefinition[] = [
       thinking_off: true,
     },
     dependencies: ['gemara'],
-    checks: ['reanchor-pesukim', 'anchor-verbatim'],
+    passes: ['reanchor-pesukim', 'anchor-verbatim'],
     status: 'promoted',
     def_hash: 'pesukim-llm-v4',
     cache_version: '5',
@@ -1392,8 +1392,8 @@ function makeEnrichment(
     mode: 'augment-content' | 'aggregate';
     scope: EnrichmentScope;
     dependencies?: EnrichmentDependency[];
-    /** Post-LLM validators this enrichment opts into (see EnrichmentDefinition.checks). */
-    checks?: string[];
+    /** Post-LLM validators this enrichment opts into (see EnrichmentDefinition.passes). */
+    passes?: string[];
     defHash: string;
     cacheVersion: string;
     model?: LLMModelId;
@@ -1416,7 +1416,7 @@ function makeEnrichment(
     mode: opts.mode,
     scope: opts.scope,
     dependencies: opts.dependencies,
-    ...(opts.checks ? { checks: opts.checks } : {}),
+    ...(opts.passes ? { passes: opts.passes } : {}),
     extractor: {
       kind: 'llm',
       ...(opts.model ? { model: opts.model } : {}),
@@ -1450,7 +1450,7 @@ const makeRabbiEnrichment = (
     mode: 'augment-content' | 'aggregate';
     scope: EnrichmentScope;
     dependencies?: EnrichmentDependency[];
-    checks?: string[];
+    passes?: string[];
     defHash: string;
     cacheVersion: string;
     systemPromptHe?: string;
@@ -1471,7 +1471,7 @@ function makeSynthesis(
   userPromptTemplate: string,
   opts: {
     dependencies: EnrichmentDependency[];
-    checks?: string[];
+    passes?: string[];
     defHash: string;
     cacheVersion: string;
     scope?: EnrichmentScope;
@@ -1488,7 +1488,7 @@ function makeSynthesis(
       mode: 'aggregate',
       scope: opts.scope ?? 'local',
       dependencies: opts.dependencies,
-      checks: opts.checks,
+      passes: opts.passes,
       defHash: opts.defHash,
       cacheVersion: opts.cacheVersion,
       model: opts.model,
@@ -1611,7 +1611,7 @@ export const CODE_ENRICHMENTS: EnrichmentDefinition[] = [
     {
       mode: 'augment-content', scope: 'local',
       dependencies: ['gemara', { enrichment: 'rabbi.relationships' }],
-      checks: ['reanchor-rabbi-evidence'],
+      passes: ['reanchor-rabbi-evidence'],
       defHash: 'rabbi.relationships.evidence-v2', cacheVersion: '2',
       systemPromptHe: RABBI_RELATIONSHIPS_EVIDENCE_SYSTEM_PROMPT_HE,
       userPromptTemplateHe: RABBI_RELATIONSHIPS_EVIDENCE_USER_TEMPLATE_HE,
@@ -1624,7 +1624,7 @@ export const CODE_ENRICHMENTS: EnrichmentDefinition[] = [
     {
       mode: 'augment-content', scope: 'local',
       dependencies: ['gemara', { enrichment: 'rabbi.geography' }],
-      checks: ['reanchor-rabbi-evidence'],
+      passes: ['reanchor-rabbi-evidence'],
       defHash: 'rabbi.geography.evidence-v2', cacheVersion: '2',
       systemPromptHe: RABBI_GEOGRAPHY_EVIDENCE_SYSTEM_PROMPT_HE,
       userPromptTemplateHe: RABBI_GEOGRAPHY_EVIDENCE_USER_TEMPLATE_HE,
@@ -2060,7 +2060,7 @@ CODE_ENRICHMENTS.push(
     {
       mode: 'augment-content', scope: 'local',
       dependencies: ['gemara', { mark: 'argument-move' }, { mark: 'rabbi' }],
-      checks: ['derive-voice-edges', 'edge-integrity'],
+      passes: ['derive-voice-edges', 'edge-integrity'],
       defHash: 'argument.voices-v5', cacheVersion: '5',
       model: ARGUMENT_FLASH_MODEL,
       systemPromptHe: ARGUMENT_VOICES_SYSTEM_PROMPT_HE,
@@ -2074,7 +2074,7 @@ CODE_ENRICHMENTS.push(
     {
       mode: 'augment-content', scope: 'local',
       dependencies: ['gemara', { mark: 'argument-move' }, { mark: 'rabbi' }],
-      checks: ['reanchor-narrative'],
+      passes: ['reanchor-narrative'],
       defHash: 'argument.narrative-v2', cacheVersion: '3', // v3: native Hebrew prompt
       model: ARGUMENT_FLASH_MODEL,
       systemPromptHe: ARGUMENT_NARRATIVE_SYSTEM_PROMPT_HE,
@@ -2610,7 +2610,7 @@ CODE_MARKS.push({
     fan_out_over: 'argument',
   },
   dependencies: ['gemara', { mark: 'argument' }],
-  checks: ['reanchor-argument-move', 'anchor-verbatim', 'partition-clean'],
+  passes: ['reanchor-argument-move', 'anchor-verbatim', 'partition-clean'],
   status: 'promoted',
   def_hash: 'argument-move-v9',
   cache_version: '9',
@@ -2986,7 +2986,7 @@ CODE_ENRICHMENTS.push(
     {
       mode: 'augment-content', scope: 'local',
       dependencies: ['gemara', 'commentaries'],
-      checks: ['commentary-verbatim'],
+      passes: ['commentary-verbatim'],
       defHash: 'argument-move.commentaries-v2', cacheVersion: '2',
       model: ARGUMENT_FLASH_MODEL,
       systemPromptHe: ARGUMENT_MOVE_COMMENTARIES_SYSTEM_PROMPT_HE,
@@ -3806,7 +3806,7 @@ CODE_ENRICHMENTS.push(
     {
       mode: 'augment-content', scope: 'local',
       dependencies: ['gemara'],
-      checks: ['hebrew-gloss'],
+      passes: ['hebrew-gloss'],
       defHash: 'halacha.codification-v3', cacheVersion: '3',
       systemPromptHe: HALACHA_CODIFICATION_SYSTEM_PROMPT_HE,
       userPromptTemplateHe: HALACHA_LEAF_USER_TEMPLATE_HE,
@@ -3819,7 +3819,7 @@ CODE_ENRICHMENTS.push(
     {
       mode: 'augment-content', scope: 'local',
       dependencies: ['gemara'],
-      checks: ['hebrew-gloss'],
+      passes: ['hebrew-gloss'],
       defHash: 'halacha.practical-v4', cacheVersion: '4',
       systemPromptHe: HALACHA_PRACTICAL_SYSTEM_PROMPT_HE,
       userPromptTemplateHe: HALACHA_LEAF_USER_TEMPLATE_HE,
@@ -3832,7 +3832,7 @@ CODE_ENRICHMENTS.push(
     {
       mode: 'augment-content', scope: 'local',
       dependencies: ['gemara'],
-      checks: ['hebrew-gloss'],
+      passes: ['hebrew-gloss'],
       defHash: 'halacha.disputes-v3', cacheVersion: '3',
       systemPromptHe: HALACHA_DISPUTES_SYSTEM_PROMPT_HE,
       userPromptTemplateHe: HALACHA_LEAF_USER_TEMPLATE_HE,
@@ -3849,7 +3849,7 @@ CODE_ENRICHMENTS.push(
         { enrichment: 'halacha.practical' },
         { enrichment: 'halacha.disputes' },
       ],
-      checks: ['hebrew-gloss'],
+      passes: ['hebrew-gloss'],
       defHash: 'halacha.synthesis-v4', cacheVersion: '4',
       systemPromptHe: HALACHA_SYNTHESIS_SYSTEM_PROMPT_HE,
       userPromptTemplateHe: HALACHA_SYNTHESIS_USER_TEMPLATE_HE,
@@ -4582,7 +4582,7 @@ CODE_ENRICHMENTS.push(
         { mark: 'rabbi' },
         { mark: 'pesukim' },
       ],
-      checks: ['hebrew-excerpt'],
+      passes: ['hebrew-excerpt'],
       defHash: 'pesukim.synthesis-v11', cacheVersion: '11',
       // Pro instead of Flash: the synthesis must follow the 3-4 sentence
       // structure and avoid the explicit banned-phrase list. Flash skims

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -68,7 +68,7 @@ import { wrapEnv, gatewayStatus, gatewayActive } from './ai-gateway';
 import { runLLM, type LLMModelId, type LLMResult, type LLMUsage } from './llm';
 import { checkBudget, isBudgetPaused, budgetStatus, clearPauses, type BudgetScope } from './budget';
 import { lookupRelationships } from './rabbi-graph';
-import { runChecks } from '../lib/check/postcheck';
+import { runPasses } from '../lib/check/passes';
 import { composeTypeProfile, type LayerId, type LayerInstance, type TypeProfile, type UnitRange } from '../lib/typing/profile';
 import { findMarkers } from '../lib/typing/markers';
 import { noteLintAttempt, readLintFailures, type LintFailuresSummary } from './lint-failures';
@@ -641,7 +641,7 @@ app.get('/api/checks/:tractate/:page', async (c) => {
   const tractate = c.req.param('tractate');
   const page = c.req.param('page');
   const lang: 'en' | 'he' = c.req.query('lang') === 'he' ? 'he' : 'en';
-  const marks = CODE_MARKS.filter((m) => (m.checks?.length ?? 0) > 0);
+  const marks = CODE_MARKS.filter((m) => (m.passes?.length ?? 0) > 0);
   if (marks.length === 0) return c.json({ tractate, page, results: [], total_issues: 0 });
 
   const slice = await getGemaraSlice(c.env, tractate, page, false);
@@ -651,7 +651,7 @@ app.get('/api/checks/:tractate/:page', async (c) => {
     const hit = await readCachedResult(c.env, keyForMark(def, tractate, page, lang));
     if (!hit || hit.parsed == null) { results.push({ mark_id: def.id, cached: false, issues: [] }); continue; }
     // Clone so the idempotent transform re-runs don't mutate the cached object.
-    const { issues } = await runChecks(def.checks ?? [], structuredClone(hit.parsed), {
+    const { issues } = await runPasses(def.passes ?? [], structuredClone(hit.parsed), {
       tractate, page, segmentsHe: slice.segments_he, defId: def.id, lang,
     });
     total += issues.length;
@@ -1156,7 +1156,7 @@ function adaptCodeEnrichment(code: SchemaEnrichmentDefinition): EnrichmentDefini
     mark: code.target_mark,
     scope: code.scope,
     dependencies: code.dependencies,
-    checks: code.checks,
+    passes: code.passes,
     system_prompt: llm?.system_prompt ?? '',
     user_prompt_template: llm?.user_prompt_template ?? '',
     system_prompt_he: llm?.system_prompt_he,
@@ -1707,19 +1707,19 @@ async function runMarkOnce(
     catch (err) { parse_error = String(err).slice(0, 200); }
   }
   // Per-mark post-processing via the declarative check layer
-  // (src/lib/check/postcheck.ts). Some extractors (notably argument-move) can't
+  // (src/lib/check/passes.ts). Some extractors (notably argument-move) can't
   // reliably emit segment indices for sub-ranges, so the verbatim re-anchorers
   // (reanchor-argument/-move/-pesukim/-aggadata) re-derive them from the Hebrew
   // excerpt the LLM IS good at copying, and compute token (word) offsets within
   // the matched segment so the highlight painter can paint exactly the
   // move/citation, not the whole containing segment. A definition opts in via
-  // `checks: []` in code-marks.ts; the transforms need the segment grid, so
+  // `passes: []` in code-marks.ts; the transforms need the segment grid, so
   // fetch the gemara slice once when any check runs.
   let markCheckIssues: unknown[] | undefined;
   let markHardIssues: unknown[] | undefined;
-  if (parsed && def.checks && def.checks.length > 0) {
+  if (parsed && def.passes && def.passes.length > 0) {
     const slice = await getGemaraSlice(rc.env, tractate, page, false);
-    const checked = await runChecks(def.checks, parsed, {
+    const checked = await runPasses(def.passes, parsed, {
       tractate, page, segmentsHe: slice.segments_he, defId: def.id, lang: rc.lang,
     });
     parsed = checked.parsed;
@@ -2045,7 +2045,7 @@ async function runEnrichmentOnce(
     catch (err) { parse_error = String(err).slice(0, 200); }
   }
   // Post-generation processing via the standardized check layer
-  // (src/lib/check/postcheck.ts). An enrichment opts in through `checks: []` in
+  // (src/lib/check/passes.ts). An enrichment opts in through `passes: []` in
   // code-marks.ts. Transforms run first:
   //   - rabbi.{relationships,geography}.evidence -> 'reanchor-rabbi-evidence'
   //     resolves each evidence excerpt to (startSegIdx, endSegIdx, tokenStart,
@@ -2062,16 +2062,16 @@ async function runEnrichmentOnce(
   let lint_issues: unknown[] | undefined;   // hard subset → gating + /api/usage path
   let check_issues: unknown[] | undefined;  // all severities → observation
   let hardIssueCount = 0;
-  if (parsed && !parse_error && def.checks && def.checks.length > 0) {
+  if (parsed && !parse_error && def.passes && def.passes.length > 0) {
     const slice = await getGemaraSlice(rc.env, tractate, page, false);
     // commentary-verbatim needs the daf's real Rashi/Tosafot text to verify
     // cited quotes against — fetch it only when a check actually wants it.
     let commentaryHe: string[] | undefined;
-    if (def.checks.includes('commentary-verbatim')) {
+    if (def.passes.includes('commentary-verbatim')) {
       const com = await getCommentariesSlice(rc.env, tractate, page, false);
       commentaryHe = Object.values(com.by_commentator).map((c) => stripHtmlServer(c.hebrew)).filter(Boolean);
     }
-    const checked = await runChecks(def.checks, parsed, {
+    const checked = await runPasses(def.passes, parsed, {
       tractate, page, segmentsHe: slice.segments_he, commentaryHe, defId: def.id, lang: rc.lang,
     });
     parsed = checked.parsed;

--- a/src/worker/studio-registry.ts
+++ b/src/worker/studio-registry.ts
@@ -44,9 +44,9 @@ export interface MarkDefinition {
   fields_schema?: unknown;
   /** Declared inputs (gemara/commentaries/other marks). See studio-schema.ts. */
   dependencies?: MarkDependency[];
-  /** Post-LLM checks (transform/validate) this mark opts into. See
-   *  MarkDefinition.checks in studio-schema.ts. Not part of the cache key. */
-  checks?: string[];
+  /** Post-LLM passes (transform/validate) this mark opts into. See
+   *  MarkDefinition.passes in studio-schema.ts. Not part of the cache key. */
+  passes?: string[];
   /** UI-only nesting hint — see MarkDefinition.parent_mark in studio-schema.ts. */
   parent_mark?: string;
   /** Experimental feature flag — dev-only visibility. See studio-schema.ts. */
@@ -70,9 +70,9 @@ export interface EnrichmentDefinition {
    *  The runner walks this array and exposes each entry as a template var. */
   dependencies?: EnrichmentDependency[];
   /** Post-LLM validators (e.g. 'hebrew-excerpt', 'hebrew-gloss') this
-   *  enrichment opts into. See EnrichmentDefinition.checks in studio-schema.ts.
+   *  enrichment opts into. See EnrichmentDefinition.passes in studio-schema.ts.
    *  Feeds the cache-gating; not part of the cache key. */
-  checks?: string[];
+  passes?: string[];
   system_prompt: string;
   user_prompt_template: string;
   /** Hebrew-output counterparts, selected when a run is requested with

--- a/src/worker/studio-schema.ts
+++ b/src/worker/studio-schema.ts
@@ -366,14 +366,14 @@ export interface MarkDefinition {
    *  current behavior of buildDafContext. Future secondary anchors declare
    *  other marks (e.g. an Israel/Bavel map = [{mark:'rabbi'},{mark:'place'}]). */
   dependencies?: MarkDependency[];
-  /** Post-LLM checks this definition opts into, run by the worker's check
-   *  layer (src/lib/check/postcheck.ts) after the extractor produces `parsed`.
-   *  Two phases: `transform` checks (e.g. the verbatim re-anchorers
-   *  'reanchor-argument') mutate the parsed output; `validate` checks return
-   *  issues. Ordered. NOT part of def_hash / the cache key — checks are
+  /** Post-LLM passes this definition opts into, run by the worker's pass
+   *  layer (src/lib/check/passes.ts) after the extractor produces `parsed`.
+   *  Two phases: `transform` passes (e.g. the verbatim re-anchorers
+   *  'reanchor-argument') mutate the parsed output; `validate` passes (checks)
+   *  return issues. Ordered. NOT part of def_hash / the cache key — passes are
    *  post-processing of generated output, not generation input, so toggling
    *  them must never bust the LLM cache. */
-  checks?: string[];
+  passes?: string[];
   /** UI-only nesting hint. When set, the dev panel groups this mark as a
    *  child of `parent_mark` in the toggle list. Architecturally the mark is
    *  still independent (own anchor, own cache, own extractor) — this just
@@ -430,11 +430,11 @@ export interface EnrichmentDefinition {
    *  here are run first (recursively); other marks are extracted on the same
    *  daf. Empty array means the enrichment only sees `mark_input`. */
   dependencies?: EnrichmentDependency[];
-  /** Post-LLM checks this enrichment opts into. See MarkDefinition.checks. The
+  /** Post-LLM passes this enrichment opts into. See MarkDefinition.passes. The
    *  validators ('hebrew-excerpt', 'hebrew-gloss') feed the bounded-retry
    *  cache-gating (a `hard` issue leaves the output uncached until
    *  MAX_LINT_ATTEMPTS). NOT part of def_hash / the cache key. */
-  checks?: string[];
+  passes?: string[];
 
   extractor: Extractor;
 
@@ -583,5 +583,5 @@ correct the ones I got wrong.
 
   14. status       — always 'draft' on creation. Promote later via UI.
 
-After fill-in, the worker computes def_hash from sha256(JSON.stringify(extractor) + JSON.stringify(render)) — NOT over `checks` (post-processing, not generation input). Save via PUT /api/marks/{id}.
+After fill-in, the worker computes def_hash from sha256(JSON.stringify(extractor) + JSON.stringify(render)) — NOT over `passes` (post-processing, not generation input). Save via PUT /api/marks/{id}.
 */

--- a/tests/check/anchor-verbatim-hard.test.ts
+++ b/tests/check/anchor-verbatim-hard.test.ts
@@ -6,17 +6,17 @@
  * excerpts) — observe-only there.
  */
 import { describe, it, expect } from 'vitest';
-import { runChecks, type CheckCtx } from '../../src/lib/check/postcheck';
+import { runPasses, type PassCtx } from '../../src/lib/check/passes';
 
 // seg 0 has the text; the instance claims its excerpt is in seg 1 (it isn't) → flagged.
 const segs = ['תנו רבנן המביא גט', 'אמר רבא הלכה כרבי'];
 const flagged = { instances: [{ startSegIdx: 0, fields: { excerpt: 'מילים שאינן שם' } }] };
-const ctx = (defId: string): CheckCtx => ({ tractate: 'Gittin', page: '67b', segmentsHe: segs, defId });
+const ctx = (defId: string): PassCtx => ({ tractate: 'Gittin', page: '67b', segmentsHe: segs, defId });
 
 describe('anchor-verbatim per-mark severity', () => {
   it('is HARD on pesukim and aggadata', async () => {
     for (const defId of ['pesukim', 'aggadata']) {
-      const { issues } = await runChecks(['anchor-verbatim'], structuredClone(flagged), ctx(defId));
+      const { issues } = await runPasses(['anchor-verbatim'], structuredClone(flagged), ctx(defId));
       expect(issues).toHaveLength(1);
       expect(issues[0].severity).toBe('hard');
     }
@@ -24,7 +24,7 @@ describe('anchor-verbatim per-mark severity', () => {
 
   it('stays SOFT on argument and argument-move', async () => {
     for (const defId of ['argument', 'argument-move']) {
-      const { issues } = await runChecks(['anchor-verbatim'], structuredClone(flagged), ctx(defId));
+      const { issues } = await runPasses(['anchor-verbatim'], structuredClone(flagged), ctx(defId));
       expect(issues).toHaveLength(1);
       expect(issues[0].severity).toBe('soft');
     }

--- a/tests/check/commentary-verbatim.test.ts
+++ b/tests/check/commentary-verbatim.test.ts
@@ -4,27 +4,27 @@
  * (quote-or-omit). Soft / observe-only.
  */
 import { describe, it, expect } from 'vitest';
-import { runChecks, type CheckCtx, type CheckIssue } from '../../src/lib/check/postcheck';
+import { runPasses, type PassCtx, type CheckIssue } from '../../src/lib/check/passes';
 
 // The daf's real Rashi/Tosafot (one entry per commentator).
 const commentaryHe = [
   'רש"י: המביא גט ממדינת הים צריך לומר בפני נכתב ובפני נחתם',
   'תוספות: והא דאמרינן בעינן שיאמר בפני נכתב',
 ];
-const ctx = (over: Partial<CheckCtx> = {}): CheckCtx =>
+const ctx = (over: Partial<PassCtx> = {}): PassCtx =>
   ({ tractate: 'Gittin', page: '2a', segmentsHe: [], commentaryHe, defId: 'argument-move.commentaries', ...over });
 const kinds = (i: CheckIssue[]) => i.map((x) => x.kind);
 
 describe('commentary-verbatim', () => {
   it('passes when the cited Hebrew quote is in the real commentary', async () => {
     const parsed = { rashi: 'Rashi explains that בפני נכתב ובפני נחתם is required.', tosafot: '', other: '' };
-    const { issues } = await runChecks(['commentary-verbatim'], parsed, ctx());
+    const { issues } = await runPasses(['commentary-verbatim'], parsed, ctx());
     expect(issues).toEqual([]);
   });
 
   it('flags an invented Hebrew quote not present in the commentary', async () => {
     const parsed = { rashi: 'Rashi says הדבר תלוי במחלוקת אביי ורבא about this.', tosafot: '', other: '' };
-    const { issues } = await runChecks(['commentary-verbatim'], parsed, ctx());
+    const { issues } = await runPasses(['commentary-verbatim'], parsed, ctx());
     expect(kinds(issues)).toEqual(['invented-commentary-quote']);
     expect(issues[0].severity).toBe('soft');
     expect(issues[0].detail).toBe('rashi');
@@ -32,20 +32,20 @@ describe('commentary-verbatim', () => {
 
   it('ignores short (1-2 word) Hebrew terms — those are glosses, not citations', async () => {
     const parsed = { rashi: 'A point about תרומה and גט.', tosafot: '', other: '' };
-    const { issues } = await runChecks(['commentary-verbatim'], parsed, ctx());
+    const { issues } = await runPasses(['commentary-verbatim'], parsed, ctx());
     expect(issues).toEqual([]);
   });
 
   it('checks all of rashi/tosafot/other', async () => {
     const parsed = { rashi: '', tosafot: 'Tosafot: מילים שלא נכתבו כאן בכלל', other: '' };
-    const { issues } = await runChecks(['commentary-verbatim'], parsed, ctx());
+    const { issues } = await runPasses(['commentary-verbatim'], parsed, ctx());
     expect(kinds(issues)).toEqual(['invented-commentary-quote']);
     expect(issues[0].detail).toBe('tosafot');
   });
 
   it('skips when no commentary is loaded (can\'t judge → no false positives)', async () => {
     const parsed = { rashi: 'Rashi says הדבר תלוי במחלוקת אביי ורבא.', tosafot: '', other: '' };
-    const { issues } = await runChecks(['commentary-verbatim'], parsed, ctx({ commentaryHe: [] }));
+    const { issues } = await runPasses(['commentary-verbatim'], parsed, ctx({ commentaryHe: [] }));
     expect(issues).toEqual([]);
   });
 });

--- a/tests/check/passes.test.ts
+++ b/tests/check/passes.test.ts
@@ -1,44 +1,44 @@
 /**
- * Tests for the standardized post-LLM check layer (src/lib/check/postcheck.ts):
- * transform checks resolve anchors, validate checks surface lint issues, the
- * two phases run in order, and unknown check ids are tolerated.
+ * Tests for the standardized post-LLM pass layer (src/lib/check/passes.ts):
+ * transform passes resolve anchors, validate passes (checks) surface lint issues, the
+ * two phases run in order, and unknown pass ids are tolerated.
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { runChecks, CHECKS, type CheckCtx } from '../../src/lib/check/postcheck';
+import { runPasses, PASSES, type PassCtx } from '../../src/lib/check/passes';
 
 const FIX = join(__dirname, '..', 'fixtures', 'golden-anchors');
-const ctx = (over: Partial<CheckCtx> = {}): CheckCtx => ({ tractate: 'Gittin', page: '67b', segmentsHe: [], defId: 'x', ...over });
+const ctx = (over: Partial<PassCtx> = {}): PassCtx => ({ tractate: 'Gittin', page: '67b', segmentsHe: [], defId: 'x', ...over });
 
-describe('runChecks — transforms', () => {
+describe('runPasses — transforms', () => {
   it('reanchor-argument resolves anchors identically to the direct re-anchorer', async () => {
     const fx = JSON.parse(readFileSync(join(FIX, 'gittin_67b_argument.json'), 'utf8'));
     const segmentsHe: string[] = JSON.parse(readFileSync(join(FIX, 'gemara_gittin_67b.json'), 'utf8')).segments_he;
-    const { parsed, issues } = await runChecks(['reanchor-argument'], structuredClone(fx.raw), ctx({ segmentsHe, defId: 'argument' }));
+    const { parsed, issues } = await runPasses(['reanchor-argument'], structuredClone(fx.raw), ctx({ segmentsHe, defId: 'argument' }));
     expect(parsed).toEqual(fx.expected);
     expect(issues).toEqual([]);
   });
 
   it('no checks = no-op', async () => {
     const input = { instances: [{ startSegIdx: 1, fields: {} }] };
-    const { parsed, issues } = await runChecks([], structuredClone(input), ctx());
+    const { parsed, issues } = await runPasses([], structuredClone(input), ctx());
     expect(parsed).toEqual(input);
     expect(issues).toEqual([]);
   });
 
-  it('ignores unknown check ids', async () => {
+  it('ignores unknown pass ids', async () => {
     const input = { foo: 1 };
-    const { parsed, issues } = await runChecks(['does-not-exist'], structuredClone(input), ctx());
+    const { parsed, issues } = await runPasses(['does-not-exist'], structuredClone(input), ctx());
     expect(parsed).toEqual(input);
     expect(issues).toEqual([]);
   });
 });
 
-describe('runChecks — validators', () => {
+describe('runPasses — validators', () => {
   it('hebrew-gloss flags a calque', async () => {
     const parsed = { ruling: 'The animal is a neveila if severed without most of the flesh.' };
-    const { issues } = await runChecks(['hebrew-gloss'], parsed, ctx({ defId: 'halacha.codification' }));
+    const { issues } = await runPasses(['hebrew-gloss'], parsed, ctx({ defId: 'halacha.codification' }));
     expect(issues.length).toBeGreaterThan(0);
     expect(issues.every((i) => i.severity === 'hard')).toBe(true);
     expect(issues.some((i) => i.kind === 'calque')).toBe(true);
@@ -46,33 +46,33 @@ describe('runChecks — validators', () => {
 
   it('hebrew-excerpt flags a pasuk cited in English with no Hebrew', async () => {
     const parsed = { synthesis: 'Tehillim 119:62 states, "At midnight I will rise to give thanks to You."' };
-    const { issues } = await runChecks(['hebrew-excerpt'], parsed, ctx({ defId: 'pesukim.synthesis' }));
+    const { issues } = await runPasses(['hebrew-excerpt'], parsed, ctx({ defId: 'pesukim.synthesis' }));
     expect(issues.some((i) => i.kind === 'missing-hebrew-excerpt')).toBe(true);
   });
 
   it('clean prose produces no issues', async () => {
     const parsed = { synthesis: 'The sugya (סוגיא) turns on whether counting (מנה) equals כולכם.' };
-    const { issues } = await runChecks(['hebrew-excerpt', 'hebrew-gloss'], parsed, ctx());
+    const { issues } = await runPasses(['hebrew-excerpt', 'hebrew-gloss'], parsed, ctx());
     expect(issues).toEqual([]);
   });
 });
 
-describe('runChecks — phase ordering', () => {
+describe('runPasses — phase ordering', () => {
   it('validators see the transformed parsed (transform runs first)', async () => {
     // A pesukim raw with an unresolved citation; after reanchor-pesukim the
     // instance gains token offsets. We assert the transform applied by checking
     // the returned parsed, then that validators ran against it without error.
     const fx = JSON.parse(readFileSync(join(FIX, 'sanhedrin_59b_pesukim.json'), 'utf8'));
     const segmentsHe: string[] = JSON.parse(readFileSync(join(FIX, 'gemara_sanhedrin_59b.json'), 'utf8')).segments_he;
-    const { parsed } = await runChecks(['reanchor-pesukim', 'hebrew-gloss'], structuredClone(fx.raw), ctx({ tractate: 'Sanhedrin', page: '59b', segmentsHe, defId: 'pesukim' }));
+    const { parsed } = await runPasses(['reanchor-pesukim', 'hebrew-gloss'], structuredClone(fx.raw), ctx({ tractate: 'Sanhedrin', page: '59b', segmentsHe, defId: 'pesukim' }));
     expect(parsed).toEqual(fx.expected);
   });
 });
 
-describe('CHECKS registry', () => {
+describe('PASSES registry', () => {
   it('exposes transform + validate checks with correct phases', () => {
-    expect(CHECKS['reanchor-argument'].phase).toBe('transform');
-    expect(CHECKS['hebrew-gloss'].phase).toBe('validate');
-    expect(CHECKS['hebrew-excerpt'].phase).toBe('validate');
+    expect(PASSES['reanchor-argument'].phase).toBe('transform');
+    expect(PASSES['hebrew-gloss'].phase).toBe('validate');
+    expect(PASSES['hebrew-excerpt'].phase).toBe('validate');
   });
 });

--- a/tests/check/soft-checks.test.ts
+++ b/tests/check/soft-checks.test.ts
@@ -10,9 +10,9 @@
  * and each kind's severity.
  */
 import { describe, it, expect } from 'vitest';
-import { runChecks, type CheckCtx, type CheckIssue } from '../../src/lib/check/postcheck';
+import { runPasses, type PassCtx, type CheckIssue } from '../../src/lib/check/passes';
 
-const ctx = (over: Partial<CheckCtx> = {}): CheckCtx => ({ tractate: 'Gittin', page: '67b', segmentsHe: [], defId: 'x', ...over });
+const ctx = (over: Partial<PassCtx> = {}): PassCtx => ({ tractate: 'Gittin', page: '67b', segmentsHe: [], defId: 'x', ...over });
 const kinds = (issues: CheckIssue[]) => issues.map((i) => i.kind).sort();
 const allSoft = (issues: CheckIssue[]) => issues.every((i) => i.severity === 'soft');
 
@@ -21,13 +21,13 @@ describe('anchor-verbatim', () => {
 
   it('passes when each excerpt is present in its claimed segment', async () => {
     const parsed = { instances: [{ startSegIdx: 1, fields: { excerpt: 'תנו רבנן' } }, { startSegIdx: 2, fields: { excerpt: 'אמר רבא' } }] };
-    const { issues } = await runChecks(['anchor-verbatim'], parsed, ctx({ segmentsHe: segs, defId: 'argument' }));
+    const { issues } = await runPasses(['anchor-verbatim'], parsed, ctx({ segmentsHe: segs, defId: 'argument' }));
     expect(issues).toEqual([]);
   });
 
   it('flags an excerpt that is not in its segment (hallucination/prefix fallback)', async () => {
     const parsed = { instances: [{ startSegIdx: 1, fields: { excerpt: 'מילים שלא קיימות' } }] };
-    const { issues } = await runChecks(['anchor-verbatim'], parsed, ctx({ segmentsHe: segs, defId: 'argument' }));
+    const { issues } = await runPasses(['anchor-verbatim'], parsed, ctx({ segmentsHe: segs, defId: 'argument' }));
     expect(kinds(issues)).toEqual(['excerpt-not-in-segment']);
     expect(allSoft(issues)).toBe(true);
     expect(issues[0].index).toBe(1);
@@ -35,20 +35,20 @@ describe('anchor-verbatim', () => {
 
   it('flags an out-of-range anchor as hard (an index past the daf is never a false positive)', async () => {
     const parsed = { instances: [{ startSegIdx: 99, fields: { excerpt: 'תנו רבנן' } }] };
-    const { issues } = await runChecks(['anchor-verbatim'], parsed, ctx({ segmentsHe: segs, defId: 'argument' }));
+    const { issues } = await runPasses(['anchor-verbatim'], parsed, ctx({ segmentsHe: segs, defId: 'argument' }));
     expect(kinds(issues)).toEqual(['anchor-out-of-range']);
     expect(issues[0].severity).toBe('hard');
   });
 
   it('skips excerpts shorter than 2 words and missing excerpts', async () => {
     const parsed = { instances: [{ startSegIdx: 0, fields: { excerpt: 'שׁוטה' } }, { startSegIdx: 0, fields: {} }] };
-    const { issues } = await runChecks(['anchor-verbatim'], parsed, ctx({ segmentsHe: segs, defId: 'argument' }));
+    const { issues } = await runPasses(['anchor-verbatim'], parsed, ctx({ segmentsHe: segs, defId: 'argument' }));
     expect(issues).toEqual([]);
   });
 
   it('ignores nikud/punctuation differences (normalized match)', async () => {
     const parsed = { instances: [{ startSegIdx: 1, fields: { excerpt: 'תְּנוּ, רַבָּנַן' } }] };
-    const { issues } = await runChecks(['anchor-verbatim'], parsed, ctx({ segmentsHe: segs, defId: 'argument' }));
+    const { issues } = await runPasses(['anchor-verbatim'], parsed, ctx({ segmentsHe: segs, defId: 'argument' }));
     expect(issues).toEqual([]);
   });
 
@@ -61,7 +61,7 @@ describe('anchor-verbatim', () => {
     // seg1 is "תנו רבנן המביא גט"; the excerpt opens on it but its tail
     // ("בידו פסול") spills past the segment / is paraphrased.
     const parsed = { instances: [{ startSegIdx: 1, fields: { excerpt: 'תנו רבנן המביא גט בידו פסול' } }] };
-    const { issues } = await runChecks(['anchor-verbatim'], parsed, ctx({ segmentsHe: segs, defId: 'argument-move' }));
+    const { issues } = await runPasses(['anchor-verbatim'], parsed, ctx({ segmentsHe: segs, defId: 'argument-move' }));
     expect(issues).toEqual([]);
   });
 
@@ -70,7 +70,7 @@ describe('anchor-verbatim', () => {
     // seg2 via the fallback bump. This is the real Pesachim-60b pile-up shape:
     // moves clamped onto the section start whose text lives further down.
     const parsed = { instances: [{ startSegIdx: 2, fields: { excerpt: 'תנו רבנן המביא גט' } }] };
-    const { issues } = await runChecks(['anchor-verbatim'], parsed, ctx({ segmentsHe: segs, defId: 'argument-move' }));
+    const { issues } = await runPasses(['anchor-verbatim'], parsed, ctx({ segmentsHe: segs, defId: 'argument-move' }));
     expect(kinds(issues)).toEqual(['excerpt-not-in-segment']);
     expect(issues[0].index).toBe(2);
     expect(allSoft(issues)).toBe(true);
@@ -80,7 +80,7 @@ describe('anchor-verbatim', () => {
     // "אמר רבא" lives in seg2, NOT seg1. Anchoring it to seg1 must still flag,
     // even though a different segment contains the prefix.
     const parsed = { instances: [{ startSegIdx: 1, fields: { excerpt: 'אמר רבא הלכה' } }] };
-    const { issues } = await runChecks(['anchor-verbatim'], parsed, ctx({ segmentsHe: segs, defId: 'argument-move' }));
+    const { issues } = await runPasses(['anchor-verbatim'], parsed, ctx({ segmentsHe: segs, defId: 'argument-move' }));
     expect(kinds(issues)).toEqual(['excerpt-not-in-segment']);
     expect(issues[0].index).toBe(1);
   });
@@ -92,7 +92,7 @@ describe('anchor-verbatim', () => {
     // seg0 has the full spelling "העולם"; the excerpt drops the vav ("העלם").
     const fuzzy = ['כל העולם כולו'];
     const parsed = { instances: [{ startSegIdx: 0, fields: { excerpt: 'כל העלם' } }] };
-    const { issues } = await runChecks(['anchor-verbatim'], parsed, ctx({ segmentsHe: fuzzy, defId: 'argument-move' }));
+    const { issues } = await runPasses(['anchor-verbatim'], parsed, ctx({ segmentsHe: fuzzy, defId: 'argument-move' }));
     expect(issues).toEqual([]);
   });
 
@@ -100,14 +100,14 @@ describe('anchor-verbatim', () => {
     // seg2 is "אמר רבא הלכה כרבי"; excerpt opens "ואמר" (extra vav) so no exact
     // prefix matches, but 3/3 words are present within one edit.
     const parsed = { instances: [{ startSegIdx: 2, fields: { excerpt: 'ואמר רבא הלכה' } }] };
-    const { issues } = await runChecks(['anchor-verbatim'], parsed, ctx({ segmentsHe: segs, defId: 'argument-move' }));
+    const { issues } = await runPasses(['anchor-verbatim'], parsed, ctx({ segmentsHe: segs, defId: 'argument-move' }));
     expect(issues).toEqual([]);
   });
 
   it('still flags when only a single common word overlaps (fuzzy fallback does not over-suppress)', async () => {
     // seg2 "אמר רבא הלכה כרבי": the excerpt shares only "אמר"; 1/3 < floor.
     const parsed = { instances: [{ startSegIdx: 2, fields: { excerpt: 'אמר אביי בגמרא' } }] };
-    const { issues } = await runChecks(['anchor-verbatim'], parsed, ctx({ segmentsHe: segs, defId: 'argument-move' }));
+    const { issues } = await runPasses(['anchor-verbatim'], parsed, ctx({ segmentsHe: segs, defId: 'argument-move' }));
     expect(kinds(issues)).toEqual(['excerpt-not-in-segment']);
   });
 
@@ -116,11 +116,11 @@ describe('anchor-verbatim', () => {
     // path above) — but on pesukim the kind is HARD, so it stays exact and a
     // non-verbatim excerpt must still flag to gate the cache.
     const parsed = { instances: [{ startSegIdx: 2, fields: { excerpt: 'ואמר רבא הלכה' } }] };
-    const pesukim = await runChecks(['anchor-verbatim'], parsed, ctx({ segmentsHe: segs, defId: 'pesukim' }));
+    const pesukim = await runPasses(['anchor-verbatim'], parsed, ctx({ segmentsHe: segs, defId: 'pesukim' }));
     expect(kinds(pesukim.issues)).toEqual(['excerpt-not-in-segment']);
     expect(pesukim.issues[0].severity).toBe('hard');
     // Same excerpt on the soft argument-move path is suppressed by the fallback.
-    const move = await runChecks(['anchor-verbatim'], parsed, ctx({ segmentsHe: segs, defId: 'argument-move' }));
+    const move = await runPasses(['anchor-verbatim'], parsed, ctx({ segmentsHe: segs, defId: 'argument-move' }));
     expect(move.issues).toEqual([]);
   });
 });
@@ -128,14 +128,14 @@ describe('anchor-verbatim', () => {
 describe('partition-clean', () => {
   it('flags an inverted range as hard (end < start is structurally impossible)', async () => {
     const parsed = { instances: [{ startSegIdx: 5, endSegIdx: 2, fields: { excerpt: 'aaa bbb' } }] };
-    const { issues } = await runChecks(['partition-clean'], parsed, ctx({ defId: 'argument-move' }));
+    const { issues } = await runPasses(['partition-clean'], parsed, ctx({ defId: 'argument-move' }));
     expect(kinds(issues)).toContain('inverted-range');
     expect(issues.find((i) => i.kind === 'inverted-range')?.severity).toBe('hard');
   });
 
   it('flags an exact duplicate instance as hard (identical id + range + anchors is never legitimate)', async () => {
     const dup = { startSegIdx: 3, endSegIdx: 4, fields: { id: '3-4_0', excerpt: 'אמר רבא הלכה', endExcerpt: 'כרבי יהודה' } };
-    const { issues } = await runChecks(['partition-clean'], { instances: [dup, { ...dup, fields: { ...dup.fields } }] }, ctx({ defId: 'argument-move' }));
+    const { issues } = await runPasses(['partition-clean'], { instances: [dup, { ...dup, fields: { ...dup.fields } }] }, ctx({ defId: 'argument-move' }));
     expect(kinds(issues)).toEqual(['duplicate-instance']);
     expect(issues[0].severity).toBe('hard');
   });
@@ -145,23 +145,23 @@ describe('partition-clean', () => {
     // different id / end anchor. Must not be hard-blocked as a duplicate.
     const a = { startSegIdx: 6, endSegIdx: 6, fields: { id: '6-6_0', excerpt: 'תא שמע', endExcerpt: 'פטור' } };
     const b = { startSegIdx: 6, endSegIdx: 6, fields: { id: '6-6_1', excerpt: 'תא שמע', endExcerpt: 'חייב' } };
-    const { issues } = await runChecks(['partition-clean'], { instances: [a, b] }, ctx({ defId: 'argument-move' }));
+    const { issues } = await runPasses(['partition-clean'], { instances: [a, b] }, ctx({ defId: 'argument-move' }));
     expect(issues).toEqual([]);
   });
 
   it('flags overlapping section ranges only for the argument mark, and only soft (a shared boundary can be legitimate)', async () => {
     const overlapping = { instances: [{ startSegIdx: 0, endSegIdx: 3, fields: {} }, { startSegIdx: 2, endSegIdx: 5, fields: {} }] };
-    const asArgument = await runChecks(['partition-clean'], overlapping, ctx({ defId: 'argument' }));
+    const asArgument = await runPasses(['partition-clean'], overlapping, ctx({ defId: 'argument' }));
     expect(kinds(asArgument.issues)).toEqual(['section-overlap']);
     expect(allSoft(asArgument.issues)).toBe(true);
     // Same shape under argument-move: overlaps are legitimate (moves share segments).
-    const asMove = await runChecks(['partition-clean'], overlapping, ctx({ defId: 'argument-move' }));
+    const asMove = await runPasses(['partition-clean'], overlapping, ctx({ defId: 'argument-move' }));
     expect(asMove.issues).toEqual([]);
   });
 
   it('passes a clean partition', async () => {
     const parsed = { instances: [{ startSegIdx: 0, endSegIdx: 2, fields: { excerpt: 'a a' } }, { startSegIdx: 3, endSegIdx: 5, fields: { excerpt: 'b b' } }] };
-    const { issues } = await runChecks(['partition-clean'], parsed, ctx({ defId: 'argument' }));
+    const { issues } = await runPasses(['partition-clean'], parsed, ctx({ defId: 'argument' }));
     expect(issues).toEqual([]);
   });
 });
@@ -171,33 +171,33 @@ describe('edge-integrity', () => {
 
   it('passes a well-formed graph', async () => {
     const parsed = { voices, edges: [{ from: 'Rava', to: 'Abaye', kind: 'opposes' }, { from: 'Sages', to: 'Rava', kind: 'supports' }] };
-    const { issues } = await runChecks(['edge-integrity'], parsed, ctx({ defId: 'argument.voices' }));
+    const { issues } = await runPasses(['edge-integrity'], parsed, ctx({ defId: 'argument.voices' }));
     expect(issues).toEqual([]);
   });
 
   it('flags an edge referencing an unknown voice', async () => {
     const parsed = { voices, edges: [{ from: 'Rava', to: 'Rav Ashi', kind: 'opposes' }] };
-    const { issues } = await runChecks(['edge-integrity'], parsed, ctx({ defId: 'argument.voices' }));
+    const { issues } = await runPasses(['edge-integrity'], parsed, ctx({ defId: 'argument.voices' }));
     expect(kinds(issues)).toEqual(['edge-unknown-voice']);
     expect(allSoft(issues)).toBe(true);
   });
 
   it('flags a self-loop', async () => {
     const parsed = { voices, edges: [{ from: 'Rava', to: 'Rava', kind: 'responds-to' }] };
-    const { issues } = await runChecks(['edge-integrity'], parsed, ctx({ defId: 'argument.voices' }));
+    const { issues } = await runPasses(['edge-integrity'], parsed, ctx({ defId: 'argument.voices' }));
     expect(kinds(issues)).toEqual(['edge-self-loop']);
   });
 
   it('flags a contradictory opposes+supports on the same pair (either direction)', async () => {
     const parsed = { voices, edges: [{ from: 'Rava', to: 'Abaye', kind: 'opposes' }, { from: 'Abaye', to: 'Rava', kind: 'supports' }] };
-    const { issues } = await runChecks(['edge-integrity'], parsed, ctx({ defId: 'argument.voices' }));
+    const { issues } = await runPasses(['edge-integrity'], parsed, ctx({ defId: 'argument.voices' }));
     expect(kinds(issues)).toContain('edge-contradiction');
   });
 
   it('tolerates an empty / missing graph', async () => {
-    const { issues } = await runChecks(['edge-integrity'], { voices, edges: [] }, ctx({ defId: 'argument.voices' }));
+    const { issues } = await runPasses(['edge-integrity'], { voices, edges: [] }, ctx({ defId: 'argument.voices' }));
     expect(issues).toEqual([]);
-    const { issues: i2 } = await runChecks(['edge-integrity'], {}, ctx({ defId: 'argument.voices' }));
+    const { issues: i2 } = await runPasses(['edge-integrity'], {}, ctx({ defId: 'argument.voices' }));
     expect(i2).toEqual([]);
   });
 });

--- a/tests/check/wiring.test.ts
+++ b/tests/check/wiring.test.ts
@@ -1,21 +1,21 @@
 /**
  * Wiring guard for A2 increment 2 — the runners (runMarkOnce / runEnrichmentOnce
  * in src/worker/index.ts) drive post-LLM processing off each definition's
- * declarative `checks: []` field instead of a hardcoded `if (def.id === …)`
+ * declarative `passes: []` field instead of a hardcoded `if (def.id === …)`
  * chain. These tests pin two invariants that wiring depends on:
  *
- *   1. The canon marks/enrichments declare the checks the old if-chains applied,
- *      and every declared id exists in the CHECKS registry (a typo'd or dropped
- *      check would silently stop re-anchoring / linting in production).
- *   2. `checks` is NOT part of any cache key — toggling it must never bust the
+ *   1. The canon marks/enrichments declare the passes the old if-chains applied,
+ *      and every declared id exists in the PASSES registry (a typo'd or dropped
+ *      pass would silently stop re-anchoring / linting in production).
+ *   2. `passes` is NOT part of any cache key — toggling it must never bust the
  *      LLM cache (a full-shas re-warm is ~$1000).
  */
 import { describe, it, expect } from 'vitest';
 import { CODE_MARKS, CODE_ENRICHMENTS } from '../../src/worker/code-marks';
-import { CHECKS } from '../../src/lib/check/postcheck';
+import { PASSES } from '../../src/lib/check/passes';
 import { keyForMark, keyForEnrichment } from '../../src/worker/cache-keys';
 
-describe('declarative check wiring', () => {
+describe('declarative pass wiring', () => {
   const markChecks: Record<string, string[]> = {
     argument: ['reanchor-argument', 'anchor-verbatim', 'partition-clean'],
     'argument-move': ['reanchor-argument-move', 'anchor-verbatim', 'partition-clean'],
@@ -34,43 +34,43 @@ describe('declarative check wiring', () => {
     'rabbi.geography.evidence': ['reanchor-rabbi-evidence'],
   };
 
-  it('canon marks declare the expected checks', () => {
+  it('canon marks declare the expected passes', () => {
     for (const [id, expected] of Object.entries(markChecks)) {
       const def = CODE_MARKS.find((m) => m.id === id);
       expect(def, `mark ${id} present`).toBeTruthy();
-      expect(def!.checks ?? [], `mark ${id} checks`).toEqual(expected);
+      expect(def!.passes ?? [], `mark ${id} passes`).toEqual(expected);
     }
   });
 
-  it('lint-gated enrichments declare the expected checks', () => {
+  it('lint-gated enrichments declare the expected passes', () => {
     for (const [id, expected] of Object.entries(enrichmentChecks)) {
       const def = CODE_ENRICHMENTS.find((e) => e.id === id);
       expect(def, `enrichment ${id} present`).toBeTruthy();
-      expect(def!.checks ?? [], `enrichment ${id} checks`).toEqual(expected);
+      expect(def!.passes ?? [], `enrichment ${id} passes`).toEqual(expected);
     }
   });
 
-  it('every declared check id is registered in CHECKS', () => {
+  it('every declared pass id is registered in PASSES', () => {
     const declared = new Set<string>();
-    for (const m of CODE_MARKS) (m.checks ?? []).forEach((c) => declared.add(c));
-    for (const e of CODE_ENRICHMENTS) (e.checks ?? []).forEach((c) => declared.add(c));
+    for (const m of CODE_MARKS) (m.passes ?? []).forEach((c) => declared.add(c));
+    for (const e of CODE_ENRICHMENTS) (e.passes ?? []).forEach((c) => declared.add(c));
     for (const id of declared) {
-      expect(CHECKS[id], `check '${id}' registered`).toBeTruthy();
+      expect(PASSES[id], `pass '${id}' registered`).toBeTruthy();
     }
   });
 });
 
-describe('checks do not affect cache keys', () => {
-  it('keyForMark is identical with and without checks', () => {
+describe('passes do not affect cache keys', () => {
+  it('keyForMark is identical with and without passes', () => {
     const base = { id: 'argument', cache_version: '4' } as Parameters<typeof keyForMark>[0];
-    const withChecks = { ...base, checks: ['reanchor-argument'] } as Parameters<typeof keyForMark>[0];
+    const withChecks = { ...base, passes: ['reanchor-argument'] } as Parameters<typeof keyForMark>[0];
     expect(keyForMark(withChecks, 'Gittin', '67b')).toBe(keyForMark(base, 'Gittin', '67b'));
     expect(keyForMark(withChecks, 'Gittin', '67b', 'he')).toBe(keyForMark(base, 'Gittin', '67b', 'he'));
   });
 
-  it('keyForEnrichment is identical with and without checks', () => {
+  it('keyForEnrichment is identical with and without passes', () => {
     const base = { id: 'pesukim.synthesis', cache_version: '11', scope: 'local' } as Parameters<typeof keyForEnrichment>[0];
-    const withChecks = { ...base, checks: ['hebrew-excerpt'] } as Parameters<typeof keyForEnrichment>[0];
+    const withChecks = { ...base, passes: ['hebrew-excerpt'] } as Parameters<typeof keyForEnrichment>[0];
     const daf = { tractate: 'Gittin', page: '67b' };
     expect(keyForEnrichment(withChecks, 'inst', daf)).toBe(keyForEnrichment(base, 'inst', daf));
   });

--- a/tests/recipe-hash.test.ts
+++ b/tests/recipe-hash.test.ts
@@ -18,7 +18,7 @@ const baseMark = () => ({
   },
   render: { kind: 'inline', style: 'underline' },
   dependencies: ['gemara'],
-  checks: ['no-empty'],
+  passes: ['no-empty'],
   cache_version: '2',
   def_hash: 'rabbi-v2',
   status: 'promoted',
@@ -69,12 +69,12 @@ describe('recipeHash — content hash of a producer recipe', () => {
     expect(await recipeHash(m)).not.toBe(await recipeHash(baseMark()));
   });
 
-  it('does NOT move for checks / dependencies / version / bookkeeping changes', async () => {
+  it('does NOT move for passes / dependencies / version / bookkeeping changes', async () => {
     const base = await recipeHash(baseMark());
-    const checks = baseMark(); checks.checks = ['no-empty', 'in-range'];
+    const passes = baseMark(); passes.passes = ['no-empty', 'in-range'];
     const deps = baseMark(); deps.dependencies = ['gemara', 'commentaries'];
     const ver = baseMark(); ver.cache_version = '9'; ver.def_hash = 'rabbi-v9'; ver.updated_at = '2030-01-01';
-    expect(await recipeHash(checks)).toBe(base);
+    expect(await recipeHash(passes)).toBe(base);
     expect(await recipeHash(deps)).toBe(base);
     expect(await recipeHash(ver)).toBe(base);
   });


### PR DESCRIPTION
## What

The post-LLM layer bundles two different things under one name. `transform` passes **mutate** the parsed output (the six re-anchorers + `derive-voice-edges`, which *builds* the voice graph); `validate` passes inspect it and return issues. Only the validators are "checks" — calling a graph-builder a check is wrong. This renames the abstraction to **passes** and reserves **check** for the validate phase.

## Renamed
- file `src/lib/check/postcheck.ts` → `src/lib/check/passes.ts` (+ `tests/check/postcheck.test.ts` → `passes.test.ts`)
- types `PostCheck`→`PostPass`, `CheckCtx`→`PassCtx`, `CheckResult`→`PassResult`
- registry `CHECKS`→`PASSES`, runner `runChecks`→`runPasses`
- declared field `def.checks`→`def.passes` (studio-schema, studio-registry, code-marks declarations, the worker projection)

## Kept on purpose
These correctly name the validator output / flag surface, so they stay:
- `CheckIssue` — a validate pass (a check) emits these
- `GET /api/checks/:t/:p` route + the dev **Checks** panel — they surface validator flags
- `check_issues` / `markCheckIssues` plumbing

## Safety
- `passes` is **not** part of `def_hash` / `recipe_hash` / any cache key (locked by `recipe-hash.test`), so zero cache invalidation.
- The field is **code-only**: `validateMark`/`validateEnrichment` never persisted it, so KV-stored studio defs carried no `checks` before and carry no `passes` now — no stored-data migration, no silent regression. (Verified by reading the validate/write/read KV paths.)

## Tests
`pnpm typecheck` clean; full suite **1535 passing**. (Codex review was unavailable this round due to an auth-token error; verified manually instead — see Safety.)