### PR TITLE
User pieces: personal highlights + notes (client-only)

### DIFF
--- a/src/client/DafViewer.tsx
+++ b/src/client/DafViewer.tsx
@@ -4,6 +4,7 @@ import { TRACTATE_OPTIONS, dafRefHe } from '../lib/sefref';
 import { DafRenderer } from '../lib/daf-render';
 import { tokenizeHebrewHtml } from './tokenize';
 import { TranslationPopup } from './TranslationPopup';
+import { HighlightNotePopover, NotesPanel } from './UserHighlightUI';
 import type {
   DafAnalysis, Section,
   HalachaResult, HalachaTopic,
@@ -16,6 +17,15 @@ import { injectHadran } from './injectHadran';
 import { ensureMasechetIncipit } from './ensureMasechetIncipit';
 import { injectAnchorMarkers, injectOpinionMarkers, injectAggadataAnchors, injectPesukimAnchors } from './anchorMarkers';
 import { buildTokenRange } from './highlightRange';
+import {
+  type UserHighlight,
+  bgForColor,
+  loadUserHighlights,
+  saveUserHighlights,
+  highlightCoversWord,
+  buildHighlight,
+  wordCoordFromTarget,
+} from './userHighlights';
 import { GutterIcons, type GutterKind } from './GutterIcons';
 import { GutterOverlay } from './GutterOverlay';
 import { ArgumentSidebar, type SidebarContent, type PlaceInstance } from './ArgumentSidebar';
@@ -111,7 +121,7 @@ function paintRangeOverlay(
   overlay: HTMLElement,
   origin: HTMLElement,
   ranges: Range[],
-  kind: 'section' | 'halacha' | 'aggadata' | 'pesuk' | 'rishonim' | 'move' | 'commentary' | 'commentary-active' | 'comm-anchor',
+  kind: 'section' | 'halacha' | 'aggadata' | 'pesuk' | 'rishonim' | 'move' | 'commentary' | 'commentary-active' | 'comm-anchor' | 'user',
   /** Optional per-range inline background color. */
   bgFor?: (rangeIdx: number) => string | undefined,
 ): void {
@@ -835,6 +845,118 @@ export default function DafViewer(): JSX.Element {
   // Ref to the DafRenderer's .daf-root — resolved imperatively because
   // DafRenderer renders it internally.
   const [dafRootEl, setDafRootEl] = createSignal<HTMLElement | null>(null);
+
+  // ── User pieces — personal highlights + notes (client-only) ──────────────
+  // Stored in localStorage per (tractate, page), re-painted through the same
+  // overlay machinery as the worker-anchored pieces. No backend, no auth.
+  const [userHighlights, setUserHighlights] = createSignal<UserHighlight[]>([]);
+  // An existing highlight opened (by clicking it) for view/edit/delete.
+  const [openHighlight, setOpenHighlight] = createSignal<{
+    id: string;
+    rect: { left: number; top: number; bottom: number };
+  } | null>(null);
+  const [showNotesList, setShowNotesList] = createSignal(false);
+  // Pending "scroll then open popover" timer from the notes panel (see
+  // jumpToHighlight); cleared on daf change / unmount.
+  let jumpTimer: ReturnType<typeof setTimeout> | undefined;
+
+  // Load this daf's saved highlights whenever the daf changes.
+  createEffect(() => {
+    const t = tractate();
+    const p = page();
+    setUserHighlights(loadUserHighlights(t, p));
+    setOpenHighlight(null);
+    setShowNotesList(false);
+    if (jumpTimer) { clearTimeout(jumpTimer); jumpTimer = undefined; }
+  });
+
+  // Persist on every mutation (untrack the daf identity — the load effect owns
+  // switching dapim; this one only mirrors in-memory changes to storage).
+  const persistHighlights = (next: UserHighlight[]) => {
+    setUserHighlights(next);
+    saveUserHighlights(tractate(), page(), next);
+  };
+  const addHighlight = (h: UserHighlight) => persistHighlights([...userHighlights(), h]);
+  const deleteHighlight = (id: string) =>
+    persistHighlights(userHighlights().filter((h) => h.id !== id));
+  const updateHighlightNote = (id: string, note: string) =>
+    persistHighlights(userHighlights().map((h) => (h.id === id ? { ...h, note } : h)));
+
+  // The main-text `.daf-text` column, or null when the daf isn't mounted.
+  const mainTextCol = (): HTMLElement | null => {
+    const root = dafRootEl();
+    if (!root) return null;
+    const dafRootDiv = root.querySelector<HTMLElement>('.daf-root') ?? root;
+    return dafRootDiv.querySelector<HTMLElement>('.daf-main .daf-text');
+  };
+
+  // Resolve the currently-active selection (from `active().els`) to a user-
+  // highlight word-range. Returns null when the selection isn't inside the
+  // main text column (e.g. a Rashi/Tosafot word) — those aren't highlightable.
+  const highlightCoordsForActive = ():
+    | { startSeg: number; startTok: number; endSeg: number; endTok: number; text: string }
+    | null => {
+    const a = active();
+    if (!a || a.els.length === 0) return null;
+    const mainCol = mainTextCol();
+    if (!mainCol) return null;
+    const first = a.els[0];
+    const last = a.els[a.els.length - 1];
+    const s = wordCoordFromTarget(first, mainCol);
+    const e = wordCoordFromTarget(last, mainCol);
+    if (!s || !e) return null;
+    const text = a.els.map((el) => el.textContent ?? '').join(' ').replace(/\s+/g, ' ').trim();
+    return { startSeg: s.seg, startTok: s.tok, endSeg: e.seg, endTok: e.tok, text };
+  };
+
+  // A plain click on a word already covered by a personal highlight opens that
+  // highlight's note popover (view/edit/delete) instead of translating it.
+  // Returns true when it consumed the click.
+  const tryOpenUserHighlight = (wordEl: HTMLElement, e: MouseEvent): boolean => {
+    const mainCol = mainTextCol();
+    if (!mainCol || !mainCol.contains(wordEl)) return false;
+    const wc = wordCoordFromTarget(wordEl, mainCol);
+    if (!wc) return false;
+    // Search newest-first so an overlap opens the highlight painted on top
+    // (highlights paint in array order; later entries sit above earlier ones).
+    const list = userHighlights();
+    let hit: UserHighlight | undefined;
+    for (let i = list.length - 1; i >= 0; i--) {
+      if (highlightCoversWord(list[i], wc.seg, wc.tok)) { hit = list[i]; break; }
+    }
+    if (!hit) return false;
+    const r = wordEl.getBoundingClientRect();
+    setOpenHighlight({ id: hit.id, rect: { left: r.left, top: r.top, bottom: r.bottom } });
+    clearActive();
+    e.stopPropagation();
+    return true;
+  };
+
+  // From the notes panel: scroll the highlight into view + open its popover.
+  const jumpToHighlight = (h: UserHighlight) => {
+    setShowNotesList(false);
+    const mainCol = mainTextCol();
+    if (!mainCol) return;
+    const range = buildTokenRange(mainCol, h.startSeg, h.endSeg, h.startTok, h.endTok);
+    if (!range) return;
+    const r = range.getBoundingClientRect();
+    const desiredTop = window.innerHeight * 0.3;
+    window.scrollBy({ top: r.top - desiredTop, behavior: 'smooth' });
+    // Re-measure after the scroll settles so the popover lands on the word.
+    if (jumpTimer) clearTimeout(jumpTimer);
+    jumpTimer = setTimeout(() => {
+      jumpTimer = undefined;
+      // The daf may have changed during the scroll — only open if this
+      // highlight is still live on the current page.
+      if (!userHighlights().some((x) => x.id === h.id)) return;
+      const r2 = range.getBoundingClientRect();
+      setOpenHighlight({ id: h.id, rect: { left: r2.left, top: r2.top, bottom: r2.bottom } });
+    }, 350);
+  };
+  onCleanup(() => {
+    if (jumpTimer) clearTimeout(jumpTimer);
+  });
+
   // Track the un-scaled daf height so the mobile scale wrapper can reserve the
   // correct (scaled) vertical space. offsetHeight is a layout value, so it is
   // unaffected by the CSS transform applied to the same element.
@@ -1476,6 +1598,26 @@ export default function DafViewer(): JSX.Element {
     paintRangeOverlay(overlay, dafRootDiv, moveRanges, 'move');
     paintRangeOverlay(overlay, dafRootDiv, commAnchorRanges, 'comm-anchor');
 
+    // User pieces — personal highlights painted under everything else's logic
+    // but on top visually (appended last). Each carries its own color; paint
+    // in one batch with a per-range bgFor so a single overlay pass covers all.
+    {
+      const mainCol = dafRootDiv.querySelector<HTMLElement>('.daf-main .daf-text');
+      if (mainCol) {
+        const list = userHighlights();
+        const ranges: Range[] = [];
+        const colors: string[] = [];
+        for (const h of list) {
+          const r = buildTokenRange(mainCol, h.startSeg, h.endSeg, h.startTok, h.endTok);
+          if (r) {
+            ranges.push(r);
+            colors.push(bgForColor(h.color));
+          }
+        }
+        paintRangeOverlay(overlay, dafRootDiv, ranges, 'user', (i) => colors[i]);
+      }
+    }
+
     // Per-rabbi name accent (yellow) — always applied on top of any tint.
     if (name) {
       const selector = `.rabbi-underline[data-rabbi="${name.replace(/"/g, '\\"')}"]`;
@@ -1549,6 +1691,7 @@ export default function DafViewer(): JSX.Element {
     void activePlace();
     void argumentMoveHighlight();
     void commAnchorActive();
+    void userHighlights();
     // Defer one frame so layout is settled before we measure client rects.
     queueMicrotask(() => queueMicrotask(applyHighlights));
   });
@@ -2445,11 +2588,15 @@ export default function DafViewer(): JSX.Element {
           const cityName = cityEl.getAttribute('data-city');
           if (cityName) { openPlace(cityName); return; }
         }
+        // A tap on a personal highlight opens its note (long-press selection
+        // produced a non-collapsed range handled earlier, so this is a tap).
+        if (wordEl && tryOpenUserHighlight(wordEl, e)) return;
         return;
       }
       // Translate mode: tap-to-translate, bypassing rabbi/city handlers so
       // the drawer doesn't hijack the popup on rabbi-underlined words.
       if (!wordEl) return;
+      if (tryOpenUserHighlight(wordEl, e)) return;
       if (active()?.els.includes(wordEl)) {
         clearActive();
         return;
@@ -2476,7 +2623,8 @@ export default function DafViewer(): JSX.Element {
     if (!wordEl) return;
     // When a commentary work is active, clicking a word inside one of its
     // anchored segments opens that work's comments for the segment instead of
-    // triggering a translation.
+    // triggering a translation. This takes precedence over the highlight
+    // popover so the commentary-on-click path is preserved.
     if (activeCommentaryWork()) {
       const segAttr = wordEl.getAttribute('data-seg');
       if (segAttr !== null) {
@@ -2487,6 +2635,8 @@ export default function DafViewer(): JSX.Element {
         }
       }
     }
+    // A click on an existing personal highlight opens its note popover.
+    if (tryOpenUserHighlight(wordEl, e)) return;
     setActiveFromWordEls([wordEl], e);
   };
 
@@ -2758,8 +2908,74 @@ export default function DafViewer(): JSX.Element {
             hebrewAfter={a().hebrewAfter}
             segIdx={a().segIdx}
             onClose={clearActive}
+            onHighlight={
+              highlightCoordsForActive()
+                ? (color, note) => {
+                    const c = highlightCoordsForActive();
+                    if (c) addHighlight(buildHighlight(c, { color, note }));
+                    clearActive();
+                  }
+                : undefined
+            }
           />
         )}
+      </Show>
+
+      <Show when={openHighlight()}>
+        {(oh) => {
+          const hl = () => userHighlights().find((h) => h.id === oh().id);
+          return (
+            <Show when={hl()}>
+              {(h) => (
+                <HighlightNotePopover
+                  highlight={h()}
+                  anchor={oh().rect}
+                  onSave={(note) => updateHighlightNote(h().id, note)}
+                  onDelete={() => {
+                    deleteHighlight(h().id);
+                    setOpenHighlight(null);
+                  }}
+                  onClose={() => setOpenHighlight(null)}
+                />
+              )}
+            </Show>
+          );
+        }}
+      </Show>
+
+      <Show when={!isMobile() && userHighlights().length > 0}>
+        <button
+          type="button"
+          onClick={() => setShowNotesList((v) => !v)}
+          title={t('highlight.notesTitle')}
+          style={{
+            position: 'fixed',
+            right: '1rem',
+            bottom: '1rem',
+            'z-index': '1000',
+            padding: '0.4rem 0.8rem',
+            'border-radius': '999px',
+            border: '1px solid #d0d0d0',
+            background: '#fff',
+            'box-shadow': '0 2px 8px rgba(0,0,0,0.12)',
+            cursor: 'pointer',
+            'font-size': '0.8rem',
+            'font-weight': 600,
+            'font-family': 'system-ui, -apple-system, sans-serif',
+            color: '#444',
+          }}
+        >
+          {t('highlight.notesToggle')} ({userHighlights().length})
+        </button>
+      </Show>
+
+      <Show when={!isMobile() && showNotesList()}>
+        <NotesPanel
+          highlights={userHighlights()}
+          onJump={jumpToHighlight}
+          onDelete={deleteHighlight}
+          onClose={() => setShowNotesList(false)}
+        />
       </Show>
 
       <BugReport tractate={tractate()} page={page()} />

--- a/src/client/TranslationPopup.tsx
+++ b/src/client/TranslationPopup.tsx
@@ -1,5 +1,6 @@
-import { createSignal, createEffect, onCleanup, Show, type JSX } from 'solid-js';
+import { createSignal, createEffect, onCleanup, Show, For, type JSX } from 'solid-js';
 import { t } from './i18n';
+import { HIGHLIGHT_COLORS } from './userHighlights';
 
 export interface TranslationPopupProps {
   word: string;
@@ -15,6 +16,10 @@ export interface TranslationPopupProps {
   /** Sefaria segment index resolved client-side from `data-seg` on the
    *  clicked .daf-word. The server uses it directly when provided. */
   segIdx?: number;
+  /** When set, the popup offers personal-highlight controls (a color-swatch
+   *  row + optional note) over the selected words. Called with the chosen
+   *  color key + note text; the host persists + closes. */
+  onHighlight?: (color: string, note: string) => void;
 }
 
 // Module-level cache so reopening the popup for a word we already translated
@@ -25,6 +30,7 @@ export function TranslationPopup(props: TranslationPopupProps): JSX.Element {
   const [translation, setTranslation] = createSignal<string | null>(null);
   const [loading, setLoading] = createSignal(true);
   const [error, setError] = createSignal<string | null>(null);
+  const [noteText, setNoteText] = createSignal('');
   let popupRef: HTMLDivElement | undefined;
 
   // Cache key includes a cheap hash of the surrounding text so the same word
@@ -150,6 +156,56 @@ export function TranslationPopup(props: TranslationPopupProps): JSX.Element {
           {translation()}
         </Show>
       </div>
+      <Show when={props.onHighlight}>
+        <div
+          style={{
+            'margin-top': '0.55rem',
+            'padding-top': '0.5rem',
+            'border-top': '1px solid #eee',
+          }}
+        >
+          <input
+            type="text"
+            value={noteText()}
+            onInput={(e) => setNoteText(e.currentTarget.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') props.onHighlight?.(HIGHLIGHT_COLORS[0].key, noteText().trim());
+            }}
+            placeholder={t('highlight.notePlaceholder')}
+            style={{
+              width: '100%',
+              'box-sizing': 'border-box',
+              'font-size': '0.82rem',
+              padding: '0.3rem 0.4rem',
+              border: '1px solid #ddd',
+              'border-radius': '4px',
+              'margin-bottom': '0.45rem',
+              'font-family': 'system-ui, -apple-system, sans-serif',
+            }}
+          />
+          <div style={{ display: 'flex', 'align-items': 'center', gap: '0.4rem' }}>
+            <span style={{ 'font-size': '0.72rem', color: '#888' }}>{t('highlight.action')}</span>
+            <For each={HIGHLIGHT_COLORS}>
+              {(c) => (
+                <button
+                  type="button"
+                  title={c.label}
+                  onClick={() => props.onHighlight?.(c.key, noteText().trim())}
+                  style={{
+                    width: '20px',
+                    height: '20px',
+                    'border-radius': '50%',
+                    border: '1px solid rgba(0,0,0,0.2)',
+                    background: c.swatch,
+                    cursor: 'pointer',
+                    padding: '0',
+                  }}
+                />
+              )}
+            </For>
+          </div>
+        </div>
+      </Show>
     </div>
   );
 }

--- a/src/client/UserHighlightUI.tsx
+++ b/src/client/UserHighlightUI.tsx
@@ -1,0 +1,255 @@
+import { createSignal, onCleanup, For, Show, type JSX } from 'solid-js';
+import { t } from './i18n';
+import { type UserHighlight, HIGHLIGHT_COLORS } from './userHighlights';
+
+/** View / edit / delete a single personal highlight, anchored near the word
+ *  the user clicked. */
+export function HighlightNotePopover(props: {
+  highlight: UserHighlight;
+  anchor: { left: number; top: number; bottom: number };
+  onSave: (note: string) => void;
+  onDelete: () => void;
+  onClose: () => void;
+}): JSX.Element {
+  const [note, setNote] = createSignal(props.highlight.note);
+  let ref: HTMLDivElement | undefined;
+
+  const onDocDown = (e: MouseEvent) => {
+    if (ref && !ref.contains(e.target as Node)) {
+      // Persist any in-progress edit before dismissing.
+      if (note().trim() !== props.highlight.note) props.onSave(note().trim());
+      props.onClose();
+    }
+  };
+  const onKey = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') props.onClose();
+  };
+  document.addEventListener('mousedown', onDocDown, true);
+  window.addEventListener('keydown', onKey);
+  onCleanup(() => {
+    document.removeEventListener('mousedown', onDocDown, true);
+    window.removeEventListener('keydown', onKey);
+  });
+
+  const style = (): JSX.CSSProperties => {
+    const a = props.anchor;
+    const h = 120;
+    const above = a.top > h + 16;
+    return {
+      position: 'fixed',
+      top: above ? `${a.top - h - 8}px` : `${a.bottom + 8}px`,
+      left: `${a.left}px`,
+      'z-index': '1001',
+    };
+  };
+
+  return (
+    <div
+      ref={ref}
+      style={{
+        ...style(),
+        background: '#fff',
+        border: '1px solid #d0d0d0',
+        'border-radius': '6px',
+        'box-shadow': '0 4px 16px rgba(0,0,0,0.14)',
+        padding: '0.6rem',
+        'min-width': '15rem',
+        'max-width': '20rem',
+        'font-family': 'system-ui, -apple-system, sans-serif',
+      }}
+    >
+      <div
+        dir="rtl"
+        lang="he"
+        style={{
+          'font-family': '"Mekorot Vilna", serif',
+          'font-size': '0.95rem',
+          color: '#555',
+          'margin-bottom': '0.45rem',
+          'max-height': '3.2em',
+          overflow: 'hidden',
+        }}
+      >
+        {props.highlight.text}
+      </div>
+      <textarea
+        value={note()}
+        onInput={(e) => setNote(e.currentTarget.value)}
+        placeholder={t('highlight.notePlaceholder')}
+        rows={3}
+        style={{
+          width: '100%',
+          'box-sizing': 'border-box',
+          'font-size': '0.85rem',
+          padding: '0.35rem 0.45rem',
+          border: '1px solid #ddd',
+          'border-radius': '4px',
+          resize: 'vertical',
+          'font-family': 'system-ui, -apple-system, sans-serif',
+        }}
+      />
+      <div style={{ display: 'flex', 'justify-content': 'space-between', 'margin-top': '0.5rem' }}>
+        <button
+          type="button"
+          onClick={() => props.onDelete()}
+          style={{
+            'font-size': '0.78rem',
+            color: '#c0392b',
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            padding: '0.25rem 0',
+          }}
+        >
+          {t('highlight.delete')}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            props.onSave(note().trim());
+            props.onClose();
+          }}
+          style={{
+            'font-size': '0.78rem',
+            'font-weight': 600,
+            color: '#fff',
+            background: '#2563eb',
+            border: 'none',
+            'border-radius': '4px',
+            cursor: 'pointer',
+            padding: '0.3rem 0.8rem',
+          }}
+        >
+          {t('highlight.save')}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/** A compact list of this daf's highlights — click to jump, with delete. */
+export function NotesPanel(props: {
+  highlights: UserHighlight[];
+  onJump: (h: UserHighlight) => void;
+  onDelete: (id: string) => void;
+  onClose: () => void;
+}): JSX.Element {
+  const swatch = (key: string) =>
+    (HIGHLIGHT_COLORS.find((c) => c.key === key) ?? HIGHLIGHT_COLORS[0]).swatch;
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        right: '1rem',
+        bottom: '4.5rem',
+        width: '18rem',
+        'max-height': '60vh',
+        overflow: 'auto',
+        background: '#fff',
+        border: '1px solid #d0d0d0',
+        'border-radius': '8px',
+        'box-shadow': '0 6px 20px rgba(0,0,0,0.16)',
+        'z-index': '1000',
+        'font-family': 'system-ui, -apple-system, sans-serif',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          'justify-content': 'space-between',
+          'align-items': 'center',
+          padding: '0.6rem 0.8rem',
+          'border-bottom': '1px solid #eee',
+          position: 'sticky',
+          top: '0',
+          background: '#fff',
+        }}
+      >
+        <strong style={{ 'font-size': '0.85rem' }}>{t('highlight.notesTitle')}</strong>
+        <button
+          type="button"
+          onClick={() => props.onClose()}
+          aria-label="Close"
+          style={{ background: 'none', border: 'none', cursor: 'pointer', 'font-size': '1rem', color: '#888' }}
+        >
+          ×
+        </button>
+      </div>
+      <Show
+        when={props.highlights.length > 0}
+        fallback={
+          <p style={{ padding: '0.8rem', color: '#999', 'font-size': '0.82rem', 'font-style': 'italic' }}>
+            {t('highlight.notesEmpty')}
+          </p>
+        }
+      >
+        <For each={props.highlights}>
+          {(h) => (
+            <div
+              style={{
+                padding: '0.55rem 0.8rem',
+                'border-bottom': '1px solid #f3f3f3',
+                cursor: 'pointer',
+                display: 'flex',
+                gap: '0.5rem',
+              }}
+              onClick={() => props.onJump(h)}
+            >
+              <span
+                style={{
+                  flex: '0 0 auto',
+                  width: '10px',
+                  height: '10px',
+                  'border-radius': '50%',
+                  background: swatch(h.color),
+                  'margin-top': '0.25rem',
+                  border: '1px solid rgba(0,0,0,0.15)',
+                }}
+              />
+              <div style={{ 'min-width': '0', flex: '1 1 auto' }}>
+                <div
+                  dir="rtl"
+                  lang="he"
+                  style={{
+                    'font-family': '"Mekorot Vilna", serif',
+                    'font-size': '0.9rem',
+                    color: '#333',
+                    'white-space': 'nowrap',
+                    overflow: 'hidden',
+                    'text-overflow': 'ellipsis',
+                  }}
+                >
+                  {h.text}
+                </div>
+                <Show when={h.note}>
+                  <div style={{ 'font-size': '0.78rem', color: '#666', 'margin-top': '0.15rem' }}>
+                    {h.note}
+                  </div>
+                </Show>
+              </div>
+              <button
+                type="button"
+                aria-label={t('highlight.delete')}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  props.onDelete(h.id);
+                }}
+                style={{
+                  flex: '0 0 auto',
+                  background: 'none',
+                  border: 'none',
+                  cursor: 'pointer',
+                  color: '#bbb',
+                  'font-size': '0.95rem',
+                }}
+              >
+                ×
+              </button>
+            </div>
+          )}
+        </For>
+      </Show>
+    </div>
+  );
+}

--- a/src/client/i18n.ts
+++ b/src/client/i18n.ts
@@ -634,6 +634,16 @@ const CATALOG = {
   // — Translation popup —
   'translation.loading': { en: 'Translating…', he: 'מתרגם…' },
 
+  // — User highlights / notes —
+  'highlight.action': { en: 'Highlight:', he: 'הדגשה:' },
+  'highlight.notePlaceholder': { en: 'Add a note…', he: 'הוספת הערה…' },
+  'highlight.delete': { en: 'Delete', he: 'מחיקה' },
+  'highlight.save': { en: 'Save', he: 'שמירה' },
+  'highlight.notesTitle': { en: 'My notes', he: 'ההערות שלי' },
+  'highlight.notesEmpty': { en: 'No highlights on this daf yet.', he: 'אין עדיין הדגשות בדף זה.' },
+  'highlight.notesToggle': { en: 'Notes', he: 'הערות' },
+  'highlight.noteLabel': { en: 'Note', he: 'הערה' },
+
   // — Bug report —
   'bugreport.open': { en: 'Report a problem', he: 'דיווח על תקלה' },
   'bugreport.sent': { en: 'Thanks — report sent for {daf}.', he: 'תודה — הדיווח נשלח עבור {daf}.' },

--- a/src/client/userHighlights.ts
+++ b/src/client/userHighlights.ts
@@ -1,0 +1,235 @@
+/**
+ * User pieces — personal highlights + notes on the daf.
+ *
+ * Client-only: persisted to `localStorage` per (tractate, page), no backend
+ * and no auth (a local-session feature). Each highlight pins to a word-range
+ * using the same (seg, tok) coordinate the worker-anchored pieces use, so it
+ * survives reflow and re-paints through the existing `buildTokenRange` /
+ * `paintRangeOverlay` machinery in DafViewer.
+ *
+ * This module is pure DOM + storage logic (no Solid, no app imports) so the
+ * selection→coordinate mapping can be unit-tested under jsdom.
+ */
+
+/** A persisted personal highlight, optionally carrying a note. */
+export interface UserHighlight {
+  id: string;
+  /** Word-range anchor (inclusive), matching the daf's `.daf-word` data-seg /
+   *  per-segment token index. */
+  startSeg: number;
+  startTok: number;
+  endSeg: number;
+  endTok: number;
+  /** Verbatim selected text — shown in the notes list and as a fallback label
+   *  if the anchor ever fails to resolve against a re-rendered daf. */
+  text: string;
+  /** Free-text note (empty string when the user only highlighted). */
+  note: string;
+  /** One of HIGHLIGHT_COLORS' `key`s. */
+  color: string;
+  createdAt: number;
+}
+
+/** Highlighter palette. `key` is stored; `bg` is the painted (translucent)
+ *  fill; `swatch` is the opaque toolbar chip. */
+export const HIGHLIGHT_COLORS: ReadonlyArray<{ key: string; label: string; bg: string; swatch: string }> = [
+  { key: 'yellow', label: 'Yellow', bg: 'rgba(250, 204, 21, 0.40)', swatch: '#facc15' },
+  { key: 'green', label: 'Green', bg: 'rgba(74, 222, 128, 0.38)', swatch: '#4ade80' },
+  { key: 'blue', label: 'Blue', bg: 'rgba(96, 165, 250, 0.38)', swatch: '#60a5fa' },
+  { key: 'pink', label: 'Pink', bg: 'rgba(244, 114, 182, 0.38)', swatch: '#f472b6' },
+];
+
+const DEFAULT_COLOR = HIGHLIGHT_COLORS[0].key;
+
+/** Translucent fill for a stored color key (falls back to yellow). */
+export function bgForColor(key: string): string {
+  return (HIGHLIGHT_COLORS.find((c) => c.key === key) ?? HIGHLIGHT_COLORS[0]).bg;
+}
+
+const KEY_PREFIX = 'talmud:user-highlights:v1';
+
+function storageKey(tractate: string, page: string): string {
+  return `${KEY_PREFIX}:${tractate}:${page}`;
+}
+
+function getStore(): Storage | null {
+  try {
+    return typeof localStorage !== 'undefined' ? localStorage : null;
+  } catch {
+    // Access can throw in private-mode / sandboxed iframes.
+    return null;
+  }
+}
+
+/** Load this daf's highlights (empty array on absence or corruption). */
+export function loadUserHighlights(tractate: string, page: string): UserHighlight[] {
+  const store = getStore();
+  if (!store) return [];
+  try {
+    const raw = store.getItem(storageKey(tractate, page));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isValidHighlight).map(normalizeHighlight);
+  } catch {
+    return [];
+  }
+}
+
+/** Coerce the optional/display fields to safe defaults so a hand-edited or
+ *  partially-corrupt record can't crash the UI (e.g. note().trim()). */
+function normalizeHighlight(h: UserHighlight): UserHighlight {
+  return {
+    ...h,
+    note: typeof h.note === 'string' ? h.note : '',
+    color: typeof h.color === 'string' ? h.color : DEFAULT_COLOR,
+    createdAt: typeof h.createdAt === 'number' ? h.createdAt : 0,
+  };
+}
+
+/** Persist this daf's highlights (a no-op when storage is unavailable). */
+export function saveUserHighlights(tractate: string, page: string, list: UserHighlight[]): void {
+  const store = getStore();
+  if (!store) return;
+  try {
+    if (list.length === 0) store.removeItem(storageKey(tractate, page));
+    else store.setItem(storageKey(tractate, page), JSON.stringify(list));
+  } catch {
+    // Quota / disabled storage — silently drop; highlights stay in-memory.
+  }
+}
+
+function isValidHighlight(h: unknown): h is UserHighlight {
+  if (!h || typeof h !== 'object') return false;
+  const o = h as Record<string, unknown>;
+  return (
+    typeof o.id === 'string' &&
+    typeof o.startSeg === 'number' &&
+    typeof o.startTok === 'number' &&
+    typeof o.endSeg === 'number' &&
+    typeof o.endTok === 'number' &&
+    typeof o.text === 'string'
+  );
+}
+
+let idCounter = 0;
+/** A stable-enough id for a single session (crypto.randomUUID when present). */
+export function makeHighlightId(): string {
+  try {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+  } catch {
+    /* fall through */
+  }
+  idCounter += 1;
+  return `uh-${Date.now().toString(36)}-${idCounter}`;
+}
+
+/** The token index of `span` within its own segment (position among the
+ *  `.daf-word[data-seg=N]` spans in document order). */
+function tokenIndexOf(mainCol: HTMLElement, span: HTMLElement): number {
+  const seg = span.getAttribute('data-seg');
+  if (seg == null) return 0;
+  const sibs = mainCol.querySelectorAll<HTMLElement>(`.daf-word[data-seg="${seg}"]`);
+  for (let i = 0; i < sibs.length; i++) if (sibs[i] === span) return i;
+  return 0;
+}
+
+/**
+ * Map a live DOM selection range to a word-range coordinate over the daf's
+ * `.daf-word` spans. Returns null when the selection covers no tagged words
+ * (e.g. landed entirely in commentary columns or between segments).
+ *
+ * Uses boundary-point comparison (portable across jsdom/browsers) to find
+ * every `.daf-word` that overlaps the range, then takes the first and last.
+ */
+export function selectionToTokenRange(
+  range: Range,
+  mainCol: HTMLElement,
+): { startSeg: number; startTok: number; endSeg: number; endTok: number; text: string } | null {
+  if (range.collapsed) return null;
+  const spans = Array.from(mainCol.querySelectorAll<HTMLElement>('.daf-word'));
+  if (spans.length === 0) return null;
+
+  const hit: HTMLElement[] = [];
+  for (const span of spans) {
+    const spanRange = span.ownerDocument.createRange();
+    spanRange.selectNode(span);
+    // Overlap iff span.start < sel.end AND span.end > sel.start. With `range`
+    // as the context object: START_TO_END compares sel.end to span.start (>0
+    // ⇒ span.start < sel.end); END_TO_START compares sel.start to span.end
+    // (<0 ⇒ span.end > sel.start).
+    const spanStartsBeforeSelEnd = range.compareBoundaryPoints(Range.START_TO_END, spanRange) > 0;
+    const spanEndsAfterSelStart = range.compareBoundaryPoints(Range.END_TO_START, spanRange) < 0;
+    if (spanStartsBeforeSelEnd && spanEndsAfterSelStart) hit.push(span);
+  }
+  if (hit.length === 0) return null;
+
+  const first = hit[0];
+  const last = hit[hit.length - 1];
+  const startSeg = Number(first.getAttribute('data-seg'));
+  const endSeg = Number(last.getAttribute('data-seg'));
+  if (!Number.isFinite(startSeg) || !Number.isFinite(endSeg)) return null;
+
+  const text = hit
+    .map((s) => s.textContent ?? '')
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  return {
+    startSeg,
+    startTok: tokenIndexOf(mainCol, first),
+    endSeg,
+    endTok: tokenIndexOf(mainCol, last),
+    text,
+  };
+}
+
+/** Does a highlight's word-range cover the (seg, tok) of a single word?
+ *  Used for click-to-open: a plain click on a highlighted word opens it. */
+export function highlightCoversWord(h: UserHighlight, seg: number, tok: number): boolean {
+  const afterStart = seg > h.startSeg || (seg === h.startSeg && tok >= h.startTok);
+  const beforeEnd = seg < h.endSeg || (seg === h.endSeg && tok <= h.endTok);
+  return afterStart && beforeEnd;
+}
+
+/** Build a UserHighlight from a mapped selection + chosen color/note. */
+export function buildHighlight(
+  coords: { startSeg: number; startTok: number; endSeg: number; endTok: number; text: string },
+  opts?: { color?: string; note?: string },
+): UserHighlight {
+  return {
+    id: makeHighlightId(),
+    startSeg: coords.startSeg,
+    startTok: coords.startTok,
+    endSeg: coords.endSeg,
+    endTok: coords.endTok,
+    text: coords.text,
+    note: opts?.note ?? '',
+    color: opts?.color ?? DEFAULT_COLOR,
+    createdAt: Date.now(),
+  };
+}
+
+/** Resolve the (seg, tok) of the `.daf-word` a click landed on, if any. */
+export function wordCoordFromTarget(
+  target: EventTarget | null,
+  mainCol: HTMLElement,
+): { seg: number; tok: number } | null {
+  // A click target is usually the `.daf-word` element; a selection boundary is
+  // usually a text node inside one — resolve both to the enclosing element.
+  const el =
+    target instanceof Element
+      ? target
+      : target instanceof Node
+        ? target.parentElement
+        : null;
+  if (!el) return null;
+  const word = el.closest<HTMLElement>('.daf-word');
+  if (!word || !mainCol.contains(word)) return null;
+  const seg = Number(word.getAttribute('data-seg'));
+  if (!Number.isFinite(seg)) return null;
+  return { seg, tok: tokenIndexOf(mainCol, word) };
+}

--- a/src/lib/daf-render/styles.css
+++ b/src/lib/daf-render/styles.css
@@ -309,6 +309,15 @@
 .daf-root .daf-range-highlight-comm-anchor {
   background-color: rgba(15, 118, 110, 0.22);
 }
+/* User pieces — personal highlights. Background is set inline per-highlight
+   (paintRangeOverlay's bgFor callback) from the chosen palette color; the
+   static rule owns only layout + the highlighter blend so the daf text reads
+   through. Pointer-events stay off so clicks fall through to the daf word
+   (the click handler opens the note popover by hit-testing coordinates). */
+.daf-root .daf-range-highlight-user {
+  pointer-events: none;
+  mix-blend-mode: multiply;
+}
 /* Era stratification tints — background color is set inline per-segment
    (paintRangeOverlay's bgFor callback) so the static rule only owns layout
    behaviour. Pointer-events stay off so clicks fall through to the daf word. */

--- a/tests/user-highlights.test.ts
+++ b/tests/user-highlights.test.ts
@@ -1,0 +1,176 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  loadUserHighlights,
+  saveUserHighlights,
+  selectionToTokenRange,
+  highlightCoversWord,
+  buildHighlight,
+  wordCoordFromTarget,
+  bgForColor,
+  HIGHLIGHT_COLORS,
+  type UserHighlight,
+} from '../src/client/userHighlights';
+
+function buildDaf(): HTMLElement {
+  // seg 0: [aleph, bet]  seg 1: [gimel, dalet, he]
+  const col = document.createElement('div');
+  col.className = 'daf-text';
+  col.innerHTML =
+    '<span class="daf-word" data-seg="0" data-word-index="0">aleph</span> ' +
+    '<span class="daf-word" data-seg="0" data-word-index="1">bet</span> ' +
+    '<span class="daf-word" data-seg="1" data-word-index="2">gimel</span> ' +
+    '<span class="daf-word" data-seg="1" data-word-index="3">dalet</span> ' +
+    '<span class="daf-word" data-seg="1" data-word-index="4">he</span>';
+  document.body.appendChild(col);
+  return col;
+}
+
+describe('selectionToTokenRange', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('maps a multi-word, cross-segment selection to (seg, tok) coords', () => {
+    const col = buildDaf();
+    const words = col.querySelectorAll<HTMLElement>('.daf-word');
+    const range = document.createRange();
+    range.setStartBefore(words[1]); // "bet"  (seg 0, tok 1)
+    range.setEndAfter(words[2]); //  "gimel" (seg 1, tok 0)
+    const out = selectionToTokenRange(range, col);
+    expect(out).toEqual({ startSeg: 0, startTok: 1, endSeg: 1, endTok: 0, text: 'bet gimel' });
+  });
+
+  it('maps a single-word selection', () => {
+    const col = buildDaf();
+    const words = col.querySelectorAll<HTMLElement>('.daf-word');
+    const range = document.createRange();
+    range.setStartBefore(words[3]); // "dalet" (seg 1, tok 1)
+    range.setEndAfter(words[3]);
+    const out = selectionToTokenRange(range, col);
+    expect(out).toEqual({ startSeg: 1, startTok: 1, endSeg: 1, endTok: 1, text: 'dalet' });
+  });
+
+  it('returns null for a collapsed selection', () => {
+    const col = buildDaf();
+    const range = document.createRange();
+    range.setStart(col, 0);
+    range.collapse(true);
+    expect(selectionToTokenRange(range, col)).toBeNull();
+  });
+
+  it('returns null when the column has no tagged words', () => {
+    const col = document.createElement('div');
+    col.textContent = 'plain text, no words';
+    document.body.appendChild(col);
+    const range = document.createRange();
+    range.selectNodeContents(col);
+    expect(selectionToTokenRange(range, col)).toBeNull();
+  });
+});
+
+describe('highlightCoversWord', () => {
+  const h: UserHighlight = {
+    id: 'x',
+    startSeg: 0,
+    startTok: 1,
+    endSeg: 1,
+    endTok: 1,
+    text: 'bet gimel dalet',
+    note: '',
+    color: 'yellow',
+    createdAt: 0,
+  };
+
+  it('covers words inside the range (inclusive endpoints)', () => {
+    expect(highlightCoversWord(h, 0, 1)).toBe(true); // start
+    expect(highlightCoversWord(h, 1, 0)).toBe(true); // middle seg
+    expect(highlightCoversWord(h, 1, 1)).toBe(true); // end
+  });
+
+  it('excludes words before the start token and after the end token', () => {
+    expect(highlightCoversWord(h, 0, 0)).toBe(false); // before startTok in startSeg
+    expect(highlightCoversWord(h, 1, 2)).toBe(false); // after endTok in endSeg
+  });
+});
+
+describe('wordCoordFromTarget', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('resolves (seg, tok) for a word element / its text node', () => {
+    const col = buildDaf();
+    const words = col.querySelectorAll<HTMLElement>('.daf-word');
+    expect(wordCoordFromTarget(words[2], col)).toEqual({ seg: 1, tok: 0 });
+    // A click usually lands on the text node inside the span.
+    expect(wordCoordFromTarget(words[4].firstChild, col)).toEqual({ seg: 1, tok: 2 });
+  });
+
+  it('returns null for a target outside the column', () => {
+    const col = buildDaf();
+    const outside = document.createElement('span');
+    outside.className = 'daf-word';
+    outside.setAttribute('data-seg', '9');
+    document.body.appendChild(outside);
+    expect(wordCoordFromTarget(outside, col)).toBeNull();
+  });
+});
+
+describe('persistence (localStorage round-trip)', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('saves and loads per (tractate, page)', () => {
+    const list = [buildHighlight({ startSeg: 0, startTok: 0, endSeg: 0, endTok: 1, text: 'aleph bet' })];
+    saveUserHighlights('Berakhot', '2a', list);
+    const back = loadUserHighlights('Berakhot', '2a');
+    expect(back).toHaveLength(1);
+    expect(back[0].text).toBe('aleph bet');
+    // A different daf is isolated.
+    expect(loadUserHighlights('Berakhot', '2b')).toEqual([]);
+  });
+
+  it('removes the key when the list is emptied', () => {
+    saveUserHighlights('Shabbat', '5a', [buildHighlight({ startSeg: 0, startTok: 0, endSeg: 0, endTok: 0, text: 'x' })]);
+    saveUserHighlights('Shabbat', '5a', []);
+    expect(loadUserHighlights('Shabbat', '5a')).toEqual([]);
+  });
+
+  it('ignores corrupt storage payloads', () => {
+    localStorage.setItem('talmud:user-highlights:v1:Eruvin:3a', '{not json');
+    expect(loadUserHighlights('Eruvin', '3a')).toEqual([]);
+  });
+
+  it('normalizes records missing the optional note/color fields', () => {
+    // A hand-edited record with only the structural anchor fields.
+    localStorage.setItem(
+      'talmud:user-highlights:v1:Eruvin:4a',
+      JSON.stringify([{ id: 'a', startSeg: 0, startTok: 0, endSeg: 0, endTok: 1, text: 'x' }]),
+    );
+    const back = loadUserHighlights('Eruvin', '4a');
+    expect(back).toHaveLength(1);
+    expect(back[0].note).toBe('');
+    expect(back[0].color).toBe(HIGHLIGHT_COLORS[0].key);
+    expect(typeof back[0].note).toBe('string'); // safe for note().trim()
+  });
+});
+
+describe('buildHighlight + palette', () => {
+  it('defaults to an empty note and the first palette color', () => {
+    const h = buildHighlight({ startSeg: 2, startTok: 0, endSeg: 2, endTok: 3, text: 'foo' });
+    expect(h.note).toBe('');
+    expect(h.color).toBe(HIGHLIGHT_COLORS[0].key);
+    expect(h.id).toBeTruthy();
+  });
+
+  it('honours explicit color + note', () => {
+    const h = buildHighlight({ startSeg: 0, startTok: 0, endSeg: 0, endTok: 0, text: 'x' }, { color: 'blue', note: 'a thought' });
+    expect(h.color).toBe('blue');
+    expect(h.note).toBe('a thought');
+  });
+
+  it('bgForColor falls back to yellow for unknown keys', () => {
+    expect(bgForColor('blue')).toBe(HIGHLIGHT_COLORS.find((c) => c.key === 'blue')!.bg);
+    expect(bgForColor('nonsense')).toBe(HIGHLIGHT_COLORS[0].bg);
+  });
+});


### PR DESCRIPTION
The final step-5 slice of the smart-notes migration: **user pieces** — personal highlights and notes on the daf. Client-only by design, persisted to `localStorage` per (tractate, page) — no backend, no auth, no new worker binding.

## What it does
- **Highlight a selection.** Selecting daf text opens the translation popup, now with a color-swatch row + optional note field; picking a color saves a personal highlight over the selected words.
- **Painted persistently.** Highlights re-paint through the existing `paintRangeOverlay` / `buildTokenRange` overlay machinery (a new `'user'` range kind, per-highlight palette color), surviving reflow/font-load and daf navigation.
- **View / edit / delete.** Clicking a highlighted word opens a note popover (edit the note, delete). A desktop "Notes (n)" panel lists the daf's highlights with click-to-jump + delete. Mobile opens notes by tapping a highlight (the floating panel is desktop-only to avoid the mobile shelf).

## Design
- `src/client/userHighlights.ts` — pure DOM + storage logic. A highlight pins to a `(seg, tok)` word-range, the same coordinate the worker-anchored pieces use. Selection→coordinate mapping uses boundary-point overlap (portable across jsdom/browsers). localStorage load normalizes optional fields; unit-tested under jsdom (15 cases).
- Commentary-on-click retains precedence over the highlight popover; the translate / rabbi / city flows are unchanged.

## Verification
- `pnpm typecheck` clean; `pnpm test` 1579 passing (15 new).
- Reviewed with Codex (`codex exec --sandbox read-only`); all four findings fixed (commentary-click precedence, overlapping-highlight topmost-wins, corrupt-record normalization, jump-timer cleanup).