### PR TITLE
Overview: button to open the full argument card

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -161,6 +161,9 @@ export interface ArgumentSidebarProps {
   /** The daf's ordered argument sections (from the `argument` mark). Feeds the
    *  whole-daf overview's flow graph — its nodes are these sections. */
   dafSections?: Section[];
+  /** Open the in-depth `argument` card for a section (by index). Lets the
+   *  whole-daf overview hand off into the full per-section argument. */
+  onOpenArgument?: (index: number) => void;
 }
 
 // Parse markdown-style links out of a bio string. Sefaria `/topics/<slug>`
@@ -771,6 +774,7 @@ function ArgumentOverviewBody(props: {
   sections: Section[];
   onPushRabbi: (name: string) => void;
   onHighlightRange?: (range: { start: number; end: number; key: string } | null) => void;
+  onOpenArgument?: (index: number) => void;
 }): JSX.Element {
   const [connections, setConnections] = createSignal<FlowConnection[]>([]);
   const [active, setActive] = createSignal<number | null>(null);
@@ -983,6 +987,20 @@ function ArgumentOverviewBody(props: {
               {t('overview.withinFlow')}: {withinFlowCounts().map((f) => `${f.count} ${relLabel(f.relation)}`).join(' · ')}
             </div>
           </Show>
+        </div>
+      </Show>
+      {/* Hand off into the in-depth argument card. Opens the section the reader
+       *  has drilled into (active), else the start of the argument. */}
+      <Show when={props.onOpenArgument && props.sections.length > 0}>
+        <div style={{ 'margin-top': '0.8rem', 'border-top': '1px solid #f0f0f0', 'padding-top': '0.6rem' }}>
+          <button
+            onClick={() => props.onOpenArgument?.(active() ?? 0)}
+            style={{
+              width: '100%', 'text-align': 'center', cursor: 'pointer', 'font-family': 'inherit',
+              'font-size': '0.78rem', color: '#8a2a2b', background: '#fdf3f3',
+              border: '1px solid #f0dcdc', 'border-radius': '7px', padding: '0.45rem 0.6rem',
+            }}
+          >{t('overview.openArgument')}</button>
         </div>
       </Show>
     </Panel>
@@ -2025,6 +2043,7 @@ export function ArgumentSidebar(props: ArgumentSidebarProps): JSX.Element {
                 sections={props.dafSections ?? []}
                 onPushRabbi={props.onPushRabbi}
                 onHighlightRange={props.onHighlightRange}
+                onOpenArgument={props.onOpenArgument}
               />
             </Show>
 

--- a/src/client/DafViewer.tsx
+++ b/src/client/DafViewer.tsx
@@ -3059,6 +3059,7 @@ export default function DafViewer(): JSX.Element {
               onOpenRabbiSlug={openRabbiSlug}
               generationByName={generationByName()}
               dafSections={analysis()?.sections ?? []}
+              onOpenArgument={openArgument}
             />
           </Show>
         </aside>
@@ -3089,6 +3090,7 @@ export default function DafViewer(): JSX.Element {
           onOpenRabbiSlug={openRabbiSlug}
           generationByName={generationByName()}
           dafSections={analysis()?.sections ?? []}
+          onOpenArgument={openArgument}
         />
       </Show>
       <DevModeShelf open={devOpen()} onClose={() => { setDevOpen(false); setDevModeActive(false); }}>

--- a/src/client/MobileShelf.tsx
+++ b/src/client/MobileShelf.tsx
@@ -28,6 +28,7 @@ interface MobileShelfProps {
   onOpenRabbiSlug: (slug: string) => void;
   generationByName: Map<string, GenerationId>;
   dafSections?: Section[];
+  onOpenArgument?: (index: number) => void;
   onHighlightRange?: (
     range: { start: number; end: number; key: string; tokenStart?: number; tokenEnd?: number } | null,
   ) => void;
@@ -150,6 +151,7 @@ function ExpansionView(props: MobileShelfProps): JSX.Element {
           onOpenRabbiSlug={props.onOpenRabbiSlug}
           generationByName={props.generationByName}
           dafSections={props.dafSections}
+          onOpenArgument={props.onOpenArgument}
         />
       </div>
     </div>

--- a/src/client/i18n.ts
+++ b/src/client/i18n.ts
@@ -189,6 +189,7 @@ const CATALOG = {
   'overview.connections': { en: 'Connections', he: 'קשרים' },
   'overview.withinFlow': { en: 'within-daf flow', he: 'מהלך פנימי בדף' },
   'overview.goToDaf': { en: 'Go to {daf}', he: 'מעבר ל{daf}' },
+  'overview.openArgument': { en: 'Open the full argument →', he: 'פתח את הסוגיה המלאה ←' },
   // Link-relation labels (the unified link layer, src/lib/context/link.ts).
   'link.rel.cites': { en: 'cites', he: 'מצטט' },
   'link.rel.continues': { en: 'continues', he: 'ממשיך' },


### PR DESCRIPTION
The whole-daf Overview is generated from the `argument` mark's sections (its flow graph nodes *are* those sections), but the panel had no affordance to hand off into the in-depth argument card — the reader could see the brief synthesis but not click through to the full per-section moves and voices.

This adds a button at the bottom of `ArgumentOverviewBody`: **Open the full argument →**. It opens the section the reader has drilled into (the active flow-graph node) if any, otherwise the start of the argument (index 0). It reuses DafViewer's existing `openArgument(index)`, so no new navigation logic — the prop is threaded DafViewer → ArgumentSidebar/MobileShelf → ArgumentOverviewBody.

Synthesis prose is untouched (no schema change, no per-phrase linking) — this is the smallest affordance that closes the overview→argument gap.

- typecheck clean, 1590 unit tests pass
- i18n key `overview.openArgument` added (en + he)