### PR TITLE
Rabbi colors: two-tier chronological spectrum (red pre-Geonim, blue Geonim+)

### DIFF
--- a/src/client/GenerationTimeline.tsx
+++ b/src/client/GenerationTimeline.tsx
@@ -1,5 +1,5 @@
 import { createMemo, For, Show, type JSX } from 'solid-js';
-import { GENERATIONS, type GenerationGroup, type GenerationId } from './generations';
+import { GENERATIONS, GENERATION_BY_ID, type GenerationGroup, type GenerationId } from './generations';
 import type { GenerationRabbi } from './injectRabbiUnderlines';
 
 export interface GenerationTimelineProps {
@@ -37,15 +37,17 @@ interface AmoraSlot {
   era: string;
 }
 
+// Colors come from the computed generation spectrum (keyed by primaryId) so
+// the timeline can't drift from the underline palette.
 const AMORA_SLOTS: AmoraSlot[] = [
-  { primaryId: 'amora-bavel-1', ids: ['amora-ey-1', 'amora-bavel-1'], color: '#7c2d12', label: 'Amora (1)', era: 'c. 220 – 250 CE' },
-  { primaryId: 'amora-bavel-2', ids: ['amora-ey-2', 'amora-bavel-2'], color: '#9a3412', label: 'Amora (2)', era: 'c. 250 – 290 CE' },
-  { primaryId: 'amora-bavel-3', ids: ['amora-ey-3', 'amora-bavel-3'], color: '#c2410c', label: 'Amora (3)', era: 'c. 290 – 320 CE' },
-  { primaryId: 'amora-bavel-4', ids: ['amora-ey-4', 'amora-bavel-4'], color: '#ea580c', label: 'Amora (4)', era: 'c. 320 – 350 CE' },
-  { primaryId: 'amora-bavel-5', ids: ['amora-ey-5', 'amora-bavel-5'], color: '#f97316', label: 'Amora (5)', era: 'c. 350 – 400 CE' },
-  { primaryId: 'amora-bavel-6', ids: ['amora-bavel-6'],                color: '#fb923c', label: 'Amora (6)', era: 'c. 375 – 427 CE' },
-  { primaryId: 'amora-bavel-7', ids: ['amora-bavel-7'],                color: '#fdba74', label: 'Amora (7)', era: 'c. 427 – 460 CE' },
-  { primaryId: 'amora-bavel-8', ids: ['amora-bavel-8'],                color: '#fed7aa', label: 'Amora (8)', era: 'c. 460 – 500 CE' },
+  { primaryId: 'amora-bavel-1', ids: ['amora-ey-1', 'amora-bavel-1'], color: GENERATION_BY_ID['amora-bavel-1'].color, label: 'Amora (1)', era: 'c. 220 – 250 CE' },
+  { primaryId: 'amora-bavel-2', ids: ['amora-ey-2', 'amora-bavel-2'], color: GENERATION_BY_ID['amora-bavel-2'].color, label: 'Amora (2)', era: 'c. 250 – 290 CE' },
+  { primaryId: 'amora-bavel-3', ids: ['amora-ey-3', 'amora-bavel-3'], color: GENERATION_BY_ID['amora-bavel-3'].color, label: 'Amora (3)', era: 'c. 290 – 320 CE' },
+  { primaryId: 'amora-bavel-4', ids: ['amora-ey-4', 'amora-bavel-4'], color: GENERATION_BY_ID['amora-bavel-4'].color, label: 'Amora (4)', era: 'c. 320 – 350 CE' },
+  { primaryId: 'amora-bavel-5', ids: ['amora-ey-5', 'amora-bavel-5'], color: GENERATION_BY_ID['amora-bavel-5'].color, label: 'Amora (5)', era: 'c. 350 – 400 CE' },
+  { primaryId: 'amora-bavel-6', ids: ['amora-bavel-6'],                color: GENERATION_BY_ID['amora-bavel-6'].color, label: 'Amora (6)', era: 'c. 375 – 427 CE' },
+  { primaryId: 'amora-bavel-7', ids: ['amora-bavel-7'],                color: GENERATION_BY_ID['amora-bavel-7'].color, label: 'Amora (7)', era: 'c. 427 – 460 CE' },
+  { primaryId: 'amora-bavel-8', ids: ['amora-bavel-8'],                color: GENERATION_BY_ID['amora-bavel-8'].color, label: 'Amora (8)', era: 'c. 460 – 500 CE' },
 ];
 
 function gensByGroup(group: GenerationGroup) {
@@ -203,7 +205,7 @@ export function GenerationTimeline(props: GenerationTimelineProps): JSX.Element 
             <span style={{
               display: 'inline-block', width: '0.65rem', height: '0.65rem',
               'border-radius': '50%',
-              border: '2px solid #d6d3d1', 'border-top-color': '#7c2d12',
+              border: '2px solid #d6d3d1', 'border-top-color': GENERATION_BY_ID['zugim'].color,
               animation: 'daf-spin 0.8s linear infinite',
               'flex-shrink': 0,
             }} />

--- a/src/client/RabbiTreeStrip.tsx
+++ b/src/client/RabbiTreeStrip.tsx
@@ -1,5 +1,5 @@
 import { createMemo, createSignal, createEffect, For, Show, onCleanup, type JSX } from 'solid-js';
-import { GENERATION_BY_ID, type GenerationId } from './generations';
+import { GENERATION_BY_ID, legibleTextColor, type GenerationId } from './generations';
 import rabbiHierarchyData from '../lib/data/rabbi-hierarchy.json';
 import { t } from './i18n';
 
@@ -88,18 +88,10 @@ function generationChronoRank(gen: string): number {
   return m ? Number(m[1]) : 0;
 }
 
-// Generation IDs whose color swatch is too pale for white text — for
-// these we render the B/E letter in dark ink instead so it stays
-// legible inside the compact collapsed block.
-const PALE_GEN_IDS: ReadonlySet<string> = new Set([
-  'tanna-6',
-  'amora-bavel-7',
-  'amora-bavel-8',
-  'unknown',
-]);
-
+// Pick dark vs white ink for the B/E letter based on the swatch's luminance,
+// so it stays legible on the pale end of the spectrum without a hand-kept list.
 function blockTextColor(gen: string): string {
-  return PALE_GEN_IDS.has(gen) ? '#1f2937' : '#fff';
+  return legibleTextColor(GENERATION_BY_ID[gen as GenerationId]?.color ?? '#888');
 }
 
 type ColumnRow =

--- a/src/client/generations.ts
+++ b/src/client/generations.ts
@@ -1,8 +1,18 @@
 /**
- * Standard taxonomy of Talmudic sages by era and generation. Used by the
- * /api/generations endpoint (server-side schema) and the client-side underline
- * injection + legend. Keep this file plain TS (no DOM), safe to import in
- * both the worker and the client.
+ * Standard taxonomy of Talmudic (and post-Talmudic) sages by era and
+ * generation. Used by the /api/generations endpoint (server-side schema) and
+ * the client-side underline injection + legend. Keep this file plain TS (no
+ * DOM), safe to import in both the worker and the client.
+ *
+ * Color model — a TWO-TIER chronological spectrum:
+ *   - Everyone BEFORE the Geonim (Zugim, Tannaim, Amoraim, Savoraim) renders
+ *     on a RED spectrum.
+ *   - The Geonim and everyone after them (Geonim, Rishonim, Achronim) render
+ *     on a BLUE spectrum.
+ * Within each tier the shade runs dark (earlier) -> light (later). 'unknown'
+ * is a neutral gray. Colors are COMPUTED from each generation's tier + rank
+ * (see buildColor below) rather than hand-maintained, so the spectrum can't
+ * drift out of order.
  */
 
 export type GenerationId =
@@ -13,58 +23,152 @@ export type GenerationId =
   | 'amora-bavel-4' | 'amora-bavel-5' | 'amora-bavel-6'
   | 'amora-bavel-7' | 'amora-bavel-8'
   | 'savora'
+  | 'geonim' | 'rishonim' | 'achronim'
   | 'unknown';
 
-export type GenerationGroup = 'zugim' | 'tanna' | 'amora-ey' | 'amora-bavel' | 'savora' | 'unknown';
+export type GenerationGroup =
+  | 'zugim' | 'tanna' | 'amora-ey' | 'amora-bavel' | 'savora'
+  | 'geonim' | 'rishonim' | 'achronim'
+  | 'unknown';
+
+/** Which spectrum a generation sits on. 'early' = pre-Geonim (red),
+ *  'late' = Geonim and after (blue), 'none' = neutral (unknown). */
+export type GenerationTier = 'early' | 'late' | 'none';
 
 export interface GenerationInfo {
   id: GenerationId;
   group: GenerationGroup;
   label: string;        // Short display label
   era: string;          // Rough date range
-  color: string;        // Hex color for underline + legend swatch
+  tier: GenerationTier; // Which color spectrum this generation sits on
+  color: string;        // Computed hex color for underline + legend swatch
 }
 
-export const GENERATIONS: GenerationInfo[] = [
-  { id: 'zugim',          group: 'zugim',        label: 'Zugim',          era: 'c. 170 BCE – 10 CE', color: '#4338ca' },
+// ---------------------------------------------------------------------------
+// Spectrum endpoints. Each tier interpolates dark (earliest) -> light (latest).
+// ---------------------------------------------------------------------------
+const EARLY_DARK = '#7f1d1d';  // red-900   — earliest pre-Geonim (Zugim)
+const EARLY_LIGHT = '#fca5a5'; // red-300   — latest pre-Geonim (Savoraim)
+const LATE_DARK = '#1e3a8a';   // blue-900  — earliest post-Talmudic (Geonim)
+const LATE_LIGHT = '#93c5fd';  // blue-300  — latest (Achronim)
+const NEUTRAL = '#d1d5db';     // gray-300  — unknown
 
-  // Tannaim — hue 210 (blue), lightness increasing over generations
-  { id: 'tanna-1',        group: 'tanna',        label: 'Tanna (1)',      era: 'c. 10 – 80 CE',      color: '#1e3a8a' },
-  { id: 'tanna-2',        group: 'tanna',        label: 'Tanna (2)',      era: 'c. 80 – 120 CE',     color: '#1e40af' },
-  { id: 'tanna-3',        group: 'tanna',        label: 'Tanna (3)',      era: 'c. 120 – 140 CE',    color: '#2563eb' },
-  { id: 'tanna-4',        group: 'tanna',        label: 'Tanna (4)',      era: 'c. 140 – 165 CE',    color: '#3b82f6' },
-  { id: 'tanna-5',        group: 'tanna',        label: 'Tanna (5)',      era: 'c. 165 – 200 CE',    color: '#60a5fa' },
-  { id: 'tanna-6',        group: 'tanna',        label: 'Tanna (6)',      era: 'c. 200 – 220 CE',    color: '#93c5fd' },
+function hexToRgb(hex: string): [number, number, number] {
+  const n = parseInt(hex.slice(1), 16);
+  return [(n >> 16) & 0xff, (n >> 8) & 0xff, n & 0xff];
+}
 
-  // Amoraim Eretz Yisrael — same palette as Bavel per chronological gen
-  // (we no longer distinguish EY vs Bavel in the timeline or underline colors)
-  { id: 'amora-ey-1',     group: 'amora-ey',     label: 'Amora E.Y. (1)', era: 'c. 220 – 250 CE',    color: '#7c2d12' },
-  { id: 'amora-ey-2',     group: 'amora-ey',     label: 'Amora E.Y. (2)', era: 'c. 250 – 290 CE',    color: '#9a3412' },
-  { id: 'amora-ey-3',     group: 'amora-ey',     label: 'Amora E.Y. (3)', era: 'c. 290 – 320 CE',    color: '#c2410c' },
-  { id: 'amora-ey-4',     group: 'amora-ey',     label: 'Amora E.Y. (4)', era: 'c. 320 – 360 CE',    color: '#ea580c' },
-  { id: 'amora-ey-5',     group: 'amora-ey',     label: 'Amora E.Y. (5)', era: 'c. 360 – 400 CE',    color: '#f97316' },
+function rgbToHex(r: number, g: number, b: number): string {
+  const h = (v: number) => Math.round(v).toString(16).padStart(2, '0');
+  return `#${h(r)}${h(g)}${h(b)}`;
+}
 
-  // Amoraim Bavel — hue 25 (amber → red)
-  { id: 'amora-bavel-1',  group: 'amora-bavel',  label: 'Amora Bavel (1)', era: 'c. 220 – 250 CE',   color: '#7c2d12' },
-  { id: 'amora-bavel-2',  group: 'amora-bavel',  label: 'Amora Bavel (2)', era: 'c. 250 – 290 CE',   color: '#9a3412' },
-  { id: 'amora-bavel-3',  group: 'amora-bavel',  label: 'Amora Bavel (3)', era: 'c. 290 – 320 CE',   color: '#c2410c' },
-  { id: 'amora-bavel-4',  group: 'amora-bavel',  label: 'Amora Bavel (4)', era: 'c. 320 – 350 CE',   color: '#ea580c' },
-  { id: 'amora-bavel-5',  group: 'amora-bavel',  label: 'Amora Bavel (5)', era: 'c. 350 – 375 CE',   color: '#f97316' },
-  { id: 'amora-bavel-6',  group: 'amora-bavel',  label: 'Amora Bavel (6)', era: 'c. 375 – 427 CE',   color: '#fb923c' },
-  { id: 'amora-bavel-7',  group: 'amora-bavel',  label: 'Amora Bavel (7)', era: 'c. 427 – 460 CE',   color: '#fdba74' },
-  { id: 'amora-bavel-8',  group: 'amora-bavel',  label: 'Amora Bavel (8)', era: 'c. 460 – 500 CE',   color: '#fed7aa' },
+/** Linear sRGB interpolation between two hex colors. t in [0, 1]. */
+function lerpHex(a: string, b: string, t: number): string {
+  const [ar, ag, ab] = hexToRgb(a);
+  const [br, bg, bb] = hexToRgb(b);
+  return rgbToHex(ar + (br - ar) * t, ag + (bg - ag) * t, ab + (bb - ab) * t);
+}
 
-  { id: 'savora',         group: 'savora',       label: 'Savora',          era: 'c. 500 – 600 CE',   color: '#475569' },
-  { id: 'unknown',        group: 'unknown',      label: 'Unknown',         era: '',                    color: '#d1d5db' },
+// Seed table: chronological `rank` within each tier drives the shade. EY and
+// Bavel amoraim of the same generation share a rank (we don't distinguish them
+// by hue). Ranks need not be contiguous — only their min/max per tier matter.
+interface GenSeed {
+  id: GenerationId;
+  group: GenerationGroup;
+  label: string;
+  era: string;
+  tier: GenerationTier;
+  rank: number;
+}
+
+const SEEDS: GenSeed[] = [
+  { id: 'zugim',         group: 'zugim',       label: 'Zugim',           era: 'c. 170 BCE – 10 CE', tier: 'early', rank: 0 },
+
+  { id: 'tanna-1',       group: 'tanna',       label: 'Tanna (1)',       era: 'c. 10 – 80 CE',      tier: 'early', rank: 1 },
+  { id: 'tanna-2',       group: 'tanna',       label: 'Tanna (2)',       era: 'c. 80 – 120 CE',     tier: 'early', rank: 2 },
+  { id: 'tanna-3',       group: 'tanna',       label: 'Tanna (3)',       era: 'c. 120 – 140 CE',    tier: 'early', rank: 3 },
+  { id: 'tanna-4',       group: 'tanna',       label: 'Tanna (4)',       era: 'c. 140 – 165 CE',    tier: 'early', rank: 4 },
+  { id: 'tanna-5',       group: 'tanna',       label: 'Tanna (5)',       era: 'c. 165 – 200 CE',    tier: 'early', rank: 5 },
+  { id: 'tanna-6',       group: 'tanna',       label: 'Tanna (6)',       era: 'c. 200 – 220 CE',    tier: 'early', rank: 6 },
+
+  // Amoraim — EY and Bavel of the same generation share a chronological rank.
+  { id: 'amora-ey-1',    group: 'amora-ey',    label: 'Amora E.Y. (1)',  era: 'c. 220 – 250 CE',    tier: 'early', rank: 7 },
+  { id: 'amora-ey-2',    group: 'amora-ey',    label: 'Amora E.Y. (2)',  era: 'c. 250 – 290 CE',    tier: 'early', rank: 8 },
+  { id: 'amora-ey-3',    group: 'amora-ey',    label: 'Amora E.Y. (3)',  era: 'c. 290 – 320 CE',    tier: 'early', rank: 9 },
+  { id: 'amora-ey-4',    group: 'amora-ey',    label: 'Amora E.Y. (4)',  era: 'c. 320 – 360 CE',    tier: 'early', rank: 10 },
+  { id: 'amora-ey-5',    group: 'amora-ey',    label: 'Amora E.Y. (5)',  era: 'c. 360 – 400 CE',    tier: 'early', rank: 11 },
+
+  { id: 'amora-bavel-1', group: 'amora-bavel', label: 'Amora Bavel (1)', era: 'c. 220 – 250 CE',    tier: 'early', rank: 7 },
+  { id: 'amora-bavel-2', group: 'amora-bavel', label: 'Amora Bavel (2)', era: 'c. 250 – 290 CE',    tier: 'early', rank: 8 },
+  { id: 'amora-bavel-3', group: 'amora-bavel', label: 'Amora Bavel (3)', era: 'c. 290 – 320 CE',    tier: 'early', rank: 9 },
+  { id: 'amora-bavel-4', group: 'amora-bavel', label: 'Amora Bavel (4)', era: 'c. 320 – 350 CE',    tier: 'early', rank: 10 },
+  { id: 'amora-bavel-5', group: 'amora-bavel', label: 'Amora Bavel (5)', era: 'c. 350 – 375 CE',    tier: 'early', rank: 11 },
+  { id: 'amora-bavel-6', group: 'amora-bavel', label: 'Amora Bavel (6)', era: 'c. 375 – 427 CE',    tier: 'early', rank: 12 },
+  { id: 'amora-bavel-7', group: 'amora-bavel', label: 'Amora Bavel (7)', era: 'c. 427 – 460 CE',    tier: 'early', rank: 13 },
+  { id: 'amora-bavel-8', group: 'amora-bavel', label: 'Amora Bavel (8)', era: 'c. 460 – 500 CE',    tier: 'early', rank: 14 },
+
+  { id: 'savora',        group: 'savora',      label: 'Savora',          era: 'c. 500 – 600 CE',    tier: 'early', rank: 15 },
+
+  // Post-Talmudic — the BLUE tier. Rarely appear in the Bavli text itself;
+  // surface mainly when a quoted commentary (Rashi/Tosafot) names a later
+  // authority, and — looking ahead — on halacha-mark codifier names.
+  { id: 'geonim',        group: 'geonim',      label: 'Geonim',          era: 'c. 589 – 1038 CE',   tier: 'late', rank: 0 },
+  { id: 'rishonim',      group: 'rishonim',    label: 'Rishonim',        era: 'c. 1038 – 1500 CE',  tier: 'late', rank: 1 },
+  { id: 'achronim',      group: 'achronim',    label: 'Achronim',        era: 'c. 1500 CE –',       tier: 'late', rank: 2 },
+
+  { id: 'unknown',       group: 'unknown',     label: 'Unknown',         era: '',                   tier: 'none', rank: 0 },
 ];
+
+function tierRange(tier: GenerationTier): [number, number] {
+  const ranks = SEEDS.filter((s) => s.tier === tier).map((s) => s.rank);
+  return [Math.min(...ranks), Math.max(...ranks)];
+}
+
+const EARLY_RANGE = tierRange('early');
+const LATE_RANGE = tierRange('late');
+
+function buildColor(tier: GenerationTier, rank: number): string {
+  if (tier === 'none') return NEUTRAL;
+  const [min, max] = tier === 'early' ? EARLY_RANGE : LATE_RANGE;
+  const [dark, light] = tier === 'early' ? [EARLY_DARK, EARLY_LIGHT] : [LATE_DARK, LATE_LIGHT];
+  const t = max === min ? 0 : (rank - min) / (max - min);
+  return lerpHex(dark, light, t);
+}
+
+export const GENERATIONS: GenerationInfo[] = SEEDS.map((s) => ({
+  id: s.id,
+  group: s.group,
+  label: s.label,
+  era: s.era,
+  tier: s.tier,
+  color: buildColor(s.tier, s.rank),
+}));
 
 export const GENERATION_BY_ID: Record<GenerationId, GenerationInfo> =
   Object.fromEntries(GENERATIONS.map((g) => [g.id, g])) as Record<GenerationId, GenerationInfo>;
 
 export const GENERATION_IDS: GenerationId[] = GENERATIONS.map((g) => g.id);
 
+/** Hex color for a generation id (falls back to neutral gray). Convenience
+ *  wrapper over GENERATION_BY_ID for callers that only need the swatch. */
+export function colorForGeneration(id: GenerationId | string | null | undefined): string {
+  if (!id) return NEUTRAL;
+  return GENERATION_BY_ID[id as GenerationId]?.color ?? NEUTRAL;
+}
+
+/** Pick a legible foreground (dark ink vs white) for text drawn on top of a
+ *  generation swatch. Uses relative luminance so it tracks the computed
+ *  spectrum automatically (no hand-maintained "pale id" list to drift). */
+export function legibleTextColor(bgHex: string): string {
+  const [r, g, b] = hexToRgb(bgHex);
+  // Perceptual luminance (sRGB-weighted, 0..1).
+  const lum = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
+  return lum > 0.6 ? '#1f2937' : '#fff';
+}
+
 /** Hebrew display label for a generation, derived from its group + index so we
- *  don't maintain 25 parallel strings. Used by the rabbi lineage / tree views
+ *  don't maintain parallel strings. Used by the rabbi lineage / tree views
  *  under Hebrew (dir=rtl) where the English `label` would read out of place. */
 export function generationLabelHe(info: GenerationInfo): string {
   const m = info.id.match(/-(\d+)$/);
@@ -75,6 +179,9 @@ export function generationLabelHe(info: GenerationInfo): string {
     case 'amora-ey': return `אמורא א״י${n}`;
     case 'amora-bavel': return `אמורא בבל${n}`;
     case 'savora': return 'סבוראים';
+    case 'geonim': return 'גאונים';
+    case 'rishonim': return 'ראשונים';
+    case 'achronim': return 'אחרונים';
     default: return 'לא ידוע';
   }
 }
@@ -107,5 +214,8 @@ Generation IDs (use exact strings):
 - amora-bavel-7: c. 427–460 CE. Mar bar Rav Ashi (Tavyomi), Rav Acha.
 - amora-bavel-8: c. 460–500 CE. Ravina II (final redactor).
 - savora: c. 500–600 CE. Post-Talmudic editors.
+- geonim: c. 589–1038 CE. Heads of the Babylonian academies (e.g. Rav Sherira Gaon, Rav Hai Gaon, Rav Saadia Gaon). RARE in the Bavli text itself — use ONLY if such a figure is explicitly named.
+- rishonim: c. 1038–1500 CE. Medieval commentators (Rashi, Tosafot, Rambam, Ramban, Rif). Use ONLY when the source text NAMES one (e.g. a quoted commentary), never for an Amora.
+- achronim: c. 1500 CE onward. Later authorities (e.g. the Shulchan Aruch, Maharsha). Use ONLY when explicitly named.
 - unknown: use ONLY if you cannot identify the rabbi or the name matches no known sage.
 `.trim();

--- a/src/client/injectRabbiUnderlines.ts
+++ b/src/client/injectRabbiUnderlines.ts
@@ -1,4 +1,4 @@
-import type { GenerationId } from './generations';
+import { colorForGeneration, type GenerationId } from './generations';
 
 export interface GenerationRabbi {
   name: string;
@@ -189,7 +189,11 @@ export function injectRabbiUnderlines(html: string, rabbis: GenerationRabbi[]): 
     if (!parent) continue;
 
     const wrapperEl = doc.createElement('span');
+    // Keep the rabbi-gen-<id> class for hover/highlight targeting, but drive
+    // the underline color from the computed generation spectrum inline so the
+    // CSS doesn't carry a parallel (drift-prone) per-id color table.
     wrapperEl.className = `rabbi-underline rabbi-gen-${w.generation}`;
+    wrapperEl.style.borderBottomColor = colorForGeneration(w.generation);
     wrapperEl.setAttribute('data-rabbi', w.rabbiName);
 
     // Move first..last (inclusive) + any whitespace/text nodes between them

--- a/src/lib/daf-render/styles.css
+++ b/src/lib/daf-render/styles.css
@@ -330,14 +330,12 @@
   box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
 }
 
-/* Anonymous-tannaitic variant: dashed underline in the Tanna-5 blue (Rebbi's
-   era, when the Mishnah was redacted). Signals "Tannaitic but specific
-   generation unknown". Uses the same .rabbi-underline base rules below. */
+/* Anonymous-tannaitic variant: dashed underline. Signals "Tannaitic but
+   specific generation unknown". The underline color is set inline from the
+   generation spectrum (see injectRabbiUnderlines.ts); this rule only switches
+   the stroke to dashed. */
 .daf-root .daf-text .rabbi-underline-anonymous {
   border-bottom-style: dashed !important;
-}
-.daf-root .daf-text .rabbi-gen-tanna-anonymous {
-  border-bottom-color: #3b82f6;
 }
 
 /* Rabbi-name underline (generation marker). Injected by
@@ -357,28 +355,9 @@
 .daf-root .daf-text .rabbi-underline > .daf-word {
   color: inherit;
 }
-.daf-root .daf-text .rabbi-gen-zugim         { border-bottom-color: #4338ca; }
-.daf-root .daf-text .rabbi-gen-tanna-1       { border-bottom-color: #1e3a8a; }
-.daf-root .daf-text .rabbi-gen-tanna-2       { border-bottom-color: #1e40af; }
-.daf-root .daf-text .rabbi-gen-tanna-3       { border-bottom-color: #2563eb; }
-.daf-root .daf-text .rabbi-gen-tanna-4       { border-bottom-color: #3b82f6; }
-.daf-root .daf-text .rabbi-gen-tanna-5       { border-bottom-color: #60a5fa; }
-.daf-root .daf-text .rabbi-gen-tanna-6       { border-bottom-color: #93c5fd; }
-.daf-root .daf-text .rabbi-gen-amora-ey-1    { border-bottom-color: #14532d; }
-.daf-root .daf-text .rabbi-gen-amora-ey-2    { border-bottom-color: #166534; }
-.daf-root .daf-text .rabbi-gen-amora-ey-3    { border-bottom-color: #16a34a; }
-.daf-root .daf-text .rabbi-gen-amora-ey-4    { border-bottom-color: #4ade80; }
-.daf-root .daf-text .rabbi-gen-amora-ey-5    { border-bottom-color: #86efac; }
-.daf-root .daf-text .rabbi-gen-amora-bavel-1 { border-bottom-color: #7c2d12; }
-.daf-root .daf-text .rabbi-gen-amora-bavel-2 { border-bottom-color: #9a3412; }
-.daf-root .daf-text .rabbi-gen-amora-bavel-3 { border-bottom-color: #c2410c; }
-.daf-root .daf-text .rabbi-gen-amora-bavel-4 { border-bottom-color: #ea580c; }
-.daf-root .daf-text .rabbi-gen-amora-bavel-5 { border-bottom-color: #f97316; }
-.daf-root .daf-text .rabbi-gen-amora-bavel-6 { border-bottom-color: #fb923c; }
-.daf-root .daf-text .rabbi-gen-amora-bavel-7 { border-bottom-color: #fdba74; }
-.daf-root .daf-text .rabbi-gen-amora-bavel-8 { border-bottom-color: #fed7aa; }
-.daf-root .daf-text .rabbi-gen-savora        { border-bottom-color: #475569; }
-.daf-root .daf-text .rabbi-gen-unknown       { border-bottom-color: #d1d5db; }
+/* Per-generation underline colors are set inline by injectRabbiUnderlines.ts
+   from the computed spectrum in src/client/generations.ts (pre-Geonim = red,
+   Geonim onward = blue, dark earlier -> light later). No per-id rules here. */
 
 /* Chapter-closing formula "הדרן עלך <chapter-name>". Displayed as its own
    block line at a slightly larger size, centered, with a touch of vertical

--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -104,7 +104,7 @@ Output STRICT JSON only (no markdown, no prose):
       "fields": {
         "name": "Rabbi's conventional English name (e.g. 'Rabbi Eliezer')",
         "nameHe": "Same Hebrew name as excerpt — duplicated for clarity downstream.",
-        "generation": "one of the IDs above (zugim, tanna-1...tanna-6, amora-ey-1...amora-ey-5, amora-bavel-1...amora-bavel-8, savora, unknown)"
+        "generation": "one of the IDs above (zugim, tanna-1...tanna-6, amora-ey-1...amora-ey-5, amora-bavel-1...amora-bavel-8, savora, geonim, rishonim, achronim, unknown). geonim/rishonim/achronim are RARE in the Bavli text — use only when a post-Talmudic authority is explicitly named (e.g. in a quoted commentary)."
       }
     }
   ]

--- a/tests/fixtures/output-schemas/ENRICH_JSON_SCHEMA.json
+++ b/tests/fixtures/output-schemas/ENRICH_JSON_SCHEMA.json
@@ -35,6 +35,9 @@
           "amora-bavel-7",
           "amora-bavel-8",
           "savora",
+          "geonim",
+          "rishonim",
+          "achronim",
           "unknown"
         ]
       },

--- a/tests/fixtures/output-schemas/RABBI_OUTPUT_SCHEMA.json
+++ b/tests/fixtures/output-schemas/RABBI_OUTPUT_SCHEMA.json
@@ -60,6 +60,9 @@
                     "amora-bavel-7",
                     "amora-bavel-8",
                     "savora",
+                    "geonim",
+                    "rishonim",
+                    "achronim",
                     "unknown"
                   ]
                 }

--- a/tests/generations.test.ts
+++ b/tests/generations.test.ts
@@ -30,6 +30,10 @@ describe('deriveRegionFromGeneration — every generation ID', () => {
     'amora-bavel-8':  'bavel',
     // Savoraim are the Babylonian post-Talmudic editors.
     'savora':         'bavel',
+    // Post-Talmudic eras aren't pinned to a Talmudic region — leave null.
+    'geonim':         null,
+    'rishonim':       null,
+    'achronim':       null,
     // Unknown falls through to null — downstream code can leave the rabbi on
     // the "other" bucket rather than forcing a region.
     'unknown':        null,


### PR DESCRIPTION
## What

Reworks the rabbi-generation color system (underlines in the gemara, voices, timeline, lineage tree, geography map) into one intuitive rule:

- **Pre-Geonim** (Zugim, Tannaim, Amoraim, Savoraim) -> **red** spectrum
- **Geonim and after** (Geonim, Rishonim, Achronim) -> **blue** spectrum
- Within each tier the shade runs **dark = earlier -> light = later**
- `unknown` stays neutral gray

## How

- **`src/client/generations.ts`** is now the single source of truth: each generation declares a `tier` (`early`/`late`/`none`) + chronological `rank`, and its `color` is **computed** by sRGB interpolation between the tier's dark/light endpoints. No hand-maintained hex table, so the palette can't drift out of order. Adds `geonim`/`rishonim`/`achronim` IDs, plus `colorForGeneration()` and a luminance-based `legibleTextColor()`.
- **`injectRabbiUnderlines.ts`** sets the underline color inline from the computed spectrum. The 25-line per-id `.rabbi-gen-*` color block in `styles.css` is removed (it had also drifted — amora-ey was green there but orange in `generations.ts`).
- **`GenerationTimeline.tsx`** / **`RabbiTreeStrip.tsx`** read computed colors; the hand-kept `PALE_GEN_IDS` list is retired in favor of luminance.
- Prompt id-list (`code-marks.ts`), output-schema golden fixtures, and the region/coverage test updated for the new IDs.

## Why the blue tier exists but is sparse today

Rishonim/Achronim don't normally appear in the Bavli text. The blue tier is forward-looking: it lights up when a quoted commentary (Rashi/Tosafot) names a later authority, and — ahead — when halacha-mark codifier names get their own bios/registry.

## Documented follow-ups (out of scope here, no data exists yet)

- The daf `GenerationTimeline` and the global `RabbiTreeStrip` only build the four Talmudic-era sections; a blue-tier rabbi is colored but has no row there yet.
- `rabbi-places.json` still labels some geonim as `savora` and Rishonim as `null`; relabeling to the new IDs is part of building the later-authority registry.

## Checks

- `pnpm typecheck` clean
- `pnpm test` — 1642 passed
- Codex read-only review: no regressions; schema/fixture parity confirmed