### PR TITLE
Entity pieces: addressable read for rabbi/place (GET /api/entity/...)

### DIFF
--- a/src/lib/registry/entity.ts
+++ b/src/lib/registry/entity.ts
@@ -1,0 +1,28 @@
+/**
+ * EntityPiece — a first-class, addressable view of a "global" entity (a rabbi or
+ * a place) assembled from its already-computed global enrichments.
+ *
+ * Rabbi/place enrichments are `scope: 'global'` (cached per-entity, daf-agnostic),
+ * so the entity's facts already live in the cache keyed by name. Today they're
+ * only reachable by clicking the entity on some daf. This makes the entity
+ * itself addressable: GET /api/entity/rabbi/:slug · /api/entity/place/:name
+ * returns the assembled pieces. READ-ONLY — the endpoint never triggers an LLM
+ * run; a piece is `null` until something has warmed it.
+ *
+ * Pure data shape (no client/worker imports) so it can live in src/lib and be
+ * shared by the worker (producer) and any future consumer.
+ */
+export type EntityType = 'rabbi' | 'place';
+
+export interface EntityPiece {
+  type: EntityType;
+  /** Canonical id: the rabbi's Sefaria slug, or the place name. */
+  id: string;
+  name: string;
+  nameHe?: string;
+  /** The entity's global pieces as cached (parsed enrichment output), keyed by
+   *  the bare leaf name (e.g. `identity`, `relationships`, `geography` for a
+   *  rabbi; `profile`, `significance`, `figures` for a place). `null` when that
+   *  piece hasn't been computed yet. */
+  pieces: Record<string, unknown>;
+}

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -50,6 +50,7 @@ import { runYomiWarmCron } from './yomi-cron';
 import { GENERATION_IDS, GENERATION_BY_ID, GENERATIONS_PROMPT_REFERENCE, type GenerationId } from '../client/generations';
 import { stripEchoParens } from '../client/hebraize';
 import rabbiPlacesData from '../lib/data/rabbi-places.json';
+import type { EntityPiece } from '../lib/registry/entity';
 import { extractTalmudContent } from '../lib/sefref/alignment';
 import { fetchHebrewBooksDaf } from '../lib/sefref/hebrewbooks/client';
 import {
@@ -860,6 +861,62 @@ app.get('/api/dependents/:id', (c) => {
   const direct = [...(rev.get(id) ?? [])].sort();
   const transitive = [...transitiveDependents(rev, id)].sort();
   return c.json({ id, direct, transitive, count: transitive.length });
+});
+
+// Entity pieces (step 5): a first-class, addressable view of a "global" entity
+// (rabbi / place), assembled READ-ONLY from its already-cached global
+// enrichments. The pieces are keyed per-entity (daf-agnostic), so they're
+// reachable here without a daf. Never triggers an LLM run — a piece is null
+// until something warmed it. See src/lib/registry/entity.ts.
+// Reads a cached GLOBAL enrichment by the SAME key the warm path writes:
+// loadEnrichmentDef (code-fallback, not KV-only) + instanceIdOf(markInput)
+// (which slug-ifies the name, e.g. 'Abaye' → 'abaye') + the daf-less global key.
+// Pass the same markInput shape the card/warmer uses so the instance_id matches.
+async function readGlobalPiece(env: Bindings, enrichmentId: string, markInput: unknown): Promise<unknown> {
+  const def = await loadEnrichmentDef(env, enrichmentId);
+  if (!def) return null;
+  const instanceId = await instanceIdOf(markInput);
+  const hit = await readCachedResult(env, keyForEnrichment(def, instanceId));
+  return hit?.parsed ?? null;
+}
+
+app.get('/api/entity/rabbi/:slug', async (c) => {
+  const slug = c.req.param('slug');
+  const entry = RABBI_PLACES.rabbis[slug];
+  if (!entry) return c.json({ error: 'not found' }, 404);
+  const name = entry.canonical;
+  const nameHe = entry.canonicalHe ?? '';
+  // identity is the deterministic rabbi-places lookup (always available); the
+  // others are the same global enrichments the card reads — keyed by the rabbi
+  // instance the card passes (flat {name,...}), so instanceIdOf matches.
+  const identity = enrichRabbi(name, nameHe, (entry.generation as GenerationId | undefined) ?? 'unknown');
+  const markInput = { name, nameHe };
+  const [relationships, geography] = await Promise.all([
+    readGlobalPiece(c.env, 'rabbi.relationships', markInput),
+    readGlobalPiece(c.env, 'rabbi.geography', markInput),
+  ]);
+  const piece: EntityPiece = {
+    type: 'rabbi', id: slug, name, nameHe: nameHe || undefined,
+    pieces: { identity, relationships, geography },
+  };
+  return c.json(piece);
+});
+
+app.get('/api/entity/place/:name', async (c) => {
+  const name = c.req.param('name');
+  // The place mark instance is {fields:{name,...}} → instanceIdOf slug-ifies it.
+  const markInput = { fields: { name } };
+  const [profile, significance, figures] = await Promise.all([
+    readGlobalPiece(c.env, 'places.profile', markInput),
+    readGlobalPiece(c.env, 'places.significance', markInput),
+    readGlobalPiece(c.env, 'places.figures', markInput),
+  ]);
+  if (!profile && !significance && !figures) return c.json({ error: 'not found (no cached pieces)' }, 404);
+  const piece: EntityPiece = {
+    type: 'place', id: name, name,
+    pieces: { profile, significance, figures },
+  };
+  return c.json(piece);
 });
 
 // Content-hash staleness probe: does the cached output of a WHOLE-DAF enrichment

--- a/tests/entity-piece.test.ts
+++ b/tests/entity-piece.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import rabbiPlaces from '../src/lib/data/rabbi-places.json';
+import type { EntityPiece } from '../src/lib/registry/entity';
+
+// Guards the assumption GET /api/entity/rabbi/:slug relies on: rabbis is
+// slug-keyed, each entry carries a canonical name (used to read the per-name
+// global enrichment cache keys).
+describe('entity piece — rabbi slug resolution', () => {
+  const data = rabbiPlaces as unknown as { rabbis: Record<string, { canonical: string; canonicalHe?: string | null }> };
+
+  it('rabbis is a non-empty slug → entry map with canonical names', () => {
+    const slugs = Object.keys(data.rabbis);
+    expect(slugs.length).toBeGreaterThan(100);
+    for (const slug of slugs.slice(0, 50)) {
+      expect(typeof data.rabbis[slug].canonical).toBe('string');
+      expect(data.rabbis[slug].canonical.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('a known slug resolves to its canonical name (the endpoint key path)', () => {
+    const entry = data.rabbis['rabbi-yochanan-b-napacha'];
+    expect(entry).toBeDefined();
+    expect(entry.canonical).toContain('Yochanan');
+    // The EntityPiece the endpoint would build for it.
+    const piece: EntityPiece = {
+      type: 'rabbi', id: 'rabbi-yochanan-b-napacha', name: entry.canonical,
+      nameHe: entry.canonicalHe ?? undefined,
+      pieces: { identity: null, relationships: null, geography: null },
+    };
+    expect(piece.type).toBe('rabbi');
+    expect(piece.id).toBe('rabbi-yochanan-b-napacha');
+    expect(Object.keys(piece.pieces)).toEqual(['identity', 'relationships', 'geography']);
+  });
+});


### PR DESCRIPTION
**Step 5 — entity pieces (the non-regressive slice you picked).** A rabbi/place is "global" (its enrichments are `scope: 'global'`, cached per-entity, daf-agnostic), but today those facts are only reachable by clicking the entity on *some daf*. This makes the entity **itself addressable**.

- **`GET /api/entity/rabbi/:slug`** (slug-keyed via `rabbi-places`) → `EntityPiece` with `{ identity (deterministic lookup), relationships, geography }`
- **`GET /api/entity/place/:name`** → `{ profile, significance, figures }`
- `src/lib/registry/entity.ts` — the shared `EntityPiece` contract

**READ-ONLY** — never triggers an LLM run (`loadEnrichmentDef` + `instanceIdOf` + a KV get); a piece is `null` until something warmed it. No new producer, **card untouched** (no regression to the recipe model). Reads the **same key the warm path writes**.

**Codex caught two real bugs, both fixed:** `readEnrichment` is KV-only (the defs are code-defined → would've returned `null` always) → use `loadEnrichmentDef`; and the cache `instance_id` is `instanceIdOf(markInput)` (which slug-ifies the name, `Abaye → abaye`), not the raw name. EN-only for v1.

`pnpm typecheck` clean · `pnpm test` 1565/1565 incl. a new `entity-piece` test (slug→name resolution + the EntityPiece shape). Codex re-reviewed after the fixes.