### PR TITLE
Tests: lock the voices gate + prompt against regression

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -12,7 +12,7 @@ import RabbiPlacesTimeline, { type LocationInference } from './RabbiPlacesTimeli
 import ArgumentVoiceMap, { type ArgumentVoicesData } from './ArgumentVoiceMap';
 import ArgumentNarrative from './ArgumentNarrative';
 import { deriveVoiceEdges } from '../lib/typing/voices';
-import { hasOpposingVoices } from '../lib/typing/profile';
+import { voicesMapEligible, voicesShowMap, voicesShowFallback } from '../lib/typing/profile';
 import ArgumentFlowGraph, { type FlowConnection } from './ArgumentFlowGraph';
 import { orderBackgroundGroups, type BackgroundGroup } from './backgroundGroups';
 import { adjacentAmud } from '../lib/sefref/amudim';
@@ -114,27 +114,14 @@ function useVoicesGate(tractate: () => string, page: () => string, section: () =
     if (!s || typeof s.startSegIdx !== 'number' || typeof s.endSegIdx !== 'number') return undefined;
     return (profiles() ?? []).find((p) => p.unit.startSegIdx === s.startSegIdx && p.unit.endSegIdx === s.endSegIdx);
   };
-  // Deterministic precheck — no warming race. Unknown profile → eligible (the
-  // prior safe default). Positively suppressed only for narrative (aggadata) or
-  // anonymous (no named speaker) sections.
-  const mapEligible = (): boolean => {
-    const p = profile();
-    if (!p) return true;
-    return p.primary !== 'aggadata' && p.hasNamedSpeaker !== false;
-  };
-  // The map shows when eligible AND the live voices graph carries real
-  // opposition. `null` voices (still loading) → false (no flicker).
-  const showVoiceMap = (voices: ArgumentVoicesData | null): boolean =>
-    mapEligible() && hasOpposingVoices(voices);
-  // The fallback (move-flow / narrative) shows when the map definitively won't:
-  // the section is ineligible, or the section synthesis has RESOLVED without a
-  // dispute (no opposition, OR voices absent/invalid). `resolved` — not
-  // `voices != null` — is the "settled" signal, so a synthesis that resolves
-  // with missing/malformed `argument.voices` still falls back to the move-flow
-  // instead of rendering bare. While an eligible section is still loading
-  // (`!resolved`), neither shows.
+  // The three decisions are pure functions in src/lib/typing/profile.ts
+  // (voicesMapEligible / voicesShowMap / voicesShowFallback) so the gate logic
+  // is unit-tested against the regressions it fixes (Chullin 2a hallucination,
+  // Gittin 90a warming race); here we just bind them to the reactive profile.
+  const mapEligible = (): boolean => voicesMapEligible(profile());
+  const showVoiceMap = (voices: ArgumentVoicesData | null): boolean => voicesShowMap(profile(), voices);
   const showFallback = (voices: ArgumentVoicesData | null, resolved: boolean): boolean =>
-    !mapEligible() || (resolved && !hasOpposingVoices(voices));
+    voicesShowFallback(profile(), voices, resolved);
   return { profile, mapEligible, showVoiceMap, showFallback };
 }
 

--- a/src/lib/typing/profile.ts
+++ b/src/lib/typing/profile.ts
@@ -187,6 +187,65 @@ export function composeTypeProfile(
   };
 }
 
+/** A move reduced to what named-speaker detection needs: its own range, its
+ *  parent-section range, and the extractor's list of NAMED speakers. */
+export interface MoveLike {
+  startSegIdx?: unknown;
+  endSegIdx?: unknown;
+  fields?: { rabbiNames?: unknown; sectionStartSegIdx?: unknown; sectionEndSegIdx?: unknown };
+}
+
+/** Does any argument-move inside [startSegIdx, endSegIdx] name an actual
+ *  speaker? A move belongs to the section when its parent-section range matches
+ *  exactly, or (failing that) when its own range falls within the section.
+ *  `rabbiNames` is empty for anonymous Stam moves, so this is the deterministic
+ *  "a real מחלוקת is possible here" signal that feeds `TypeProfile.hasNamedSpeaker`
+ *  — the anti-hallucination guard (an `opposes` edge on an all-anonymous section
+ *  is a fabrication). */
+export function sectionHasNamedSpeaker(moves: readonly MoveLike[], startSegIdx: number, endSegIdx: number): boolean {
+  for (const m of moves) {
+    const f = m.fields ?? {};
+    const names = Array.isArray(f.rabbiNames) ? f.rabbiNames : [];
+    if (names.length === 0) continue;
+    const sectionMatch = f.sectionStartSegIdx === startSegIdx && f.sectionEndSegIdx === endSegIdx;
+    const withinSection = typeof m.startSegIdx === 'number' && typeof m.endSegIdx === 'number'
+      && m.startSegIdx >= startSegIdx && m.endSegIdx <= endSegIdx;
+    if (sectionMatch || withinSection) return true;
+  }
+  return false;
+}
+
+/** The profile fields the voice-dispute-map render gate reads. A subset of
+ *  `TypeProfile`; `undefined` means the profile is unknown/uncomputed. */
+export interface GateProfile { primary: string; hasNamedSpeaker?: boolean }
+
+/** Deterministic precheck — could this section EVER show the voice-dispute map?
+ *  Yes unless the profile positively says it's an aggadata story or has no named
+ *  speaker (a fabricated dispute on an anonymous section). Unknown profile →
+ *  eligible (the safe default). No warming race: both inputs are deterministic. */
+export function voicesMapEligible(profile: GateProfile | undefined): boolean {
+  if (!profile) return true;
+  return profile.primary !== 'aggadata' && profile.hasNamedSpeaker !== false;
+}
+
+/** The map shows when the section is eligible AND the (live, just-loaded) voices
+ *  graph carries real opposition. Reading the live graph — not the profile's
+ *  cached `isDispute` — is what dodges the warming race that hid real disputes
+ *  on cold dapim. `null` voices (still loading) → false. */
+export function voicesShowMap(profile: GateProfile | undefined, voices: VoicesGraph | null): boolean {
+  return voicesMapEligible(profile) && hasOpposingVoices(voices);
+}
+
+/** The fallback (move-flow / narrative) shows when the map definitively won't:
+ *  the section is ineligible, OR the synthesis has RESOLVED without a dispute
+ *  (no opposition, or voices absent/invalid). `resolved` — not `voices != null`
+ *  — is the "settled" signal, so a synthesis that resolves with missing/malformed
+ *  voices still falls back instead of rendering bare. Mutually exclusive with
+ *  `voicesShowMap`. */
+export function voicesShowFallback(profile: GateProfile | undefined, voices: VoicesGraph | null, resolved: boolean): boolean {
+  return !voicesMapEligible(profile) || (resolved && !hasOpposingVoices(voices));
+}
+
 /**
  * P0 coverage helper: the unit segments NOT covered by any CONTENT overlay
  * (halacha/aggadata/pesukim). These are the "pure dialectic" segments — covered

--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -1712,7 +1712,7 @@ const ARGUMENT_PRO_MODEL = 'openrouter/deepseek/deepseek-v4-pro' as LLMModelId;
 
 // ---------------- argument.voices (kept) ----------------
 
-const ARGUMENT_VOICES_SYSTEM_PROMPT = `You are a Talmud scholar. For each NAMED rabbi appearing in this section, describe their argumentative role within the section, AND emit a graph showing how the voices relate (who argues with whom, who supports whom). Daf-local — about what they're doing here, not their general biography.
+export const ARGUMENT_VOICES_SYSTEM_PROMPT = `You are a Talmud scholar. For each NAMED rabbi appearing in this section, describe their argumentative role within the section, AND emit a graph showing how the voices relate (who argues with whom, who supports whom). Daf-local — about what they're doing here, not their general biography.
 
 Output STRICT JSON only:
 
@@ -1937,7 +1937,7 @@ Compose ONE paragraph per the schema.`;
 
 // ---------------- Hebrew-output parallels (argument section level) ----------------
 
-const ARGUMENT_VOICES_SYSTEM_PROMPT_HE = `אתה תלמיד חכם הבקיא בש"ס. עבור כל חכם נקוב המופיע במקטע זה, תאר את תפקידו הטיעוני בתוך המקטע, ופלוט גרף המראה כיצד הקולות מתקשרים (מי חולק על מי, מי תומך במי). מקומי-לדף — על מה שהם עושים כאן, לא על הביוגרפיה הכללית שלהם.
+export const ARGUMENT_VOICES_SYSTEM_PROMPT_HE = `אתה תלמיד חכם הבקיא בש"ס. עבור כל חכם נקוב המופיע במקטע זה, תאר את תפקידו הטיעוני בתוך המקטע, ופלוט גרף המראה כיצד הקולות מתקשרים (מי חולק על מי, מי תומך במי). מקומי-לדף — על מה שהם עושים כאן, לא על הביוגרפיה הכללית שלהם.
 
 החזר JSON תקין בלבד:
 

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -71,7 +71,7 @@ import { runLLM, type LLMModelId, type LLMResult, type LLMUsage } from './llm';
 import { checkBudget, isBudgetPaused, budgetStatus, clearPauses, type BudgetScope } from './budget';
 import { lookupRelationships } from './rabbi-graph';
 import { runPasses } from '../lib/check/passes';
-import { composeTypeProfile, type LayerId, type LayerInstance, type TypeProfile, type UnitRange } from '../lib/typing/profile';
+import { composeTypeProfile, sectionHasNamedSpeaker, type LayerId, type LayerInstance, type TypeProfile, type UnitRange } from '../lib/typing/profile';
 import { findMarkers } from '../lib/typing/markers';
 import { noteLintAttempt, readLintFailures, type LintFailuresSummary } from './lint-failures';
 import { partitionSections, dedupeByRange, dedupeBy, selectSectionMoves, type MoveLike } from '../lib/argumentMoves';
@@ -706,26 +706,6 @@ function toLayerInstances(layer: LayerId, insts: RawInstance[]): LayerInstance[]
     out.push({ layer, instanceId: id, startSegIdx: i.startSegIdx, endSegIdx: i.endSegIdx });
   });
   return out;
-}
-// Does any argument-move inside [startSegIdx, endSegIdx] name an actual speaker?
-// A move belongs to the section when its parent-section range matches exactly
-// (the move's `sectionStartSegIdx`/`sectionEndSegIdx`) or, failing that, when its
-// own range falls within the section. `rabbiNames` is the move extractor's list
-// of NAMED speakers (empty for anonymous Stam moves), so this is the
-// deterministic "a real מחלוקת is possible here" signal — see
-// TypeProfile.hasNamedSpeaker.
-function sectionHasNamedSpeaker(moves: RawInstance[], startSegIdx: number, endSegIdx: number): boolean {
-  for (const m of moves) {
-    const f = m.fields ?? {};
-    const names = Array.isArray(f.rabbiNames) ? (f.rabbiNames as unknown[]) : [];
-    if (names.length === 0) continue;
-    const ss = f.sectionStartSegIdx, se = f.sectionEndSegIdx;
-    const sectionMatch = ss === startSegIdx && se === endSegIdx;
-    const withinSection = typeof m.startSegIdx === 'number' && typeof m.endSegIdx === 'number'
-      && m.startSegIdx >= startSegIdx && m.endSegIdx <= endSegIdx;
-    if (sectionMatch || withinSection) return true;
-  }
-  return false;
 }
 async function buildDafTypeProfiles(env: Bindings, tractate: string, page: string): Promise<(TypeProfile & { title?: string })[]> {
   const sections = await readMarkInstances(env, 'argument', tractate, page);

--- a/tests/typing/voicesGate.test.ts
+++ b/tests/typing/voicesGate.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest';
+import {
+  sectionHasNamedSpeaker,
+  voicesMapEligible,
+  voicesShowMap,
+  voicesShowFallback,
+  type GateProfile,
+  type MoveLike,
+} from '../../src/lib/typing/profile';
+
+/**
+ * Regression guards for the VOICES dispute-map render gate. These lock the two
+ * fixes from the June 2026 voices audit:
+ *   (a) anti-hallucination — an `opposes` edge on a section with NO named
+ *       move-speaker (Chullin 2a's anonymous "hakol shochtin" Mishnah, where the
+ *       LLM fabricated a machloket from Chullin 27a) must NOT show the map.
+ *   (b) warming race — the map decision reads the LIVE voices graph + the
+ *       deterministic profile signals, never the cache-prone `isDispute`, so a
+ *       real dispute (Gittin 90a's Beit Hillel/Shammai) is never hidden on a
+ *       cold daf. A `resolved` flag distinguishes "still loading" from "settled
+ *       without a dispute" so a missing/invalid voices graph still falls back.
+ */
+
+const OPPOSES = { edges: [{ kind: 'opposes' }] };
+const NO_OPPOSITION = { edges: [{ kind: 'responds-to' }, { kind: 'supports' }] };
+
+describe('sectionHasNamedSpeaker (anti-hallucination signal)', () => {
+  const move = (start: number, end: number, rabbiNames: string[], section?: [number, number]): MoveLike => ({
+    startSegIdx: start,
+    endSegIdx: end,
+    fields: {
+      rabbiNames,
+      sectionStartSegIdx: section?.[0],
+      sectionEndSegIdx: section?.[1],
+    },
+  });
+
+  it('true when a move inside the section names a speaker (parent-section match)', () => {
+    const moves = [move(1, 1, ['Rabbi Meir'], [1, 2]), move(2, 2, ['Sages'], [1, 2])];
+    expect(sectionHasNamedSpeaker(moves, 1, 2)).toBe(true);
+  });
+
+  it('true via segment containment when the parent-section range is absent', () => {
+    expect(sectionHasNamedSpeaker([move(3, 3, ['Rava'])], 0, 5)).toBe(true);
+  });
+
+  it('false when every move in the section is anonymous (the Chullin 2a case)', () => {
+    // seg0-0 "hakol shochtin" — an anonymous opening move, no named speaker.
+    const moves = [move(0, 0, []), move(0, 0, [])];
+    expect(sectionHasNamedSpeaker(moves, 0, 0)).toBe(false);
+  });
+
+  it('ignores named moves that belong to OTHER sections', () => {
+    // A named move at seg4-5 must not make the anonymous seg0-0 section a dispute.
+    const moves = [move(0, 0, []), move(4, 5, ['Rabbi Yehuda'], [4, 5])];
+    expect(sectionHasNamedSpeaker(moves, 0, 0)).toBe(false);
+  });
+
+  it('false on an empty move list', () => {
+    expect(sectionHasNamedSpeaker([], 0, 3)).toBe(false);
+  });
+});
+
+describe('voicesMapEligible (deterministic precheck)', () => {
+  it('unknown profile → eligible (safe default)', () => {
+    expect(voicesMapEligible(undefined)).toBe(true);
+  });
+
+  it('aggadata story → ineligible (a narrative is not a dispute map)', () => {
+    expect(voicesMapEligible({ primary: 'aggadata', hasNamedSpeaker: true })).toBe(false);
+  });
+
+  it('no named speaker → ineligible (anti-hallucination)', () => {
+    expect(voicesMapEligible({ primary: 'halacha', hasNamedSpeaker: false })).toBe(false);
+  });
+
+  it('named, non-narrative section → eligible', () => {
+    expect(voicesMapEligible({ primary: 'halacha', hasNamedSpeaker: true })).toBe(true);
+  });
+
+  it('missing hasNamedSpeaker is treated as permissive (only an explicit false suppresses)', () => {
+    expect(voicesMapEligible({ primary: 'pure-dialectic' })).toBe(true);
+  });
+});
+
+describe('voicesShowMap', () => {
+  it('shows for an eligible section with live opposition (Gittin 90a Beit Hillel/Shammai)', () => {
+    expect(voicesShowMap({ primary: 'halacha', hasNamedSpeaker: true }, OPPOSES)).toBe(true);
+  });
+
+  it('does NOT show the fabricated dispute on an anonymous section (Chullin 2a)', () => {
+    // Live voices DO carry an opposes edge (the hallucination), but no named speaker.
+    expect(voicesShowMap({ primary: 'halacha', hasNamedSpeaker: false }, OPPOSES)).toBe(false);
+  });
+
+  it('does not show while voices are still loading (null)', () => {
+    expect(voicesShowMap({ primary: 'halacha', hasNamedSpeaker: true }, null)).toBe(false);
+  });
+
+  it('does not show when the loaded voices carry no opposition', () => {
+    expect(voicesShowMap({ primary: 'halacha', hasNamedSpeaker: true }, NO_OPPOSITION)).toBe(false);
+  });
+
+  it('does not show on an aggadata story even with stray opposes edges', () => {
+    expect(voicesShowMap({ primary: 'aggadata', hasNamedSpeaker: true }, OPPOSES)).toBe(false);
+  });
+});
+
+describe('voicesShowFallback', () => {
+  const eligible: GateProfile = { primary: 'halacha', hasNamedSpeaker: true };
+
+  it('shows immediately for an ineligible section (aggadata / anonymous)', () => {
+    expect(voicesShowFallback({ primary: 'aggadata', hasNamedSpeaker: true }, null, false)).toBe(true);
+    expect(voicesShowFallback({ primary: 'halacha', hasNamedSpeaker: false }, null, false)).toBe(true);
+  });
+
+  it('shows once resolved without opposition', () => {
+    expect(voicesShowFallback(eligible, NO_OPPOSITION, true)).toBe(true);
+  });
+
+  it('shows when the synthesis resolved but voices were missing/invalid (no bare render)', () => {
+    expect(voicesShowFallback(eligible, null, true)).toBe(true);
+  });
+
+  it('does NOT show while an eligible section is still loading', () => {
+    expect(voicesShowFallback(eligible, null, false)).toBe(false);
+  });
+
+  it('does NOT show when the map is showing (a real dispute)', () => {
+    expect(voicesShowFallback(eligible, OPPOSES, true)).toBe(false);
+  });
+});
+
+describe('map and fallback are mutually exclusive', () => {
+  const profiles: (GateProfile | undefined)[] = [
+    undefined,
+    { primary: 'halacha', hasNamedSpeaker: true },
+    { primary: 'halacha', hasNamedSpeaker: false },
+    { primary: 'aggadata', hasNamedSpeaker: true },
+    { primary: 'pure-dialectic' },
+  ];
+  const graphs = [null, OPPOSES, NO_OPPOSITION];
+
+  it('never renders both the map and the fallback for any state', () => {
+    for (const p of profiles) {
+      for (const g of graphs) {
+        for (const resolved of [true, false]) {
+          const both = voicesShowMap(p, g) && voicesShowFallback(p, g, resolved);
+          expect(both, `profile=${JSON.stringify(p)} graph=${JSON.stringify(g)} resolved=${resolved}`).toBe(false);
+        }
+      }
+    }
+  });
+});

--- a/tests/voices-prompt.test.ts
+++ b/tests/voices-prompt.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { ARGUMENT_VOICES_SYSTEM_PROMPT, ARGUMENT_VOICES_SYSTEM_PROMPT_HE } from '../src/worker/code-marks';
+
+/**
+ * Regression guards for the argument.voices prompt (the per-section dispute map).
+ *
+ * The June 2026 voices audit found four recurring quality issues on real
+ * disputes; the prompt (EN + HE) was tightened to fix them. The cache-identity
+ * snapshot (tests/code-enrichments-snapshot) only catches a cache_version bump —
+ * NOT silent deletion of the guidance text. These tests lock the actual rules so
+ * a revert is caught.
+ */
+describe('ARGUMENT_VOICES_SYSTEM_PROMPT (English)', () => {
+  const p = ARGUMENT_VOICES_SYSTEM_PROMPT;
+
+  it('reserves "respondent" for Q&A; co-equal Mishnaic disputants are "objector"', () => {
+    // The Berakhot 2a mislabel: Sages / Rabban Gamliel were tagged "respondent".
+    expect(p).toMatch(/ROLES/);
+    expect(p).toMatch(/OBJECTOR, not a respondent/);
+    expect(p).toMatch(/ONLY for genuine Q&A|NEVER for a parallel disputant/);
+  });
+
+  it('keeps sides minimal (no A–F over-fragmentation)', () => {
+    expect(p).toMatch(/KEEP SIDES MINIMAL/);
+    expect(p).toMatch(/not D\/E\/F/);
+  });
+
+  it('emits "opposes" only for a real disagreement, not harmonized views', () => {
+    // The Berakhot Rabban-Gamliel-vs-Sages spurious edge (midnight is a "fence").
+    expect(p).toMatch(/HARMONIZES/);
+    expect(p).toMatch(/not opposition when the sugya reconciles them/);
+  });
+
+  it('requires a clean speaker label for "name", never a move description', () => {
+    expect(p).toMatch(/CLEAN speaker label/);
+    expect(p).toMatch(/NEVER a description of the move/);
+  });
+});
+
+describe('ARGUMENT_VOICES_SYSTEM_PROMPT_HE (Hebrew parity)', () => {
+  const p = ARGUMENT_VOICES_SYSTEM_PROMPT_HE;
+
+  it('carries the same four rules (roles / sides / opposition / names)', () => {
+    expect(p).toMatch(/objector ולא respondent/);       // role reservation
+    expect(p).toMatch(/שמור על מספר side מינימלי/);       // minimal sides
+    expect(p).toMatch(/מחלוקת ממשית/);                    // opposes = real dispute
+    expect(p).toMatch(/תווית דובר נקייה/);                // clean speaker label
+  });
+});


### PR DESCRIPTION
Regression locks for the three voices-audit fixes (PRs #168, #169). No behavior change — extracts the gate decision into pure, unit-tested functions and adds tests.

## What moved
The voice-dispute-map gate logic was inline in the worker (`sectionHasNamedSpeaker`) and in the client's `useVoicesGate` (mapEligible / showVoiceMap / showFallback) — untestable. Extracted to pure functions in `src/lib/typing/profile.ts` (`sectionHasNamedSpeaker`, `voicesMapEligible`, `voicesShowMap`, `voicesShowFallback`); the worker and client now delegate to them.

## Tests added
- **`tests/typing/voicesGate.test.ts`** — the named-speaker signal + the gate, with cases named after the real regressions:
  - the Chullin 2a hallucination (opposes edge + zero named speakers) is suppressed;
  - the Gittin 90a dispute (opposes + named, non-narrative) is shown;
  - a missing/invalid voices graph that *resolved* falls back to the move-flow (no bare render);
  - map and fallback are mutually exclusive across **every** profile × graph × resolved combination.
- **`tests/voices-prompt.test.ts`** — asserts the v6 prompt (EN + HE) keeps the roles / sides / opposition / clean-name rules. The cache-identity snapshot only catches a `cache_version` bump, not silent deletion of the guidance.

`pnpm typecheck` clean; full suite 1634 pass (+34).