### PR TITLE
Aggadata theme tag: drop biography, capitalize the rest

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -1661,7 +1661,7 @@ export const AGGADATA_RECIPE: SidebarRecipe = {
   titleField: 'title',
   titleHeField: 'titleHe',
   sections: [
-    { type: 'tags', fields: ['theme'] },
+    { type: 'tags', fields: ['theme'], drop: ['biography'] },
     { type: 'prose', field: 'summary', untilSynthesis: true },
     { type: 'synthesis' },
     { type: 'explainer', dep: 'aggadata.background', textField: 'background', labelKey: 'aggadata.background' },

--- a/src/client/sidebar/primitives.tsx
+++ b/src/client/sidebar/primitives.tsx
@@ -369,8 +369,10 @@ export type SpecialBlock = (props: SpecialBlockProps) => JSX.Element;
 
 /** One section of a card, top → bottom. */
 export type SectionSpec =
-  /** Accent-tinted chips from instance fields (e.g. an aggadata theme). */
-  | { type: 'tags'; fields: string[] }
+  /** Small chips from instance fields (e.g. an aggadata theme). `drop` hides
+   *  specific values (e.g. a retired 'biography' theme that may linger in old
+   *  cached extractions). */
+  | { type: 'tags'; fields: string[]; drop?: string[] }
   /** A paragraph of an instance field, rabbi-linked + Hebraized (e.g. a summary).
    *  `untilSynthesis` makes it a placeholder: shown only until the synthesis
    *  section resolves, then replaced by it (the instant field fills the slot
@@ -491,17 +493,20 @@ export function SidebarCardFromHint(props: {
   const renderSection = (s: SectionSpec): JSX.Element => {
     switch (s.type) {
       case 'tags': {
-        const vals = (): string[] => s.fields.map((f) => str(fields()[f])).filter(Boolean);
+        const dropped = new Set((s.drop ?? []).map((d) => d.toLowerCase()));
+        const vals = (): string[] => s.fields
+          .map((f) => str(fields()[f]))
+          .filter((v) => v && !dropped.has(v.toLowerCase()));
         return (
           <Show when={vals().length > 0}>
             <div style={{ display: 'flex', 'flex-wrap': 'wrap', gap: '0.3rem', 'margin-bottom': '0.7rem' }}>
               <For each={vals()}>{(v) => (
                 // Neutral & quiet: a theme tag is a coarse, not-fully-trusted
                 // label, so it stays unobtrusive — muted gray, faint fill,
-                // hairline border, lowercase — rather than a loud accent chip.
+                // hairline border. Title-case so single-word themes read cleanly.
                 <span style={{
                   display: 'inline-block', padding: '0.1rem 0.5rem', 'font-size': '0.7rem',
-                  'text-transform': 'lowercase', 'letter-spacing': '0.02em',
+                  'text-transform': 'capitalize', 'letter-spacing': '0.02em',
                   color: '#777', background: '#f5f5f4', border: '1px solid #e8e8e6',
                   'border-radius': '3px',
                 }}>{v}</span>

--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -306,7 +306,7 @@ Output STRICT JSON only:
         "summary": "2-3 sentence English summary of what happens in this story / what the maxim teaches.",
         "excerpt": "3-5 Hebrew/Aramaic words copied VERBATIM from the source where this aggadah BEGINS.",
         "endExcerpt": "Last 3-5 Hebrew/Aramaic words of the story, copied VERBATIM from the source — where this aggadah ENDS on the daf. NOT the start of the next halachic discussion or the next story. If the story is one line long, this can still be the closing 3-5 words of that same line; it MUST NOT equal excerpt.",
-        "theme": "One word/short phrase tag: 'martyrdom' | 'study' | 'prayer' | 'reward' | 'suffering' | 'miracle' | 'parable' | 'ethics' | 'biography' | 'other'."
+        "theme": "One word/short phrase tag: 'martyrdom' | 'study' | 'prayer' | 'reward' | 'suffering' | 'miracle' | 'parable' | 'ethics' | 'other'."
       }
     }
   ]
@@ -342,7 +342,7 @@ const AGGADATA_SYSTEM_PROMPT_HE = `אתה תלמיד חכם הבקיא בש"ס. 
         "summary": "סיכום בן 2–3 משפטים בעברית של מה שקורה בסיפור / מה שהמימרה מלמדת.",
         "excerpt": "3-5 מילים בעברית/ארמית המועתקות מילה-במילה מן המקור, במקום שבו האגדה מתחילה.",
         "endExcerpt": "3-5 המילים האחרונות של הסיפור, מועתקות מילה-במילה מן המקור — במקום שבו האגדה מסתיימת בדף. לא תחילת הדיון ההלכתי הבא או הסיפור הבא. אם הסיפור באורך שורה אחת, אלה עדיין מילות הסיום של אותה שורה; חייבות להיות שונות מ-excerpt.",
-        "theme": "תגית של מילה/ביטוי קצר באנגלית: 'martyrdom' | 'study' | 'prayer' | 'reward' | 'suffering' | 'miracle' | 'parable' | 'ethics' | 'biography' | 'other'."
+        "theme": "תגית של מילה/ביטוי קצר באנגלית: 'martyrdom' | 'study' | 'prayer' | 'reward' | 'suffering' | 'miracle' | 'parable' | 'ethics' | 'other'."
       }
     }
   ]


### PR DESCRIPTION
Removes **biography** from the theme taxonomy — it mislabels halachic *maasim* and isn't useful.

- **Prompt (EN+HE):** drops 'biography' from the tag list so new extractions don't produce it.
- **No mark cache bump** — re-extracting every story in Shas for one tag word isn't worth it. Instead the client **hides** any lingering cached 'biography' via a new declarative `drop: ['biography']` on the tags section (reusable for any retired value).
- **Capitalize:** tags are now Title Case (were lowercase), so 'martyrdom' → 'Martyrdom' etc.

`pnpm typecheck` clean · `pnpm test` 1541/1541.