### PR TITLE
Background: stop using the word "realia"

### DIFF
--- a/src/client/i18n.ts
+++ b/src/client/i18n.ts
@@ -207,7 +207,7 @@ const CATALOG = {
     he: 'לא נמצאו עדיין מושגי רקע לדף זה.',
   },
   'background.cat.legal-concepts': { en: 'Legal concepts', he: 'מושגים הלכתיים' },
-  'background.cat.realia': { en: 'Realia', he: 'מציאות' },
+  'background.cat.realia': { en: 'Everyday life', he: 'מציאות' },
   'background.cat.assumed-prior': { en: 'Assumed background', he: 'רקע מוקדם' },
   // — Common —
   'common.open': { en: 'Open {name}', he: 'פתיחת {name}' },

--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -2389,12 +2389,13 @@ const DAF_BACKGROUND_SYNTHESIS_SYSTEM_PROMPT = `You are a Talmud teacher. You'll
 Output STRICT JSON only:
 
 {
-  "synthesis": "ONE sentence, MAX 30 words, naming the kind of background the daf leans on (e.g. 'This daf assumes you know the laws of the four guardians and the realia of a borrowed ox'). NOT a summary of the argument."
+  "synthesis": "ONE sentence, MAX 30 words, naming the kind of background the daf leans on (e.g. 'This daf assumes you know the laws of the four guardians and what a borrowed ox is worth'). NOT a summary of the argument."
 }
 
 HARD RULES:
 - ONE sentence. Point at the prerequisites, do not list every term.
 - NO puff. Hebrew script (not transliteration) for technical terms in parentheses.
+- Write plainly. Never use academic jargon — in particular NEVER the word "realia"; name the concrete things directly (everyday objects, places, measures).
 
 ${HEBREW_GLOSS_STYLE}`;
 
@@ -2466,7 +2467,7 @@ CODE_ENRICHMENTS.push(
         'context',
         { enrichment: 'daf-background.concepts' },
       ],
-      defHash: 'daf-background.synthesis-v1', cacheVersion: '5', // v5: native Hebrew prompt + re-resolve concepts v5
+      defHash: 'daf-background.synthesis-v1', cacheVersion: '6', // v6: drop "realia" from the example + ban the word in the synthesis sentence
       model: ARGUMENT_FLASH_MODEL,
       systemPromptHe: DAF_BACKGROUND_SYNTHESIS_SYSTEM_PROMPT_HE,
       userPromptTemplateHe: DAF_BACKGROUND_SYNTHESIS_USER_TEMPLATE_HE,

--- a/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
+++ b/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
@@ -19,7 +19,7 @@ exports[`CODE_ENRICHMENTS cache identity > per-enrichment fingerprint is stable 
   "argument.synthesis@11 mode=aggregate scope=local mark=argument schema=argument_synthesis[synthesis] deps=[gemara|commentaries|mishna|e:argument.voices|e:argument.background|m:rabbi|m:argument-move]",
   "argument.voices@5 mode=augment-content scope=local mark=argument schema=argument_voices[voices,edges] deps=[gemara|m:argument-move|m:rabbi]",
   "daf-background.concepts@5 mode=augment-content scope=local mark=daf-background schema=daf_background_concepts[groups] deps=[gemara|context|m:argument]",
-  "daf-background.synthesis@5 mode=aggregate scope=local mark=daf-background schema=daf_background_synthesis[synthesis] deps=[gemara|context|e:daf-background.concepts]",
+  "daf-background.synthesis@6 mode=aggregate scope=local mark=daf-background schema=daf_background_synthesis[synthesis] deps=[gemara|context|e:daf-background.concepts]",
   "halacha.codification@3 mode=augment-content scope=local mark=halacha schema=halacha_codification[mishnehTorah,tur,shulchanAruch,rema,prose] deps=[gemara]",
   "halacha.disputes@3 mode=augment-content scope=local mark=halacha schema=halacha_disputes[disputes] deps=[gemara]",
   "halacha.practical@4 mode=augment-content scope=local mark=halacha schema=halacha_practical[lechatchila,bedieved,appliesWhen,exceptions,prose] deps=[gemara]",


### PR DESCRIPTION
"Realia" is too academic. It surfaced two ways in the daf-background card:

1. **The category section header** — `background.cat.realia` rendered "Realia". Relabeled to **"Everyday life"** (English; Hebrew מציאות unchanged). Client-only, so it's gone from every already-cached background card immediately.
2. **The synthesis sentence** — the prompt's example literally seeded `"the realia of a borrowed ox"` into the model's one-sentence output. Reworded the example to `"...and what a borrowed ox is worth"` and added an explicit ban on the word. Bumped `daf-background.synthesis` cacheVersion `5 → 6` so new/refreshed dapim generate it plainly.

The internal category key stays `'realia'` (changing the enum would churn the schema/cache for no user benefit — only the display label matters).

## Verification
- `pnpm typecheck` clean; `pnpm test` 1590 passing; snapshot guard delta is exactly the `5 → 6` bump.