### PR TITLE
Voices gate: require a named speaker + gate on live voices

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -11,6 +11,7 @@ import RabbiPlacesTimeline, { type LocationInference } from './RabbiPlacesTimeli
 import ArgumentVoiceMap, { type ArgumentVoicesData } from './ArgumentVoiceMap';
 import ArgumentNarrative from './ArgumentNarrative';
 import { deriveVoiceEdges } from '../lib/typing/voices';
+import { hasOpposingVoices } from '../lib/typing/profile';
 import ArgumentFlowGraph, { type FlowConnection } from './ArgumentFlowGraph';
 import { orderBackgroundGroups, type BackgroundGroup } from './backgroundGroups';
 import { adjacentAmud } from '../lib/sefref/amudim';
@@ -82,13 +83,20 @@ export interface PlaceInstance {
 /** Section-typing gate for the voice-dispute map (Track C, P2). The voices
  *  graph models a מחלוקת; rendering it on a story or a one-sided Stam Q&A is the
  *  "Demons"/"Stam questioner→respondent" pathology. We compute the section's
- *  TypeProfile (deterministic, cached marks, via /api/type-profiles) and
- *  suppress the map unless the section is a real, non-narrative dispute. Gated
- *  to dev mode + reversible: readers are unaffected until this is promoted, and
- *  when the profile is unknown we default to showing (current behavior). The
- *  reliable signal is `primary` (the deterministic composition) overriding the
- *  noisy `isDispute` voices flag — a story can carry stray `opposes` edges. */
-interface SectionTypeProfile { unit: { startSegIdx: number; endSegIdx: number }; primary: string; isDispute: boolean }
+ *  TypeProfile (deterministic, cached marks, via /api/type-profiles).
+ *
+ *  Two signals, deliberately split by where they're reliable:
+ *   - DETERMINISTIC (from the profile, always available): `primary` (a story is
+ *     never a dispute map) and `hasNamedSpeaker` (a fabricated dispute on an
+ *     anonymous Stam section has no named move-speaker to ground it). These form
+ *     `mapEligible` — could this section EVER show the map.
+ *   - LIVE (from the loaded voices graph, passed in at render): real opposition
+ *     (`hasOpposingVoices`). We read this from the just-loaded graph rather than
+ *     the profile's cached `isDispute` because `isDispute` suffers a warming
+ *     race — on a cold daf the profile reports `false` until the (LLM) voices
+ *     warm, which silently hid the map on genuine disputes (e.g. Gittin 90a's
+ *     Beit Hillel/Shammai). The live graph is present exactly when we'd draw. */
+interface SectionTypeProfile { unit: { startSegIdx: number; endSegIdx: number }; primary: string; isDispute: boolean; hasNamedSpeaker?: boolean }
 function useVoicesGate(tractate: () => string, page: () => string, section: () => { startSegIdx?: number; endSegIdx?: number } | undefined) {
   const [profiles] = createResource(
     () => `${tractate()}|${page()}`,
@@ -105,15 +113,28 @@ function useVoicesGate(tractate: () => string, page: () => string, section: () =
     if (!s || typeof s.startSegIdx !== 'number' || typeof s.endSegIdx !== 'number') return undefined;
     return (profiles() ?? []).find((p) => p.unit.startSegIdx === s.startSegIdx && p.unit.endSegIdx === s.endSegIdx);
   };
-  const suppress = (): boolean => {
-    // Promoted to readers: section typing now drives the view for everyone, not
-    // just dev mode. Safe-by-default — an unknown/uncomputed profile shows the
-    // voice graph exactly as before, so a missing profile never regresses.
+  // Deterministic precheck — no warming race. Unknown profile → eligible (the
+  // prior safe default). Positively suppressed only for narrative (aggadata) or
+  // anonymous (no named speaker) sections.
+  const mapEligible = (): boolean => {
     const p = profile();
-    if (!p) return false;                          // unknown → show (safe default)
-    return !(p.isDispute && p.primary !== 'aggadata'); // hide unless a real, non-narrative dispute
+    if (!p) return true;
+    return p.primary !== 'aggadata' && p.hasNamedSpeaker !== false;
   };
-  return { profile, suppress };
+  // The map shows when eligible AND the live voices graph carries real
+  // opposition. `null` voices (still loading) → false (no flicker).
+  const showVoiceMap = (voices: ArgumentVoicesData | null): boolean =>
+    mapEligible() && hasOpposingVoices(voices);
+  // The fallback (move-flow / narrative) shows when the map definitively won't:
+  // the section is ineligible, or the section synthesis has RESOLVED without a
+  // dispute (no opposition, OR voices absent/invalid). `resolved` — not
+  // `voices != null` — is the "settled" signal, so a synthesis that resolves
+  // with missing/malformed `argument.voices` still falls back to the move-flow
+  // instead of rendering bare. While an eligible section is still loading
+  // (`!resolved`), neither shows.
+  const showFallback = (voices: ArgumentVoicesData | null, resolved: boolean): boolean =>
+    !mapEligible() || (resolved && !hasOpposingVoices(voices));
+  return { profile, mapEligible, showVoiceMap, showFallback };
 }
 
 export type SidebarContent =
@@ -523,6 +544,10 @@ export function ArgumentBody(props: {
   // argument.voices output (structured voices + edges) — resolved via the
   // section synthesis aggregate's deps_resolved. Drives ArgumentVoiceMap.
   const [voicesData, setVoicesData] = createSignal<ArgumentVoicesData | null>(null);
+  // True once the section synthesis has resolved (whether or not it carried a
+  // valid voices graph) — lets the gate distinguish "still loading" from
+  // "settled, no dispute" so a missing/invalid voices graph falls back cleanly.
+  const [voicesResolved, setVoicesResolved] = createSignal(false);
   // Section-typing gate: hide the voice-dispute map on non-dispute sections (dev mode).
   const voicesGate = useVoicesGate(() => props.tractate, () => props.page, () => props.section);
 
@@ -544,10 +569,12 @@ export function ArgumentBody(props: {
     setAllMoves(null);
     setHighlightedMoveId(null);
     setVoicesData(null);
+    setVoicesResolved(false);
     props.onHighlightRange(null);
   });
 
   const handleResolved = (r: { deps_resolved?: Record<string, unknown>; anchors_resolved?: Record<string, unknown> }) => {
+    setVoicesResolved(true);
     const moves = r.anchors_resolved?.['argument-move'] as ArgumentMoveInstance[] | undefined;
     if (Array.isArray(moves)) setAllMoves(moves);
     const voices = r.deps_resolved?.['argument.voices'] as ArgumentVoicesData | undefined;
@@ -616,7 +643,7 @@ export function ArgumentBody(props: {
         page={props.page}
         onResolved={handleResolved}
       />
-      <Show when={!voicesGate.suppress() && voicesData()}>
+      <Show when={voicesGate.showVoiceMap(voicesData()) && voicesData()}>
         {(data) => (
           <div style={{ position: 'relative' }}>
             <InspectDot instanceKey={instanceKey()} leafId="argument.voices" style={{ position: 'absolute', top: '0.2rem', right: 0, 'z-index': 2 }} />
@@ -624,7 +651,7 @@ export function ArgumentBody(props: {
           </div>
         )}
       </Show>
-      <Show when={voicesGate.suppress()}>
+      <Show when={voicesGate.showFallback(voicesData(), voicesResolved())}>
         <Show
           when={voicesGate.profile()?.primary === 'aggadata'}
           fallback={
@@ -685,10 +712,12 @@ function OverviewSectionVoices(props: {
   onPushRabbi: (name: string) => void;
 }): JSX.Element {
   const [voices, setVoices] = createSignal<ArgumentVoicesData | null>(null);
+  const [resolved, setResolved] = createSignal(false);
   const voicesGate = useVoicesGate(() => props.tractate, () => props.page, () => props.section);
   const instanceKey = () => `${props.section.startSegIdx}-${props.section.endSegIdx}-${props.section.title}`;
-  createEffect(() => { void instanceKey(); setVoices(null); });
+  createEffect(() => { void instanceKey(); setVoices(null); setResolved(false); });
   const onResolved = (r: { deps_resolved?: Record<string, unknown> }) => {
+    setResolved(true);
     const v = r.deps_resolved?.['argument.voices'] as ArgumentVoicesData | undefined;
     if (v && Array.isArray(v.voices)) setVoices(deriveVoiceEdges({ voices: v.voices, edges: Array.isArray(v.edges) ? v.edges : [] }) as ArgumentVoicesData);
   };
@@ -715,10 +744,10 @@ function OverviewSectionVoices(props: {
         page={props.page}
         onResolved={onResolved}
       />
-      <Show when={!voicesGate.suppress() && voices()}>
+      <Show when={voicesGate.showVoiceMap(voices()) && voices()}>
         {(data) => <ArgumentVoiceMap data={data()} onClickVoice={props.onPushRabbi} />}
       </Show>
-      <Show when={voicesGate.suppress() && voicesGate.profile()?.primary === 'aggadata'}>
+      <Show when={voicesGate.showFallback(voices(), resolved()) && voicesGate.profile()?.primary === 'aggadata'}>
         <ArgumentNarrative section={props.section} tractate={props.tractate} page={props.page} />
       </Show>
     </div>

--- a/src/lib/typing/profile.ts
+++ b/src/lib/typing/profile.ts
@@ -70,10 +70,21 @@ export interface TypeProfile {
    *  the floor (the always-present dialectical base). Derived, not stored. */
   primary: PrimaryType;
   /** True only when the argument structure over the unit has real opposing
-   *  voices (≥1 `opposes` edge). Gates dispute rendering (P2). Orthogonal to
-   *  `primary`: a כולכם dispute with no content overlay is
-   *  `primary: 'pure-dialectic'`, `isDispute: true`. */
+   *  voices (≥1 `opposes` edge) AND the unit actually contains a NAMED speaker
+   *  (`hasNamedSpeaker`). Gates dispute rendering (P2). Orthogonal to `primary`:
+   *  a כולכם dispute with no content overlay is `primary: 'pure-dialectic'`,
+   *  `isDispute: true`. The named-speaker conjunct is the anti-hallucination
+   *  guard: an anonymous Stam-only section can't host a real מחלוקת, so an
+   *  `opposes` edge there is a fabrication (the model inventing a dispute from
+   *  tractate memory) and must not register as one. */
   isDispute: boolean;
+  /** True when ≥1 of the unit's argument-moves names an actual speaker
+   *  (move `rabbiNames` non-empty). Deterministic — derived from the cached
+   *  move marks, so it's available even before the (LLM) voices graph warms.
+   *  The voices map's render gate ANDs this with live opposition so a section
+   *  with a confidently-wrong fabricated dispute (no named speaker to ground it)
+   *  is suppressed. Defaults to `true` when unknown (permissive). */
+  hasNamedSpeaker: boolean;
   /** The unit's textual register — `mishnah` when the majority of its segments
    *  fall in the daf's mishnah-in-talmud ranges, else `gemara`. Orthogonal to
    *  `primary`. `gemara` when no mishnah ranges were supplied (the common case;
@@ -135,7 +146,7 @@ export function hasOpposingVoices(voices?: VoicesGraph | null): boolean {
 export function composeTypeProfile(
   unit: UnitRange,
   instances: readonly LayerInstance[],
-  opts: { voices?: VoicesGraph | null; mishnaSegs?: ReadonlySet<number> } = {},
+  opts: { voices?: VoicesGraph | null; mishnaSegs?: ReadonlySet<number>; hasNamedSpeaker?: boolean } = {},
 ): TypeProfile {
   const unitSegs = rangeSegs(unit.startSegIdx, unit.endSegIdx);
   const unitSet = new Set(unitSegs);
@@ -165,11 +176,13 @@ export function composeTypeProfile(
     if (score > bestScore) { bestScore = score; primary = c.layer as OverlayLayer; }
   }
 
+  const hasNamedSpeaker = opts.hasNamedSpeaker ?? true; // unknown → permissive
   return {
     unit,
     claims,
     primary,
-    isDispute: hasOpposingVoices(opts.voices),
+    isDispute: hasOpposingVoices(opts.voices) && hasNamedSpeaker,
+    hasNamedSpeaker,
     register: registerOf(unit, opts.mishnaSegs),
   };
 }

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -682,7 +682,9 @@ app.get('/api/checks/:tractate/:page', async (c) => {
 // claim the section, the dominant `primary` content dimension (pure-dialectic
 // when no overlay materially covers it), `register` (mishnah/gemara — the
 // textual axis orthogonal to primary, from the cached mishnah-in-talmud ranges),
-// and `isDispute` (from the section's cached argument.voices graph). This is the
+// and `isDispute` (the section's cached argument.voices graph has an `opposes`
+// edge AND the section has a named move-speaker — see `hasNamedSpeaker`, the
+// anti-hallucination guard). This is the
 // observation/validation surface for
 // section typing — it shows, on real content, that e.g. the Ashmedai story is
 // narrative-primary (not a voice dispute). Gating + new enrichments build on it.
@@ -705,13 +707,34 @@ function toLayerInstances(layer: LayerId, insts: RawInstance[]): LayerInstance[]
   });
   return out;
 }
+// Does any argument-move inside [startSegIdx, endSegIdx] name an actual speaker?
+// A move belongs to the section when its parent-section range matches exactly
+// (the move's `sectionStartSegIdx`/`sectionEndSegIdx`) or, failing that, when its
+// own range falls within the section. `rabbiNames` is the move extractor's list
+// of NAMED speakers (empty for anonymous Stam moves), so this is the
+// deterministic "a real מחלוקת is possible here" signal — see
+// TypeProfile.hasNamedSpeaker.
+function sectionHasNamedSpeaker(moves: RawInstance[], startSegIdx: number, endSegIdx: number): boolean {
+  for (const m of moves) {
+    const f = m.fields ?? {};
+    const names = Array.isArray(f.rabbiNames) ? (f.rabbiNames as unknown[]) : [];
+    if (names.length === 0) continue;
+    const ss = f.sectionStartSegIdx, se = f.sectionEndSegIdx;
+    const sectionMatch = ss === startSegIdx && se === endSegIdx;
+    const withinSection = typeof m.startSegIdx === 'number' && typeof m.endSegIdx === 'number'
+      && m.startSegIdx >= startSegIdx && m.endSegIdx <= endSegIdx;
+    if (sectionMatch || withinSection) return true;
+  }
+  return false;
+}
 async function buildDafTypeProfiles(env: Bindings, tractate: string, page: string): Promise<(TypeProfile & { title?: string })[]> {
   const sections = await readMarkInstances(env, 'argument', tractate, page);
+  const moves = await readMarkInstances(env, 'argument-move', tractate, page);
   const overlays: LayerInstance[] = [
     ...toLayerInstances('aggadata', await readMarkInstances(env, 'aggadata', tractate, page)),
     ...toLayerInstances('halacha', await readMarkInstances(env, 'halacha', tractate, page)),
     ...toLayerInstances('pesukim', await readMarkInstances(env, 'pesukim', tractate, page)),
-    ...toLayerInstances('argument-move', await readMarkInstances(env, 'argument-move', tractate, page)),
+    ...toLayerInstances('argument-move', moves),
   ];
   // Deterministic register axis: which segments are mishnah-in-talmud (cached
   // Sefaria /api/related anchors). A section whose majority falls here is
@@ -730,7 +753,13 @@ async function buildDafTypeProfiles(env: Bindings, tractate: string, page: strin
       const vhit = await readCachedResult(env, keyForEnrichment(voicesDef, iid, { tractate, page }));
       voices = (vhit?.parsed as { edges?: { kind?: string }[] }) ?? null;
     }
-    profiles.push({ ...composeTypeProfile(unit, overlays, { voices, mishnaSegs }), title: typeof sec.fields?.title === 'string' ? sec.fields.title : undefined });
+    // When the move mark isn't cached yet (`moves` empty), we can't tell named
+    // from anonymous — pass `undefined` so composeTypeProfile stays permissive
+    // (unknown → not suppressed) rather than mislabel a cold daf's real dispute
+    // as anonymous. Only with moves actually loaded does an empty section mean
+    // "no named speaker".
+    const hasNamedSpeaker = moves.length > 0 ? sectionHasNamedSpeaker(moves, sec.startSegIdx, sec.endSegIdx) : undefined;
+    profiles.push({ ...composeTypeProfile(unit, overlays, { voices, mishnaSegs, hasNamedSpeaker }), title: typeof sec.fields?.title === 'string' ? sec.fields.title : undefined });
   }
   return profiles;
 }

--- a/tests/typing/profile.test.ts
+++ b/tests/typing/profile.test.ts
@@ -119,6 +119,26 @@ describe('isDispute', () => {
     expect(hasOpposingVoices({ edges: [{ kind: 'supports' }, { kind: 'responds-to' }] })).toBe(false);
     expect(composeTypeProfile(unit(0, 3), []).isDispute).toBe(false);
   });
+
+  it('requires a named speaker: an opposes edge on an anonymous section is NOT a dispute', () => {
+    // The Chullin 2a pathology — the voices graph fabricates a מחלוקת (an
+    // `opposes` edge) on the anonymous "hakol shochtin" Mishnah, which has no
+    // named move-speaker. Without a named speaker to ground it, that opposition
+    // is a hallucination and must not register as a dispute.
+    const p = composeTypeProfile(unit(0, 0), [], { voices: { edges: [{ kind: 'opposes' }] }, hasNamedSpeaker: false });
+    expect(p.hasNamedSpeaker).toBe(false);
+    expect(p.isDispute).toBe(false);
+  });
+
+  it('a named speaker + opposition IS a dispute', () => {
+    const p = composeTypeProfile(unit(0, 4), [], { voices: { edges: [{ kind: 'opposes' }] }, hasNamedSpeaker: true });
+    expect(p.hasNamedSpeaker).toBe(true);
+    expect(p.isDispute).toBe(true);
+  });
+
+  it('hasNamedSpeaker defaults to true (permissive) when unknown', () => {
+    expect(composeTypeProfile(unit(0, 3), []).hasNamedSpeaker).toBe(true);
+  });
 });
 
 describe('overlayUncoveredSegs (P0 coverage)', () => {


### PR DESCRIPTION
Fixes two correctness problems in **when the per-section VOICES dispute map renders**, surfaced by auditing the voices output across Berakhot 2a, Sanhedrin 2a, Gittin 2a, Gittin 90a, Sukkah 3a, and Chullin 2a.

## (a) Anti-hallucination — stop showing fabricated disputes
On an anonymous section with no named speaker (e.g. Chullin 2a's `hakol shochtin` Mishnah), the `argument.voices` LLM can invent a מחלוקת from its memory of the tractate (it fabricated a Chullin **27a** R. Yehuda 'veins' dispute on 2a) and emit an `opposes` edge — which registered as a real dispute and was shown to readers.

`isDispute` now requires an `opposes` edge **AND** `hasNamedSpeaker` — a new deterministic field derived from the cached `argument-move` marks (a section whose moves name zero speakers can't host a real dispute). Validated: every genuine dispute in the audit has a named move-speaker; the Chullin fabrication has none. Cold/uncached moves read as *unknown* (permissive), never as 'anonymous', so a partially-warmed daf can't mislabel a real dispute.

## (b) Warming race — stop hiding real disputes
The reader gate read the section's cached `isDispute`, which is `false` on a cold daf until `argument.voices` warms. This silently hid the map on textbook disputes — e.g. Gittin 90a's Beit Hillel/Shammai/R. Akiva Mishnah showed nothing. Confirmed root cause: after warming the voices, those sections flip to `isDispute=true`.

The client now gates on the **live loaded voices graph** (present exactly when we'd draw) plus the deterministic profile signals (aggadata veto + `hasNamedSpeaker`), not the warming-prone cached flag. A `resolved` signal distinguishes 'still loading' from 'settled, no dispute', so a missing/invalid voices graph falls back to the move-flow instead of rendering bare.

## Notes
- Reviewed with `codex --sandbox read-only`; both findings (cold-moves false-suppression, invalid-voices bare render) fixed in this PR.
- No cache bump — `/api/type-profiles` is recomputed, not cached.
- `pnpm typecheck` clean; 1600 unit tests pass (added 3 for the named-speaker gate).
- Prompt-level role/side fixes (the third audit finding) are a separate follow-up PR.