### PR TITLE
Aggadata: retire the theme tag from the card for now

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -1661,7 +1661,9 @@ export const AGGADATA_RECIPE: SidebarRecipe = {
   titleField: 'title',
   titleHeField: 'titleHe',
   sections: [
-    { type: 'tags', fields: ['theme'], drop: ['biography'] },
+    // Theme tag retired for now — the taxonomy isn't comprehensive enough to be
+    // worth showing. `theme` is still extracted (latent); restore a
+    // `{ type: 'tags', fields: ['theme'] }` section here to bring it back.
     { type: 'prose', field: 'summary', untilSynthesis: true },
     { type: 'synthesis' },
     { type: 'explainer', dep: 'aggadata.background', textField: 'background', labelKey: 'aggadata.background' },

--- a/tests/client/aggadata-panel.test.tsx
+++ b/tests/client/aggadata-panel.test.tsx
@@ -45,7 +45,7 @@ const renderCard = () =>
   ));
 
 describe('aggadata card (recipe-driven)', () => {
-  it('renders the accent title, Hebrew twin subtitle, theme tag, summary, and QA affordance', () => {
+  it('renders the accent title, Hebrew twin subtitle, summary, and QA affordance', () => {
     const { container } = renderCard();
 
     const h3 = container.querySelector('h3')!;
@@ -56,7 +56,8 @@ describe('aggadata card (recipe-driven)', () => {
     expect(subtitle.getAttribute('lang')).toBe('he');
     expect(subtitle.textContent).toContain('מעשה רבי בנידבך');
 
-    expect(container.textContent).toContain('designation'); // theme tag
+    // Theme tag is retired from the card — the value isn't rendered.
+    expect(container.textContent).not.toContain('designation');
     expect(container.textContent).toContain('A short summary of the story.'); // prose
 
     // QA toggle renders synchronously (its lists are lazy on expand).


### PR DESCRIPTION
The theme taxonomy isn't comprehensive enough to be worth surfacing yet, so the tag comes off the card.

`theme` is **still extracted** (latent data, no loss) — the card just doesn't render it. Bringing it back later is a one-line section add (the comment marks where). The generic `tags` section + its `drop`/capitalize support stay in primitives for other cards and a future revival.

`pnpm typecheck` clean · `pnpm test` 1541/1541.