### PR TITLE
Rishonim mark: sync allowlist to the expanded set (+ fix dead Ramban entry)

### DIFF
--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -3448,11 +3448,14 @@ CODE_ENRICHMENTS.push(
 // rishonim mark + its synthesis enrichment
 //
 // Computed extractor (no LLM): pulls per-segment commentary from the existing
-// Sefaria links fetch in the worker, filtered to a hardcoded rishonim
-// allowlist (Rashi / Tosafot family / Ramban / Rashba / Ritva / Ran / Rosh /
-// Meiri / R. Chananel / R. Yonah / Yad Ramah / Or Zarua). One mark instance
-// per segment that has at least one rishon, with the per-rishon text
-// payloads attached for downstream synthesis.
+// Sefaria links fetch in the worker, filtered to the rishonim allowlist
+// (RISHONIM_TITLES in index.ts — Rashi / Tosafot family / R. Chananel /
+// R. Gershom / R. Yonah / Ri Migash / Ramban / Rashba / Ritva / Ran / Rosh /
+// Meiri / Rif / Yad Ramah / Or Zarua / Shita Mekubetzet / Baal HaMaor /
+// Ra'ah / Maharam / Mordechai / Maharsha — kept in step with the alignment
+// pool in sefaria/client.ts). One mark instance per segment that has at least
+// one rishon, with the per-rishon text payloads attached for downstream
+// synthesis.
 //
 // Renders as a per-segment gutter icon (left margin) — NOT inline — so dense
 // commentary doesn't clutter the daf body. Click opens the
@@ -3477,8 +3480,8 @@ CODE_MARKS.push({
   },
   dependencies: [],
   status: 'promoted',
-  def_hash: 'rishonim-v1',
-  cache_version: '1',
+  def_hash: 'rishonim-v2',
+  cache_version: '2',
   source: 'code',
   updated_at: NOW,
 });

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1521,27 +1521,61 @@ async function writeCachedResult(env: Bindings, key: string, result: RunResult):
  *  deterministic source (e.g. Sefaria) rather than an LLM. */
 type ComputedMarkFn = (env: Bindings, tractate: string, page: string) => Promise<{ instances: unknown[] }>;
 
-/** Hardcore rishonim allowlist for the `rishonim` mark. Sefaria's
+/** Rishonim allowlist for the `rishonim` mark. Sefaria's
  *  `category: 'Commentary'` sweeps in acharonim + modern works too — we
- *  filter down to the established Bavli rishonim. Match is on Sefaria's
- *  `collectiveTitle.en`. Add titles here as gaps surface. */
+ *  filter down to the established rishonim, kept in step with the
+ *  alignment-pool list in sefaria/client.ts.
+ *
+ *  Match is on Sefaria's `collectiveTitle.en`, and these are the RAW Sefaria
+ *  forms — which are NOT always the bare name:
+ *    - Ramban is "Chiddushei Ramban" (never bare "Ramban").
+ *    - Baal HaMaor is "HaMaor" (HaMaor HaGadol/HaKatan both collapse here).
+ *    - Maharsha is "Chidushei Halachot" / "Chidushei Agadot".
+ *    - The Rosh on Nedarim/Nazir is "Commentary of the Rosh".
+ *    - Ra'ah appears as both "Ra'ah" and "Chiddushei HaRa'ah".
+ *    - Mordechai is tractate-suffixed ("Mordechai on Bava Batra") so it's
+ *      matched by prefix (see RISHONIM_TITLE_PREFIXES), not exact title.
+ *  Add titles here as gaps surface. */
 const RISHONIM_TITLES = new Set<string>([
+  // Rashi + the Tosafot family
   'Rashi',
   'Tosafot',
   'Tosafot Yeshanim',
   'Tosafot Rid',
   'Tosafot HaRosh',
+  // Geonim / early rishonim
   'Rabbeinu Chananel',
-  'Ramban',
+  'Rabbeinu Gershom',
+  'Rabbeinu Yonah',
+  'Ri Migash',
+  // Core rishonim
+  'Chiddushei Ramban', // Ramban — Sefaria never keys this bare "Ramban"
   'Rashba',
   'Ritva',
   'Ran',
   'Rosh',
+  'Commentary of the Rosh', // the Rosh on Nedarim/Nazir
   'Meiri',
-  'Rabbeinu Yonah',
+  'Rif',
   'Yad Ramah',
   'Or Zarua',
+  'Shita Mekubetzet',
+  'HaMaor', // Baal HaMaor
+  "Ra'ah",
+  "Chiddushei HaRa'ah",
+  'Maharam', // Maharam of Rothenburg
+  // Maharsha is an acharon, surfaced here by the same deliberate choice that
+  // keeps it in the alignment-pool rishonim tier (sefaria/client.ts).
+  'Chidushei Halachot', // Maharsha (al ha-Shas)
+  'Chidushei Agadot', // Maharsha (al ha-Aggados)
 ]);
+
+/** Titles Sefaria stores tractate-suffixed (e.g. "Mordechai on Bava Batra"),
+ *  matched by prefix rather than exact `collectiveTitle.en`. */
+const RISHONIM_TITLE_PREFIXES = ['Mordechai'] as const;
+
+const isRishonTitle = (title: string): boolean =>
+  RISHONIM_TITLES.has(title) || RISHONIM_TITLE_PREFIXES.some((p) => title.startsWith(p));
 
 const COMPUTED_FNS: Record<string, ComputedMarkFn> = {
   'rishonim-from-sefaria': async (env, tractate, page) => {
@@ -1552,7 +1586,7 @@ const COMPUTED_FNS: Record<string, ComputedMarkFn> = {
     // for downstream synthesis.
     const bySeg = new Map<number, Array<{ work: string; workHe: string; textHe: string; textEn: string; sourceRef: string }>>();
     for (const work of result.works) {
-      if (!RISHONIM_TITLES.has(work.title)) continue;
+      if (!isRishonTitle(work.title)) continue;
       for (const c of work.comments) {
         const list = bySeg.get(c.anchorSegIdx) ?? [];
         list.push({ work: work.title, workHe: work.titleHe, textHe: c.textHe, textEn: c.textEn, sourceRef: c.sourceRef });


### PR DESCRIPTION
## What

The `rishonim` mark's extractor allowlist (`RISHONIM_TITLES` in `index.ts`) had drifted from the alignment-pool list in `sefaria/client.ts` — the latter was expanded in 50350ba ("Expand the Rishonim allowlist") but the mark never followed. So the gutter rishonim marks/anchors recognized a smaller, partly-stale set than the alignment pool. This syncs them.

The mark filters on Sefaria's raw `collectiveTitle.en`, which (verified live against `/api/links`) is **not** always the bare name — so this isn't a copy-paste of labels:

- **Fix dead `'Ramban'` entry** → `'Chiddushei Ramban'`. Sefaria never keys the Ramban bare, so the mark was silently capturing **no Ramban at all** on every daf.
- **Add** Rif, Ri Migash, Rabbeinu Gershom, Shita Mekubetzet, Baal HaMaor (`'HaMaor'`), Ra'ah (both `"Ra'ah"` and `"Chiddushei HaRa'ah"`), Maharam, Maharsha (`'Chidushei Halachot'` / `'Chidushei Agadot'`), and the Rosh-on-Nedarim/Nazir variant (`'Commentary of the Rosh'`).
- **Match Mordechai by prefix** — Sefaria stores it tractate-suffixed (`'Mordechai on Bava Batra'`), so an exact-Set match never fired.
- **Bump mark `cache_version` 1 → 2** so existing dapim re-extract with the new allowlist.

## Notes

- Maharsha is technically an *acharon*; it's included to match the deliberate "restore Maharsha" choice already made in the alignment-pool rishonim tier (`client.ts`). Maharam here is Maharam of Rothenburg (a rishon).
- Pre-existing entries `Rabbeinu Yonah` / `Or Zarua` were left as-is; they did not surface in spot-checks (may be inert under different Sefaria categorization), but they predate this change and are out of scope.

## Verification

- Forms confirmed against live Sefaria `/api/links` across Berakhot, Eruvin, Pesachim, Shabbat, Gittin, Nedarim, Ketubot, Kiddushin, Bava Batra, Bava Metzia, Sanhedrin, Chullin, Beitzah, Sukkah, Avodah Zarah.
- `pnpm typecheck` clean; `pnpm test` 1634 passing.