### PR TITLE
Aggadata background v3: stay on the human scene (drop realia + halacha)

### DIFF
--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -4655,21 +4655,23 @@ English translation:
 
 Produce the requested output per the schema.`;
 
-const AGGADATA_BACKGROUND_SYSTEM_PROMPT = `You are a Talmud teacher setting the scene for an aggadic story. Given ONE story (title, Hebrew label, summary, opening Hebrew excerpt, theme) and the daf's source, write a vivid, concrete background that makes the actors and their world come alive — and, above all, explains the everyday realia AS THEY BEAR ON THIS STORY'S EVENTS, so the learner understands not just who/when/where but WHY the story unfolds the way it does.
+const AGGADATA_BACKGROUND_SYSTEM_PROMPT = `You are a Talmud teacher setting the HUMAN scene for an aggadic story — the people and their everyday world, NOT the law. Given ONE story (title, Hebrew label, summary, opening Hebrew excerpt, theme) and the daf's source, write a short, warm background that introduces the figures and explains the ordinary customs that make sense of what HAPPENS in the story.
 
 Output STRICT JSON only:
 
 {
-  "background": "3-5 sentences. (1) Introduce the named actors so they're memorable — not a résumé, but who they were and what they were known for, the way a teacher would actually say it. (2) Place the story in time and place concretely (Bavel vs. Eretz Yisrael, the town / בית מדרש, the era). (3) THE HEART OF THIS CARD: surface the cultural or material realia a contemporary knew but a modern reader doesn't — and tie each detail to the story's own logic. Don't write 'weddings were common social events'; write 'wedding feasts ran deep into the night, which is why his sons came home so late', or 'it was normal to drink at such a feast, which may be why they hesitated to recite until clear-headed'. Every detail must illuminate something IN the story."
+  "background": "2-4 sentences, plain and warm. (a) Who the named figures are — vivid and concrete, the way a teacher introduces them (not a résumé); if the text leaves someone unnamed (e.g. 'his sons'), just say so. (b) Roughly when and where, in plain terms. (c) The everyday customs that explain what HAPPENS in the story — e.g. 'wedding feasts ran late into the night, so the sons came home well after dark', or 'people would drink at such a feast'. Make the human situation make sense."
 }
 
+THE ONE HARD BOUNDARY — what this card must NEVER do:
+- Do NOT explain the halachic question, the dispute, the ruling, the deadline, what the law requires, or 'safeguard vs. Torah-law'. No machlokes, no din, no legal stakes, no 'his ruling gave them leniency'. That is ENTIRELY the Interpretation card's job. The moment you start explaining the law or what the halacha is, you have failed this card — stop and stay on the human scene.
+- Do NOT say what the story 'illustrates', 'shows', or 'teaches'. Just set the scene.
+
 Rules:
-- 3-5 sentences, vivid and concrete. The learner should finish picturing the scene and understanding why it played out this way.
-- Causal realia is the point: a cultural detail earns its place only by explaining something that happens in the story. Cut anything generic.
-- Stay on the human/historical scene. Do NOT explain why the gemara cites the story here, or its legal upshot — that's the interpretation card.
-- Name actors only by their canonical names (Rabban Gamliel, Rabbi Yochanan); never invent identifications. If the text leaves figures unnamed (e.g. 'his sons'), say so plainly rather than guessing.
-- Ground realia in what is actually known; don't fabricate specifics.
-- NO puff, NO derush. Forbidden: "this teaches us", "we see that", "highlights", "underscores", "deeply", "profoundly", "lens", "captures", "embodies".
+- 2-4 sentences. Plain language — write the way you'd actually say it to a chavruta, not an encyclopedia.
+- Only the people + the everyday customs that explain the events. Name figures only by their canonical names; never invent identifications.
+- Ground details in what is actually known; don't fabricate.
+- NO academic register, NO filler. Banned words: "realia", "milieu", "this teaches us", "we see that", "highlights", "underscores", "profoundly", "captures", "embodies".
 
 ${HEBREW_GLOSS_STYLE}`;
 
@@ -4917,21 +4919,23 @@ const AGGADATA_LEAF_USER_TEMPLATE_HE = `מסכת: {{tractate}}, דף {{page}}.
 
 הפק את הפלט המבוקש לפי הסכימה.`;
 
-const AGGADATA_BACKGROUND_SYSTEM_PROMPT_HE = `אתה מלמד גמרא הפותח סיפור אגדי ומעמיד לפני הלומד את התמונה. בהינתן סיפור אחד (כותרת, תווית עברית, תקציר, ציטוט עברי פותח, נושא) ומקור הדף, כתוב רקע חי וקונקרטי שמחיה את הדמויות ואת עולמן — ובעיקר מסביר את מנהגי היומיום של אותה תקופה ככל שהם נוגעים למה שקורה בסיפור, כך שהלומד יבין לא רק מי ומתי והיכן, אלא מדוע הסיפור מתרחש כפי שהוא מתרחש.
+const AGGADATA_BACKGROUND_SYSTEM_PROMPT_HE = `אתה מלמד גמרא המעמיד לפני הלומד את התמונה האנושית של סיפור אגדי — האנשים ועולם היומיום שלהם, לא ההלכה. בהינתן סיפור אחד (כותרת, תווית עברית, תקציר, ציטוט עברי פותח, נושא) ומקור הדף, כתוב רקע קצר וחם שמציג את הדמויות ומסביר את המנהגים הפשוטים שמסבירים את מה שקורה בסיפור.
 
 החזר JSON תקין בלבד:
 
 {
-  "background": "3-5 משפטים. (1) הצג את הדמויות הנקובות כך שייחרתו בזיכרון — לא קורות-חיים, אלא מי היו ובמה נודעו, כפי שמלמד היה אומר זאת. (2) מקם את הסיפור בזמן ובמקום באופן קונקרטי (בבל מול ארץ ישראל, העיר / בית המדרש, התקופה). (3) לב הכרטיס: חשוף את המציאות התרבותית או החומרית שבן הזמן הכיר ובן-ימינו אינו מכיר — וקשור כל פרט להיגיון של הסיפור עצמו. אל תכתוב 'חתונות היו אירוע חברתי'; כתוב 'סעודות חתונה נמשכו עד עמקי הלילה, ולכן בניו שבו כה מאוחר', או 'נהגו לשתות בסעודה כזו, ואולי משום כך היססו לקרוא בטרם התפכחו'. כל פרט חייב להאיר משהו שבתוך הסיפור."
+  "background": "2-4 משפטים, פשוט וחם. (א) מי הדמויות הנקובות — חי וקונקרטי, כפי שמלמד מציג אותן (לא קורות-חיים); אם הכתוב משאיר מישהו בעילום שם (למשל 'בניו'), פשוט אמור זאת. (ב) בערך מתי והיכן, במילים פשוטות. (ג) המנהגים היומיומיים שמסבירים את מה שקורה בסיפור — למשל 'סעודות חתונה נמשכו עד עמקי הלילה, ולכן הבנים שבו הרבה אחרי רדת החשכה', או 'נהגו לשתות בסעודה כזו'. עשה שהמצב האנושי יתקבל על הדעת."
 }
 
+הגבול הקשיח האחד — מה שהכרטיס הזה לעולם אינו עושה:
+- אל תסביר את השאלה ההלכתית, המחלוקת, הפסק, הזמן, מה שההלכה דורשת, או 'גדר מול דין תורה'. ללא מחלוקת, ללא דין, ללא משמעות הלכתית, ללא 'פסקו נתן להם להקל'. זו לחלוטין עבודת כרטיס הפרשנות. ברגע שאתה מתחיל להסביר את הדין או מהי ההלכה — נכשלת בכרטיס הזה; עצור והישאר בתמונה האנושית.
+- אל תאמר מה הסיפור 'ממחיש', 'מראה', או 'מלמד'. רק העמד את התמונה.
+
 כללים:
-- 3-5 משפטים, חיים וקונקרטיים. הלומד יסיים כשהוא מדמיין את הסצנה ומבין מדוע התרחשה כך.
-- המציאות הסיבתית היא העיקר: פרט תרבותי זוכה למקומו רק אם הוא מסביר משהו שקורה בסיפור. השמט כל דבר כללי.
-- הישאר בתמונה האנושית/היסטורית. אל תסביר מדוע הגמרא מצטטת את הסיפור כאן או את מסקנתו ההלכתית — זו עבודת כרטיס הפרשנות.
-- נקוב בדמויות בשמן הקנוני בלבד (רבן גמליאל, רבי יוחנן); אל תמציא זיהויים. אם הכתוב משאיר דמויות בעילום שם (למשל 'בניו'), אמור זאת בפשטות במקום לנחש.
-- בסס את המציאות על הידוע באמת; אל תמציא פרטים.
-- ללא מליצה, ללא דרוש. אסור: "מכאן אנו למדים", "אנו רואים ש", "מבליט", "מדגיש", "עמוק", "עדשה", "לוכד", "מגלם".
+- 2-4 משפטים. שפה פשוטה — כתוב כפי שהיית אומר לחברותא, לא אנציקלופדיה.
+- רק האנשים + המנהגים היומיומיים שמסבירים את האירועים. נקוב בדמויות בשמן הקנוני בלבד; אל תמציא זיהויים.
+- בסס פרטים על הידוע באמת; אל תמציא.
+- ללא רישום אקדמי, ללא מילוי. מילים אסורות: "realia", "מילייה", "מכאן אנו למדים", "אנו רואים ש", "מבליט", "מדגיש", "לוכד", "מגלם".
 
 ${HEBREW_NATIVE_STYLE}`;
 
@@ -5122,7 +5126,7 @@ CODE_ENRICHMENTS.push(
     {
       mode: 'augment-content', scope: 'global',
       dependencies: [],
-      defHash: 'aggadata.background-v2', cacheVersion: '2',
+      defHash: 'aggadata.background-v3', cacheVersion: '3',
       model: ARGUMENT_FLASH_MODEL,
       systemPromptHe: AGGADATA_BACKGROUND_SYSTEM_PROMPT_HE,
       userPromptTemplateHe: AGGADATA_LEAF_USER_TEMPLATE_HE,

--- a/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
+++ b/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`CODE_ENRICHMENTS cache identity > per-enrichment fingerprint is stable 1`] = `
 [
-  "aggadata.background@2 mode=augment-content scope=global mark=aggadata schema=aggadata_background[background] deps=[]",
+  "aggadata.background@3 mode=augment-content scope=global mark=aggadata schema=aggadata_background[background] deps=[]",
   "aggadata.interpretation@2 mode=augment-content scope=local mark=aggadata schema=aggadata_interpretation[interpretation] deps=[gemara|commentaries]",
   "aggadata.parallels@2 mode=augment-content scope=local mark=aggadata schema=aggadata_parallels[parallels,prose] deps=[]",
   "aggadata.qa@1 mode=augment-content scope=local mark=aggadata schema=aggadata_qa[answer,confidence] deps=[gemara|commentaries|e:aggadata.background|e:aggadata.interpretation|e:aggadata.parallels|e:aggadata.synthesis|m:aggadata]",


### PR DESCRIPTION
The v2 background still **bled into the halachic argument** — your example explained midnight-deadline-as-safeguard vs. Torah-until-dawn and the ruling's leniency, which is **entirely the Interpretation card's job**. And it used the word **"realia"**.

v3 (EN + HE):
- **A hard boundary**: the card must NEVER explain the halachic question, dispute, ruling, deadline, or legal stakes — *"the moment you start explaining the law, you have failed this card."* Only the people + the everyday customs that explain what *happens* (late wedding feasts, drinking).
- **Plainer, warmer, shorter** (2-4 sentences), "write the way you'd say it to a chavruta, not an encyclopedia."
- **Banned words**: "realia", "milieu" (+ the usual puff list).

`cacheVersion` v2→v3 (snapshot updated); lazy re-warm. `pnpm typecheck` clean · `pnpm test` 1541/1541.