### PR TITLE
Section typing: add a deterministic register (mishnah/gemara) axis

### DIFF
--- a/src/client/TypeProfilePanel.tsx
+++ b/src/client/TypeProfilePanel.tsx
@@ -11,7 +11,7 @@
 import { createResource, For, Show, type JSX } from 'solid-js';
 
 interface Claim { layer: string; coverage: number }
-interface Profile { unit: { startSegIdx: number; endSegIdx: number }; claims: Claim[]; primary: string; isDispute: boolean; title?: string }
+interface Profile { unit: { startSegIdx: number; endSegIdx: number }; claims: Claim[]; primary: string; isDispute: boolean; register?: string; title?: string }
 interface Marker { startSegIdx: number; endSegIdx: number; kind: string }
 interface ProfilesResponse { tractate: string; page: string; count: number; profiles: Profile[]; markers?: Marker[] }
 
@@ -80,6 +80,12 @@ export default function TypeProfilePanel(props: {
               'flex-shrink': 0, 'font-size': '0.62rem', 'border-radius': '3px', padding: '0 0.3rem',
               background: (PRIMARY_COLOR[p.primary] ?? '#888') + '22', color: PRIMARY_COLOR[p.primary] ?? '#666',
             }}>{p.primary}</span>
+            <Show when={p.register === 'mishnah'}>
+              <span style={{
+                'flex-shrink': 0, 'font-size': '0.62rem', 'border-radius': '3px', padding: '0 0.3rem',
+                background: '#1e3a8a22', color: '#1e3a8a',
+              }} title="register: mishnah (majority of segments are mishnah-in-talmud)">mishnah</span>
+            </Show>
             <Show when={p.isDispute}>
               <span style={{ 'flex-shrink': 0, 'font-size': '0.6rem', color: '#b91c1c' }} title="argument.voices has an opposes edge">⚔</span>
             </Show>

--- a/src/lib/typing/profile.ts
+++ b/src/lib/typing/profile.ts
@@ -26,6 +26,13 @@ export type OverlayLayer = 'halacha' | 'aggadata' | 'pesukim';
 export type LayerId = 'argument' | 'argument-move' | OverlayLayer | 'rabbi' | 'places';
 export type PrimaryType = 'pure-dialectic' | OverlayLayer;
 
+/** The textual register of a unit — what KIND of text it is, an axis orthogonal
+ *  to the content `primary` (a unit can be a `mishnah` that is `halacha`, or a
+ *  `gemara` that is `pure-dialectic`). Derived deterministically from the
+ *  mishnah-in-talmud segment ranges; `baraita` is intentionally absent until a
+ *  deterministic signal for it exists (the source only labels mishnah). */
+export type Register = 'mishnah' | 'gemara';
+
 export interface UnitRange {
   tractate: string;
   page: string;
@@ -67,6 +74,11 @@ export interface TypeProfile {
    *  `primary`: a כולכם dispute with no content overlay is
    *  `primary: 'pure-dialectic'`, `isDispute: true`. */
   isDispute: boolean;
+  /** The unit's textual register — `mishnah` when the majority of its segments
+   *  fall in the daf's mishnah-in-talmud ranges, else `gemara`. Orthogonal to
+   *  `primary`. `gemara` when no mishnah ranges were supplied (the common case;
+   *  mishnah is the labeled minority). */
+  register: Register;
 }
 
 /** An overlay must cover at least this fraction of the unit to win `primary`;
@@ -78,6 +90,20 @@ export const PRIMARY_FLOOR = 0.5;
  *  dominates a ruling dominates a bare verse citation. (Design open question
  *  #1 — tune empirically.) */
 export const LAYER_PRIORITY: Record<OverlayLayer, number> = { aggadata: 3, halacha: 2, pesukim: 1 };
+
+/** A unit is `mishnah` when at least this fraction of its segments fall in the
+ *  daf's mishnah ranges; otherwise `gemara`. Majority rule so a section that
+ *  merely brushes a mishnah boundary stays gemara. */
+export const REGISTER_FLOOR = 0.5;
+
+/** The unit's register from the daf's mishnah segment set. Pure; `gemara` when
+ *  no mishnah set is supplied (unknown → the common case, not mishnah). */
+export function registerOf(unit: UnitRange, mishnaSegs?: ReadonlySet<number>): Register {
+  const segs = rangeSegs(unit.startSegIdx, unit.endSegIdx);
+  if (!mishnaSegs || mishnaSegs.size === 0 || segs.length === 0) return 'gemara';
+  const inMishna = segs.filter((s) => mishnaSegs.has(s)).length;
+  return inMishna / segs.length >= REGISTER_FLOOR ? 'mishnah' : 'gemara';
+}
 
 const OVERLAYS: ReadonlySet<LayerId> = new Set<LayerId>(['halacha', 'aggadata', 'pesukim']);
 
@@ -103,11 +129,13 @@ export function hasOpposingVoices(voices?: VoicesGraph | null): boolean {
  * daf (argument/halacha/aggadata/pesukim/…); only those overlapping the unit
  * contribute claims. Pass the unit's `argument.voices` graph (when available) to
  * derive `isDispute`; omit it and `isDispute` is false (unknown → not a dispute).
+ * Pass `mishnaSegs` (the daf's mishnah segment indices) to derive `register`;
+ * omit it and `register` is `gemara`.
  */
 export function composeTypeProfile(
   unit: UnitRange,
   instances: readonly LayerInstance[],
-  opts: { voices?: VoicesGraph | null } = {},
+  opts: { voices?: VoicesGraph | null; mishnaSegs?: ReadonlySet<number> } = {},
 ): TypeProfile {
   const unitSegs = rangeSegs(unit.startSegIdx, unit.endSegIdx);
   const unitSet = new Set(unitSegs);
@@ -137,7 +165,13 @@ export function composeTypeProfile(
     if (score > bestScore) { bestScore = score; primary = c.layer as OverlayLayer; }
   }
 
-  return { unit, claims, primary, isDispute: hasOpposingVoices(opts.voices) };
+  return {
+    unit,
+    claims,
+    primary,
+    isDispute: hasOpposingVoices(opts.voices),
+    register: registerOf(unit, opts.mishnaSegs),
+  };
 }
 
 /**

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -665,8 +665,10 @@ app.get('/api/checks/:tractate/:page', async (c) => {
 // section on the daf, intersect the content overlays (halacha/aggadata/pesukim)
 // + the dialectical base (argument-move) and emit a TypeProfile: which layers
 // claim the section, the dominant `primary` content dimension (pure-dialectic
-// when no overlay materially covers it), and `isDispute` (from the section's
-// cached argument.voices graph). This is the observation/validation surface for
+// when no overlay materially covers it), `register` (mishnah/gemara — the
+// textual axis orthogonal to primary, from the cached mishnah-in-talmud ranges),
+// and `isDispute` (from the section's cached argument.voices graph). This is the
+// observation/validation surface for
 // section typing — it shows, on real content, that e.g. the Ashmedai story is
 // narrative-primary (not a voice dispute). Gating + new enrichments build on it.
 type RawInstance = { startSegIdx?: unknown; endSegIdx?: unknown; fields?: Record<string, unknown> };
@@ -696,6 +698,12 @@ async function buildDafTypeProfiles(env: Bindings, tractate: string, page: strin
     ...toLayerInstances('pesukim', await readMarkInstances(env, 'pesukim', tractate, page)),
     ...toLayerInstances('argument-move', await readMarkInstances(env, 'argument-move', tractate, page)),
   ];
+  // Deterministic register axis: which segments are mishnah-in-talmud (cached
+  // Sefaria /api/related anchors). A section whose majority falls here is
+  // `register: mishnah`, else `gemara`.
+  const mishnaBundle = await getMishnaBundleCached(env.CACHE, tractate, page);
+  const mishnaSegs = new Set<number>();
+  for (const m of mishnaBundle) for (let s = m.anchorStartSeg; s <= m.anchorEndSeg; s++) mishnaSegs.add(s);
   const voicesDef = findCodeEnrichment('argument.voices');
   const profiles: (TypeProfile & { title?: string })[] = [];
   for (const sec of sections) {
@@ -707,7 +715,7 @@ async function buildDafTypeProfiles(env: Bindings, tractate: string, page: strin
       const vhit = await readCachedResult(env, keyForEnrichment(voicesDef, iid, { tractate, page }));
       voices = (vhit?.parsed as { edges?: { kind?: string }[] }) ?? null;
     }
-    profiles.push({ ...composeTypeProfile(unit, overlays, { voices }), title: typeof sec.fields?.title === 'string' ? sec.fields.title : undefined });
+    profiles.push({ ...composeTypeProfile(unit, overlays, { voices, mishnaSegs }), title: typeof sec.fields?.title === 'string' ? sec.fields.title : undefined });
   }
   return profiles;
 }

--- a/tests/typing/profile.test.ts
+++ b/tests/typing/profile.test.ts
@@ -7,7 +7,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import {
-  composeTypeProfile, overlayUncoveredSegs, hasOpposingVoices, PRIMARY_FLOOR,
+  composeTypeProfile, overlayUncoveredSegs, hasOpposingVoices, registerOf, PRIMARY_FLOOR,
   type LayerInstance, type UnitRange,
 } from '../../src/lib/typing/profile';
 
@@ -79,6 +79,32 @@ describe('composeTypeProfile — primary selection', () => {
     const p = composeTypeProfile(unit(0, 3), [inst('rabbi', 'Rava', 0, 3), inst('places', 'Bavel', 0, 3)]);
     expect(p.primary).toBe('pure-dialectic');
     expect(p.claims).toHaveLength(2); // recorded as claims, just not primary-eligible
+  });
+});
+
+describe('register (mishnah/gemara axis)', () => {
+  it('is gemara when no mishnah segments are supplied (the default)', () => {
+    expect(composeTypeProfile(unit(0, 3), []).register).toBe('gemara');
+    expect(registerOf(unit(0, 3))).toBe('gemara');
+    expect(registerOf(unit(0, 3), new Set())).toBe('gemara');
+  });
+
+  it('is mishnah when the majority of the unit segments are mishnah', () => {
+    // unit 0..3; segs 0,1,2 are mishnah → 3/4 ≥ 0.5.
+    const mishnaSegs = new Set([0, 1, 2]);
+    expect(composeTypeProfile(unit(0, 3), [], { mishnaSegs }).register).toBe('mishnah');
+    expect(registerOf(unit(0, 3), mishnaSegs)).toBe('mishnah');
+  });
+
+  it('stays gemara when only a minority brushes the mishnah range', () => {
+    // unit 0..3; only seg 0 is mishnah → 1/4 < 0.5.
+    expect(registerOf(unit(0, 3), new Set([0]))).toBe('gemara');
+  });
+
+  it('is orthogonal to primary: a mishnah unit can be halacha-primary', () => {
+    const p = composeTypeProfile(unit(0, 4), [inst('halacha', 'h', 0, 4)], { mishnaSegs: new Set([0, 1, 2, 3, 4]) });
+    expect(p.primary).toBe('halacha');
+    expect(p.register).toBe('mishnah');
   });
 });
 


### PR DESCRIPTION
## What

The section-type `primary` slot conflated two orthogonal axes: **what** a section is about (halacha/aggadata/pesukim/pure-dialectic) and **what kind of text** it is. The register — mishnah vs gemara — was invisible to the type system even though the source data carries it (your screenshot's row 1 is an "Opening Mishnah" that the type system could only call `halacha`).

This adds `register: 'mishnah' | 'gemara'` as a separate axis, derived **deterministically (no LLM)**.

## How
- **Source**: the cached mishnah-in-talmud segment ranges (Sefaria `/api/related`, already fetched via `getMishnaBundleCached` — `anchorStartSeg..anchorEndSeg`).
- **Rule**: `registerOf(unit, mishnaSegs)` → `mishnah` when ≥ `REGISTER_FLOOR` (0.5) of the unit's segments fall in those ranges, else `gemara` (also `gemara` when no ranges supplied — mishnah is the labeled minority). Majority rule so a section merely brushing a boundary stays gemara.
- `profile.ts`: `Register` type, pure `registerOf`, the `register` field, `REGISTER_FLOOR`.
- worker `buildDafTypeProfiles`: builds the mishnah segment set and passes it to `composeTypeProfile`; the field flows out additively on `/api/type-profiles`.
- dev `TypeProfilePanel`: a `mishnah` chip (shown only for the labeled minority, to keep the panel uncluttered).

## Design notes
- **Orthogonal & additive.** Register is independent of `primary` (a unit can be a *mishnah* that is *halacha*-primary) and of `isDispute`. No rendering-dispatch changes yet — observation first, per the precision-over-recall principle.
- **No `baraita`.** The source only deterministically labels mishnah-in-talmud; there's no deterministic signal for baraita, so it's intentionally omitted rather than guessed.

## Safety / tests
Additive field — existing consumers (the sidebar reads `primary`/`isDispute`) ignore it. Codex review: no findings (1-indexed→0-indexed anchor conversion is consistent; field is additive). `pnpm typecheck` clean; full suite **1541 passing** (5 new register tests).