### PR TITLE
Generic sidebar: convert Pasuk to a recipe

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -17,7 +17,7 @@ import { adjacentAmud } from '../lib/sefref/amudim';
 import { dafRefHe, pageLabelHe } from '../lib/sefref/tractates';
 import { selectSectionMoves } from '../lib/argumentMoves';
 import { t, lang } from './i18n';
-import { ACCENTS, HebrewProse, Panel, QASection, SectionCard, Synthesis, SidebarPanelFromHint, SidebarCardFromHint, setActiveCard, kindLabelKey, type SidebarHint, type SidebarRecipe, type SpecialBlockProps } from './sidebar/primitives';
+import { ACCENTS, HE_FONT, HebrewProse, Panel, QASection, SectionCard, Synthesis, SidebarPanelFromHint, SidebarCardFromHint, setActiveCard, kindLabelKey, type SidebarHint, type SidebarRecipe, type SpecialBlockProps } from './sidebar/primitives';
 import { InspectDot } from './MarkEnrichmentCards';
 
 /** Localize an era date-range ("c. 290 – 320 CE") for Hebrew display. */
@@ -1493,59 +1493,24 @@ export function HalachaBody(props: {
  *  on expand, the surrounding verses inlined as one continuous Hebrew block
  *  (prev + cited + next) with the cited verse rendered dark and the others
  *  dimmed so the citation still stands out. */
-export function PasukPanel(props: { pasuk: Pasuk; tractate: string; page: string }): JSX.Element {
+// The pasuk card's custom header + verse block: the fetched Hebrew verse
+// reference as the heading, the verse text (Tanakh font), and the prev/next
+// verses shown dimmed while expanded. A NAMED special block referenced first in
+// PASUK_RECIPE — everything below it (synthesis + the four explainers + Q&A) is
+// standard recipe vocabulary.
+function PasukVerse(props: SpecialBlockProps): JSX.Element {
+  const verseRef = (): string => (typeof props.instance.fields.verseRef === 'string' ? props.instance.fields.verseRef : '');
   const [expanded, setExpanded] = createSignal(true);
-  const [detail] = createResource(() => props.pasuk.verseRef, fetchPasuk);
-  const [prev] = createResource(
-    () => (expanded() ? detail()?.prevRef ?? null : null),
-    (r) => fetchPasuk(r),
-  );
-  const [next] = createResource(
-    () => (expanded() ? detail()?.nextRef ?? null : null),
-    (r) => fetchPasuk(r),
-  );
-
-  // Section leaves, surfaced from the synthesis aggregate's deps_resolved
-  // (same mechanism HalachaBody uses). Each renders as its own card below the
-  // synthesis paragraph.
-  const [tanachContext, setTanachContext] = createSignal<string | null>(null);
-  const [whyHere, setWhyHere] = createSignal<string | null>(null);
-  const [mechanism, setMechanism] = createSignal<string | null>(null);
-  const [landing, setLanding] = createSignal<string | null>(null);
-
-  createEffect(() => {
-    void props.pasuk.verseRef;
-    setTanachContext(null);
-    setWhyHere(null);
-    setMechanism(null);
-    setLanding(null);
-  });
-
-  const handleResolved = (r: { deps_resolved?: Record<string, unknown>; anchors_resolved?: Record<string, unknown> }) => {
-    const deps = r.deps_resolved ?? {};
-    const tc = deps['pesukim.tanach-context'] as { context?: string } | undefined;
-    if (tc && typeof tc.context === 'string') setTanachContext(tc.context);
-    const wh = deps['pesukim.why-here'] as { why_here?: string } | undefined;
-    if (wh && typeof wh.why_here === 'string') setWhyHere(wh.why_here);
-    const me = deps['pesukim.mechanism'] as { mechanism?: string } | undefined;
-    if (me && typeof me.mechanism === 'string') setMechanism(me.mechanism);
-    const la = deps['pesukim.landing'] as { landing?: string } | undefined;
-    if (la && typeof la.landing === 'string') setLanding(la.landing);
-  };
-
-  const pesukimInstance = () => ({
-    startSegIdx: props.pasuk.startSegIdx,
-    endSegIdx: props.pasuk.endSegIdx,
-    fields: {
-      verseRef: props.pasuk.verseRef,
-      citationStyle: props.pasuk.citationStyle,
-      excerpt: props.pasuk.excerpt,
-      summary: props.pasuk.summary,
-    },
-  });
-
+  const [detail] = createResource(verseRef, fetchPasuk);
+  const [prev] = createResource(() => (expanded() ? detail()?.prevRef ?? null : null), (r) => fetchPasuk(r));
+  const [next] = createResource(() => (expanded() ? detail()?.nextRef ?? null : null), (r) => fetchPasuk(r));
   return (
-    <Panel accent={ACCENTS.pesuk} title={detail()?.heRef ?? props.pasuk.verseRef} titleLang="he">
+    <>
+      {/* Hebrew verse ref heading — the card's real header (fetched, so it can't
+          be a static recipe title; the recipe omits titleField for this). */}
+      <h3 dir="rtl" lang="he" style={{ margin: '0 0 0.3rem', 'font-size': '1.05rem', color: ACCENTS.pesuk, 'font-family': HE_FONT }}>
+        {detail()?.heRef ?? verseRef()}
+      </h3>
       <Show when={detail.loading && !detail()}>
         <p style={{ color: '#999', 'font-style': 'italic', margin: '0 0 0.5rem' }}>{t('pasuk.loading')}</p>
       </Show>
@@ -1574,34 +1539,43 @@ export function PasukPanel(props: { pasuk: Pasuk; tractate: string; page: string
         }}
         title={expanded() ? t('pasuk.verses.hide') : t('pasuk.verses.show')}
       >{expanded() ? `› ${t('common.collapse')} ‹` : `‹ ${t('common.expand')} ›`}</button>
-      {/* Per-pasuk synthesis card. Mounts MarkEnrichmentCards markId="pesukim":
-          the synthesis paragraph renders in its own box, and its resolved
-          leaves (tanach-context / why-here / mechanism / landing) come back
-          via onResolved and render as separate section cards below — the same
-          structure as the halacha panel. */}
-      <Synthesis
-        markId="pesukim"
-        instance={pesukimInstance()}
-        instanceKey={props.pasuk.verseRef}
-        tractate={props.tractate}
-        page={props.page}
-        onResolved={handleResolved}
-      />
-      <Show when={tanachContext()}>{(tc) => <SectionCard label="pasuk.tanachContext" text={tc()} inspect={{ instanceKey: props.pasuk.verseRef, leafId: 'pesukim.tanach-context' }} />}</Show>
-      <Show when={whyHere()}>{(wh) => <SectionCard label="pasuk.whyHere" text={wh()} inspect={{ instanceKey: props.pasuk.verseRef, leafId: 'pesukim.why-here' }} />}</Show>
-      <Show when={mechanism()}>{(me) => <SectionCard label="pasuk.mechanism" text={me()} inspect={{ instanceKey: props.pasuk.verseRef, leafId: 'pesukim.mechanism' }} />}</Show>
-      <Show when={landing()}>{(la) => <SectionCard label="pasuk.landing" text={la()} inspect={{ instanceKey: props.pasuk.verseRef, leafId: 'pesukim.landing' }} />}</Show>
-      {/* Questions panel: curated follow-ups + community + free-form asking. */}
-      <QASection
-        mark="pesukim"
-        instanceId={props.pasuk.verseRef}
-        instance={pesukimInstance()}
-        tractate={props.tractate}
-        page={props.page}
-      />
-    </Panel>
+    </>
   );
 }
+
+/** The pasuk mark-instance shape (mark_input for the pesukim leaves). Seg indices
+ *  are passed through as-is (may be undefined) — coercing an absent index to 0
+ *  would mis-scope a malformed pasuk to segment 0, which the old panel avoided. */
+export function pasukInstance(pasuk: Pasuk): { fields: Record<string, unknown>; startSegIdx?: number; endSegIdx?: number } {
+  return {
+    startSegIdx: pasuk.startSegIdx,
+    endSegIdx: pasuk.endSegIdx,
+    fields: {
+      verseRef: pasuk.verseRef,
+      citationStyle: pasuk.citationStyle,
+      excerpt: pasuk.excerpt,
+      summary: pasuk.summary,
+    },
+  };
+}
+
+export const PASUK_RECIPE: SidebarRecipe = {
+  kind: 'pesuk',
+  markId: 'pesukim',
+  // No titleField — the verse special block renders the fetched Hebrew ref.
+  sections: [
+    { type: 'special', block: 'pasuk-verse' },
+    { type: 'synthesis' },
+    { type: 'explainer', dep: 'pesukim.tanach-context', textField: 'context', labelKey: 'pasuk.tanachContext' },
+    { type: 'explainer', dep: 'pesukim.why-here', textField: 'why_here', labelKey: 'pasuk.whyHere' },
+    { type: 'explainer', dep: 'pesukim.mechanism', textField: 'mechanism', labelKey: 'pasuk.mechanism' },
+    { type: 'explainer', dep: 'pesukim.landing', textField: 'landing', labelKey: 'pasuk.landing' },
+    { type: 'qa' },
+  ],
+};
+export const PASUK_BLOCKS: Record<string, (p: SpecialBlockProps) => JSX.Element> = {
+  'pasuk-verse': PasukVerse,
+};
 
 // ===========================================================================
 // Aggadata — per-story narrative sidebar panel.
@@ -1687,6 +1661,7 @@ export const AGGADATA_BLOCKS: Record<string, (p: SpecialBlockProps) => JSX.Eleme
  *  unmounted instanceKey (a dead click). */
 export const RECIPES_BY_KIND: Partial<Record<SidebarContent['kind'], SidebarRecipe>> = {
   aggadata: AGGADATA_RECIPE,
+  pesuk: PASUK_RECIPE,
 };
 
 /** The instanceKey a recipe-driven card mounts under (the client run memo + the
@@ -1696,6 +1671,7 @@ export const RECIPES_BY_KIND: Partial<Record<SidebarContent['kind'], SidebarReci
 export function instanceKeyForContent(content: SidebarContent, tractate: string, page: string): string | null {
   switch (content.kind) {
     case 'aggadata': return `${tractate}:${page}:${content.index}:${content.story.title}`;
+    case 'pesuk': return content.pasuk.verseRef;
     default: return null;
   }
 }
@@ -1964,10 +1940,13 @@ export function ArgumentSidebar(props: ArgumentSidebarProps): JSX.Element {
             </Show>
 
             <Show when={c().kind === 'pesuk'}>
-              <PasukPanel
-                pasuk={(c() as Extract<SidebarContent, { kind: 'pesuk' }>).pasuk}
+              <SidebarCardFromHint
+                recipe={PASUK_RECIPE}
+                instance={pasukInstance((c() as Extract<SidebarContent, { kind: 'pesuk' }>).pasuk)}
+                instanceKey={instanceKeyForContent(c() as Extract<SidebarContent, { kind: 'pesuk' }>, props.tractate, props.page)!}
                 tractate={props.tractate}
                 page={props.page}
+                specialBlocks={PASUK_BLOCKS}
               />
             </Show>
 

--- a/src/client/sidebar/primitives.tsx
+++ b/src/client/sidebar/primitives.tsx
@@ -82,7 +82,7 @@ const SECTION_PROSE: JSX.CSSProperties = {
   'line-height': 1.55,
 };
 
-const HE_FONT = '"Mekorot Vilna", serif';
+export const HE_FONT = '"Mekorot Vilna", serif';
 // Tanakh verses carry cantillation; widen the fallback chain so a reader
 // without Mekorot still gets correct mark placement.
 const HE_FONT_TANAKH =
@@ -221,21 +221,24 @@ export function Panel(props: {
 
   return (
     <div>
-      <Show
-        when={primaryIsHe()}
-        fallback={
-          <h3 style={{ margin: '0 0 0.3rem', 'font-size': '1.05rem', color: props.accent }}>
+      {/* No title → the card owns its header via a special section (e.g. pasuk). */}
+      <Show when={primary()}>
+        <Show
+          when={primaryIsHe()}
+          fallback={
+            <h3 style={{ margin: '0 0 0.3rem', 'font-size': '1.05rem', color: props.accent }}>
+              {primary()}
+            </h3>
+          }
+        >
+          <h3
+            dir="rtl"
+            lang="he"
+            style={{ margin: '0 0 0.3rem', 'font-size': '1.05rem', color: props.accent, 'font-family': HE_FONT }}
+          >
             {primary()}
           </h3>
-        }
-      >
-        <h3
-          dir="rtl"
-          lang="he"
-          style={{ margin: '0 0 0.3rem', 'font-size': '1.05rem', color: props.accent, 'font-family': HE_FONT }}
-        >
-          {primary()}
-        </h3>
+        </Show>
       </Show>
       <Show when={secondary()}>
         <Show
@@ -395,7 +398,10 @@ export type SectionSpec =
 export interface SidebarRecipe {
   kind: SidebarKind;
   markId: string;
-  titleField: string;
+  /** Instance field for the card heading. Omit to suppress the Panel heading
+   *  entirely — a card whose header is genuinely custom (e.g. pasuk's fetched
+   *  Hebrew verse ref) renders it from a `special` section instead. */
+  titleField?: string;
   titleHeField?: string;
   titleLang?: 'en' | 'he';
   flip?: 'name' | 'rabbi';
@@ -427,9 +433,9 @@ export interface RecipeInfo {
   sections: RecipeSectionInfo[];
 }
 export function describeRecipe(recipe: SidebarRecipe): RecipeInfo {
-  const header = recipe.titleHeField
-    ? `${recipe.titleField} / ${recipe.titleHeField}`
-    : recipe.titleField;
+  const header = recipe.titleField
+    ? (recipe.titleHeField ? `${recipe.titleField} / ${recipe.titleHeField}` : recipe.titleField)
+    : '(custom header)';
   const sections = recipe.sections.map((s, i): RecipeSectionInfo => {
     const n = i + 1;
     // tags/prose render fields off the mark instance → their provenance is the
@@ -567,7 +573,7 @@ export function SidebarCardFromHint(props: {
   return (
     <Panel
       accent={accent()}
-      title={str(fields()[props.recipe.titleField])}
+      title={props.recipe.titleField ? str(fields()[props.recipe.titleField]) : ''}
       titleHe={props.recipe.titleHeField ? str(fields()[props.recipe.titleHeField]) || undefined : undefined}
       titleLang={props.recipe.titleLang}
       flip={props.recipe.flip}

--- a/tests/client/pasuk-panel.test.tsx
+++ b/tests/client/pasuk-panel.test.tsx
@@ -2,13 +2,14 @@
 import { render } from '@solidjs/testing-library';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Pasuk } from '../../src/client/shapes';
-import { PasukPanel } from '../../src/client/ArgumentSidebar';
+import { PASUK_RECIPE, PASUK_BLOCKS, pasukInstance } from '../../src/client/ArgumentSidebar';
+import { SidebarCardFromHint } from '../../src/client/sidebar/primitives';
 import { setLang, t } from '../../src/client/i18n';
 
 beforeEach(() => {
   setLang('en');
   // Verse + enrichment fetches both go through fetch; an empty payload lets
-  // the panel mount and fall back to the verseRef as title.
+  // the card mount and fall back to the verseRef as the heading.
   vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({}) }) as unknown as Response));
 });
 afterEach(() => {
@@ -24,9 +25,21 @@ const pasuk: Pasuk = {
   endSegIdx: 2,
 };
 
-describe('PasukPanel', () => {
-  it('renders the verse reference as an RTL Hebrew-mode title and a tanakh-font verse block', () => {
-    const { container } = render(() => <PasukPanel pasuk={pasuk} tractate="Shabbat" page="125b" />);
+const renderCard = () =>
+  render(() => (
+    <SidebarCardFromHint
+      recipe={PASUK_RECIPE}
+      instance={pasukInstance(pasuk)}
+      instanceKey={pasuk.verseRef}
+      tractate="Shabbat"
+      page="125b"
+      specialBlocks={PASUK_BLOCKS}
+    />
+  ));
+
+describe('Pasuk recipe card', () => {
+  it('renders the verse ref as an RTL Hebrew heading (from the special verse block) + a tanakh-font verse paragraph', () => {
+    const { container } = renderCard();
 
     const h3 = container.querySelector('h3')!;
     expect(h3.getAttribute('dir')).toBe('rtl');
@@ -43,5 +56,14 @@ describe('PasukPanel', () => {
     const buttons = Array.from(container.querySelectorAll('button'));
     expect(buttons.length).toBeGreaterThanOrEqual(2);
     expect(buttons.some((b) => b.textContent?.includes(t('qa.questions')))).toBe(true);
+  });
+
+  it('declares the four explainer leaves + Q&A in order', () => {
+    const ids = PASUK_RECIPE.sections.flatMap((s) => (s.type === 'explainer' ? [s.dep] : []));
+    expect(ids).toEqual([
+      'pesukim.tanach-context', 'pesukim.why-here', 'pesukim.mechanism', 'pesukim.landing',
+    ]);
+    expect(PASUK_RECIPE.sections.some((s) => s.type === 'qa')).toBe(true);
+    expect(PASUK_RECIPE.titleField).toBeUndefined(); // header is the custom verse block
   });
 });


### PR DESCRIPTION
Retires the bespoke `PasukPanel` — the second card conversion (after Aggadata).

The pasuk card is now **`PASUK_RECIPE`**: a custom **verse block** → `synthesis` → the four explainers (`tanach-context` · `why-here` · `mechanism` · `landing`) → `qa`. Rendered-equivalent, except the explainers now **start collapsed** (the standard recipe behavior, consistent with Aggadata).

Pasuk's header is genuinely custom — the Hebrew verse ref is *fetched*, so it can't be a static instance field. Two small enablers:
- **`SidebarRecipe.titleField` is now optional**; `Panel` renders its heading only when a title is present, so a card can omit it and let a `special` section own the header. (Existing titled cards are unaffected.)
- **`PasukVerse`** is a named special block that fetches the verse detail + prev/next and renders the RTL Hebrew ref heading, the tanakh-font verse text, and the expand toggle.

`instanceKey` stays `verseRef` (inspector + memo key unchanged), `markId` stays `pesukim`, and the Q&A + explainer leaf mappings are identical. Seg indices pass through as-is (not coerced to `0`).

Pasuk now lights up **second** in the dev Recipe-panel scoreboard.

`pnpm typecheck` clean · `pnpm test` 1542/1542 (pasuk test rewritten to drive the recipe). Codex-reviewed (seg-index fix applied; the flagged background-version delta was a stale-branch artifact, resolved by merging master).