### PR TITLE
Halacha: codifier-anchored data layer (chain + derivation)

### DIFF
--- a/src/lib/halacha/codifiers.ts
+++ b/src/lib/halacha/codifiers.ts
@@ -1,0 +1,210 @@
+/**
+ * Codifier-anchored halacha: the data layer.
+ * ------------------------------------------
+ * The halacha redesign anchors each card on the law as it is actually CODIFIED
+ * (Mishneh Torah / Tur / Shulchan Aruch), not on topics guessed from the gemara.
+ * Sefaria already gives us the grounded links both ways:
+ *
+ *   forward  (daf  → codifiers): `fetchHalachicRefs` → `HalachicRefBundle`
+ *            (Sefaria `/api/related`, category "Halakhah", grouped by index_title)
+ *   reverse  (code → gemara sources, "where it comes from"): `/api/related` on a
+ *            code ref → its Talmud/Tanakh links.
+ *
+ * This module is the PURE classification + assembly over those shapes — no I/O,
+ * no client imports — so the worker (collection/enrichment) and the client
+ * (render) share one source of truth, and it is unit-tested against the real
+ * Sefaria link shapes.
+ *
+ * Two things the raw Sefaria data needs:
+ *   1. an ALLOWLIST — the "Halakhah" category is noisy (Sefer Mitzvot Gadol,
+ *      Halakhot Gedolot, Peninei Halakhah, Ben Ish Hai, Contemporary Halakhic
+ *      Problems, …). We keep only the canonical codifiers, matched by the
+ *      index_title PREFIX (codifier index_titles are "Mishneh Torah, <topic>",
+ *      "Tur, <section>", "Shulchan Arukh, <section>" — keyed by prefix, not by
+ *      tractate as the Rishonim are).
+ *   2. Bavli-PRIMARY marking — the reverse links mix the Bavli daf (the source
+ *      we care about) with Yerushalmi parallels and Tanakh roots.
+ */
+
+import type { HalachicRefBundle, HalachicSnippet } from '../sefref/sefaria/client';
+
+// ---------------------------------------------------------------------------
+// Codifier registry (forward: daf → codifiers)
+// ---------------------------------------------------------------------------
+
+export type CodifierId =
+  | 'mishneh-torah'
+  | 'tur'
+  | 'shulchan-aruch'
+  | 'mishnah-berurah'
+  | 'arukh-hashulchan';
+
+export type CodifierTier = 'primary' | 'secondary';
+
+export interface CodifierMeta {
+  id: CodifierId;
+  /** Display name of the work (e.g. "Shulchan Aruch"). */
+  label: string;
+  /** The author/short handle used in the lineage chip (e.g. "Mechaber"). */
+  short: string;
+  /** Chronological position in the lineage spine (lower = earlier). */
+  order: number;
+  tier: CodifierTier;
+  /** Matches the START of a Sefaria `index_title`. */
+  prefix: RegExp;
+}
+
+/**
+ * The canonical codifiers we anchor on, in lineage order. "primary" is the
+ * Rambam→Tur→SA spine every card is built from; "secondary" are the major
+ * Acharonim glosses we surface only when asked (they sharpen, they don't anchor).
+ *
+ * Sefaria spells Shulchan Aruch "Shulchan Arukh"; we match both. Rema is not a
+ * separate Sefaria index_title here (its glosses live inside / alongside the SA),
+ * so the Mechaber/Rema split is carried by the dispute enrichment, not by link
+ * classification — see the redesign notes.
+ */
+export const CODIFIERS: readonly CodifierMeta[] = [
+  { id: 'mishneh-torah', label: 'Mishneh Torah', short: 'Rambam', order: 1, tier: 'primary', prefix: /^Mishneh Torah\b/ },
+  { id: 'tur', label: 'Tur', short: 'Tur', order: 2, tier: 'primary', prefix: /^(?:Tur\b|Arba'ah Turim\b)/ },
+  { id: 'shulchan-aruch', label: 'Shulchan Aruch', short: 'Mechaber', order: 3, tier: 'primary', prefix: /^Shulchan Aru[ck]h\b/ },
+  { id: 'mishnah-berurah', label: 'Mishnah Berurah', short: 'Mishnah Berurah', order: 4, tier: 'secondary', prefix: /^Mishnah Berurah\b/ },
+  { id: 'arukh-hashulchan', label: 'Arukh HaShulchan', short: 'Arukh HaShulchan', order: 5, tier: 'secondary', prefix: /^Arukh HaShulchan\b/ },
+];
+
+/** Classify a Sefaria `index_title` to a canonical codifier, or null when it is
+ *  not one we anchor on (the bulk of the noisy "Halakhah" category). */
+export function classifyCodifier(indexTitle: string): CodifierMeta | null {
+  const title = (indexTitle ?? '').trim();
+  for (const c of CODIFIERS) if (c.prefix.test(title)) return c;
+  return null;
+}
+
+/** One codifier in the lineage, carrying every grounded ref+snippet that maps
+ *  to it (a codifier can appear under several Sefaria sub-books, e.g. "Mishneh
+ *  Torah, Reading the Shema" and "Mishneh Torah, Heave Offerings"). */
+export interface CodifierNode {
+  id: CodifierId;
+  label: string;
+  short: string;
+  order: number;
+  tier: CodifierTier;
+  /** Grounded refs (with text + daf anchors), in bundle order. */
+  refs: HalachicSnippet[];
+}
+
+/**
+ * Assemble the ordered codification chain from the already-cached
+ * `HalachicRefBundle` (keyed by Sefaria index_title). Keeps only allowlisted
+ * codifiers, merges a codifier's sub-books into one node, and orders the spine
+ * chronologically. `includeSecondary` adds the Acharonim glosses (off by
+ * default — the anchor is the primary spine).
+ */
+export function buildCodificationChain(
+  bundle: HalachicRefBundle | undefined,
+  opts: { includeSecondary?: boolean } = {},
+): CodifierNode[] {
+  if (!bundle) return [];
+  const byId = new Map<CodifierId, CodifierNode>();
+  for (const [indexTitle, snippets] of Object.entries(bundle)) {
+    const meta = classifyCodifier(indexTitle);
+    if (!meta) continue;
+    if (meta.tier === 'secondary' && !opts.includeSecondary) continue;
+    let node = byId.get(meta.id);
+    if (!node) {
+      node = { id: meta.id, label: meta.label, short: meta.short, order: meta.order, tier: meta.tier, refs: [] };
+      byId.set(meta.id, node);
+    }
+    for (const s of snippets) {
+      if (!node.refs.some((r) => r.ref === s.ref)) node.refs.push(s);
+    }
+  }
+  return Array.from(byId.values()).sort((a, b) => a.order - b.order);
+}
+
+/** True when a daf has any codifier anchor — i.e. is genuinely practical
+ *  halacha. The redesign suppresses cards on dapim with no codifier hit
+ *  (the aggadah over-fire). */
+export function hasCodification(bundle: HalachicRefBundle | undefined): boolean {
+  return buildCodificationChain(bundle, { includeSecondary: true }).length > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Derivation (reverse: code → gemara sources, "where it comes from")
+// ---------------------------------------------------------------------------
+
+export type SourceKind = 'bavli' | 'yerushalmi' | 'tanakh' | 'other';
+
+/** A Sefaria related-link as seen from a code ref (only the fields we use). */
+export interface RelatedLink {
+  ref: string;
+  category: string;
+}
+
+/** Classify a source ref returned when querying a code ref's related links.
+ *  Bavli is the source we care about; Yerushalmi/Tanakh are parallels/roots. */
+export function classifyShasSource(ref: string, category?: string): SourceKind {
+  const r = (ref ?? '').trim();
+  if (/^Jerusalem Talmud\b/i.test(r)) return 'yerushalmi';
+  if (category === 'Tanakh') return 'tanakh';
+  if (category === 'Talmud') return 'bavli';
+  return 'other';
+}
+
+/** Strip a Bavli ref down to its "Tractate Daf" base, dropping the trailing
+ *  segment / range — including amud-spanning ranges (e.g. "Berakhot 2a:1-3" →
+ *  "Berakhot 2a", "Sanhedrin 2a:1-2b:2" → "Sanhedrin 2a"). Falls back to
+ *  trimming a trailing ":N" when there's no daf-form match. */
+export function baseDafRef(ref: string): string {
+  const r = (ref ?? '').trim();
+  const m = r.match(/^(.+?\s\d+[ab])\b/);
+  return m ? m[1] : r.replace(/:\d+(?:-\d+)?$/, '');
+}
+
+export type DerivationRole = 'primary' | 'related' | 'root';
+
+export interface DerivationSource {
+  /** Base ref ("Berakhot 2a", "Leviticus 19:5"). */
+  ref: string;
+  kind: SourceKind;
+  role: DerivationRole;
+  /** True when this is the daf currently being viewed. */
+  isCurrent: boolean;
+}
+
+function roleFor(kind: SourceKind): DerivationRole {
+  if (kind === 'bavli') return 'primary';
+  if (kind === 'tanakh') return 'root';
+  return 'related';
+}
+
+/**
+ * Build the "where it comes from" source list from a code ref's related links.
+ * Bavli dapim become primary sources, Yerushalmi are related, Tanakh are roots;
+ * the daf currently being read is flagged `isCurrent`. Deduped to base refs and
+ * ordered primary → related → root, current daf first within its group.
+ */
+export function buildDerivation(
+  links: RelatedLink[],
+  current?: { tractate: string; page: string },
+): DerivationSource[] {
+  const curBase = current ? `${current.tractate} ${current.page}`.trim() : null;
+  const seen = new Set<string>();
+  const out: DerivationSource[] = [];
+  for (const l of links ?? []) {
+    const kind = classifyShasSource(l.ref, l.category);
+    if (kind === 'other') continue;
+    // Only Bavli refs collapse to the daf; Yerushalmi (chapter:halacha:segment)
+    // and Tanakh (verse-precise) refs are kept whole.
+    const ref = kind === 'bavli' ? baseDafRef(l.ref) : (l.ref ?? '').trim();
+    if (!ref || seen.has(ref)) continue;
+    seen.add(ref);
+    out.push({ ref, kind, role: roleFor(kind), isCurrent: curBase != null && ref === curBase });
+  }
+  const roleRank: Record<DerivationRole, number> = { primary: 0, related: 1, root: 2 };
+  return out.sort((a, b) => {
+    if (a.role !== b.role) return roleRank[a.role] - roleRank[b.role];
+    if (a.isCurrent !== b.isCurrent) return a.isCurrent ? -1 : 1; // current daf leads its group
+    return a.ref.localeCompare(b.ref);
+  });
+}

--- a/tests/halacha-codifiers.test.ts
+++ b/tests/halacha-codifiers.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import {
+  classifyCodifier, buildCodificationChain, hasCodification, CODIFIERS,
+  classifyShasSource, baseDafRef, buildDerivation,
+  type RelatedLink,
+} from '../src/lib/halacha/codifiers';
+import type { HalachicRefBundle } from '../src/lib/sefref/sefaria/client';
+
+// Fixtures below are the SHAPES observed live from Sefaria (/api/related):
+// index_titles like "Mishneh Torah, Reading the Shema", "Tur, Orach Chayim",
+// "Shulchan Arukh, Orach Chayim", plus the noise we must filter out, and the
+// reverse Talmud/Tanakh sources for a code ref.
+
+describe('classifyCodifier', () => {
+  it('matches the canonical codifiers by index_title prefix', () => {
+    expect(classifyCodifier('Mishneh Torah, Reading the Shema')?.id).toBe('mishneh-torah');
+    expect(classifyCodifier('Mishneh Torah, Ritual Slaughter')?.id).toBe('mishneh-torah');
+    expect(classifyCodifier('Tur, Orach Chayim')?.id).toBe('tur');
+    expect(classifyCodifier('Tur, Choshen Mishpat')?.id).toBe('tur');
+    expect(classifyCodifier('Shulchan Arukh, Orach Chayim')?.id).toBe('shulchan-aruch');
+    expect(classifyCodifier('Shulchan Aruch, Yoreh Deah')?.id).toBe('shulchan-aruch'); // alt spelling
+    expect(classifyCodifier('Mishnah Berurah')?.id).toBe('mishnah-berurah');
+    expect(classifyCodifier("Arukh HaShulchan, Yoreh De'ah")?.id).toBe('arukh-hashulchan');
+  });
+
+  it('rejects the noisy "Halakhah" non-codifiers', () => {
+    for (const noise of [
+      'Sefer Mitzvot Gadol, Positive Commandments',
+      'Halakhot Gedolot',
+      'Sefer Yereim',
+      'Peninei Halakhah, Prayer',
+      'Ben Ish Hai, Halachot',
+      'Sefer HaChinukh',
+      'Contemporary Halakhic Problems, Vol IV, Chapter XIII',
+      'Ohr Zarua, Volume I',
+    ]) {
+      expect(classifyCodifier(noise)).toBeNull();
+    }
+  });
+
+  it('tiers the big-three as primary and the glosses as secondary', () => {
+    const primary = CODIFIERS.filter((c) => c.tier === 'primary').map((c) => c.id);
+    expect(primary).toEqual(['mishneh-torah', 'tur', 'shulchan-aruch']);
+  });
+});
+
+describe('buildCodificationChain', () => {
+  // Berakhot 2a (evening Shema) as the bundle arrives today: a mix of canonical
+  // codifiers (under several MT sub-books) and noise.
+  const bundle: HalachicRefBundle = {
+    'Mishneh Torah, Reading the Shema': [{ ref: 'Mishneh Torah, Reading the Shema 1:9', hebrew: 'he', english: 'en' }],
+    'Mishneh Torah, Heave Offerings': [{ ref: 'Mishneh Torah, Heave Offerings 7:2', hebrew: 'he', english: 'en' }],
+    'Tur, Orach Chayim': [{ ref: 'Tur, Orach Chayim 235', hebrew: 'he', english: 'en' }],
+    'Shulchan Arukh, Orach Chayim': [{ ref: 'Shulchan Arukh, Orach Chayim 235:1', hebrew: 'he', english: 'en' }],
+    'Sefer Mitzvot Gadol, Positive Commandments': [{ ref: 'Sefer Mitzvot Gadol, Positive Commandments 18', hebrew: 'he', english: 'en' }],
+    'Mishnah Berurah': [{ ref: 'Mishnah Berurah 235:1', hebrew: 'he', english: 'en' }],
+  };
+
+  it('keeps only allowlisted codifiers, ordered chronologically, by default primary-only', () => {
+    const chain = buildCodificationChain(bundle);
+    expect(chain.map((n) => n.id)).toEqual(['mishneh-torah', 'tur', 'shulchan-aruch']);
+    expect(chain.map((n) => n.short)).toEqual(['Rambam', 'Tur', 'Mechaber']);
+  });
+
+  it("merges a codifier's sub-books into one node", () => {
+    const chain = buildCodificationChain(bundle);
+    const mt = chain.find((n) => n.id === 'mishneh-torah')!;
+    expect(mt.refs.map((r) => r.ref)).toEqual([
+      'Mishneh Torah, Reading the Shema 1:9',
+      'Mishneh Torah, Heave Offerings 7:2',
+    ]);
+  });
+
+  it('adds the secondary glosses only when asked', () => {
+    const chain = buildCodificationChain(bundle, { includeSecondary: true });
+    expect(chain.map((n) => n.id)).toEqual(['mishneh-torah', 'tur', 'shulchan-aruch', 'mishnah-berurah']);
+  });
+
+  it('returns empty for a bundle with no codifiers (the aggadah case)', () => {
+    const aggadic: HalachicRefBundle = {
+      'Sefer Yereim': [{ ref: 'Sefer Yereim 300:1', hebrew: 'he', english: 'en' }],
+      'Ohr Zarua, Volume I': [{ ref: 'Ohr Zarua, Volume I 1:1', hebrew: 'he', english: 'en' }],
+    };
+    expect(buildCodificationChain(aggadic)).toEqual([]);
+    expect(hasCodification(aggadic)).toBe(false);
+    expect(hasCodification(bundle)).toBe(true);
+    expect(hasCodification(undefined)).toBe(false);
+  });
+});
+
+describe('classifyShasSource + baseDafRef', () => {
+  it('distinguishes Bavli, Yerushalmi, Tanakh', () => {
+    expect(classifyShasSource('Berakhot 2a:1', 'Talmud')).toBe('bavli');
+    expect(classifyShasSource('Jerusalem Talmud Berakhot 1:1:1', 'Talmud')).toBe('yerushalmi');
+    expect(classifyShasSource('Leviticus 19:5', 'Tanakh')).toBe('tanakh');
+    expect(classifyShasSource('Rashi on Berakhot 2a', 'Commentary')).toBe('other');
+  });
+
+  it('collapses a Talmud ref to its daf', () => {
+    expect(baseDafRef('Berakhot 2a:1-3')).toBe('Berakhot 2a');
+    expect(baseDafRef('Sanhedrin 2a:1-2b:2')).toBe('Sanhedrin 2a'); // range across amudim → first
+    expect(baseDafRef('Shabbat 35b:2')).toBe('Shabbat 35b');
+  });
+});
+
+describe('buildDerivation', () => {
+  // Reverse links observed for "Mishneh Torah, Reading the Shema 1:9".
+  const links: RelatedLink[] = [
+    { ref: 'Shabbat 34b', category: 'Talmud' },
+    { ref: 'Pesachim 94a', category: 'Talmud' },
+    { ref: 'Berakhot 2a:1', category: 'Talmud' },
+    { ref: 'Berakhot 2a:2', category: 'Talmud' },
+    { ref: 'Berakhot 2a:3', category: 'Talmud' },
+    { ref: 'Jerusalem Talmud Berakhot 1:1:1', category: 'Talmud' },
+    { ref: 'Leviticus 19:5', category: 'Tanakh' },
+    { ref: 'Rashi on Berakhot 2a', category: 'Commentary' }, // dropped
+  ];
+
+  it('dedupes to base dapim, marks the current daf, orders primary→related→root', () => {
+    const d = buildDerivation(links, { tractate: 'Berakhot', page: '2a' });
+    expect(d.map((s) => s.ref)).toEqual([
+      'Berakhot 2a',                  // primary + current → first
+      'Pesachim 94a',                 // primary
+      'Shabbat 34b',                  // primary
+      'Jerusalem Talmud Berakhot 1:1:1', // related (yerushalmi)
+      'Leviticus 19:5',               // root (tanakh)
+    ]);
+    const current = d.find((s) => s.isCurrent)!;
+    expect(current).toMatchObject({ ref: 'Berakhot 2a', kind: 'bavli', role: 'primary', isCurrent: true });
+    expect(d.filter((s) => s.isCurrent)).toHaveLength(1);
+    expect(d.find((s) => s.kind === 'tanakh')!.role).toBe('root');
+  });
+
+  it('drops commentary/other and survives no-current', () => {
+    const d = buildDerivation(links);
+    expect(d.some((s) => s.ref.startsWith('Rashi'))).toBe(false);
+    expect(d.every((s) => !s.isCurrent)).toBe(true);
+  });
+});


### PR DESCRIPTION
First PR of the halacha redesign. A **pure, fully-tested data layer** that anchors halacha on the law as it is actually **codified** (Mishneh Torah / Tur / Shulchan Aruch) instead of topics guessed from the gemara. No I/O, no UI, no cache changes — zero risk to existing behavior; it nails down the data shape the rest of the redesign consumes.

### What's here (`src/lib/halacha/codifiers.ts`)
- **`CODIFIERS` registry + `classifyCodifier`** — allowlist the canonical codifiers by Sefaria `index_title` prefix, filtering out the noisy `Halakhah` category (Sefer Mitzvot Gadol, Halakhot Gedolot, Peninei Halakhah, Ben Ish Hai, Contemporary Halakhic Problems, …).
- **`buildCodificationChain`** — assemble the ordered Rambam→Tur→SA spine from the already-cached `HalachicRefBundle`, merging a codifier's sub-books into one node; primary-only by default, opt-in secondary glosses (Mishnah Berurah / Arukh HaShulchan).
- **`hasCodification`** — gates the aggadah over-fire: no codifier hit → no halacha card.
- **`classifyShasSource` / `baseDafRef` / `buildDerivation`** — the reverse "where it comes from": classify a code ref's Talmud/Tanakh sources; Bavli = primary, Yerushalmi = related, Tanakh = root; the current daf is marked and leads.

### Why this is safe / grounded
The data both directions was **probed live against Sefaria** before building — forward links match or sharpen the refs the LLM had been asserting (Berakhot 2a → SA OC 235:1, Sanhedrin 2a → SA CM 3:1, Chullin 42a → 16+ YD refs), and reverse derivation works (MT Reading the Shema 1:9 → Berakhot 2a + Shabbat 34b / Pesachim 94a). Tests use those real link shapes.

### Next PRs
2. Generalize `ArgumentVoiceMap` → shared lineage/codification map (renders this chain + relation edges).
3. Codifier-first collection: wire the grounded refs into the halacha prompts.
4. `derivation` enrichment ("where it comes from").
5. Retire pills + disputes block, recipe wiring, `cache_version` bump + re-warm.

`pnpm typecheck` clean; `pnpm test` 1650 passed (incl. 11 new).