### PR TITLE
Sidebar recipes live in the registry (carried on the mark definition)

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -19,6 +19,11 @@ import { selectSectionMoves } from '../lib/argumentMoves';
 import { t, lang } from './i18n';
 import { ACCENTS, HE_FONT, HebrewProse, Panel, QASection, SectionCard, Synthesis, SidebarPanelFromHint, SidebarCardFromHint, setActiveCard, kindLabelKey, type SidebarHint, type SidebarRecipe, type SpecialBlockProps } from './sidebar/primitives';
 import { InspectDot } from './MarkEnrichmentCards';
+// Recipes now live in the shared lib (carried on the worker mark def too).
+// Re-exported so existing importers (CARD_DEFS, tests) keep their `from
+// './ArgumentSidebar'` path.
+import { AGGADATA_RECIPE, PASUK_RECIPE, HALACHA_RECIPE, RISHONIM_RECIPE, RABBI_RECIPE } from '../lib/sidebar/recipe';
+export { AGGADATA_RECIPE, PASUK_RECIPE, HALACHA_RECIPE, RISHONIM_RECIPE, RABBI_RECIPE };
 
 /** Localize an era date-range ("c. 290 – 320 CE") for Hebrew display. */
 function eraLabel(era: string): string {
@@ -1251,20 +1256,6 @@ export function rabbiDisplayInstance(rabbi: IdentifiedRabbi): { fields: Record<s
 export function rabbiSynthInstance(rabbi: IdentifiedRabbi): unknown {
   return { name: rabbi.name, nameHe: rabbi.nameHe, generation: rabbi.generation, region: rabbi.region, places: rabbi.places };
 }
-
-export const RABBI_RECIPE: SidebarRecipe = {
-  kind: 'rabbi',
-  markId: 'rabbi',
-  titleField: 'name',
-  titleHeField: 'nameHe',
-  flip: 'rabbi',
-  sections: [
-    { type: 'special', block: 'rabbi-meta', deps: ['rabbi.identity'] },
-    { type: 'synthesis' },
-    { type: 'special', block: 'rabbi-lineage', deps: ['rabbi.relationships', 'rabbi.relationships.evidence'] },
-    { type: 'special', block: 'rabbi-geography', deps: ['rabbi.geography', 'rabbi.geography.evidence', 'rabbi.location'] },
-  ],
-};
 export const RABBI_BLOCKS: Record<string, (p: SpecialBlockProps) => JSX.Element> = {
   'rabbi-meta': RabbiMeta,
   'rabbi-lineage': RabbiLineage,
@@ -1478,19 +1469,6 @@ export function halachaInstance(topic: HalachaTopic): { fields: Record<string, u
     },
   };
 }
-
-export const HALACHA_RECIPE: SidebarRecipe = {
-  kind: 'halacha',
-  markId: 'halacha',
-  titleField: 'topic',
-  titleHeField: 'topicHe',
-  sections: [
-    { type: 'synthesis' },
-    { type: 'special', block: 'halacha-codification', deps: ['halacha.codification'] },
-    { type: 'special', block: 'halacha-practical', deps: ['halacha.practical'] },
-    { type: 'special', block: 'halacha-disputes', deps: ['halacha.disputes'] },
-  ],
-};
 export const HALACHA_BLOCKS: Record<string, (p: SpecialBlockProps) => JSX.Element> = {
   'halacha-codification': HalachaCodification,
   'halacha-practical': HalachaPractical,
@@ -1566,21 +1544,6 @@ export function pasukInstance(pasuk: Pasuk): { fields: Record<string, unknown>; 
     },
   };
 }
-
-export const PASUK_RECIPE: SidebarRecipe = {
-  kind: 'pesuk',
-  markId: 'pesukim',
-  // No titleField — the verse special block renders the fetched Hebrew ref.
-  sections: [
-    { type: 'special', block: 'pasuk-verse' },
-    { type: 'synthesis' },
-    { type: 'explainer', dep: 'pesukim.tanach-context', textField: 'context', labelKey: 'pasuk.tanachContext' },
-    { type: 'explainer', dep: 'pesukim.why-here', textField: 'why_here', labelKey: 'pasuk.whyHere' },
-    { type: 'explainer', dep: 'pesukim.mechanism', textField: 'mechanism', labelKey: 'pasuk.mechanism' },
-    { type: 'explainer', dep: 'pesukim.landing', textField: 'landing', labelKey: 'pasuk.landing' },
-    { type: 'qa' },
-  ],
-};
 export const PASUK_BLOCKS: Record<string, (p: SpecialBlockProps) => JSX.Element> = {
   'pasuk-verse': PasukVerse,
 };
@@ -1636,25 +1599,7 @@ function AggadataParallels(props: SpecialBlockProps): JSX.Element {
 }
 
 /** The aggadata card as a recipe: a theme tag, the story summary, the synthesis,
- *  two explainer boxes, the custom parallels block, then follow-up Q&A. */
-export const AGGADATA_RECIPE: SidebarRecipe = {
-  kind: 'aggadata',
-  markId: 'aggadata',
-  titleField: 'title',
-  titleHeField: 'titleHe',
-  sections: [
-    // Theme tag retired for now — the taxonomy isn't comprehensive enough to be
-    // worth showing. `theme` is still extracted (latent); restore a
-    // `{ type: 'tags', fields: ['theme'] }` section here to bring it back.
-    { type: 'prose', field: 'summary', untilSynthesis: true },
-    { type: 'synthesis' },
-    { type: 'explainer', dep: 'aggadata.background', textField: 'background', labelKey: 'aggadata.background' },
-    { type: 'explainer', dep: 'aggadata.interpretation', textField: 'interpretation', labelKey: 'aggadata.interpretation' },
-    { type: 'special', block: 'aggadata-parallels', deps: ['aggadata.parallels'] },
-    { type: 'qa' },
-  ],
-};
-export const AGGADATA_BLOCKS: Record<string, (p: SpecialBlockProps) => JSX.Element> = {
+ *  two explainer boxes, the custom parallels block, then follow-up Q&A. */export const AGGADATA_BLOCKS: Record<string, (p: SpecialBlockProps) => JSX.Element> = {
   'aggadata-parallels': AggadataParallels,
 };
 
@@ -1667,19 +1612,6 @@ export const AGGADATA_BLOCKS: Record<string, (p: SpecialBlockProps) => JSX.Eleme
  *  `synthesis` section — that's what mounts the MarkEnrichmentCards host the
  *  inspect drawer renders inside. Without it the panel's 'i' targets an
  *  unmounted instanceKey (a dead click). */
-// Defined ahead of its blocks/helpers (which live by the old RishonimBody site)
-// so it's in scope before CARD_DEFS; it names blocks by string.
-export const RISHONIM_RECIPE: SidebarRecipe = {
-  kind: 'rishonim',
-  markId: 'rishonim',
-  // No titleField — the header block renders the computed "on segment N" title.
-  sections: [
-    { type: 'special', block: 'rishonim-header' },
-    { type: 'synthesis' },
-    { type: 'special', block: 'rishonim-sources' },
-  ],
-};
-
 /** The instanceKey a recipe-driven card mounts under (the client run memo + the
  *  inspect drawer are keyed by it). Single source of truth so the dispatch and
  *  the dev Recipe panel target the SAME drawer byte-for-byte. null for kinds not

--- a/src/client/MarksRegistryPanel.tsx
+++ b/src/client/MarksRegistryPanel.tsx
@@ -25,6 +25,7 @@ import { trackAI } from './aiActivity';
 import { lang } from './i18n';
 import { devModeActive } from './DevModeShelf';
 import type { SeedMark } from './seed-marks';
+import type { SidebarRecipe } from '../lib/sidebar/recipe';
 import type { MarkDef as RendererMarkDef, MarkRunOutput as RendererMarkRunOutput } from './renderers/dispatch';
 import { producerNodesFrom, reverseDependencyIndex, type RawDependency } from '../lib/registry/depGraph';
 
@@ -66,6 +67,8 @@ export interface WorkerMarkDefinition {
   experimental?: boolean;
   anchor: 'segment' | 'segment-range' | 'phrase' | 'multi-anchor' | 'cross-daf' | 'external' | 'whole-daf';
   render: { kind: string; [k: string]: unknown };
+  /** Declarative sidebar-card recipe, when the mark's card is recipe-driven. */
+  recipe?: SidebarRecipe;
   extractor: {
     kind: 'llm' | 'sefaria' | 'computed' | 'manual';
     model?: LLMModelId;

--- a/src/client/sidebar/primitives.tsx
+++ b/src/client/sidebar/primitives.tsx
@@ -127,7 +127,9 @@ export function HebrewProse(props: {
  * halacha until harmonized.
  */
 export function SectionCard(props: {
-  label: CatalogKey;
+  // CatalogKey for literal call-sites (keeps autocomplete); a recipe's labelKey
+  // arrives as a plain string — t() resolves known keys and falls back otherwise.
+  label: CatalogKey | (string & {});
   spacing?: 'tight' | 'loose';
   text?: string;
   children?: JSX.Element;
@@ -380,43 +382,11 @@ export interface SpecialBlockProps {
 }
 export type SpecialBlock = (props: SpecialBlockProps) => JSX.Element;
 
-/** One section of a card, top → bottom. */
-export type SectionSpec =
-  /** Small chips from instance fields (e.g. an aggadata theme). `drop` hides
-   *  specific values (e.g. a retired 'biography' theme that may linger in old
-   *  cached extractions). */
-  | { type: 'tags'; fields: string[]; drop?: string[] }
-  /** A paragraph of an instance field, rabbi-linked + Hebraized (e.g. a summary).
-   *  `untilSynthesis` makes it a placeholder: shown only until the synthesis
-   *  section resolves, then replaced by it (the instant field fills the slot
-   *  while the richer paragraph computes). */
-  | { type: 'prose'; field: string; untilSynthesis?: boolean }
-  /** The synthesis card for the recipe's mark; feeds the shared `deps`. */
-  | { type: 'synthesis' }
-  /** A labeled prose box rendering one dependent enrichment's `textField`.
-   *  Collapsed by default (the "dig deeper" layer under the synthesis); set
-   *  `defaultOpen` to lead with it expanded. */
-  | { type: 'explainer'; dep: string; textField: string; labelKey: CatalogKey; defaultOpen?: boolean }
-  /** The follow-up Q&A affordance. */
-  | { type: 'qa' }
-  /** A genuinely-custom block, looked up by name in the card's `specialBlocks`.
-   *  `deps` declares the dependent leaf ids it reads from the shared deps bag —
-   *  so even a custom block has *declared inputs* (shown in the Recipe panel,
-   *  and the first is what its inspect 'i' opens). */
-  | { type: 'special'; block: string; deps?: string[] };
-
-export interface SidebarRecipe {
-  kind: SidebarKind;
-  markId: string;
-  /** Instance field for the card heading. Omit to suppress the Panel heading
-   *  entirely — a card whose header is genuinely custom (e.g. pasuk's fetched
-   *  Hebrew verse ref) renders it from a `special` section instead. */
-  titleField?: string;
-  titleHeField?: string;
-  titleLang?: 'en' | 'he';
-  flip?: 'name' | 'rabbi';
-  sections: SectionSpec[];
-}
+// The recipe shape (SectionSpec / SidebarRecipe) now lives in src/lib/sidebar/
+// recipe.ts so the worker mark definition can carry it. Re-exported here so the
+// many `from './sidebar/primitives'` importers keep working.
+import type { SectionSpec, SidebarRecipe } from '../../lib/sidebar/recipe';
+export type { SectionSpec, SidebarRecipe } from '../../lib/sidebar/recipe';
 
 /** A flat, render-ready description of a recipe for the dev shelf's Recipe panel.
  *  Pure (no reactivity) so it's unit-testable and the panel needn't know the
@@ -437,7 +407,7 @@ export interface RecipeSectionInfo {
   custom: boolean;
 }
 export interface RecipeInfo {
-  kind: SidebarKind;
+  kind: string;
   markId: string;
   header: string;
   sections: RecipeSectionInfo[];
@@ -503,7 +473,7 @@ export function SidebarCardFromHint(props: {
 }): JSX.Element {
   const str = (v: unknown): string => (typeof v === 'string' ? v : '');
   const fields = (): Record<string, unknown> => props.instance.fields;
-  const accent = (): string => ACCENTS[props.recipe.kind];
+  const accent = (): string => ACCENTS[props.recipe.kind as SidebarKind] ?? '#222';
   const [deps, setDeps] = createSignal<Record<string, unknown>>({});
   // True once the synthesis has resolved (cache hit or fresh). A `prose` section
   // with `untilSynthesis` shows only until then — the instant `summary` field

--- a/src/lib/sidebar/recipe.ts
+++ b/src/lib/sidebar/recipe.ts
@@ -1,0 +1,123 @@
+/**
+ * Sidebar card RECIPES — the declarative shape of each recipe-driven card,
+ * shared between the worker (attached to its mark definition, exposed via
+ * /api/marks) and the client (rendered by SidebarCardFromHint via CARD_DEFS).
+ *
+ * This module is PURE DATA + types — no client (Solid/i18n) or worker imports —
+ * so it can live in src/lib and be the single source of a card's structure. The
+ * non-serializable parts (special-block components, instance adapters) stay in
+ * the client; the recipe references blocks by name and labels by catalog key
+ * string. `kind` and `labelKey` are plain strings here (the client narrows them
+ * to its SidebarKind / CatalogKey on use; a client test guards that labelKeys
+ * resolve).
+ */
+
+/** One section of a card, top → bottom. */
+export type SectionSpec =
+  /** Small chips from instance fields (e.g. an aggadata theme). `drop` hides
+   *  specific values (e.g. a retired 'biography' theme that may linger in old
+   *  cached extractions). */
+  | { type: 'tags'; fields: string[]; drop?: string[] }
+  /** A paragraph of an instance field, rabbi-linked + Hebraized (e.g. a summary).
+   *  `untilSynthesis` makes it a placeholder: shown only until the synthesis
+   *  section resolves, then replaced by it (the instant field fills the slot
+   *  while the richer paragraph computes). */
+  | { type: 'prose'; field: string; untilSynthesis?: boolean }
+  /** The synthesis card for the recipe's mark; feeds the shared `deps`. */
+  | { type: 'synthesis' }
+  /** A labeled prose box rendering one dependent enrichment's `textField`.
+   *  Collapsed by default (the "dig deeper" layer under the synthesis); set
+   *  `defaultOpen` to lead with it expanded. `labelKey` is a client catalog key. */
+  | { type: 'explainer'; dep: string; textField: string; labelKey: string; defaultOpen?: boolean }
+  /** The follow-up Q&A affordance. */
+  | { type: 'qa' }
+  /** A genuinely-custom block, looked up by name in the card's `specialBlocks`.
+   *  `deps` declares the dependent leaf ids it reads from the shared deps bag —
+   *  so even a custom block has *declared inputs* (shown in the Recipe panel,
+   *  and the first is what its inspect 'i' opens). */
+  | { type: 'special'; block: string; deps?: string[] };
+
+export interface SidebarRecipe {
+  /** The sidebar card kind (a client SidebarKind value as a string). */
+  kind: string;
+  markId: string;
+  /** Instance field for the card heading. Omit to suppress the Panel heading
+   *  entirely — a card whose header is genuinely custom (e.g. pasuk's fetched
+   *  Hebrew verse ref) renders it from a `special` section instead. */
+  titleField?: string;
+  titleHeField?: string;
+  titleLang?: 'en' | 'he';
+  flip?: 'name' | 'rabbi';
+  sections: SectionSpec[];
+}
+
+export const AGGADATA_RECIPE: SidebarRecipe = {
+  kind: 'aggadata',
+  markId: 'aggadata',
+  titleField: 'title',
+  titleHeField: 'titleHe',
+  sections: [
+    // Theme tag retired for now — the taxonomy isn't comprehensive enough to be
+    // worth showing. `theme` is still extracted (latent); restore a
+    // `{ type: 'tags', fields: ['theme'] }` section here to bring it back.
+    { type: 'prose', field: 'summary', untilSynthesis: true },
+    { type: 'synthesis' },
+    { type: 'explainer', dep: 'aggadata.background', textField: 'background', labelKey: 'aggadata.background' },
+    { type: 'explainer', dep: 'aggadata.interpretation', textField: 'interpretation', labelKey: 'aggadata.interpretation' },
+    { type: 'special', block: 'aggadata-parallels', deps: ['aggadata.parallels'] },
+    { type: 'qa' },
+  ],
+};
+
+export const PASUK_RECIPE: SidebarRecipe = {
+  kind: 'pesuk',
+  markId: 'pesukim',
+  // No titleField — the verse special block renders the fetched Hebrew ref.
+  sections: [
+    { type: 'special', block: 'pasuk-verse' },
+    { type: 'synthesis' },
+    { type: 'explainer', dep: 'pesukim.tanach-context', textField: 'context', labelKey: 'pasuk.tanachContext' },
+    { type: 'explainer', dep: 'pesukim.why-here', textField: 'why_here', labelKey: 'pasuk.whyHere' },
+    { type: 'explainer', dep: 'pesukim.mechanism', textField: 'mechanism', labelKey: 'pasuk.mechanism' },
+    { type: 'explainer', dep: 'pesukim.landing', textField: 'landing', labelKey: 'pasuk.landing' },
+    { type: 'qa' },
+  ],
+};
+
+export const HALACHA_RECIPE: SidebarRecipe = {
+  kind: 'halacha',
+  markId: 'halacha',
+  titleField: 'topic',
+  titleHeField: 'topicHe',
+  sections: [
+    { type: 'synthesis' },
+    { type: 'special', block: 'halacha-codification', deps: ['halacha.codification'] },
+    { type: 'special', block: 'halacha-practical', deps: ['halacha.practical'] },
+    { type: 'special', block: 'halacha-disputes', deps: ['halacha.disputes'] },
+  ],
+};
+
+export const RISHONIM_RECIPE: SidebarRecipe = {
+  kind: 'rishonim',
+  markId: 'rishonim',
+  // No titleField — the header block renders the computed "on segment N" title.
+  sections: [
+    { type: 'special', block: 'rishonim-header' },
+    { type: 'synthesis' },
+    { type: 'special', block: 'rishonim-sources' },
+  ],
+};
+
+export const RABBI_RECIPE: SidebarRecipe = {
+  kind: 'rabbi',
+  markId: 'rabbi',
+  titleField: 'name',
+  titleHeField: 'nameHe',
+  flip: 'rabbi',
+  sections: [
+    { type: 'special', block: 'rabbi-meta', deps: ['rabbi.identity'] },
+    { type: 'synthesis' },
+    { type: 'special', block: 'rabbi-lineage', deps: ['rabbi.relationships', 'rabbi.relationships.evidence'] },
+    { type: 'special', block: 'rabbi-geography', deps: ['rabbi.geography', 'rabbi.geography.evidence', 'rabbi.location'] },
+  ],
+};

--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -79,6 +79,7 @@ import {
   RISHONIM_SYNTHESIS_OUTPUT_SCHEMA,
   proseSchema,
 } from './output-schemas';
+import { AGGADATA_RECIPE, PASUK_RECIPE, HALACHA_RECIPE, RISHONIM_RECIPE, RABBI_RECIPE } from '../lib/sidebar/recipe';
 
 // ---------------------------------------------------------------------------
 // Rabbi mark — phrase anchor + inline render
@@ -446,6 +447,7 @@ const PESUKIM_USER_TEMPLATE_HE = `מסכת: {{tractate}}, דף {{page}}.
 export const CODE_MARKS: MarkDefinition[] = [
   {
     id: 'rabbi',
+    recipe: RABBI_RECIPE,
     label: 'Rabbis',
     description: 'Inline underline of rabbi names with generation coloring; click for relationship card.',
     category: 'canon',
@@ -566,6 +568,7 @@ export const CODE_MARKS: MarkDefinition[] = [
   },
   {
     id: 'halacha',
+    recipe: HALACHA_RECIPE,
     label: 'Halachot',
     description: 'Halacha-topic gutter icons + sidebar.',
     category: 'canon',
@@ -594,6 +597,7 @@ export const CODE_MARKS: MarkDefinition[] = [
   },
   {
     id: 'aggadata',
+    recipe: AGGADATA_RECIPE,
     label: 'Aggadatot',
     description: 'Aggadic-story gutter icons + sidebar.',
     category: 'canon',
@@ -623,6 +627,7 @@ export const CODE_MARKS: MarkDefinition[] = [
   },
   {
     id: 'pesukim',
+    recipe: PASUK_RECIPE,
     label: 'Pesukim',
     description: 'Biblical-citation gutter icons + sidebar.',
     category: 'canon',
@@ -3433,6 +3438,7 @@ CODE_ENRICHMENTS.push(
 
 CODE_MARKS.push({
   id: 'rishonim',
+  recipe: RISHONIM_RECIPE,
   label: 'Rishonim',
   description: 'Per-segment rishonim indicator (Rashi, Tosafot, Ramban, …). Gutter icon next to each commented segment; click for the per-segment synthesis.',
   category: 'canon',

--- a/src/worker/studio-schema.ts
+++ b/src/worker/studio-schema.ts
@@ -40,6 +40,7 @@
  */
 
 import type { LLMModelId } from './llm';
+import type { SidebarRecipe } from '../lib/sidebar/recipe';
 
 // ===========================================================================
 // Anchor — where in the daf this mark's instances live.
@@ -361,6 +362,12 @@ export interface MarkDefinition {
 
   anchor: AnchorKind;
   render: RenderConfig;
+  /** Declarative sidebar-card recipe (header + ordered sections). Carried here
+   *  so the card's structure lives with its mark and is exposed via /api/marks;
+   *  the client renders it (CARD_DEFS) using the same shared recipe object plus
+   *  its special-block components + instance adapters. Absent for marks whose
+   *  card is still a bespoke view. */
+  recipe?: SidebarRecipe;
   extractor: Extractor;
   /** Declared inputs to the extractor. Defaults to ['gemara'] when absent —
    *  current behavior of buildDafContext. Future secondary anchors declare

--- a/tests/sidebar-recipe-on-marks.test.ts
+++ b/tests/sidebar-recipe-on-marks.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { CODE_MARKS } from '../src/worker/code-marks';
+import {
+  AGGADATA_RECIPE, PASUK_RECIPE, HALACHA_RECIPE, RISHONIM_RECIPE, RABBI_RECIPE,
+  type SidebarRecipe,
+} from '../src/lib/sidebar/recipe';
+import { t, setLang } from '../src/client/i18n';
+
+const RECIPES: SidebarRecipe[] = [AGGADATA_RECIPE, PASUK_RECIPE, HALACHA_RECIPE, RISHONIM_RECIPE, RABBI_RECIPE];
+
+describe('sidebar recipes carried on mark definitions', () => {
+  it('each recipe is attached to its mark (by markId), and recipe.kind/markId line up', () => {
+    for (const recipe of RECIPES) {
+      const mark = CODE_MARKS.find((m) => m.id === recipe.markId);
+      expect(mark, `no mark for recipe.markId=${recipe.markId}`).toBeDefined();
+      expect(mark!.recipe, `mark ${recipe.markId} missing recipe`).toBe(recipe);
+    }
+  });
+
+  it('every explainer labelKey is a real catalog key (resolves, not a passthrough)', () => {
+    setLang('en');
+    for (const recipe of RECIPES) {
+      for (const s of recipe.sections) {
+        if (s.type !== 'explainer') continue;
+        // t() returns the key itself for unknown keys; a real key resolves to
+        // something different. Guards against a typo'd labelKey now that the
+        // shared type widened CatalogKey to string.
+        expect(t(s.labelKey as never), `labelKey '${s.labelKey}' doesn't resolve`).not.toBe(s.labelKey);
+      }
+    }
+  });
+
+  it('every special block declares a kebab name and every recipe has a synthesis when it has inspectable sections', () => {
+    for (const recipe of RECIPES) {
+      const specials = recipe.sections.filter((s) => s.type === 'special');
+      for (const s of specials) expect((s as { block: string }).block).toMatch(/^[a-z][a-z-]*$/);
+      const hasInspectable = recipe.sections.some((s) => s.type === 'explainer' || s.type === 'special');
+      if (hasInspectable) expect(recipe.sections.some((s) => s.type === 'synthesis')).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
**Slice 2 of the recipe migration — the payoff.** The 5 sidebar-card recipes move into a shared **`src/lib/sidebar/recipe.ts`** (pure data + types, no client/worker imports) and each is **attached to its mark definition** in `code-marks.ts`. A recipe-driven card's *structure now lives with its mark* and is exposed via **`/api/marks`**.

**One source of truth:** the client `CARD_DEFS` imports the same recipe objects (via `ArgumentSidebar`'s re-export) and the worker references them on `MarkDefinition`. No duplication, no async fetch, **behavior byte-identical** — Codex confirmed the 5 recipe literals are unchanged from the old client consts, and `CARD_DEFS` uses the same imported objects.

**Type tradeoff (recovered):** the shared type loosens two client-only narrowings to plain strings — `kind` (`accent()` casts back to `SidebarKind` with a `#222` fallback) and explainer `labelKey` (`CatalogKey` → `string`; `SectionCard`'s label widened to `CatalogKey | (string & {})` so literal call-sites keep autocomplete). A **new test** asserts every explainer `labelKey` still resolves via `t()`, recovering the lost compile-time check.

`MarkDefinition` + the client `/api/marks` type gain optional `recipe?`. **Cache untouched** — `recipeHash`/mark keys hash `extractor[+render]`, not the whole def (Codex-verified).

`pnpm typecheck` clean (worker + client) · `pnpm test` 1563/1563 incl. a new `sidebar-recipe-on-marks` test (recipe attached by markId; labelKeys resolve; special-block naming + synthesis-host invariant). Codex: no blocking findings.