### PR TITLE
Centralize the last batch of cache keys into cache-keys.ts

### DIFF
--- a/src/worker/cache-keys.ts
+++ b/src/worker/cache-keys.ts
@@ -286,6 +286,71 @@ export function keyForBridge(tractate: string, page: string): string {
   return `bridge:v1:${norm(tractate)}:${norm(page)}`;
 }
 
+// Single-site content + rabbi caches, previously hand-built in index.ts — the
+// last batch of producer keys to centralise (roadmap step 6). Shapes preserved
+// byte-for-byte (raw interpolation, no slugDaf). Several are built at MANY call
+// sites (pasuk ×2, rabbi-bio's shapes, the rabbi aggregate blobs ×6+ sites
+// each) where an inline literal could drift into a silent cold-miss.
+
+/** A Tanach verse's Hebrew, keyed by a sanitised Sefaria ref (caller replaces
+ *  any char outside [A-Za-z0-9 .:-] with '_'). */
+export function keyForPasuk(safeRef: string): string {
+  return `pasuk:v4:${safeRef}`;
+}
+
+/** The AI context-matcher's per-daf placement of a fixed item set (`itemsHash`
+ *  = hash of the item keys). */
+export function keyForCtxMatch(tractate: string, page: string, itemsHash: string): string {
+  return `ctx-match:v2:${tractate}:${page}:${itemsHash}`;
+}
+
+/** A single word's contextual translation. `ctxHash` is the caller's
+ *  surrounding-text hash, already carrying its own leading separator. */
+export function keyForTranslate(tractate: string, page: string, word: string, ctxHash: string): string {
+  return `translate:v3:${tractate}:${page}:${word}${ctxHash}`;
+}
+
+/** A hebraised English string, keyed by a content hash. */
+export function keyForHebraize(hash: string): string {
+  return `hebraize:v2:${hash}`;
+}
+
+/** A rabbi's global bio enrichment, keyed by slug alone. */
+export function keyForRabbiBioBySlug(slug: string): string {
+  return `rabbi-bio:v1:${slug}`;
+}
+
+/** A rabbi's per-daf bio synthesis. When `include` (the normalised, sorted,
+ *  comma-joined section list) is non-empty it is embedded as an `i=` segment;
+ *  an empty `include` yields the plain (tractate, page, slug) shape. */
+export function keyForRabbiBioOnDaf(tractate: string, page: string, slug: string, include = ''): string {
+  return include
+    ? `rabbi-bio:v1:i=${include}:${tractate}:${page}:${slug}`
+    : `rabbi-bio:v1:${tractate}:${page}:${slug}`;
+}
+
+// Rabbi aggregate blobs — single fixed keys (no params), compiled once by the
+// admin stages and read by the bio synthesiser. Built as raw literals at many
+// call sites (put + several gets + readGeneratedAt); centralised so a typo in
+// one can't silently miss the compiled blob.
+export function keyForRabbiGraph(): string { return 'rabbi-graph:v1'; }
+export function keyForRabbiCohort(): string { return 'rabbi-cohort:v1'; }
+export function keyForRabbiPlacesIndex(): string { return 'rabbi-places-index:v1'; }
+export function keyForRabbiAcademyRoster(): string { return 'rabbi-academy-roster:v1'; }
+
+// Rabbi-observations reverse index — one slice per (rabbi, daf), plus a
+// per-rabbi dirty marker. `dafSlug` is the caller's obsDafSlug(tractate, page).
+export function keyForRabbiObs(slug: string, dafSlug: string): string {
+  return `rabbi-obs:v1:${slug}:${dafSlug}`;
+}
+export function keyForRabbiObsDirty(slug: string): string {
+  return `rabbi-obs-dirty:v1:${slug}`;
+}
+/** Prefix for listing every daf slice of one rabbi (note the trailing ':'). */
+export function prefixForRabbiObs(slug: string): string {
+  return `rabbi-obs:v1:${slug}:`;
+}
+
 export function keyForMark(
   def: AnyMarkDefinition,
   tractate: string,

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -123,6 +123,19 @@ import {
   keyForCommentaryText,
   keyForReferences,
   keyForBridge,
+  keyForPasuk,
+  keyForCtxMatch,
+  keyForTranslate,
+  keyForHebraize,
+  keyForRabbiBioBySlug,
+  keyForRabbiBioOnDaf,
+  keyForRabbiGraph,
+  keyForRabbiCohort,
+  keyForRabbiPlacesIndex,
+  keyForRabbiAcademyRoster,
+  keyForRabbiObs,
+  keyForRabbiObsDirty,
+  prefixForRabbiObs,
 } from './cache-keys';
 import {
   buildObservationSlices,
@@ -320,7 +333,7 @@ function cleanVerseText(s: string): string {
 async function fetchPasukHebrewForPrompt(env: Bindings, ref: string): Promise<string> {
   if (!ref) return '';
   const safe = ref.replace(/[^A-Za-z0-9 .:-]/g, '_');
-  const key = `pasuk:v4:${safe}`;
+  const key = keyForPasuk(safe);
   const cache = env.CACHE;
   if (cache) {
     const hit = await cache.get(key);
@@ -2238,9 +2251,6 @@ async function runEnrichmentOnce(
 // LLM cost (location is read-from-cache only). This is the COLLECT half.
 // ===========================================================================
 
-const RABBI_OBS_PREFIX = 'rabbi-obs:v1';
-const RABBI_OBS_DIRTY_PREFIX = 'rabbi-obs-dirty:v1';
-
 /** Daf component of a rabbi-obs key — mirrors cache-keys.ts slugDaf so the
  *  inspect endpoint's prefix list is stable. */
 export function obsDafSlug(tractate: string, page: string): string {
@@ -2344,8 +2354,8 @@ async function runRabbiObservations(
   let totalObs = 0;
   if (rc.env.CACHE) {
     for (const slice of slices) {
-      await rc.env.CACHE.put(`${RABBI_OBS_PREFIX}:${slice.slug}:${dafSlug}`, JSON.stringify(slice));
-      await rc.env.CACHE.put(`${RABBI_OBS_DIRTY_PREFIX}:${slice.slug}`, computedAt);
+      await rc.env.CACHE.put(keyForRabbiObs(slice.slug, dafSlug), JSON.stringify(slice));
+      await rc.env.CACHE.put(keyForRabbiObsDirty(slice.slug), computedAt);
       totalObs += slice.observations.length;
       for (const o of slice.observations) byType[o.type] = (byType[o.type] ?? 0) + 1;
     }
@@ -2732,7 +2742,7 @@ app.get('/api/rabbi-observations/:slug', async (c) => {
   const cache = c.env.CACHE;
   if (!cache) return c.json({ error: 'no cache binding' }, 503);
   const slug = c.req.param('slug');
-  const prefix = `rabbi-obs:v1:${slug}:`;
+  const prefix = prefixForRabbiObs(slug);
 
   const keys: string[] = [];
   let cursor: string | undefined;
@@ -4226,7 +4236,7 @@ app.post('/api/context/match', async (c) => {
   // re-requests it on every visit — so cache it forever (bump the version to
   // invalidate). v1 -> v2: the matcher now chunks large item sets; v1 entries
   // were matched in one oversized batch that silently left everything unplaced.
-  const cacheKey = `ctx-match:v2:${t}:${p}:${hashMatchKeys(items.map((i) => i.key))}`;
+  const cacheKey = keyForCtxMatch(t, p, hashMatchKeys(items.map((i) => i.key)));
   if (cache) {
     const hit = await cache.get(cacheKey);
     if (hit !== null) {
@@ -4502,7 +4512,7 @@ app.post('/api/translate', async (c) => {
   // v3: DeepSeek V4 Flash primary + hardcoded dict short-circuit +
   // morphology-aware prompt. Bumped from v2 to invalidate stale Gemma-era
   // translations (Gemma 4 26B was returning e.g. שעות → "watches").
-  const cacheKey = `translate:v3:${tractate}:${page}:${word}${ctxHash}`;
+  const cacheKey = keyForTranslate(tractate, page, word, ctxHash);
   const t0 = Date.now();
   if (cache) {
     const cached = await cache.get(cacheKey);
@@ -4964,7 +4974,7 @@ app.get('/api/admin/enrich-rabbi/:slug', async (c) => {
   // gateway returns transient 502s. Once any daf surfaces a rabbi, every
   // other daf that references them reuses the same enrichment.
   const cache = c.env.CACHE;
-  const cacheKey = `rabbi-bio:v1:${slug}`;
+  const cacheKey = keyForRabbiBioBySlug(slug);
   const bypass = c.req.query('refresh') === '1';
   if (cache && !bypass) {
     const hit = await cache.get(cacheKey);
@@ -6088,7 +6098,7 @@ app.post('/api/admin/rabbi-compile/graph', async (c) => {
     count: Object.keys(nodes).length,
     nodes,
   };
-  await cache.put('rabbi-graph:v1', JSON.stringify(blob), { expirationTtl: RABBI_STAGE_TTL_S });
+  await cache.put(keyForRabbiGraph(), JSON.stringify(blob), { expirationTtl: RABBI_STAGE_TTL_S });
   return c.json({ ok: true, count: blob.count, _ms: Date.now() - t0 });
 });
 
@@ -6123,7 +6133,7 @@ app.post('/api/admin/rabbi-compile/cohort', async (c) => {
     byGeneration,
     bySage,
   };
-  await cache.put('rabbi-cohort:v1', JSON.stringify(blob), { expirationTtl: RABBI_STAGE_TTL_S });
+  await cache.put(keyForRabbiCohort(), JSON.stringify(blob), { expirationTtl: RABBI_STAGE_TTL_S });
   return c.json({ ok: true, generations: Object.keys(byGeneration).length, sages: Object.keys(bySage).length, _ms: Date.now() - t0 });
 });
 
@@ -6152,7 +6162,7 @@ app.post('/api/admin/rabbi-compile/places-index', async (c) => {
     generatedAt: new Date().toISOString(),
     byPlace,
   };
-  await cache.put('rabbi-places-index:v1', JSON.stringify(blob), { expirationTtl: RABBI_STAGE_TTL_S });
+  await cache.put(keyForRabbiPlacesIndex(), JSON.stringify(blob), { expirationTtl: RABBI_STAGE_TTL_S });
   return c.json({ ok: true, places: Object.keys(byPlace).length, _ms: Date.now() - t0 });
 });
 
@@ -6178,7 +6188,7 @@ app.post('/api/admin/rabbi-compile/academy-roster', async (c) => {
     generatedAt: new Date().toISOString(),
     byAcademy,
   };
-  await cache.put('rabbi-academy-roster:v1', JSON.stringify(blob), { expirationTtl: RABBI_STAGE_TTL_S });
+  await cache.put(keyForRabbiAcademyRoster(), JSON.stringify(blob), { expirationTtl: RABBI_STAGE_TTL_S });
   return c.json({ ok: true, academies: Object.keys(byAcademy).length, _ms: Date.now() - t0 });
 });
 
@@ -6186,28 +6196,28 @@ app.post('/api/admin/rabbi-compile/academy-roster', async (c) => {
 // later by daf views).
 app.get('/api/admin/rabbi-graph', async (c) => {
   if (!c.env.CACHE) return c.json({ error: 'CACHE unavailable' }, 503);
-  const hit = await c.env.CACHE.get('rabbi-graph:v1');
+  const hit = await c.env.CACHE.get(keyForRabbiGraph());
   if (!hit) return c.json({ error: 'not compiled' }, 404);
   return c.json(JSON.parse(hit));
 });
 
 app.get('/api/admin/rabbi-cohort', async (c) => {
   if (!c.env.CACHE) return c.json({ error: 'CACHE unavailable' }, 503);
-  const hit = await c.env.CACHE.get('rabbi-cohort:v1');
+  const hit = await c.env.CACHE.get(keyForRabbiCohort());
   if (!hit) return c.json({ error: 'not compiled' }, 404);
   return c.json(JSON.parse(hit));
 });
 
 app.get('/api/admin/rabbi-places-index', async (c) => {
   if (!c.env.CACHE) return c.json({ error: 'CACHE unavailable' }, 503);
-  const hit = await c.env.CACHE.get('rabbi-places-index:v1');
+  const hit = await c.env.CACHE.get(keyForRabbiPlacesIndex());
   if (!hit) return c.json({ error: 'not compiled' }, 404);
   return c.json(JSON.parse(hit));
 });
 
 app.get('/api/admin/rabbi-academy-roster', async (c) => {
   if (!c.env.CACHE) return c.json({ error: 'CACHE unavailable' }, 503);
-  const hit = await c.env.CACHE.get('rabbi-academy-roster:v1');
+  const hit = await c.env.CACHE.get(keyForRabbiAcademyRoster());
   if (!hit) return c.json({ error: 'not compiled' }, 404);
   return c.json(JSON.parse(hit));
 });
@@ -6250,10 +6260,10 @@ app.get('/api/admin/rabbi-cache-stats', async (c) => {
     countPrefix('rabbi-influences:v1:'),
     countPrefix('rabbi-appearances:v1:'),
     countPrefix('rabbi-key-dafim:v1:'),
-    readGeneratedAt('rabbi-graph:v1'),
-    readGeneratedAt('rabbi-cohort:v1'),
-    readGeneratedAt('rabbi-places-index:v1'),
-    readGeneratedAt('rabbi-academy-roster:v1'),
+    readGeneratedAt(keyForRabbiGraph()),
+    readGeneratedAt(keyForRabbiCohort()),
+    readGeneratedAt(keyForRabbiPlacesIndex()),
+    readGeneratedAt(keyForRabbiAcademyRoster()),
   ]);
 
   return c.json({
@@ -6440,7 +6450,7 @@ app.get('/api/mesorah/:tractate/:page', async (c) => {
   }
   const skeleton = JSON.parse(skelRaw) as DafSkeleton;
 
-  const graphRaw = await cache.get('rabbi-graph:v1');
+  const graphRaw = await cache.get(keyForRabbiGraph());
   let graph: RabbiGraphBlob | null = null;
   if (graphRaw) {
     try { graph = JSON.parse(graphRaw) as RabbiGraphBlob; } catch { graph = null; }
@@ -6599,7 +6609,7 @@ app.get('/api/pasuk', async (c) => {
   if (!ref || ref.length > 100) return c.json({ error: 'missing or invalid ref' }, 400);
   const cache = c.env.CACHE;
   const safe = ref.replace(/[^A-Za-z0-9 .:-]/g, '_');
-  const key = `pasuk:v4:${safe}`;
+  const key = keyForPasuk(safe);
   if (cache) {
     const hit = await cache.get(key);
     if (hit) return c.json({ ...JSON.parse(hit), _cached: true });
@@ -6719,7 +6729,7 @@ app.post('/api/hebraize', async (c) => {
   // v2: bumped when the primary model switched Gemma -> DeepSeek and the
   // echo-strip guard was added. Old v1 entries (which can hold Gemma echoes)
   // are abandoned rather than re-cleaned.
-  const key = `hebraize:v2:${hash}`;
+  const key = keyForHebraize(hash);
   if (cache) {
     const hit = await cache.get(key);
     if (hit) return c.json({ hebraized: leading + hit + trailing, _cached: true });
@@ -6801,9 +6811,7 @@ app.post('/api/enrich-rabbi-bio/:tractate/:page/:slug', async (c) => {
   const includeNormBio = includeRawBio
     ? includeRawBio.split(',').map((s) => s.trim()).filter(Boolean).sort().join(',')
     : '';
-  const cacheKey = includeNormBio
-    ? `rabbi-bio:v1:i=${includeNormBio}:${tractate}:${page}:${slug}`
-    : `rabbi-bio:v1:${tractate}:${page}:${slug}`;
+  const cacheKey = keyForRabbiBioOnDaf(tractate, page, slug, includeNormBio);
   const includeSetBio = new Set(includeNormBio ? includeNormBio.split(',') : []);
   const wantBio = (s: string) => includeSetBio.size === 0 || includeSetBio.has(s);
 
@@ -6821,7 +6829,7 @@ app.post('/api/enrich-rabbi-bio/:tractate/:page/:slug', async (c) => {
     (wantBio('unified') || needsUnifiedForRegion) ? cache.get(keyForRabbiEnriched(slug)) : Promise.resolve(null),
     wantBio('wikidata')     ? cache.get(keyForRabbiWikidata(slug))         : Promise.resolve(null),
     wantBio('wiki-bio')     ? cache.get(keyForRabbiWikiBio(slug))         : Promise.resolve(null),
-    (wantBio('rabbi-graph') || needsGraphForMesorah) ? cache.get('rabbi-graph:v1') : Promise.resolve(null),
+    (wantBio('rabbi-graph') || needsGraphForMesorah) ? cache.get(keyForRabbiGraph()) : Promise.resolve(null),
     wantBio('daf-role')     ? cache.get(keyForAnalyzeSkeleton(tractate, page)) : Promise.resolve(null),
     wantBio('region')       ? cache.get(keyForRegion(tractate, page))    : Promise.resolve(null),
     wantBio('mesorah')      ? cache.get(keyForMesorah(tractate, page))   : Promise.resolve(null),
@@ -6976,7 +6984,7 @@ app.post('/api/enrich-rabbi-bio/:tractate/:page/:slug', async (c) => {
 app.get('/api/enrich-rabbi-bio/:tractate/:page/:slug', async (c) => {
   if (!c.env.CACHE) return c.json({ error: 'CACHE unavailable' }, 503);
   const { tractate, page, slug } = c.req.param();
-  const hit = await c.env.CACHE.get(`rabbi-bio:v1:${tractate}:${page}:${slug}`);
+  const hit = await c.env.CACHE.get(keyForRabbiBioOnDaf(tractate, page, slug));
   if (!hit) return c.json({ error: 'not synthesized' }, 404);
   return c.json(JSON.parse(hit));
 });

--- a/tests/source-cache-keys.test.ts
+++ b/tests/source-cache-keys.test.ts
@@ -5,6 +5,10 @@ import {
   keyForRabbiEnriched, keyForRabbiWikidata, keyForRabbiWikiBio,
   keyForAnalyzeSkeleton, keyForRegion, keyForMesorah,
   keyForCommentaryWorks, keyForCommentaryText, keyForReferences, keyForBridge,
+  keyForPasuk, keyForCtxMatch, keyForTranslate, keyForHebraize,
+  keyForRabbiBioBySlug, keyForRabbiBioOnDaf,
+  keyForRabbiGraph, keyForRabbiCohort, keyForRabbiPlacesIndex, keyForRabbiAcademyRoster,
+  keyForRabbiObs, keyForRabbiObsDirty, prefixForRabbiObs,
 } from '../src/worker/cache-keys';
 
 // These keys address a TTL-bounded but huge KV namespace already populated across
@@ -59,5 +63,35 @@ describe('commentary-spine + bridge keys — byte-exact contract', () => {
   it('the bridge key slug-normalises tractate AND page (lowercase, non-alnum -> _)', () => {
     expect(keyForBridge('Berakhot', '2a')).toBe('bridge:v1:berakhot:2a');
     expect(keyForBridge('Bava Kamma', '117b')).toBe('bridge:v1:bava_kamma:117b');
+  });
+});
+
+// The last batch: single-site content caches + the rabbi family, centralised
+// out of index.ts. Raw interpolation (no slug normalisation) — byte-exact.
+describe('content + rabbi caches — byte-exact contract', () => {
+  it('content keys: pasuk / ctx-match / translate / hebraize', () => {
+    expect(keyForPasuk('Genesis 1:1')).toBe('pasuk:v4:Genesis 1:1');
+    expect(keyForCtxMatch('Berakhot', '2a', 'abc123')).toBe('ctx-match:v2:Berakhot:2a:abc123');
+    // translate: ctxHash already carries its own leading separator.
+    expect(keyForTranslate('Berakhot', '2a', 'שלום', ':deadbeef')).toBe('translate:v3:Berakhot:2a:שלום:deadbeef');
+    expect(keyForHebraize('ff00aa')).toBe('hebraize:v2:ff00aa');
+  });
+  it('rabbi-bio: the slug-only and per-daf shapes (incl. the i= include segment)', () => {
+    expect(keyForRabbiBioBySlug('abaye')).toBe('rabbi-bio:v1:abaye');
+    expect(keyForRabbiBioOnDaf('Berakhot', '2a', 'abaye')).toBe('rabbi-bio:v1:Berakhot:2a:abaye');
+    expect(keyForRabbiBioOnDaf('Berakhot', '2a', 'abaye', '')).toBe('rabbi-bio:v1:Berakhot:2a:abaye');
+    expect(keyForRabbiBioOnDaf('Berakhot', '2a', 'abaye', 'mesorah,region'))
+      .toBe('rabbi-bio:v1:i=mesorah,region:Berakhot:2a:abaye');
+  });
+  it('rabbi aggregate blobs: fixed keys, no params', () => {
+    expect(keyForRabbiGraph()).toBe('rabbi-graph:v1');
+    expect(keyForRabbiCohort()).toBe('rabbi-cohort:v1');
+    expect(keyForRabbiPlacesIndex()).toBe('rabbi-places-index:v1');
+    expect(keyForRabbiAcademyRoster()).toBe('rabbi-academy-roster:v1');
+  });
+  it('rabbi-observations: per-(rabbi,daf) slice, dirty marker, and list prefix', () => {
+    expect(keyForRabbiObs('abaye', 'berakhot:2a')).toBe('rabbi-obs:v1:abaye:berakhot:2a');
+    expect(keyForRabbiObsDirty('abaye')).toBe('rabbi-obs-dirty:v1:abaye');
+    expect(prefixForRabbiObs('abaye')).toBe('rabbi-obs:v1:abaye:');
   });
 });


### PR DESCRIPTION
Finishes the **cache-key centralization** (roadmap step 6). The remaining inline KV key literals in `src/worker/index.ts` move into byte-exact `keyFor*` functions in `cache-keys.ts`, so no producer key is hand-built at a call site where a one-byte drift would silently cold-miss a KV namespace already populated across Shas — and every producer key is now enumerable from one place (the basis the reverse-dependency index relies on).

## New helpers (shapes preserved byte-for-byte, raw interpolation)
- `keyForPasuk`, `keyForCtxMatch`, `keyForTranslate`, `keyForHebraize`
- `keyForRabbiBioBySlug` + `keyForRabbiBioOnDaf` — the two rabbi-bio shapes, including the `i=<include>` segment ternary
- `keyForRabbiGraph` / `keyForRabbiCohort` / `keyForRabbiPlacesIndex` / `keyForRabbiAcademyRoster` — the fixed aggregate blobs, each previously a raw literal at 3–6 call sites (put + several gets + `readGeneratedAt`)
- `keyForRabbiObs` / `keyForRabbiObsDirty` / `prefixForRabbiObs` — retires the `RABBI_OBS_PREFIX` / `RABBI_OBS_DIRTY_PREFIX` module consts

## Scope notes
- The vestigial count-prefixes `rabbi-influences` / `rabbi-appearances` / `rabbi-key-dafim` have **no producer anywhere** (those `countPrefix` calls always return 0), so they're left untouched rather than centralizing dead keys.
- Operational/telemetry keys (`aigw-cost`, `llmcost`, `telemetry`, `reports`, `recent-errors`, `zone-activity`) are dashboard metrics, not content producers — out of scope.

## Verification
- `pnpm typecheck` clean; `pnpm test` 1594 passing (4 new lock cases in `tests/source-cache-keys.test.ts`, pinning every new helper's exact bytes).
- No migrated literal left behind; removed consts have no remaining refs.
- **Byte-exactness verified with Codex** (`codex exec --sandbox read-only`): "No byte discrepancies found" across every migrated site (version digits, separators, raw interpolation, arg order, the `i=` ternary, the `prefixForRabbiObs` trailing colon).