### PR TITLE
Rishonim synthesis: content-sensitive cache key (fix poisoned entries)

### DIFF
--- a/src/worker/cache-keys.ts
+++ b/src/worker/cache-keys.ts
@@ -160,6 +160,24 @@ function pickStable(o: Record<string, unknown>): Record<string, unknown> {
     for (const k of ['excerpt', 'title', 'topic', 'theme', 'verseRef']) {
       if (typeof f[k] === 'string') out[`fields.${k}`] = f[k];
     }
+    // Content signature for comment-bearing instances (rishonim): the synthesis
+    // is a pure function of these comments, so fold their content into the id.
+    // Without it a rishonim instance has no usable label and pickStable yields
+    // only {segIdx} — the key collapses to (segIdx, daf, cache_version), blind to
+    // the comments. A single bad generation then caches permanently and cannot
+    // self-heal even after the source content is corrected; including the content
+    // makes the key change with the comments, so a corrected source regenerates.
+    if (Array.isArray(f.comments)) {
+      out['fields.comments'] = (f.comments as unknown[])
+        .map((c) => {
+          if (!c || typeof c !== 'object') return String(c);
+          const cc = c as Record<string, unknown>;
+          return [cc.work, cc.sourceRef, cc.textHe, cc.textEn]
+            .map((v) => (typeof v === 'string' ? v : ''))
+            .join('|');
+        })
+        .join('\n');
+    }
   }
   return out;
 }

--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -3527,7 +3527,7 @@ CODE_ENRICHMENTS.push(
     RISHONIM_SYNTHESIS_SYSTEM_PROMPT, RISHONIM_SYNTHESIS_USER_TEMPLATE,
     {
       dependencies: ['gemara', { mark: 'rishonim' }],
-      defHash: 'rishonim.synthesis-v3', cacheVersion: '3',
+      defHash: 'rishonim.synthesis-v4', cacheVersion: '4',
       model: ARGUMENT_FLASH_MODEL,
       systemPromptHe: RISHONIM_SYNTHESIS_SYSTEM_PROMPT_HE,
       userPromptTemplateHe: RISHONIM_SYNTHESIS_USER_TEMPLATE_HE,

--- a/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
+++ b/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
@@ -46,6 +46,6 @@ exports[`CODE_ENRICHMENTS cache identity > per-enrichment fingerprint is stable 
   "rabbi.relationships.evidence@2 mode=augment-content scope=local mark=rabbi schema=rabbi_relationships_evidence[evidence] deps=[gemara|e:rabbi.relationships]",
   "rabbi.relationships@6 mode=augment-content scope=global mark=rabbi schema=rabbi_relationships[teachers,students,debatePartners,family,prose] deps=[]",
   "rabbi.synthesis@11 mode=aggregate scope=local mark=rabbi schema=rabbi_synthesis[synthesis] deps=[gemara|e:rabbi.bio|e:rabbi.philosophy|e:rabbi.relationships|e:rabbi.classification|e:rabbi.geography|e:rabbi.relationships.evidence|e:rabbi.geography.evidence|e:rabbi.location|e:rabbi.identity|m:rabbi]",
-  "rishonim.synthesis@3 mode=aggregate scope=local mark=rishonim schema=rishonim_synthesis[synthesis] deps=[gemara|m:rishonim]",
+  "rishonim.synthesis@4 mode=aggregate scope=local mark=rishonim schema=rishonim_synthesis[synthesis] deps=[gemara|m:rishonim]",
 ]
 `;

--- a/tests/instance-id.test.ts
+++ b/tests/instance-id.test.ts
@@ -43,3 +43,25 @@ describe('instanceIdOf — Hebrew title collision', () => {
     expect(await instanceIdOf({ fields: { id: '6-8_0' } })).toBe('6-8_0');
   });
 });
+
+// Regression: a rishonim instance carries no id/title/excerpt, so its id used to
+// hash to just {segIdx} — the synthesis cache key was blind to the comments. One
+// bad generation then stuck permanently (saw Berakhot 2a:1 render a Pesachim
+// chametz synthesis from a poisoned entry the correct source couldn't evict).
+// The id must now move with the comment content so a corrected source regenerates.
+describe('instanceIdOf — rishonim comment content sensitivity', () => {
+  const rishonim = (segIdx: number, comments: Array<{ work: string; sourceRef: string; textHe: string; textEn: string }>) =>
+    ({ segIdx, fields: { works: [...new Set(comments.map((c) => c.work))], commentCount: comments.length, comments } });
+
+  it('gives DISTINCT ids to the same segment with different comments', async () => {
+    const shema = rishonim(0, [{ work: 'Rashi', sourceRef: 'Rashi on Berakhot 2a:1:1', textHe: 'מאימתי קורין את שמע', textEn: 'From what time' }]);
+    const chametz = rishonim(0, [{ work: 'Rashi', sourceRef: 'Rashi on Pesachim 2a:1:1', textHe: 'אור לארבעה עשר בודקין את החמץ', textEn: 'On the eve of the 14th' }]);
+    expect(await instanceIdOf(shema)).not.toBe(await instanceIdOf(chametz));
+  });
+
+  it('is stable for identical comment content', async () => {
+    const a = rishonim(0, [{ work: 'Rashi', sourceRef: 'Rashi on Berakhot 2a:1:1', textHe: 'מאימתי', textEn: 'From when' }]);
+    const b = rishonim(0, [{ work: 'Rashi', sourceRef: 'Rashi on Berakhot 2a:1:1', textHe: 'מאימתי', textEn: 'From when' }]);
+    expect(await instanceIdOf(a)).toBe(await instanceIdOf(b));
+  });
+});


### PR DESCRIPTION
## Problem

Berakhot 2a:1 rendered a rishonim synthesis about **Pesachim 2a** (אור לי״ד, בדיקת חמץ) — a different tractate. Investigation showed:

- The live source for Berakhot 2a:1 (Rashi/Tosafot/Meiri/Tosafot HaRosh) is entirely about evening Shema; the HebrewBooks gemara is correct. Feeding the real `mark_input` to the same model produces a correct synthesis. So the displayed text was a **stale/poisoned cache entry**, not what the pipeline produces.
- It could never self-heal because `instanceIdOf` yields only `{segIdx}` for a rishonim instance (no id/title/excerpt to key on), so the `rishonim.synthesis` cache key collapsed to `(segIdx, daf, cache_version)` — **blind to the comment content**. A single bad generation (model runs at temp 0.2) caches permanently.

## Fix

- `pickStable` now folds the comment content (`work | sourceRef | textHe | textEn`) into the instance id when `fields.comments` is present. The id moves with the comments, so a corrected source produces a new key and regenerates. Only comment-bearing (rishonim) instances are affected.
- Bump `rishonim.synthesis` `cacheVersion` 3→4 to clear existing poisoned entries shas-wide.
- Regression test: same `segIdx`, different comments → distinct ids; identical content → stable id.

`pnpm typecheck` + `pnpm test` (1544) green; snapshot updated for the version bump.