### PR TITLE
Commentary spines: lift commentary glosses into the unified Link layer

### DIFF
--- a/src/client/i18n.ts
+++ b/src/client/i18n.ts
@@ -197,6 +197,7 @@ const CATALOG = {
   'link.rel.parallels': { en: 'parallels', he: 'מקביל' },
   'link.rel.contrasts': { en: 'contrasts', he: 'מנוגד' },
   'link.rel.generalizes': { en: 'generalizes', he: 'מכליל' },
+  'link.rel.glosses': { en: 'glosses', he: 'מפרש' },
 
   // — Whole-daf background (terms/concepts a reader needs) —
   'background.chip': { en: 'Background', he: 'רקע' },

--- a/src/lib/context/coord.ts
+++ b/src/lib/context/coord.ts
@@ -24,6 +24,12 @@ export interface AnchorCoord {
   tractate: string;
   page: string;
   seg: number;
+  /** The spine this coordinate addresses. ABSENT means the Gemara spine (the
+   *  daf itself) — the default for everything that existed before commentary
+   *  spines, so spine-less coords serialize/label byte-identically. Present
+   *  (e.g. 'Rashi', 'Tosafot') addresses a commentary spine ON this daf: a
+   *  cross-spine coordinate. See {@link spineCoord}. */
+  spine?: string;
 }
 
 /** An ordered set of coordinates that may straddle multiple dapim. */
@@ -32,9 +38,13 @@ export type AnchorSpan = AnchorCoord[];
 /** A daf reference (the (tractate, page) half of a coordinate). */
 export type DafRef = { tractate: string; page: string };
 
-/** Stable string id for a coordinate — safe as a Map/Set key. */
+/** Stable string id for a coordinate — safe as a Map/Set key. A spine-less
+ *  (Gemara) coordinate keys EXACTLY as before (`tractate:page:seg`); a
+ *  spine-addressed coordinate prefixes its spine so a commentary coord never
+ *  collides with the Gemara segment at the same (tractate, page, seg). */
 export function coordKey(c: AnchorCoord): string {
-  return `${c.tractate}:${c.page}:${c.seg}`;
+  const base = `${c.tractate}:${c.page}:${c.seg}`;
+  return c.spine ? `${c.spine}::${base}` : base;
 }
 
 /** Whether two daf references name the same page. */
@@ -57,6 +67,15 @@ export function dafCoord(daf: DafRef): AnchorCoord {
   return { tractate: daf.tractate, page: daf.page, seg: DAF_SEG };
 }
 
+/** A coordinate on a commentary spine (e.g. Rashi / Tosafot) over a given daf.
+ *  `seg` defaults to {@link DAF_SEG} — "the work's gloss of this daf as a whole"
+ *  — since a commentary work's links cover many daf segments at once. This is
+ *  the cross-spine address the framework reserves: a piece on a NON-daf spine,
+ *  still pinned to (tractate, page) so it renders alongside the daf. */
+export function spineCoord(spine: string, daf: DafRef, seg: number = DAF_SEG): AnchorCoord {
+  return { spine, tractate: daf.tractate, page: daf.page, seg };
+}
+
 /** Coordinates for a list of local segment indices on a given daf. */
 export function coordsForSegs(daf: DafRef, segs: number[]): AnchorSpan {
   return segs.map((seg) => coordForSeg(daf, seg));
@@ -75,8 +94,11 @@ export function isCrossDaf(c: AnchorCoord, currentDaf: DafRef): boolean {
   return !sameDaf(c, currentDaf);
 }
 
-/** Dedupe + order a span by (tractate, page, seg). Stable across processes so
- *  the same span always serializes identically (cache-key friendly). */
+/** Dedupe + order a span by (tractate, page, seg, spine). Stable across
+ *  processes so the same span always serializes identically (cache-key
+ *  friendly). Spine is part of the sort so mixed-spine coords at the same
+ *  (tractate, page, seg) order deterministically rather than by caller order;
+ *  spine-less (Gemara) spans sort exactly as before (empty spine sorts first). */
 export function normalizeSpan(span: AnchorSpan): AnchorSpan {
   const seen = new Set<string>();
   const out: AnchorCoord[] = [];
@@ -88,22 +110,25 @@ export function normalizeSpan(span: AnchorSpan): AnchorSpan {
     (a, b) =>
       a.tractate.localeCompare(b.tractate) ||
       a.page.localeCompare(b.page) ||
-      a.seg - b.seg,
+      a.seg - b.seg ||
+      (a.spine ?? '').localeCompare(b.spine ?? ''),
   );
 }
 
 /** Group a span into per-daf segment lists (normalized: deduped + ordered).
  *  The shape a cross-page sugya map consumes — one entry per daf, each with the
- *  local segments it touches. */
+ *  local segments it touches. Spine is intentionally collapsed here (the sugya
+ *  map addresses Gemara segments); segs are deduped so mixed-spine coords at the
+ *  same (tractate, page, seg) don't emit a duplicate segment. */
 export function spanByDaf(span: AnchorSpan): { tractate: string; page: string; segs: number[] }[] {
-  const groups = new Map<string, { tractate: string; page: string; segs: number[] }>();
+  const groups = new Map<string, { tractate: string; page: string; segs: number[]; seen: Set<number> }>();
   for (const c of normalizeSpan(span)) {
     const dk = `${c.tractate}:${c.page}`;
-    const g = groups.get(dk) ?? { tractate: c.tractate, page: c.page, segs: [] };
-    g.segs.push(c.seg);
+    const g = groups.get(dk) ?? { tractate: c.tractate, page: c.page, segs: [], seen: new Set<number>() };
+    if (!g.seen.has(c.seg)) { g.seen.add(c.seg); g.segs.push(c.seg); }
     groups.set(dk, g);
   }
-  return [...groups.values()];
+  return [...groups.values()].map(({ tractate, page, segs }) => ({ tractate, page, segs }));
 }
 
 /** Bridge from the existing CrossDafAnchor target shape

--- a/src/lib/context/dafLinks.ts
+++ b/src/lib/context/dafLinks.ts
@@ -13,14 +13,14 @@
  */
 
 import { coordForSeg, dafCoord, type AnchorCoord, type DafRef } from './coord.ts';
-import { citationLink, continuationLink, flowLinks, type FlowEdge, type LinkRelation } from './link.ts';
+import { citationLink, continuationLink, flowLinks, glossLinks, type CommentaryWorkLike, type FlowEdge, type LinkRelation } from './link.ts';
 import type { ContextItem } from './types.ts';
 
 /** A link on a daf: where it lives (`source`), the `relation`, and what it
  *  points at (`targets`). `via` records which producer it came from, for
  *  display + debugging. */
 export interface DafLink {
-  via: 'bridge' | 'context' | 'flow';
+  via: 'bridge' | 'context' | 'flow' | 'commentary';
   source: AnchorCoord;
   relation: LinkRelation;
   targets: AnchorCoord[];
@@ -38,6 +38,9 @@ export interface DafLinkInputs {
   /** startSegIdx of each argument section, in flow-index order, so a flow edge's
    *  section index resolves to a coordinate. */
   sectionStartSegs: readonly number[];
+  /** Commentary works on this daf — each becomes a 'glosses' link from its own
+   *  spine to the daf segments it glosses. Optional/absent contributes nothing. */
+  commentaryWorks?: readonly CommentaryWorkLike[];
 }
 
 export function dafLinks(daf: DafRef, input: DafLinkInputs): DafLink[] {
@@ -61,6 +64,11 @@ export function dafLinks(daf: DafRef, input: DafLinkInputs): DafLink[] {
     i >= 0 && i < input.sectionStartSegs.length ? coordForSeg(daf, input.sectionStartSegs[i]) : null;
   for (const fl of flowLinks(input.flowEdges, coordOf)) {
     out.push({ via: 'flow', source: fl.source, relation: fl.link.relation, targets: fl.link.targets });
+  }
+
+  // 4) Commentary spines: each work glosses the daf segments it sits over.
+  for (const gl of glossLinks(daf, input.commentaryWorks ?? [])) {
+    out.push({ via: 'commentary', source: gl.source, relation: gl.link.relation, targets: gl.link.targets, note: gl.source.spine });
   }
 
   return out;

--- a/src/lib/context/link.ts
+++ b/src/lib/context/link.ts
@@ -17,7 +17,7 @@
  * bespoke encoding.
  */
 
-import { dafCoord, type AnchorCoord, type DafRef } from './coord.ts';
+import { dafCoord, spineCoord, coordForSeg, type AnchorCoord, type DafRef } from './coord.ts';
 import { coordLabel } from './types.ts';
 
 /** The kinds of link the system models. This is the SAME relation set the
@@ -31,15 +31,30 @@ export type LinkRelation =
   | 'depends-on'
   | 'parallels'
   | 'contrasts'
-  | 'generalizes';
+  | 'generalizes'
+  // A commentary spine (Rashi / Tosafot / a rishon) glossing the daf text it
+  // sits over. Not a flow relation — it's the cross-spine edge from a
+  // commentary spine into the Gemara. See `glossLinks`.
+  | 'glosses';
 
 /** Runtime membership test for the LinkRelation union (for validating an
  *  untyped `kind` string from an enrichment's JSON output). */
 const LINK_RELATIONS: ReadonlySet<string> = new Set<LinkRelation>([
-  'cites', 'continues', 'resolves', 'depends-on', 'parallels', 'contrasts', 'generalizes',
+  'cites', 'continues', 'resolves', 'depends-on', 'parallels', 'contrasts', 'generalizes', 'glosses',
 ]);
 export function isLinkRelation(kind: string): kind is LinkRelation {
   return LINK_RELATIONS.has(kind);
+}
+
+/** The subset of relations the argument-overview FLOW graph can emit between
+ *  sections. Excludes `cites` (a citation, not a flow edge) and `glosses` (the
+ *  cross-spine commentary edge) so `flowLinks` can't promote either to a
+ *  `via: 'flow'` link from stray cached flow data. */
+const FLOW_RELATIONS: ReadonlySet<string> = new Set<LinkRelation>([
+  'continues', 'resolves', 'depends-on', 'parallels', 'contrasts', 'generalizes',
+]);
+function isFlowRelation(kind: string): kind is LinkRelation {
+  return FLOW_RELATIONS.has(kind);
 }
 
 export interface Link {
@@ -110,11 +125,43 @@ export function flowLinks(
 ): FlowLink[] {
   const out: FlowLink[] = [];
   for (const e of edges) {
-    if (!isLinkRelation(e.kind) || e.from === e.to) continue;
+    if (!isFlowRelation(e.kind) || e.from === e.to) continue;
     const source = coordOf(e.from);
     const target = coordOf(e.to);
     if (!source || !target) continue;
     out.push({ source, link: { relation: e.kind, targets: [target] } });
+  }
+  return out;
+}
+
+/** The minimal shape `glossLinks` needs from a commentary work — kept
+ *  structural so this lib doesn't depend on the worker's `CommentaryWork`. Each
+ *  comment carries the daf segment index it glosses (the Sefaria anchor). */
+export interface CommentaryWorkLike {
+  title: string;
+  comments: readonly { anchorSegIdx: number }[];
+}
+
+/**
+ * Express a daf's commentary as Links — the cross-spine edges the framework's
+ * "commentary spines" step adds. Each commentary work (Rashi, Tosafot, a
+ * rishon) becomes ONE link sourced on its own spine ({@link spineCoord}) and
+ * targeting the deduped daf segments it glosses, under relation 'glosses'. One
+ * link per work (not per comment) keeps the daf-level graph compact: "Rashi
+ * glosses segs 0,1,4 of this daf." Works with no resolvable anchor segment are
+ * dropped. This lifts the bespoke `CommentaryAnchorIndex` (segToPieces /
+ * pieceToSegs) into the same Link vocabulary as citations, bridges, and flow.
+ */
+export function glossLinks(daf: DafRef, works: readonly CommentaryWorkLike[]): FlowLink[] {
+  const out: FlowLink[] = [];
+  for (const work of works) {
+    const segs = new Set<number>();
+    for (const cm of work.comments) {
+      if (typeof cm.anchorSegIdx === 'number' && cm.anchorSegIdx >= 0) segs.add(cm.anchorSegIdx);
+    }
+    if (segs.size === 0) continue;
+    const targets = [...segs].sort((a, b) => a - b).map((s) => coordForSeg(daf, s));
+    out.push({ source: spineCoord(work.title, daf), link: { relation: 'glosses', targets } });
   }
   return out;
 }

--- a/src/lib/context/types.ts
+++ b/src/lib/context/types.ts
@@ -87,9 +87,11 @@ export function rangeLabel(segs: number[], amud?: 'a' | 'b'): string {
 }
 
 /** One coordinate as a compact citation string: "Pesachim 50a" (daf-level, i.e.
- *  `seg < 0`) or "Pesachim 50a:7" (with a real segment, including segment 0). */
+ *  `seg < 0`) or "Pesachim 50a:7" (with a real segment, including segment 0).
+ *  A commentary-spine coordinate prefixes its spine: "Rashi · Berakhot 2a". */
 export function coordLabel(c: AnchorCoord): string {
-  return c.seg >= 0 ? `${c.tractate} ${c.page}:${c.seg}` : `${c.tractate} ${c.page}`;
+  const daf = c.seg >= 0 ? `${c.tractate} ${c.page}:${c.seg}` : `${c.tractate} ${c.page}`;
+  return c.spine ? `${c.spine} · ${daf}` : daf;
 }
 
 // Citations were rendered here via a `citesLabel` side channel. They are now a

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -839,12 +839,17 @@ app.get('/api/links/:tractate/:page', async (c) => {
   const bridge = await computeDafBridge(c.env, tractate, page).catch(() => null);
   const items = await collectContext(c.env, tractate, page, { sections }).catch(() => []);
   const flowEdges = await readFlowConnections(c.env, tractate, page);
+  // Commentary spines: best-effort (cached 30d). A cold/failed fetch contributes
+  // nothing rather than failing the response — same contract as the others.
+  const commentary = await fetchCommentaryWorks(c.env, tractate, page).catch(() => null);
+  const commentaryWorks = commentary && !('error' in commentary) ? commentary.works : [];
 
   const links = dafLinks(daf, {
     continuesTo: bridge?.continues ? bridge.to : null,
     items,
     flowEdges,
     sectionStartSegs,
+    commentaryWorks,
   });
   return c.json({ tractate, page, count: links.length, links });
 });

--- a/tests/context-coord.test.ts
+++ b/tests/context-coord.test.ts
@@ -7,8 +7,9 @@
 import { describe, it, expect } from 'vitest';
 import {
   coordKey, sameDaf, coordForSeg, coordsForSegs, localSeg, isCrossDaf,
-  normalizeSpan, spanByDaf, coordFromTarget,
+  normalizeSpan, spanByDaf, coordFromTarget, spineCoord, DAF_SEG,
 } from '../src/lib/context/coord.ts';
+import { coordLabel } from '../src/lib/context/types.ts';
 import { placementOf } from '../src/lib/context/placement.ts';
 import { applyMatches, type SegMatch } from '../src/lib/context/match.ts';
 import type { ContextItem } from '../src/lib/context/types.ts';
@@ -23,6 +24,30 @@ describe('coord helpers', () => {
     expect(coordKey(c)).toBe('Gittin:68a:4');
     expect(sameDaf(c, G68)).toBe(true);
     expect(sameDaf(c, G67)).toBe(false);
+  });
+
+  it('spineCoord addresses a commentary spine; spine-less coords are byte-identical', () => {
+    const daf = { tractate: 'Berakhot', page: '2a' };
+    // A spine-less (Gemara) coord keys + labels EXACTLY as before.
+    expect(coordKey(coordForSeg(daf, 3))).toBe('Berakhot:2a:3');
+    // A spine coord defaults to whole-daf-of-the-work and keys distinctly so it
+    // never collides with the Gemara segment at the same (tractate, page, seg).
+    expect(spineCoord('Rashi', daf)).toEqual({ spine: 'Rashi', tractate: 'Berakhot', page: '2a', seg: DAF_SEG });
+    expect(coordKey(spineCoord('Rashi', daf, 3))).toBe('Rashi::Berakhot:2a:3');
+    expect(coordKey(spineCoord('Rashi', daf, 3))).not.toBe(coordKey(coordForSeg(daf, 3)));
+    expect(coordLabel(spineCoord('Rashi', daf, 3))).toBe('Rashi · Berakhot 2a:3');
+    expect(coordLabel(spineCoord('Tosafot', daf))).toBe('Tosafot · Berakhot 2a');
+  });
+
+  it('normalizeSpan/spanByDaf collapse mixed-spine coords deterministically', () => {
+    const daf = { tractate: 'Berakhot', page: '2a' };
+    // Same (tractate, page, seg) on the Gemara and two commentary spines.
+    const span = [spineCoord('Tosafot', daf, 3), coordForSeg(daf, 3), spineCoord('Rashi', daf, 3)];
+    // All three survive dedup (distinct keys) and sort deterministically by
+    // seg then spine ('' < 'Rashi' < 'Tosafot').
+    expect(normalizeSpan(span).map(coordKey)).toEqual(['Berakhot:2a:3', 'Rashi::Berakhot:2a:3', 'Tosafot::Berakhot:2a:3']);
+    // spanByDaf collapses spine + dedupes the segment (no duplicate seg 3).
+    expect(spanByDaf(span)).toEqual([{ tractate: 'Berakhot', page: '2a', segs: [3] }]);
   });
 
   it('localSeg returns the seg only on its own daf', () => {

--- a/tests/context-link.test.ts
+++ b/tests/context-link.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { citationLink, continuationLink, flowLinks, isLinkRelation, linkLabel, type Link } from '../src/lib/context/link.ts';
-import { dafCoord, coordForSeg, DAF_SEG } from '../src/lib/context/coord.ts';
+import { citationLink, continuationLink, flowLinks, glossLinks, isLinkRelation, linkLabel, type Link } from '../src/lib/context/link.ts';
+import { dafCoord, coordForSeg, spineCoord, DAF_SEG } from '../src/lib/context/coord.ts';
 import { formatContextForPrompt } from '../src/lib/context/select.ts';
 import type { ContextItem } from '../src/lib/context/types.ts';
 
@@ -28,12 +28,37 @@ describe('continuationLink — the tractate-continuity edge', () => {
 });
 
 describe('isLinkRelation — guards an untyped kind string', () => {
-  it('accepts the seven modelled relations, rejects others', () => {
-    for (const k of ['cites', 'continues', 'resolves', 'depends-on', 'parallels', 'contrasts', 'generalizes']) {
+  it('accepts the modelled relations, rejects others', () => {
+    for (const k of ['cites', 'continues', 'resolves', 'depends-on', 'parallels', 'contrasts', 'generalizes', 'glosses']) {
       expect(isLinkRelation(k)).toBe(true);
     }
     expect(isLinkRelation('elaborates')).toBe(false);
     expect(isLinkRelation('')).toBe(false);
+  });
+});
+
+describe('glossLinks — commentary spines as cross-spine Links', () => {
+  const DAF = { tractate: 'Berakhot', page: '2a' };
+
+  it('emits one link per work, sourced on its spine, targeting the deduped daf segs it glosses', () => {
+    const works = [
+      { title: 'Rashi', comments: [{ anchorSegIdx: 1 }, { anchorSegIdx: 0 }, { anchorSegIdx: 1 }] },
+      { title: 'Tosafot', comments: [{ anchorSegIdx: 4 }] },
+    ];
+    expect(glossLinks(DAF, works)).toEqual([
+      { source: spineCoord('Rashi', DAF), link: { relation: 'glosses', targets: [coordForSeg(DAF, 0), coordForSeg(DAF, 1)] } },
+      { source: spineCoord('Tosafot', DAF), link: { relation: 'glosses', targets: [coordForSeg(DAF, 4)] } },
+    ]);
+  });
+
+  it('drops works with no resolvable anchor segment', () => {
+    const works = [{ title: 'Meiri', comments: [{ anchorSegIdx: -1 }] }];
+    expect(glossLinks(DAF, works)).toEqual([]);
+  });
+
+  it('a gloss link labels its source with the spine name', () => {
+    expect(linkLabel({ relation: 'glosses', targets: [spineCoord('Rashi', DAF, 3)] }))
+      .toBe('Rashi · Berakhot 2a:3');
   });
 });
 

--- a/tests/daf-links.test.ts
+++ b/tests/daf-links.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { dafLinks } from '../src/lib/context/dafLinks';
-import { dafCoord, coordForSeg } from '../src/lib/context/coord';
+import { dafCoord, coordForSeg, spineCoord } from '../src/lib/context/coord';
 import type { ContextItem } from '../src/lib/context/types';
 
 const DAF = { tractate: 'Shabbat', page: '125b' };
@@ -44,13 +44,27 @@ describe('dafLinks — the unified link layer of a daf', () => {
     ]);
   });
 
-  it('combines all three sources in order: bridge, then cites, then flow', () => {
+  it('emits a commentary gloss link per work, sourced on its spine, targeting the daf segs it glosses', () => {
+    const out = dafLinks(DAF, {
+      continuesTo: null, items: [], flowEdges: [], sectionStartSegs: [],
+      commentaryWorks: [
+        { title: 'Rashi', comments: [{ anchorSegIdx: 2 }, { anchorSegIdx: 0 }] },
+        { title: 'Tosafot', comments: [{ anchorSegIdx: -1 }] }, // no resolvable anchor → dropped
+      ],
+    });
+    expect(out).toEqual([
+      { via: 'commentary', source: spineCoord('Rashi', DAF), relation: 'glosses', targets: [coordForSeg(DAF, 0), coordForSeg(DAF, 2)], note: 'Rashi' },
+    ]);
+  });
+
+  it('combines all sources in order: bridge, cites, flow, then commentary', () => {
     const out = dafLinks(DAF, {
       continuesTo: { tractate: 'Shabbat', page: '126a' },
       items: [item({ segs: [4], refs: [dafCoord({ tractate: 'Pesachim', page: '50a' })] })],
       flowEdges: [{ from: 0, to: 1, kind: 'continues' }],
       sectionStartSegs: [4, 8],
+      commentaryWorks: [{ title: 'Rashi', comments: [{ anchorSegIdx: 4 }] }],
     });
-    expect(out.map((l) => l.via)).toEqual(['bridge', 'context', 'flow']);
+    expect(out.map((l) => l.via)).toEqual(['bridge', 'context', 'flow', 'commentary']);
   });
 });


### PR DESCRIPTION
Roadmap **step 6 — commentary spines**. A daf's commentary (Rashi / Tosafot / rishonim) is lifted into the existing unified Link layer as first-class Links, retiring its status as a bespoke island, and introducing the **cross-spine coordinate** the framework reserves. Fully additive.

## What changes
- **`coord.ts`** — `AnchorCoord` gains an optional `spine?` field. **Absent = the Gemara spine** (the daf itself), so every pre-existing spine-less coordinate serializes (`coordKey`) and labels (`coordLabel`) byte-identically — no cache/dedup drift. `spineCoord('Rashi', daf)` addresses a commentary spine over a daf. `normalizeSpan` now sorts spine deterministically; `spanByDaf` dedupes segments under mixed spines.
- **`link.ts`** — new `'glosses'` relation + `glossLinks(daf, works)`: one link per commentary work, **sourced on its own spine**, targeting the deduped daf segments it glosses (`Rashi · Berakhot 2a → segs 0,1,4`). `flowLinks` now validates against a flow-only relation set, so neither `cites` nor `glosses` can surface as a `via:'flow'` edge.
- **`dafLinks` / `GET /api/links`** — emits the gloss links (`via:'commentary'`), best-effort from `fetchCommentaryWorks` (cached 30d; a cold/failed fetch contributes nothing). On Berakhot 2a this adds ~23 compact gloss links.
- The reader-facing **Connections** panel is unaffected: glosses target same-daf segments and aren't `via:'flow'`, so both of its filters exclude them. The new links serve cross-spine/programmatic consumers.

## Verification
- `pnpm typecheck` clean; `pnpm test` 1586 passing (7 new across coord/link/daf-links).
- Confirmed live `/api/commentaries` shape (`title` + `comments[].anchorSegIdx`) matches the structural `CommentaryWorkLike` contract.
- Reviewed with Codex (`codex exec --sandbox read-only`); both findings fixed: `flowLinks` flow-only guard, and `normalizeSpan`/`spanByDaf` determinism under mixed spines.

Remaining in step 6: the tractate-continuous spine view and the `external` mark anchor (wiki/image) wiring.