### PR TITLE
Rishonim mark: add Piskei Tosafot to the allowlist

### DIFF
--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -3480,8 +3480,8 @@ CODE_MARKS.push({
   },
   dependencies: [],
   status: 'promoted',
-  def_hash: 'rishonim-v2',
-  cache_version: '2',
+  def_hash: 'rishonim-v3',
+  cache_version: '3',
   source: 'code',
   updated_at: NOW,
 });

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1544,6 +1544,7 @@ const RISHONIM_TITLES = new Set<string>([
   'Tosafot Yeshanim',
   'Tosafot Rid',
   'Tosafot HaRosh',
+  'Piskei Tosafot', // Tosafot's halachic-ruling digest
   // Geonim / early rishonim
   'Rabbeinu Chananel',
   'Rabbeinu Gershom',


### PR DESCRIPTION
Adds 'Piskei Tosafot' (Tosafot's halachic-ruling digest) to the rishonim mark's `RISHONIM_TITLES` allowlist, completing the sync started in #171 — this was the one entry the earlier abandoned `expand-rishonim` branch had that #171 didn't carry over.

Bumps the mark `cache_version` 2 → 3 so existing dapim re-extract.

`pnpm typecheck` clean; `pnpm test` 1639 passing.