### PR TITLE
hebraize: collapse doubled parentheticals (X) (X)

### DIFF
--- a/src/client/hebraize.ts
+++ b/src/client/hebraize.ts
@@ -476,6 +476,12 @@ export function stripStopwordHebrewParens(text: string): string {
  *  the regex bounded. */
 const ECHO_PAREN_RE = /(\S+(?:\s+\S+){0,5})\s*\(\1\)/g;
 
+/** Two ADJACENT identical parentheticals — `(X) (X)` → `(X)`. ECHO_PAREN_RE only
+ *  catches the bare `X (X)` form; the LLM gloss convention sometimes doubles a
+ *  *parenthesized* term instead (`(ביאת שמשו) (ביאת שמשו)`). A repeated
+ *  parenthetical is never intentional, so collapsing it is always safe. */
+const DOUBLE_PAREN_RE = /\(\s*([^()]+?)\s*\)(\s*)\(\s*\1\s*\)/g;
+
 // Hebrew/Aramaic ranges as \u escapes - see the same note in Hebraized.tsx:
 // a literal presentation form (U+FB1D..) can decompose under normalization and
 // silently blow the range open. ־/׳/״ = maqaf/geresh/gershayim.
@@ -521,6 +527,7 @@ export function stripEchoParens(text: string): string {
   // glosses) need a second pass to fully collapse.
   for (let i = 0; i < 3; i++) {
     let next = prev.replace(ECHO_PAREN_RE, '$1');
+    next = next.replace(DOUBLE_PAREN_RE, '($1)');
     next = dropHebrewGlossEchoes(next);
     if (next === prev) break;
     prev = next;

--- a/tests/hebraize.test.ts
+++ b/tests/hebraize.test.ts
@@ -49,6 +49,15 @@ const ECHO_STRIP: Array<[string, string]> = [
   ['the redactor of the משנה (משנה) and',          'the redactor of the משנה and'],
   ['requires a concrete מעשה (מעשה) or mere',      'requires a concrete מעשה or mere'],
   ['community in ארץ ישראל (ארץ ישראל) in the',    'community in ארץ ישראל in the'],
+  // Berakhot 2b pesukim regression — DOUBLED PARENTHETICALS `(X) (X)` (not the
+  // bare `X (X)` form). The pesukim synthesis/explainers emitted these.
+  ['whether (ביאת השמש) (ביאת השמש) refers to',   'whether (ביאת השמש) refers to'],
+  ['reading (ביאת שמשו) (ביאת שמשו) as the',      'reading (ביאת שמשו) as the'],
+  ['and (כפרה) (כפרה) does not delay',            'and (כפרה) does not delay'],
+  // English doubled parenthetical, same bug class.
+  ['cites (sunset) (sunset) permits',             'cites (sunset) permits'],
+  // Two distinct doubled parentheticals in one string.
+  ['(ביאת שמשו) (ביאת שמשו) and (כפרה) (כפרה)',    '(ביאת שמשו) and (כפרה)'],
 ];
 
 describe('stripEchoParens — collapses `X (X)`', () => {
@@ -85,6 +94,9 @@ const ECHO_PRESERVE: string[] = [
   'see the see the cat',
   // Parens-only content (no preceding token), should not crash or alter.
   '(תהילים קי״ט:ס״ב) is the source',
+  // Two ADJACENT but DIFFERENT parentheticals — not a doubled echo, leave both.
+  'compare (ביאת השמש) (צאת הכוכבים) here',
+  'a (sunset) (nightfall) distinction',
 ];
 
 describe('stripEchoParens — preserves non-echo parens', () => {


### PR DESCRIPTION
The pesukim cards showed a Hebrew term parenthesized **twice in a row** — `(ביאת שמשו) (ביאת שמשו)`, `(ביאת השמש) (ביאת השמש)`. `stripEchoParens` only caught the bare `X (X)` echo; a repeated **parenthesized** term slipped through.

Adds `DOUBLE_PAREN_RE` (`(X) (X)` → `(X)`) to the same sanitizer loop every card's text already runs through (synthesis via `<Hebraized>`, explainers via `HebraizedWithRabbis`). A doubled parenthetical is never intentional, so the collapse is unconditional; adjacent **different** parentheticals `(X) (Y)` are preserved (the backreference requires an exact match).

**Client-side → fixes existing cached text immediately, no re-warm.**

`pnpm typecheck` clean · `pnpm test` 1551/1551 (5 new strip cases + 2 preserve guards).