### PR TITLE
Tractate-continuous spine: addressable GET /api/spine read

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -811,19 +811,21 @@ function ArgumentOverviewBody(props: {
   const [bridge] = createResource(
     () => `${props.tractate}|${props.page}`,
     async (): Promise<{ prev: string | null; next: string | null; fromPrev: boolean; toNext: boolean }> => {
-      const prev = adjacentAmud(props.tractate, props.page, -1);
-      const next = adjacentAmud(props.tractate, props.page, 1);
-      const continues = async (p: string | null): Promise<boolean> => {
-        if (!p) return false;
-        try {
-          const r = await fetch(`/api/bridge/${encodeURIComponent(props.tractate)}/${encodeURIComponent(p)}`);
-          if (!r.ok) return false;
-          return !!((await r.json()) as { continues?: boolean }).continues;
-        } catch { return false; }
+      // The tractate-spine neighborhood in one read (GET /api/spine assembles
+      // both cross-daf bridges server-side). Falls back to local page
+      // arithmetic + no-continuation on any failure.
+      const fallback = {
+        prev: adjacentAmud(props.tractate, props.page, -1),
+        next: adjacentAmud(props.tractate, props.page, 1),
+        fromPrev: false,
+        toNext: false,
       };
-      // bridge(prev) = prev->this; bridge(this) = this->next.
-      const [fromPrev, toNext] = await Promise.all([continues(prev), continues(props.page)]);
-      return { prev, next, fromPrev, toNext };
+      try {
+        const r = await fetch(`/api/spine/${encodeURIComponent(props.tractate)}/${encodeURIComponent(props.page)}`);
+        if (!r.ok) return fallback;
+        const d = (await r.json()) as { prev: string | null; next: string | null; fromPrev?: boolean; toNext?: boolean };
+        return { prev: d.prev, next: d.next, fromPrev: !!d.fromPrev, toNext: !!d.toNext };
+      } catch { return fallback; }
     },
   );
 

--- a/src/lib/context/spine.ts
+++ b/src/lib/context/spine.ts
@@ -1,0 +1,58 @@
+/**
+ * dafSpine — the "tractate as one addressable spine" primitive (framework
+ * step 6). A page (amud) is a WINDOW onto the continuous Gemara spine; this
+ * assembles the local neighborhood of that window: the adjacent pages and
+ * whether the sugya flows across each boundary, with the forward continuity
+ * expressed as a Link so a continuous-spine view can stitch pages from
+ * `link.targets` instead of re-deriving the next daf.
+ *
+ * Pure: the worker gathers the inputs (page arithmetic + the two cached
+ * cross-daf bridge verdicts) and calls this — the same lib/worker split as
+ * `dafLinks`. The first CONSUMER is `GET /api/spine/:tractate/:page`, which
+ * replaces the client overview's bespoke pair of `/api/bridge` fetches.
+ */
+
+import { continuationLink, type Link } from './link.ts';
+import type { DafRef } from './coord.ts';
+
+/** The local neighborhood of a daf on its tractate spine. */
+export interface DafSpine {
+  tractate: string;
+  page: string;
+  /** The adjacent windows on the spine (null at a tractate edge). */
+  prev: string | null;
+  next: string | null;
+  /** The previous daf's discussion continues INTO this one. */
+  fromPrev: boolean;
+  /** This daf's discussion continues into the next. */
+  toNext: boolean;
+  /** The forward continuity edge (this daf → next) as a Link, or null when the
+   *  sugya closes here / there is no next daf. */
+  link: Link | null;
+}
+
+export interface DafSpineInputs {
+  /** Adjacent page slugs from the spine's amud arithmetic. */
+  prev: string | null;
+  next: string | null;
+  /** Cross-daf bridge verdicts: does prev→this carry, does this→next carry. */
+  fromPrev: boolean;
+  toNext: boolean;
+}
+
+export function dafSpine(daf: DafRef, input: DafSpineInputs): DafSpine {
+  // Forward continuity is a Link only when the sugya actually carries into a
+  // real next page. continuationLink keeps the 'continues' edge in the shared
+  // vocabulary (same as /api/bridge + /api/links surface it).
+  const link =
+    input.toNext && input.next ? continuationLink({ tractate: daf.tractate, page: input.next }) : null;
+  return {
+    tractate: daf.tractate,
+    page: daf.page,
+    prev: input.prev,
+    next: input.next,
+    fromPrev: input.fromPrev,
+    toNext: input.toNext,
+    link,
+  };
+}

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -12,6 +12,7 @@ import { collectContext } from './context-providers';
 import { placeRevachWithAi } from './revach-ai-place';
 import { formatContextForPrompt, contextForAnchor, segsFromMarkInput } from '../lib/context/select';
 import { continuationLink, type FlowEdge } from '../lib/context/link';
+import { dafSpine } from '../lib/context/spine';
 import { dafLinks } from '../lib/context/dafLinks';
 import { producerNodesFrom, reverseDependencyIndex, transitiveDependents } from '../lib/registry/depGraph';
 import { aiMatchToSegments } from './context-match';
@@ -794,6 +795,30 @@ app.get('/api/bridge/:tractate/:page', async (c) => {
   // Computed (not stored on the cached DafBridge), so it needs no cache bump.
   const link = bridge.continues ? continuationLink(bridge.to) : null;
   return c.json({ ...bridge, link });
+});
+
+// The tractate-spine neighborhood of a daf (framework step 6): the adjacent
+// windows + whether the sugya flows across each boundary, assembled from the
+// two cached cross-daf bridges (this→next and prev→this). One read replaces the
+// client overview's bespoke pair of /api/bridge fetches; `dafSpine` keeps the
+// forward continuity in the shared Link vocabulary. Best-effort per bridge: a
+// cold/failed compute reads as "no continuation" rather than failing.
+app.get('/api/spine/:tractate/:page', async (c) => {
+  const tractate = c.req.param('tractate');
+  const page = c.req.param('page');
+  const prev = adjacentAmud(tractate, page, -1);
+  const next = adjacentAmud(tractate, page, 1);
+  // Both bridges in parallel (this→next and prev→this), each best-effort.
+  const [thisBridge, prevBridge] = await Promise.all([
+    computeDafBridge(c.env, tractate, page).catch(() => null),
+    prev ? computeDafBridge(c.env, tractate, prev).catch(() => null) : Promise.resolve(null),
+  ]);
+  return c.json(
+    dafSpine(
+      { tractate, page },
+      { prev, next, fromPrev: !!prevBridge?.continues, toNext: !!thisBridge?.continues },
+    ),
+  );
 });
 
 // Read the cached argument-overview.flow connections (section-index edges).

--- a/tests/daf-spine.test.ts
+++ b/tests/daf-spine.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { dafSpine } from '../src/lib/context/spine';
+import { dafCoord } from '../src/lib/context/coord';
+
+const DAF = { tractate: 'Berakhot', page: '2b' };
+
+describe('dafSpine — the tractate-spine neighborhood of a daf', () => {
+  it('carries the adjacent windows + boundary verdicts through', () => {
+    const s = dafSpine(DAF, { prev: '2a', next: '3a', fromPrev: true, toNext: false });
+    expect(s).toEqual({
+      tractate: 'Berakhot', page: '2b', prev: '2a', next: '3a',
+      fromPrev: true, toNext: false, link: null,
+    });
+  });
+
+  it('expresses forward continuity as a continues Link to the next page', () => {
+    const s = dafSpine(DAF, { prev: '2a', next: '3a', fromPrev: false, toNext: true });
+    expect(s.link).toEqual({ relation: 'continues', targets: [dafCoord({ tractate: 'Berakhot', page: '3a' })] });
+  });
+
+  it('has no link at a tractate edge even if toNext is set (no next page)', () => {
+    const s = dafSpine({ tractate: 'Berakhot', page: '64a' }, { prev: '63b', next: null, fromPrev: true, toNext: true });
+    expect(s.next).toBeNull();
+    expect(s.link).toBeNull();
+  });
+
+  it('is fully isolated (fromPrev and toNext are independent)', () => {
+    const s = dafSpine(DAF, { prev: '2a', next: '3a', fromPrev: true, toNext: true });
+    expect(s.fromPrev).toBe(true);
+    expect(s.toNext).toBe(true);
+    expect(s.link).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Roadmap **step 6 — tractate-continuous spine**. The tractate becomes one *addressable spine*: a page (amud) is a window onto it, and this read returns that window's local continuity. Additive; retires the client's bespoke double-bridge fetch.

## What changes
- **`src/lib/context/spine.ts`** — pure `dafSpine(daf, {prev, next, fromPrev, toNext})` assembling the spine neighborhood `{tractate, page, prev, next, fromPrev, toNext, link}`, with forward continuity expressed as a `'continues'` Link (null at a tractate edge / no next page). Same lib/worker split as `dafLinks`.
- **`GET /api/spine/:tractate/:page`** — gathers the two cached cross-daf bridges (`this→next` and `prev→this`) **in parallel**, best-effort (a cold/failed compute reads as "no continuation"), and returns `dafSpine(...)`.
- **`ArgumentSidebar`** — the overview's continuity captions ("continues from 2a" / "continues onto 2b") now read this **one** spine call instead of **two** ad-hoc `/api/bridge` fetches + an inline `continues()` helper. Identical `{prev, next, fromPrev, toNext}` shape and failure fallback.

## Why
`fromPrev`/`toNext` were assembled client-side from two bridge calls. Consolidating into one addressable spine read mirrors the entity-piece pattern (#159) — make the thing addressable as data first — and gives a continuous-spine view a single primitive to stitch pages from `link.targets`.

## Verification
- `pnpm typecheck` clean; `pnpm test` 1590 passing (4 new for `dafSpine`).
- Reviewed with Codex (`codex exec --sandbox read-only`): only finding was serial bridge computation — fixed (both bridges now run via `Promise.all`); `dafSpine` semantics + client shape/fallback confirmed correct.

Remaining in step 6: the `external` mark anchor (wiki/image) is deliberately **not** wired — it has no producer today, so doing so would be speculative.