### PR TITLE
Sidebar: one CARD_DEFS registry, generic recipe dispatch

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -1667,8 +1667,8 @@ export const AGGADATA_BLOCKS: Record<string, (p: SpecialBlockProps) => JSX.Eleme
  *  `synthesis` section — that's what mounts the MarkEnrichmentCards host the
  *  inspect drawer renders inside. Without it the panel's 'i' targets an
  *  unmounted instanceKey (a dead click). */
-// Defined here (ahead of its blocks/helpers, which live by the old RishonimBody
-// site) so RECIPES_BY_KIND below can reference it; it names blocks by string.
+// Defined ahead of its blocks/helpers (which live by the old RishonimBody site)
+// so it's in scope before CARD_DEFS; it names blocks by string.
 export const RISHONIM_RECIPE: SidebarRecipe = {
   kind: 'rishonim',
   markId: 'rishonim',
@@ -1678,14 +1678,6 @@ export const RISHONIM_RECIPE: SidebarRecipe = {
     { type: 'synthesis' },
     { type: 'special', block: 'rishonim-sources' },
   ],
-};
-
-export const RECIPES_BY_KIND: Partial<Record<SidebarContent['kind'], SidebarRecipe>> = {
-  aggadata: AGGADATA_RECIPE,
-  pesuk: PASUK_RECIPE,
-  halacha: HALACHA_RECIPE,
-  rabbi: RABBI_RECIPE,
-  rishonim: RISHONIM_RECIPE,
 };
 
 /** The instanceKey a recipe-driven card mounts under (the client run memo + the
@@ -1846,6 +1838,69 @@ export const RISHONIM_BLOCKS: Record<string, (p: SpecialBlockProps) => JSX.Eleme
   'rishonim-sources': RishonimSources,
 };
 
+// ===========================================================================
+// CARD_DEFS — the single registry of recipe-driven sidebar cards. One entry per
+// SidebarContent kind that renders through SidebarCardFromHint, replacing a wall
+// of per-kind dispatch arms with one generic render. Each entry is the
+// client-side adapter (recipe + special blocks + how to build the display /
+// synthesis instance) — the shape the worker mark-def `recipe` field will later
+// supply directly. Place keeps the older hint adapter; the argument-family +
+// voice-group cards are bespoke views (no recipe).
+//
+// The builders receive the (kind-narrowed) SidebarContent; CARD_DEFS is keyed by
+// kind and only invoked for its own kind, so the casts are sound.
+// ===========================================================================
+interface CardDef {
+  recipe: SidebarRecipe;
+  blocks: Record<string, (p: SpecialBlockProps) => JSX.Element>;
+  /** Display instance ({fields}) feeding the heading + non-synthesis sections. */
+  instance: (c: SidebarContent) => { fields: Record<string, unknown> };
+  /** Optional distinct shape sent to the mark synthesis as mark_input. */
+  synthInstance?: (c: SidebarContent) => unknown;
+  /** Optional Q&A cache qualifier (defaults to instanceKey). */
+  qaInstanceId?: (c: SidebarContent) => string;
+  /** Forward the reader-highlight channel to the card's special blocks. */
+  forwardHighlight?: boolean;
+  /** Card-specific extras for special blocks (e.g. rabbi's generationByName). */
+  extras?: (ctx: { generationByName: Map<string, GenerationId> }) => Record<string, unknown>;
+}
+
+export const CARD_DEFS: Partial<Record<SidebarContent['kind'], CardDef>> = {
+  aggadata: {
+    recipe: AGGADATA_RECIPE,
+    blocks: AGGADATA_BLOCKS,
+    instance: (c) => aggadataInstance((c as Extract<SidebarContent, { kind: 'aggadata' }>).story),
+    qaInstanceId: (c) => {
+      const s = (c as Extract<SidebarContent, { kind: 'aggadata' }>).story;
+      return `${s.title}|${s.excerpt}`;
+    },
+  },
+  pesuk: {
+    recipe: PASUK_RECIPE,
+    blocks: PASUK_BLOCKS,
+    instance: (c) => pasukInstance((c as Extract<SidebarContent, { kind: 'pesuk' }>).pasuk),
+  },
+  halacha: {
+    recipe: HALACHA_RECIPE,
+    blocks: HALACHA_BLOCKS,
+    instance: (c) => halachaInstance((c as Extract<SidebarContent, { kind: 'halacha' }>).topic),
+  },
+  rishonim: {
+    recipe: RISHONIM_RECIPE,
+    blocks: RISHONIM_BLOCKS,
+    instance: (c) => rishonimDisplayInstance((c as Extract<SidebarContent, { kind: 'rishonim' }>).instance),
+    synthInstance: (c) => rishonimSynthInstance((c as Extract<SidebarContent, { kind: 'rishonim' }>).instance),
+  },
+  rabbi: {
+    recipe: RABBI_RECIPE,
+    blocks: RABBI_BLOCKS,
+    instance: (c) => rabbiDisplayInstance((c as Extract<SidebarContent, { kind: 'rabbi' }>).rabbi),
+    synthInstance: (c) => rabbiSynthInstance((c as Extract<SidebarContent, { kind: 'rabbi' }>).rabbi),
+    forwardHighlight: true,
+    extras: (ctx) => ({ generationByName: ctx.generationByName }),
+  },
+};
+
 /** Collective "voice group" panel (e.g. the Stam / anonymous Gemara voice):
  *  a name + Hebrew twin + a one-line collective bio. No enrichments. */
 export function VoiceGroupBody(props: { group: { name: string; nameHe: string; bio: string } }): JSX.Element {
@@ -1877,7 +1932,7 @@ export function ArgumentSidebar(props: ArgumentSidebarProps): JSX.Element {
   createEffect(() => {
     const content = props.content;
     if (!content) { setActiveCard(null); return; }
-    const recipe = RECIPES_BY_KIND[content.kind];
+    const recipe = CARD_DEFS[content.kind]?.recipe;
     const instanceKey = instanceKeyForContent(content, props.tractate, props.page);
     setActiveCard(recipe && instanceKey ? { recipe, instanceKey } : null);
   });
@@ -1964,44 +2019,28 @@ export function ArgumentSidebar(props: ArgumentSidebarProps): JSX.Element {
               />
             </Show>
 
-            <Show when={c().kind === 'rabbi'}>
-              <SidebarCardFromHint
-                recipe={RABBI_RECIPE}
-                instance={rabbiDisplayInstance((c() as Extract<SidebarContent, { kind: 'rabbi' }>).rabbi)}
-                synthInstance={rabbiSynthInstance((c() as Extract<SidebarContent, { kind: 'rabbi' }>).rabbi)}
-                instanceKey={instanceKeyForContent(c() as Extract<SidebarContent, { kind: 'rabbi' }>, props.tractate, props.page)!}
-                tractate={props.tractate}
-                page={props.page}
-                specialBlocks={RABBI_BLOCKS}
-                onHighlightRange={(r) => props.onHighlightRange?.(r)}
-                extras={{ generationByName: props.generationByName }}
-              />
+            {/* All recipe-driven cards (aggadata/pesuk/halacha/rishonim/rabbi)
+                render through one generic arm, keyed by CARD_DEFS. Place keeps
+                the hint adapter; the argument-family + voice-group stay bespoke. */}
+            <Show when={CARD_DEFS[c().kind]}>
+              {(def) => (
+                <SidebarCardFromHint
+                  recipe={def().recipe}
+                  instance={def().instance(c())}
+                  synthInstance={def().synthInstance?.(c())}
+                  instanceKey={instanceKeyForContent(c(), props.tractate, props.page)!}
+                  qaInstanceId={def().qaInstanceId?.(c())}
+                  tractate={props.tractate}
+                  page={props.page}
+                  specialBlocks={def().blocks}
+                  onHighlightRange={def().forwardHighlight ? (r) => props.onHighlightRange?.(r) : undefined}
+                  extras={def().extras?.({ generationByName: props.generationByName })}
+                />
+              )}
             </Show>
 
             <Show when={c().kind === 'voice-group'}>
               <VoiceGroupBody group={(c() as Extract<SidebarContent, { kind: 'voice-group' }>).group} />
-            </Show>
-
-            <Show when={c().kind === 'halacha'}>
-              <SidebarCardFromHint
-                recipe={HALACHA_RECIPE}
-                instance={halachaInstance((c() as Extract<SidebarContent, { kind: 'halacha' }>).topic)}
-                instanceKey={instanceKeyForContent(c() as Extract<SidebarContent, { kind: 'halacha' }>, props.tractate, props.page)!}
-                specialBlocks={HALACHA_BLOCKS}
-                tractate={props.tractate}
-                page={props.page}
-              />
-            </Show>
-
-            <Show when={c().kind === 'pesuk'}>
-              <SidebarCardFromHint
-                recipe={PASUK_RECIPE}
-                instance={pasukInstance((c() as Extract<SidebarContent, { kind: 'pesuk' }>).pasuk)}
-                instanceKey={instanceKeyForContent(c() as Extract<SidebarContent, { kind: 'pesuk' }>, props.tractate, props.page)!}
-                tractate={props.tractate}
-                page={props.page}
-                specialBlocks={PASUK_BLOCKS}
-              />
             </Show>
 
             <Show when={c().kind === 'place'}>
@@ -2011,30 +2050,6 @@ export function ArgumentSidebar(props: ArgumentSidebarProps): JSX.Element {
                 tractate={props.tractate}
                 page={props.page}
                 chips={<PlaceChips place={(c() as Extract<SidebarContent, { kind: 'place' }>).place} />}
-              />
-            </Show>
-
-            <Show when={c().kind === 'rishonim'}>
-              <SidebarCardFromHint
-                recipe={RISHONIM_RECIPE}
-                instance={rishonimDisplayInstance((c() as Extract<SidebarContent, { kind: 'rishonim' }>).instance)}
-                synthInstance={rishonimSynthInstance((c() as Extract<SidebarContent, { kind: 'rishonim' }>).instance)}
-                instanceKey={instanceKeyForContent(c() as Extract<SidebarContent, { kind: 'rishonim' }>, props.tractate, props.page)!}
-                tractate={props.tractate}
-                page={props.page}
-                specialBlocks={RISHONIM_BLOCKS}
-              />
-            </Show>
-
-            <Show when={c().kind === 'aggadata'}>
-              <SidebarCardFromHint
-                recipe={AGGADATA_RECIPE}
-                instance={aggadataInstance((c() as Extract<SidebarContent, { kind: 'aggadata' }>).story)}
-                instanceKey={instanceKeyForContent(c() as Extract<SidebarContent, { kind: 'aggadata' }>, props.tractate, props.page)!}
-                qaInstanceId={`${(c() as Extract<SidebarContent, { kind: 'aggadata' }>).story.title}|${(c() as Extract<SidebarContent, { kind: 'aggadata' }>).story.excerpt}`}
-                tractate={props.tractate}
-                page={props.page}
-                specialBlocks={AGGADATA_BLOCKS}
               />
             </Show>
 

--- a/src/client/sidebar/primitives.tsx
+++ b/src/client/sidebar/primitives.tsx
@@ -470,7 +470,7 @@ export function describeRecipe(recipe: SidebarRecipe): RecipeInfo {
  *  its recipe + the `instanceKey` (so each panel row's inspect 'i' can target the
  *  drawer for this exact instance). null when no card is open OR the open card is
  *  still a bespoke (un-converted) *Body — so the panel doubles as a conversion
- *  scoreboard. ArgumentSidebar's dispatch is the single writer (RECIPES_BY_KIND). */
+ *  scoreboard. ArgumentSidebar's dispatch is the single writer (CARD_DEFS). */
 export interface ActiveCard { recipe: SidebarRecipe; instanceKey: string; }
 const [activeCardSig, setActiveCardSig] = createSignal<ActiveCard | null>(null);
 export function activeCard(): ActiveCard | null { return activeCardSig(); }

--- a/tests/client/card-defs.test.ts
+++ b/tests/client/card-defs.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { CARD_DEFS } from '../../src/client/ArgumentSidebar';
+
+describe('CARD_DEFS registry', () => {
+  it('every entry self-describes: recipe.kind === key, blocks registered for every special section', () => {
+    for (const [kind, def] of Object.entries(CARD_DEFS)) {
+      if (!def) continue;
+      expect(def.recipe.kind).toBe(kind);
+      const specialBlocks = def.recipe.sections.flatMap((s) => (s.type === 'special' ? [s.block] : []));
+      for (const b of specialBlocks) {
+        expect(def.blocks[b], `${kind} declares special '${b}' but it isn't in blocks`).toBeTypeOf('function');
+      }
+    }
+  });
+
+  it('covers exactly the recipe-driven kinds', () => {
+    expect(Object.keys(CARD_DEFS).sort()).toEqual(
+      ['aggadata', 'halacha', 'pesuk', 'rabbi', 'rishonim'].sort(),
+    );
+  });
+});


### PR DESCRIPTION
**First slice of the registry-driven payoff.** Collapses the five per-kind recipe dispatch arms (aggadata / pesuk / halacha / rishonim / rabbi) into **one generic render** keyed by a new **`CARD_DEFS`** registry, and folds `RECIPES_BY_KIND` into it.

Each recipe-driven card is now a **registry entry** — `{ recipe, blocks, instance(c), synthInstance?(c), qaInstanceId?(c), forwardHighlight?, extras?(ctx) }` — instead of a bespoke `<Show>` arm. The dispatch becomes:

```tsx
<Show when={CARD_DEFS[c().kind]}>
  {(def) => <SidebarCardFromHint recipe={def().recipe} instance={def().instance(c())} … />}
</Show>
```

So a recipe-driven card is now **data on the client**: adding one means adding a `CARD_DEFS` entry, not a new dispatch arm. And it's the exact shape the worker mark-def `recipe` field will later populate — the next slice. Place keeps the hint adapter; the argument-family + voice-group stay bespoke.

**Equivalence (Codex-verified):** each card keeps its exact props — aggadata's `qaInstanceId`, rabbi's `synthInstance` + highlight-forwarding + `extras.generationByName`, rishonim's `synthInstance`, halacha/pesuk none — and omitted is identical to the old explicit `undefined`. The generic `<Show>` no-ops for non-registry kinds so their bespoke arms still render.

`pnpm typecheck` clean · `pnpm test` 1560/1560 incl. a new `card-defs` test guarding registry self-consistency (recipe.kind === key; every declared special block is registered).