### PR TITLE
Concept tooltips: link background-term mentions to their gloss in prose

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -4,6 +4,7 @@ import { GENERATION_BY_ID, generationLabelHe, type GenerationId } from './genera
 import type { IdentifiedRabbi } from './dafContext';
 import { Hebraized } from './Hebraized';
 import { RabbiText, RabbiLinkProvider, HebraizedWithRabbis } from './rabbiLinks';
+import { ConceptLinkProvider, type ConceptTerm } from './conceptLinks';
 
 import RabbiLineageTree, { type RelationshipsData, type RelationshipsEvidence } from './RabbiLineageTree';
 import { type GeographyData, type GeographyEvidence } from './RabbiGeographyCard';
@@ -151,6 +152,9 @@ export interface ArgumentSidebarProps {
    *  rabbi-places dataset has gaps). Matched in prose; routing falls
    *  through pushRabbi's name-lookup chain. */
   dafRabbiNames: string[];
+  /** This daf's background terms (daf-background.concepts, flattened across
+   *  groups). Mentions of these in any card's prose get a gloss tooltip. */
+  dafBackgroundTerms: ConceptTerm[];
   /** Highlights a contiguous segment range on the daf. Used when the user
    *  clicks an argument-move card so the corresponding sub-range of the
    *  section is painted. Pass null to clear. `key` is a stable id (e.g. the
@@ -1929,6 +1933,7 @@ export function ArgumentSidebar(props: ArgumentSidebarProps): JSX.Element {
           extraNames: () => props.dafRabbiNames,
           onPushRabbi: props.onPushRabbi,
         }}>
+        <ConceptLinkProvider value={{ terms: () => props.dafBackgroundTerms }}>
         <aside
           style={{
             background: '#fff',
@@ -2052,6 +2057,7 @@ export function ArgumentSidebar(props: ArgumentSidebarProps): JSX.Element {
             </Show>
 
         </aside>
+        </ConceptLinkProvider>
         </RabbiLinkProvider>
       )}
     </Show>

--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -4,7 +4,7 @@ import { GENERATION_BY_ID, generationLabelHe, type GenerationId } from './genera
 import type { IdentifiedRabbi } from './dafContext';
 import { Hebraized } from './Hebraized';
 import { RabbiText, RabbiLinkProvider, HebraizedWithRabbis } from './rabbiLinks';
-import { ConceptLinkProvider, type ConceptTerm } from './conceptLinks';
+import { ConceptLinkProvider, buildConceptMatcher, type ConceptTerm } from './conceptLinks';
 
 import RabbiLineageTree, { type RelationshipsData, type RelationshipsEvidence } from './RabbiLineageTree';
 import { type GeographyData, type GeographyEvidence } from './RabbiGeographyCard';
@@ -1906,6 +1906,9 @@ export function VoiceGroupBody(props: { group: { name: string; nameHe: string; b
 }
 
 export function ArgumentSidebar(props: ArgumentSidebarProps): JSX.Element {
+  // Compile the daf's background-term matcher once (not per prose fragment).
+  const conceptMatcher = createMemo(() => buildConceptMatcher(props.dafBackgroundTerms));
+
   const onKey = (e: KeyboardEvent) => {
     if (e.key === 'Escape') props.onClose();
   };
@@ -1933,7 +1936,7 @@ export function ArgumentSidebar(props: ArgumentSidebarProps): JSX.Element {
           extraNames: () => props.dafRabbiNames,
           onPushRabbi: props.onPushRabbi,
         }}>
-        <ConceptLinkProvider value={{ terms: () => props.dafBackgroundTerms }}>
+        <ConceptLinkProvider value={{ matcher: conceptMatcher }}>
         <aside
           style={{
             background: '#fff',

--- a/src/client/DafViewer.tsx
+++ b/src/client/DafViewer.tsx
@@ -29,6 +29,9 @@ import {
 import { GutterIcons, type GutterKind } from './GutterIcons';
 import { GutterOverlay } from './GutterOverlay';
 import { ArgumentSidebar, type SidebarContent, type PlaceInstance } from './ArgumentSidebar';
+import { enqueueEnrichmentRun } from './MarkEnrichmentCards';
+import { orderBackgroundGroups, type BackgroundGroup } from './backgroundGroups';
+import type { ConceptTerm } from './conceptLinks';
 import { BugReport } from './BugReport';
 import { type CommentaryWork, type CommentaryComment } from './CommentaryPicker';
 import { CommentaryStrip } from './CommentaryStrip';
@@ -682,6 +685,28 @@ export default function DafViewer(): JSX.Element {
     }
     return out;
   });
+
+  // This daf's background terms (daf-background.concepts), flattened for the
+  // concept-tooltip layer. Reads the SAME daf-background.synthesis run the
+  // prefetcher already warms on daf load (its deps_resolved carries the
+  // concepts), so this is a cache hit, not a second generation. Failures /
+  // not-yet-warm degrade to no tooltips. Keyed on the daf so it refetches on
+  // navigation.
+  const [dafBackgroundTermsRes] = createResource(
+    () => `${tractate()}/${page()}`,
+    async () => {
+      try {
+        const r = await enqueueEnrichmentRun('daf-background.synthesis', tractate(), page(), { fields: {} }, 'daf-background:daf');
+        const concepts = r.deps_resolved?.['daf-background.concepts'] as { groups?: BackgroundGroup[] } | undefined;
+        const out: ConceptTerm[] = [];
+        for (const g of orderBackgroundGroups(concepts?.groups)) {
+          for (const tm of g.terms) out.push({ term: tm.term, termHe: tm.termHe ?? '', gloss: tm.gloss, category: g.category });
+        }
+        return out;
+      } catch { return []; }
+    },
+  );
+  const dafBackgroundTerms = createMemo<ConceptTerm[]>(() => dafBackgroundTermsRes() ?? []);
 
   // TODO(geography-rederive): the rabbiPlaces memo previously fed
   // GeographyMap from the legacy dafContext fetch. Removed pending a
@@ -3055,6 +3080,7 @@ export default function DafViewer(): JSX.Element {
               onBack={popSidebar}
               dafRabbis={dafRabbis()}
               dafRabbiNames={dafRabbiNames()}
+              dafBackgroundTerms={dafBackgroundTerms()}
               onHighlightRange={setArgumentMoveHighlight}
               onOpenRabbiSlug={openRabbiSlug}
               generationByName={generationByName()}
@@ -3086,6 +3112,7 @@ export default function DafViewer(): JSX.Element {
           onBack={popSidebar}
           dafRabbis={dafRabbis()}
           dafRabbiNames={dafRabbiNames()}
+          dafBackgroundTerms={dafBackgroundTerms()}
           onHighlightRange={setArgumentMoveHighlight}
           onOpenRabbiSlug={openRabbiSlug}
           generationByName={generationByName()}

--- a/src/client/DafViewer.tsx
+++ b/src/client/DafViewer.tsx
@@ -692,11 +692,19 @@ export default function DafViewer(): JSX.Element {
   // concepts), so this is a cache hit, not a second generation. Failures /
   // not-yet-warm degrade to no tooltips. Keyed on the daf so it refetches on
   // navigation.
+  // Keyed on lang() too — the synthesis run is language-specific (/api/run
+  // sends lang), so a language switch must refetch the glossary, not show stale
+  // EN terms. Each fetch aborts the previous so quick daf-flipping doesn't pile
+  // stale runs onto the shared enrichment queue.
+  let bgTermsAbort: AbortController | null = null;
   const [dafBackgroundTermsRes] = createResource(
-    () => `${tractate()}/${page()}`,
+    () => `${tractate()}/${page()}/${lang()}`,
     async () => {
+      bgTermsAbort?.abort();
+      const ac = new AbortController();
+      bgTermsAbort = ac;
       try {
-        const r = await enqueueEnrichmentRun('daf-background.synthesis', tractate(), page(), { fields: {} }, 'daf-background:daf');
+        const r = await enqueueEnrichmentRun('daf-background.synthesis', tractate(), page(), { fields: {} }, 'daf-background:daf', ac.signal);
         const concepts = r.deps_resolved?.['daf-background.concepts'] as { groups?: BackgroundGroup[] } | undefined;
         const out: ConceptTerm[] = [];
         for (const g of orderBackgroundGroups(concepts?.groups)) {

--- a/src/client/MobileShelf.tsx
+++ b/src/client/MobileShelf.tsx
@@ -1,5 +1,6 @@
 import { Show, type JSX } from 'solid-js';
 import { ArgumentSidebar, type SidebarContent } from './ArgumentSidebar';
+import type { ConceptTerm } from './conceptLinks';
 import type { GenerationId } from './generations';
 import type { IdentifiedRabbi } from './dafContext';
 import type { Section } from './shapes';
@@ -25,6 +26,7 @@ interface MobileShelfProps {
   onBack: () => void;
   dafRabbis: IdentifiedRabbi[];
   dafRabbiNames: string[];
+  dafBackgroundTerms: ConceptTerm[];
   onOpenRabbiSlug: (slug: string) => void;
   generationByName: Map<string, GenerationId>;
   dafSections?: Section[];
@@ -147,6 +149,7 @@ function ExpansionView(props: MobileShelfProps): JSX.Element {
           onBack={props.onBack}
           dafRabbis={props.dafRabbis}
           dafRabbiNames={props.dafRabbiNames}
+          dafBackgroundTerms={props.dafBackgroundTerms}
           onHighlightRange={props.onHighlightRange}
           onOpenRabbiSlug={props.onOpenRabbiSlug}
           generationByName={props.generationByName}

--- a/src/client/conceptLinks.tsx
+++ b/src/client/conceptLinks.tsx
@@ -28,8 +28,15 @@ export interface ConceptTerm {
   category?: string;
 }
 
+/** A compiled term matcher: a regex over the term surfaces + a lowercased
+ *  surface -> term map for gloss lookup. Built once per terms array (hoisted to
+ *  the provider) rather than per prose fragment. */
+export interface ConceptMatcher { re: RegExp; bySurface: Map<string, ConceptTerm> }
+
 export interface ConceptLinkContextValue {
-  terms: Accessor<ConceptTerm[]>;
+  /** Pre-compiled matcher for this daf's terms. Null when there's nothing to
+   *  match. Memoized at the provider so prose fragments don't recompile it. */
+  matcher: Accessor<ConceptMatcher | null>;
 }
 
 const ConceptLinkContext = createContext<ConceptLinkContextValue | null>(null);
@@ -56,7 +63,7 @@ export function useConceptLinks(): ConceptLinkContextValue | null {
 export function ConceptAwareText(props: { text: string | undefined | null }): JSX.Element {
   const ctx = useConceptLinks();
   if (!ctx) return <Hebraized text={props.text} />;
-  return <ConceptText text={props.text} terms={ctx.terms()} />;
+  return <ConceptText text={props.text} matcher={ctx.matcher()} />;
 }
 
 export interface ConceptTextPart {
@@ -65,10 +72,11 @@ export interface ConceptTextPart {
   term?: ConceptTerm;
 }
 
-/** Build a whole-word, case-insensitive regex over the English term labels,
- *  longest-first so "oral law" beats "law". Returns the regex + a lowercased
- *  surface -> term map for gloss lookup. Null when there's nothing to match. */
-function buildConceptMatcher(terms: ConceptTerm[]): { re: RegExp; bySurface: Map<string, ConceptTerm> } | null {
+/** Compile a whole-word, case-insensitive matcher over the English term labels,
+ *  longest-first so "oral law" beats "law". Word boundaries are Unicode-aware
+ *  (a term may carry transliteration diacritics, e.g. "ḥerem", that ASCII `\b`
+ *  splits wrongly). Null when there's nothing to match. */
+export function buildConceptMatcher(terms: ConceptTerm[]): ConceptMatcher | null {
   const bySurface = new Map<string, ConceptTerm>();
   for (const t of terms) {
     const surface = (t.term || '').trim();
@@ -81,16 +89,21 @@ function buildConceptMatcher(terms: ConceptTerm[]): { re: RegExp; bySurface: Map
   const surfaces = [...bySurface.keys()]
     .sort((a, b) => b.length - a.length)
     .map((s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
-  return { re: new RegExp(`\\b(${surfaces.join('|')})\\b`, 'gi'), bySurface };
+  // Unicode letter/number/underscore lookarounds instead of \b: a "word" edge
+  // is "not adjacent to another letter/digit", which holds for diacritics and
+  // (later) Hebrew script too. `u` makes \p{...} valid; `i` for case-insensitive.
+  return {
+    re: new RegExp(`(?<![\\p{L}\\p{N}_])(${surfaces.join('|')})(?![\\p{L}\\p{N}_])`, 'giu'),
+    bySurface,
+  };
 }
 
-/** Split prose into plain-text and concept parts. Each matched term yields a
- *  'concept' part whose `value` is the matched text verbatim (so a linkified
- *  term is never rendered empty) and whose `term` carries the gloss. Matching
- *  is whole-word, case-insensitive, longest-first. Pure + exported for tests. */
-export function tokenizeConceptMentions(text: string, terms: ConceptTerm[]): ConceptTextPart[] {
+/** Split prose into plain-text and concept parts using a pre-compiled matcher.
+ *  Each matched term yields a 'concept' part whose `value` is the matched text
+ *  verbatim (so a linkified term is never rendered empty) and whose `term`
+ *  carries the gloss. Pure. */
+export function tokenizeWithMatcher(text: string, matcher: ConceptMatcher | null): ConceptTextPart[] {
   if (!text) return [];
-  const matcher = buildConceptMatcher(terms);
   if (!matcher) return [{ kind: 'text', value: text }];
   const { re, bySurface } = matcher;
   const out: ConceptTextPart[] = [];
@@ -105,6 +118,12 @@ export function tokenizeConceptMentions(text: string, terms: ConceptTerm[]): Con
   }
   if (lastIdx < text.length) out.push({ kind: 'text', value: text.slice(lastIdx) });
   return out;
+}
+
+/** Convenience for callers that have terms but no compiled matcher (tests).
+ *  Whole-word, case-insensitive, longest-first. Pure + exported for tests. */
+export function tokenizeConceptMentions(text: string, terms: ConceptTerm[]): ConceptTextPart[] {
+  return tokenizeWithMatcher(text, buildConceptMatcher(terms));
 }
 
 const termStyle: JSX.CSSProperties = {
@@ -166,10 +185,11 @@ function ConceptMention(props: { value: string; term: ConceptTerm }): JSX.Elemen
 }
 
 /** Render `text`, wrapping every occurrence of a known background term as a
- *  gloss-tooltip mention. Pure-ish: reads `props` inside a memo so a late daf
- *  background load re-tokenizes. */
-export function ConceptText(props: { text: string | undefined | null; terms: ConceptTerm[] }): JSX.Element {
-  const parts = createMemo(() => tokenizeConceptMentions(props.text ?? '', props.terms));
+ *  gloss-tooltip mention. Reads `props` inside a memo so a late daf background
+ *  load (new matcher) re-tokenizes. The matcher is compiled once at the
+ *  provider, so this is just a scan per fragment. */
+export function ConceptText(props: { text: string | undefined | null; matcher: ConceptMatcher | null }): JSX.Element {
+  const parts = createMemo(() => tokenizeWithMatcher(props.text ?? '', props.matcher));
   return (
     <For each={parts()}>{(p) => {
       if (p.kind === 'text' || !p.term) return <Hebraized text={p.value} />;

--- a/src/client/conceptLinks.tsx
+++ b/src/client/conceptLinks.tsx
@@ -1,0 +1,179 @@
+/**
+ * Concept-link utilities: wrap mentions of the current daf's background terms
+ * (the daf-background.concepts enrichment — legal-concepts / realia /
+ * assumed-prior) in prose with a hover tooltip showing the term's gloss.
+ *
+ * This is the local, same-daf, high-precision half of the concept glossary:
+ * the pool is THIS daf's curated background terms, so a match is a term the
+ * daf itself defined — no cross-daf identity resolution, no anchoring. The
+ * canonical cross-daf glossary (built from the observed-concept backlog) is a
+ * later step; this just connects a term a reader meets in the overview/halacha
+ * prose to the definition the Background card already produced.
+ *
+ * Layering: rabbi mentions take priority (RabbiText tokenizes first, then hands
+ * its plain-text parts to ConceptAwareText), so a rabbi name is never also
+ * tagged as a concept. This module imports only Hebraized — RabbiText imports
+ * ConceptAwareText, not the reverse, so there's no cycle.
+ *
+ * The context value uses ACCESSORS (functions) so Solid tracks reads and
+ * consumers re-tokenize when the daf's background terms load async.
+ */
+import { For, Show, createContext, createMemo, createSignal, useContext, type Accessor, type JSX } from 'solid-js';
+import { Hebraized } from './Hebraized';
+
+export interface ConceptTerm {
+  term: string;     // English label (the match surface, e.g. "Kohen")
+  termHe: string;   // Hebrew script (shown in the tooltip)
+  gloss: string;    // 1-2 sentence explanation
+  category?: string;
+}
+
+export interface ConceptLinkContextValue {
+  terms: Accessor<ConceptTerm[]>;
+}
+
+const ConceptLinkContext = createContext<ConceptLinkContextValue | null>(null);
+
+export function ConceptLinkProvider(props: {
+  value: ConceptLinkContextValue;
+  children: JSX.Element;
+}): JSX.Element {
+  return (
+    <ConceptLinkContext.Provider value={props.value}>
+      {props.children}
+    </ConceptLinkContext.Provider>
+  );
+}
+
+export function useConceptLinks(): ConceptLinkContextValue | null {
+  return useContext(ConceptLinkContext);
+}
+
+/** Render `text` with background-term mentions wrapped in a gloss tooltip when
+ *  a ConceptLink context is in scope; otherwise behave exactly like Hebraized.
+ *  This is what RabbiText hands its plain-text parts to (and what cards with no
+ *  rabbi pool can use directly). */
+export function ConceptAwareText(props: { text: string | undefined | null }): JSX.Element {
+  const ctx = useConceptLinks();
+  if (!ctx) return <Hebraized text={props.text} />;
+  return <ConceptText text={props.text} terms={ctx.terms()} />;
+}
+
+export interface ConceptTextPart {
+  kind: 'text' | 'concept';
+  value: string;
+  term?: ConceptTerm;
+}
+
+/** Build a whole-word, case-insensitive regex over the English term labels,
+ *  longest-first so "oral law" beats "law". Returns the regex + a lowercased
+ *  surface -> term map for gloss lookup. Null when there's nothing to match. */
+function buildConceptMatcher(terms: ConceptTerm[]): { re: RegExp; bySurface: Map<string, ConceptTerm> } | null {
+  const bySurface = new Map<string, ConceptTerm>();
+  for (const t of terms) {
+    const surface = (t.term || '').trim();
+    if (surface.length < 2) continue; // 1-char labels are too noisy to link
+    const key = surface.toLowerCase();
+    // First term to claim a surface wins (deterministic; dedupes repeats).
+    if (!bySurface.has(key)) bySurface.set(key, t);
+  }
+  if (bySurface.size === 0) return null;
+  const surfaces = [...bySurface.keys()]
+    .sort((a, b) => b.length - a.length)
+    .map((s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+  return { re: new RegExp(`\\b(${surfaces.join('|')})\\b`, 'gi'), bySurface };
+}
+
+/** Split prose into plain-text and concept parts. Each matched term yields a
+ *  'concept' part whose `value` is the matched text verbatim (so a linkified
+ *  term is never rendered empty) and whose `term` carries the gloss. Matching
+ *  is whole-word, case-insensitive, longest-first. Pure + exported for tests. */
+export function tokenizeConceptMentions(text: string, terms: ConceptTerm[]): ConceptTextPart[] {
+  if (!text) return [];
+  const matcher = buildConceptMatcher(terms);
+  if (!matcher) return [{ kind: 'text', value: text }];
+  const { re, bySurface } = matcher;
+  const out: ConceptTextPart[] = [];
+  let lastIdx = 0;
+  re.lastIndex = 0;
+  for (let m = re.exec(text); m !== null; m = re.exec(text)) {
+    const term = bySurface.get(m[1].toLowerCase());
+    if (!term) continue;
+    if (m.index > lastIdx) out.push({ kind: 'text', value: text.slice(lastIdx, m.index) });
+    out.push({ kind: 'concept', value: m[1], term });
+    lastIdx = m.index + m[0].length;
+  }
+  if (lastIdx < text.length) out.push({ kind: 'text', value: text.slice(lastIdx) });
+  return out;
+}
+
+const termStyle: JSX.CSSProperties = {
+  'text-decoration': 'underline',
+  'text-decoration-style': 'dotted',
+  'text-decoration-color': '#9ca3af',
+  'text-underline-offset': '2px',
+  cursor: 'help',
+  position: 'relative',
+};
+
+const tooltipStyle: JSX.CSSProperties = {
+  position: 'absolute',
+  'z-index': 50,
+  top: '1.5em',
+  left: 0,
+  'max-width': '20rem',
+  'min-width': '12rem',
+  width: 'max-content',
+  background: '#1f2937',
+  color: '#f9fafb',
+  padding: '0.5rem 0.6rem',
+  'border-radius': '5px',
+  'box-shadow': '0 4px 12px rgba(0,0,0,0.18)',
+  'font-size': '0.78rem',
+  'line-height': 1.45,
+  'text-align': 'left',
+  'white-space': 'normal',
+  cursor: 'default',
+};
+
+/** A single background-term mention: dotted-underlined, with a gloss tooltip on
+ *  hover/focus. The matched text stays in the document flow (copyable). */
+function ConceptMention(props: { value: string; term: ConceptTerm }): JSX.Element {
+  const [open, setOpen] = createSignal(false);
+  return (
+    <span
+      style={termStyle}
+      tabindex={0}
+      role="button"
+      aria-label={`${props.term.term}: ${props.term.gloss}`}
+      onMouseEnter={() => setOpen(true)}
+      onMouseLeave={() => setOpen(false)}
+      onFocus={() => setOpen(true)}
+      onBlur={() => setOpen(false)}
+    >
+      {props.value}
+      <Show when={open()}>
+        <span style={tooltipStyle} dir="ltr" onClick={(e) => e.stopPropagation()}>
+          <span style={{ 'font-weight': 600 }}>{props.term.term}</span>
+          <Show when={props.term.termHe}>
+            <span dir="rtl" style={{ 'margin-left': '0.35rem', color: '#cbd5e1' }}>{props.term.termHe}</span>
+          </Show>
+          <span style={{ display: 'block', 'margin-top': '0.25rem', color: '#e5e7eb' }}>{props.term.gloss}</span>
+        </span>
+      </Show>
+    </span>
+  );
+}
+
+/** Render `text`, wrapping every occurrence of a known background term as a
+ *  gloss-tooltip mention. Pure-ish: reads `props` inside a memo so a late daf
+ *  background load re-tokenizes. */
+export function ConceptText(props: { text: string | undefined | null; terms: ConceptTerm[] }): JSX.Element {
+  const parts = createMemo(() => tokenizeConceptMentions(props.text ?? '', props.terms));
+  return (
+    <For each={parts()}>{(p) => {
+      if (p.kind === 'text' || !p.term) return <Hebraized text={p.value} />;
+      return <ConceptMention value={p.value} term={p.term} />;
+    }}</For>
+  );
+}

--- a/src/client/rabbiLinks.tsx
+++ b/src/client/rabbiLinks.tsx
@@ -18,6 +18,7 @@
 import { For, createContext, createMemo, useContext, type Accessor, type JSX } from 'solid-js';
 import type { IdentifiedRabbi } from './dafContext';
 import { Hebraized } from './Hebraized';
+import { ConceptAwareText } from './conceptLinks';
 
 export interface RabbiLinkContextValue {
   rabbis: Accessor<IdentifiedRabbi[]>;
@@ -47,7 +48,9 @@ export function useRabbiLinks(): RabbiLinkContextValue | null {
  *  context is present (e.g. outside the sidebar), behaves like Hebraized. */
 export function HebraizedWithRabbis(props: { text: string | undefined | null }): JSX.Element {
   const ctx = useRabbiLinks();
-  if (!ctx) return <Hebraized text={props.text} />;
+  // No rabbi pool here — still layer in concept tooltips (ConceptAwareText
+  // itself falls back to plain Hebraized when there's no concept context).
+  if (!ctx) return <ConceptAwareText text={props.text} />;
   return (
     <RabbiText
       text={props.text}
@@ -152,7 +155,9 @@ export function RabbiText(props: {
 
   return (
     <For each={parts()}>{(p) => {
-      if (p.kind === 'text') return <Hebraized text={p.value} />;
+      // Concept tooltips layer UNDER rabbi links: a name matched as a rabbi is
+      // already a 'link' part, so only the non-rabbi text is scanned for terms.
+      if (p.kind === 'text') return <ConceptAwareText text={p.value} />;
       // For routing: try slug resolution against rabbis; if missing,
       // still emit a link button — pushRabbi handles unresolved names by
       // building a stub from the rabbi mark or just highlighting on the

--- a/tests/concept-links.test.ts
+++ b/tests/concept-links.test.ts
@@ -47,6 +47,16 @@ describe('tokenizeConceptMentions', () => {
     expect(parts.every((p) => p.kind === 'text')).toBe(true);
   });
 
+  it('handles transliteration diacritics with Unicode word boundaries', () => {
+    const terms: ConceptTerm[] = [{ term: 'ḥerem', termHe: 'חרם', gloss: 'A ban / excommunication.' }];
+    // matches as a standalone word...
+    const hit = tokenizeConceptMentions('They declared ḥerem on him.', terms);
+    expect(hit[1]).toMatchObject({ kind: 'concept', value: 'ḥerem' });
+    // ...but not as a substring of a longer diacritic-bearing word
+    const miss = tokenizeConceptMentions('the ḥeremite stayed', terms);
+    expect(miss.every((p) => p.kind === 'text')).toBe(true);
+  });
+
   it('returns a single text part when nothing matches, and [] for empty input', () => {
     expect(tokenizeConceptMentions('nothing here', TERMS)).toEqual([{ kind: 'text', value: 'nothing here' }]);
     expect(tokenizeConceptMentions('', TERMS)).toEqual([]);

--- a/tests/concept-links.test.ts
+++ b/tests/concept-links.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { tokenizeConceptMentions, type ConceptTerm } from '../src/client/conceptLinks';
+
+// The concept-tooltip layer wraps mentions of THIS daf's background terms in
+// prose so a reader can see the gloss inline. tokenizeConceptMentions is the
+// pure splitter; these guard the matching (whole-word, case-insensitive,
+// longest-first) and the parenthetical-Hebrew case the feature targets.
+
+const TERMS: ConceptTerm[] = [
+  { term: 'Kohen', termHe: 'כהן', gloss: 'A descendant of Aharon who serves in the Temple.' },
+  { term: 'Oral Law', termHe: 'תורה שבעל פה', gloss: 'The transmitted interpretation of the Written Torah.' },
+  { term: 'law', termHe: 'דין', gloss: 'A legal ruling.' },
+];
+
+describe('tokenizeConceptMentions', () => {
+  it('wraps a known term and carries its gloss; surrounding text stays plain', () => {
+    const parts = tokenizeConceptMentions('Only a Kohen may eat terumah.', TERMS);
+    expect(parts).toEqual([
+      { kind: 'text', value: 'Only a ' },
+      { kind: 'concept', value: 'Kohen', term: TERMS[0] },
+      { kind: 'text', value: ' may eat terumah.' },
+    ]);
+  });
+
+  it('leaves the parenthetical Hebrew as text (the English label is the match)', () => {
+    const parts = tokenizeConceptMentions('a Kohen (כהן) may not', TERMS);
+    expect(parts.map((p) => p.kind)).toEqual(['text', 'concept', 'text']);
+    expect(parts[1]).toMatchObject({ kind: 'concept', value: 'Kohen' });
+    expect(parts[2].value).toBe(' (כהן) may not'); // Hebrew + rest untouched
+  });
+
+  it('matches case-insensitively but preserves the matched casing verbatim', () => {
+    const parts = tokenizeConceptMentions('The kohen blessed them.', TERMS);
+    expect(parts[1]).toMatchObject({ kind: 'concept', value: 'kohen', term: TERMS[0] });
+  });
+
+  it('prefers the longest term (multi-word beats the single-word substring)', () => {
+    const parts = tokenizeConceptMentions('This is Oral Law, not custom.', TERMS);
+    const concepts = parts.filter((p) => p.kind === 'concept');
+    expect(concepts).toHaveLength(1);
+    expect(concepts[0]).toMatchObject({ value: 'Oral Law', term: TERMS[1] });
+  });
+
+  it('matches whole words only — never mid-word', () => {
+    const parts = tokenizeConceptMentions('The lawyer outlawed it.', TERMS);
+    // "law" must not fire inside "lawyer" / "outlawed"
+    expect(parts.every((p) => p.kind === 'text')).toBe(true);
+  });
+
+  it('returns a single text part when nothing matches, and [] for empty input', () => {
+    expect(tokenizeConceptMentions('nothing here', TERMS)).toEqual([{ kind: 'text', value: 'nothing here' }]);
+    expect(tokenizeConceptMentions('', TERMS)).toEqual([]);
+  });
+
+  it('skips 1-char labels (too noisy) and dedupes repeated surfaces', () => {
+    const noisy: ConceptTerm[] = [
+      { term: 'a', termHe: '', gloss: 'x' },
+      { term: 'Get', termHe: 'גט', gloss: 'A bill of divorce.' },
+      { term: 'Get', termHe: 'גט', gloss: 'duplicate' },
+    ];
+    const parts = tokenizeConceptMentions('She received a Get today.', noisy);
+    const concepts = parts.filter((p) => p.kind === 'concept');
+    expect(concepts).toHaveLength(1);
+    expect(concepts[0].term?.gloss).toBe('A bill of divorce.'); // first claimant wins
+  });
+});


### PR DESCRIPTION
## What

Builds on #166. A reader who meets a term like **Kohen** in the overview / halacha / aggadata prose can now **hover it to see the gloss** the Background card already produced — the felt half of the concept glossary. Same-daf, high-precision: a match is a term the daf itself defined.

## How

- **`src/client/conceptLinks.tsx`** (mirrors `rabbiLinks.tsx`): `ConceptLinkProvider` + pure `tokenizeConceptMentions` (whole-word, case-insensitive, longest-first match over the daf's `daf-background.concepts` terms) + a hover/focus gloss tooltip (`ConceptMention`).
- **Layered UNDER rabbi links**: `HebraizedWithRabbis` tokenizes rabbis first, then hands its plain-text parts to `ConceptAwareText`, so a name matched as a rabbi is never also tagged a concept. No import cycle (rabbiLinks → conceptLinks, one direction). Every prose field that already used `HebraizedWithRabbis` gets tooltips at once.
- **Term pool sourced once per daf** in `DafViewer` from the **same `daf-background.synthesis` run the prefetcher already warms** (its `deps_resolved` carries the concepts) — a cache hit, not a second generation. Threaded through `ArgumentSidebar` + `MobileShelf` into the provider. Not-yet-warm / fetch failure → no tooltips (graceful).

## Scope

The `Kohen (כהן)` parenthetical-Hebrew case is covered: v1 matches the **English label** (which is what appears in the English prose); the `(כהן)` stays as adjacent text. Matching Hebrew surface forms in Hebrew prose is a deliberate follow-up. Cross-daf canonical glossary (dedupe the #166 backlog → entity) is the later step.

## Test

`tests/concept-links.test.ts` — matching, the parenthetical-Hebrew case, case-insensitivity, longest-first, whole-word-only, dedup, empties. Full suite (1604) + typecheck + vite build green.