### PR TITLE
Halacha: CodificationMap component (lineage + Voices grammar)

### DIFF
--- a/src/client/CodificationMap.tsx
+++ b/src/client/CodificationMap.tsx
@@ -1,0 +1,183 @@
+/**
+ * CodificationMap — the halacha lineage (Gemara → Rambam → Tur → Shulchan Aruch
+ * → Rema) rendered in the Voices visual grammar, with codifier disagreements as
+ * relation edges and Sephardi/Ashkenazi practice folded onto the nodes. This is
+ * the "merged lineage + Voices" design (mockup: Sandbox/halacha/v6.html).
+ *
+ * Tech note: like ArgumentVoiceMap the *look* is white rounded cards + a spine
+ * with side-colour dots + colour/dash relation edges + a legend — but the cards
+ * here carry richer content (ref + ruling + a practice chip), so they render as
+ * HTML and a single SVG layer draws the spine + edges over them (positions
+ * measured from the laid-out cards). The geometry/colour mapping lives in
+ * ./flow/codeMapLayout (unit-tested); this file is the Solid shell.
+ *
+ * Presentational only — props in, no data fetching. The collection/enrichment
+ * PRs feed it real grounded codifier data.
+ */
+
+import { For, Show, createSignal, onMount, onCleanup, type JSX } from 'solid-js';
+import {
+  SIDE_COLOR, relationStyle, gutterEdgePath,
+  type NodeSide, type RelationKind,
+} from './flow/codeMapLayout';
+
+/** One node in the lineage (a codifier, or the gemara source at the top). */
+export interface CodeMapNode {
+  /** Stable id; relation edges reference these. */
+  id: string;
+  /** Authority handle shown bold (e.g. "Rambam", "Shulchan Aruch", "Gemara"). */
+  label: string;
+  /** Citation shown in link-blue next to the label (e.g. "OC 235:3"). */
+  ref?: string;
+  /** A short, plain ruling line under the heading. */
+  ruling?: string;
+  /** Small uppercase tag after the label (e.g. "source"). */
+  era?: string;
+  /** Dispute side → badge / spine-dot colour. */
+  side: NodeSide;
+  /** Optional practice chip (Sephardi / Ashkenazi / accepted-by-all). */
+  practice?: { en: string; he?: string; tone: 'sef' | 'ashk' | 'both' };
+}
+
+export interface CodeMapEdge {
+  from: string;
+  to: string;
+  kind: RelationKind;
+}
+
+interface Props {
+  nodes: CodeMapNode[];
+  edges?: CodeMapEdge[];
+  /** Which relations appear in the legend (defaults to the ones in `edges`,
+   *  plus "transmits" for the spine). */
+  legend?: RelationKind[];
+}
+
+const PRACTICE_STYLE: Record<'sef' | 'ashk' | 'both', JSX.CSSProperties> = {
+  sef: { background: '#eaf0fb', color: '#1a3e7e' },
+  ashk: { background: '#fbeaea', color: '#7e1a1a' },
+  both: { background: '#eef6ef', color: '#2f6b43' },
+};
+
+const LEGEND_LABEL: Record<RelationKind, string> = {
+  transmits: 'transmits', agrees: 'agrees', disagrees: 'disagrees', cites: 'cites',
+};
+
+const SPINE_X = 18;       // left-gutter x of the spine + dots
+const GUTTER = 22;        // right gutter width for relation lanes
+const LANE_STEP = 9;      // x between parallel relation lanes
+
+export default function CodificationMap(props: Props): JSX.Element {
+  let mapEl: HTMLDivElement | undefined;
+  const [svg, setSvg] = createSignal('');
+
+  const draw = () => {
+    const root = mapEl;
+    if (!root) return;
+    const cards = Array.from(root.querySelectorAll<HTMLElement>('[data-node]'));
+    if (cards.length === 0) { setSvg(''); return; }
+    const box = root.getBoundingClientRect();
+    const W = root.clientWidth;
+    const center = (el: HTMLElement) => {
+      const r = el.getBoundingClientRect();
+      return { right: r.right - box.left, cy: (r.top + r.bottom) / 2 - box.top };
+    };
+    const pos = new Map<string, { right: number; cy: number }>();
+    for (const c of cards) pos.set(c.dataset.node!, center(c));
+
+    const first = center(cards[0]);
+    const last = center(cards[cards.length - 1]);
+    let s = `<line x1="${SPINE_X}" y1="${first.cy}" x2="${SPINE_X}" y2="${last.cy}" stroke="#cfc9bb" stroke-width="1.5" stroke-linecap="round"/>`;
+    for (const c of cards) {
+      const p = center(c);
+      const color = SIDE_COLOR[(c.dataset.side as NodeSide) ?? 'neutral'];
+      s += `<circle cx="${SPINE_X}" cy="${p.cy}" r="5" fill="${color}" stroke="#fdfcf9" stroke-width="2"/>`;
+    }
+    (props.edges ?? []).forEach((e, i) => {
+      const a = pos.get(e.from), b = pos.get(e.to);
+      if (!a || !b) return;
+      const { color, dash } = relationStyle(e.kind);
+      const laneX = W - 11 - i * LANE_STEP;
+      const rightX = Math.max(a.right, b.right);
+      const d = gutterEdgePath(a.cy, b.cy, rightX, laneX);
+      s += `<path d="${d}" fill="none" stroke="${color}" stroke-width="1.5" stroke-linecap="round" stroke-opacity="0.85"${dash ? ` stroke-dasharray="${dash}"` : ''}/>`;
+    });
+    setSvg(s);
+  };
+
+  onMount(() => {
+    draw();
+    // Redraw on resize so the edges track reflowed cards. Guarded — ResizeObserver
+    // is absent under jsdom (tests) and irrelevant there (no real layout).
+    if (typeof ResizeObserver !== 'undefined' && mapEl) {
+      const ro = new ResizeObserver(() => draw());
+      ro.observe(mapEl);
+      onCleanup(() => ro.disconnect());
+    }
+  });
+
+  const legendKinds = (): RelationKind[] => {
+    if (props.legend) return props.legend;
+    const used = new Set<RelationKind>(['transmits']);
+    for (const e of props.edges ?? []) used.add(e.kind);
+    return Array.from(used);
+  };
+
+  return (
+    <div style={{ border: '1px solid #ece9df', 'border-radius': '8px', background: '#fdfcf9', padding: '8px 6px' }}>
+      <div
+        ref={mapEl}
+        style={{ position: 'relative', padding: `6px ${GUTTER}px 6px 38px` }}
+      >
+        <svg
+          innerHTML={svg()}
+          style={{ position: 'absolute', inset: 0, 'pointer-events': 'none', 'z-index': 0, overflow: 'visible' }}
+        />
+        <For each={props.nodes}>{(n) => (
+          <div
+            data-node={n.id}
+            data-side={n.side}
+            style={{
+              position: 'relative', 'z-index': 1, background: '#fff',
+              border: '1px solid #e4e0d4', 'border-radius': '10px',
+              padding: '8px 11px 9px 13px', 'margin-bottom': '15px',
+              'box-shadow': '0 1px 1.4px rgba(58,51,32,0.12)',
+            }}
+          >
+            <div style={{ 'font-family': 'system-ui, -apple-system, sans-serif', 'font-size': '11.5px', 'font-weight': 600, color: '#2a2723', 'line-height': 1.3 }}>
+              {n.label}
+              <Show when={n.ref}><span style={{ 'font-weight': 400, color: '#1e5fae' }}>{` · ${n.ref}`}</span></Show>
+              <Show when={n.era}><span style={{ 'font-weight': 400, color: '#a39e92', 'font-size': '10px', 'text-transform': 'uppercase', 'letter-spacing': '0.04em', 'margin-left': '4px' }}>{n.era}</span></Show>
+            </div>
+            <Show when={n.ruling}>
+              <div style={{ 'font-size': '12px', color: '#585348', 'line-height': 1.45, 'margin-top': '2px' }}>{n.ruling}</div>
+            </Show>
+            <Show when={n.practice}>
+              {(p) => (
+                <span style={{
+                  display: 'inline-block', 'font-family': 'system-ui, -apple-system, sans-serif',
+                  'font-size': '10px', 'border-radius': '6px', padding: '2px 7px',
+                  'margin-top': '6px', 'line-height': 1.35, ...PRACTICE_STYLE[p().tone],
+                }}>
+                  <Show when={p().he}><span lang="he" style={{ 'font-weight': 700 }}>{p().he}</span>{' · '}</Show>
+                  {p().en}
+                </span>
+              )}
+            </Show>
+          </div>
+        )}</For>
+      </div>
+      <div style={{ display: 'flex', gap: '13px', margin: '10px 2px 2px', 'font-family': 'system-ui, -apple-system, sans-serif', 'font-size': '10px', color: '#999', 'align-items': 'center', 'flex-wrap': 'wrap' }}>
+        <For each={legendKinds()}>{(k) => {
+          const st = relationStyle(k);
+          return (
+            <span style={{ display: 'inline-flex', 'align-items': 'center', gap: '5px' }}>
+              <span style={{ display: 'inline-block', width: '15px', height: 0, 'border-top': `${st.dash ? '1.6px dashed' : '1.6px solid'} ${st.color}` }} />
+              {LEGEND_LABEL[k]}
+            </span>
+          );
+        }}</For>
+      </div>
+    </div>
+  );
+}

--- a/src/client/flow/codeMapLayout.ts
+++ b/src/client/flow/codeMapLayout.ts
@@ -1,0 +1,62 @@
+/**
+ * Pure layout helpers for the codification map (CodificationMap.tsx) — the
+ * halacha lineage rendered in the Voices visual grammar. Kept separate from the
+ * component so the geometry + colour mapping are unit-testable without a DOM.
+ *
+ * The map is time-as-Y (lineage top→bottom): a left spine threads the codifier
+ * cards (the "transmits" thread), and relation edges (agrees / disagrees /
+ * cites) draw in a right gutter as rounded connectors — the same shape as
+ * ArgumentFlowGraph's lane connectors, the same colours as ArgumentVoiceMap's
+ * edges, so the two maps read as one component language.
+ */
+
+/** Which dispute side a node sits on → its badge / spine-dot colour. Mirrors
+ *  ArgumentVoiceMap's side palette (A blue, B red) plus a green "source" for the
+ *  gemara node and a slate "neutral" for an undisputed codifier. */
+export type NodeSide = 'source' | 'a' | 'b' | 'neutral';
+
+export const SIDE_COLOR: Record<NodeSide, string> = {
+  source: '#3f6212',  // gemara — green
+  a: '#1d4ed8',       // position A — blue   (matches ArgumentVoiceMap COLOR_A)
+  b: '#b91c1c',       // position B — red    (matches ArgumentVoiceMap COLOR_B)
+  neutral: '#475569', // undisputed codifier — slate
+};
+
+/** The relations an edge can express in the codification lineage. */
+export type RelationKind = 'transmits' | 'agrees' | 'disagrees' | 'cites';
+
+const REL_COLOR: Record<RelationKind, string> = {
+  transmits: '#cfc9bb', // the lineage spine — warm grey
+  agrees: '#15803d',    // green   (ArgumentVoiceMap EDGE_SUPPORT)
+  disagrees: '#b91c1c', // red     (ArgumentVoiceMap EDGE_OPPOSE)
+  cites: '#475569',     // slate   (ArgumentFlowGraph cites)
+};
+
+/** Stroke colour + dash for a relation edge. Only `disagrees` is dashed,
+ *  matching the Voices map's opposes style (5 3). */
+export function relationStyle(kind: RelationKind): { color: string; dash?: string } {
+  return { color: REL_COLOR[kind], dash: kind === 'disagrees' ? '5 3' : undefined };
+}
+
+/**
+ * Rounded right-gutter connector between two card mid-Ys. Exits the cards' right
+ * edge, runs to the lane, turns with a quarter-circle, runs vertically, turns
+ * back, and re-enters at the lower card's right edge — never diagonal.
+ *
+ * @param y1 mid-Y of the from-card
+ * @param y2 mid-Y of the to-card
+ * @param rightX the cards' right edge (where the connector attaches)
+ * @param laneX the vertical lane x in the right gutter (rightX < laneX)
+ */
+export function gutterEdgePath(y1: number, y2: number, rightX: number, laneX: number): string {
+  const dir = y2 >= y1 ? 1 : -1;
+  const r = Math.max(0, Math.min(10, Math.abs(y2 - y1) / 2, laneX - rightX));
+  return [
+    `M ${rightX} ${y1}`,
+    `L ${laneX - r} ${y1}`,
+    `Q ${laneX} ${y1} ${laneX} ${y1 + dir * r}`,
+    `L ${laneX} ${y2 - dir * r}`,
+    `Q ${laneX} ${y2} ${laneX - r} ${y2}`,
+    `L ${rightX} ${y2}`,
+  ].join(' ');
+}

--- a/tests/client/codification-map.test.tsx
+++ b/tests/client/codification-map.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import { render } from '@solidjs/testing-library';
+import { describe, expect, it } from 'vitest';
+import CodificationMap, { type CodeMapNode, type CodeMapEdge } from '../../src/client/CodificationMap';
+
+// Kitniyot lineage (the v6 mockup shape): gemara source + two disputing codifiers.
+const nodes: CodeMapNode[] = [
+  { id: 'gem', label: 'Gemara', ref: 'Pesachim 35a', era: 'source', side: 'source', ruling: "Kitniyot isn't one of the five grains." },
+  { id: 'mech', label: 'Mechaber', ref: 'SA, OC 453:1', side: 'a', ruling: 'Permits.', practice: { en: 'eats kitniyot', he: 'ספרד', tone: 'sef' } },
+  { id: 'rema', label: 'Rema', ref: 'gloss', side: 'b', ruling: 'Prohibits.', practice: { en: 'avoids kitniyot', he: 'אשכנז', tone: 'ashk' } },
+];
+const edges: CodeMapEdge[] = [
+  { from: 'gem', to: 'mech', kind: 'cites' },
+  { from: 'mech', to: 'rema', kind: 'disagrees' },
+];
+
+describe('CodificationMap', () => {
+  it('renders one positioned card per node, carrying ref + ruling + practice', () => {
+    const { container, getByText } = render(() => <CodificationMap nodes={nodes} edges={edges} />);
+    const cards = container.querySelectorAll('[data-node]');
+    expect(cards).toHaveLength(3);
+    expect(Array.from(cards).map((c) => c.getAttribute('data-node'))).toEqual(['gem', 'mech', 'rema']);
+    // side drives the spine-dot colour downstream; assert it's carried on the DOM.
+    expect(Array.from(cards).map((c) => c.getAttribute('data-side'))).toEqual(['source', 'a', 'b']);
+    getByText('SA, OC 453:1', { exact: false });
+    getByText('eats kitniyot', { exact: false });
+    getByText('avoids kitniyot', { exact: false });
+  });
+
+  it('builds the legend from the edge kinds plus the transmits spine', () => {
+    const { getByText } = render(() => <CodificationMap nodes={nodes} edges={edges} />);
+    getByText('transmits');
+    getByText('cites');
+    getByText('disagrees');
+  });
+
+  it('renders without edges (the agree case) and still draws cards', () => {
+    const agree: CodeMapNode[] = [
+      { id: 'g', label: 'Gemara', ref: 'Berakhot 2a', side: 'source' },
+      { id: 'ram', label: 'Rambam', ref: 'Krias Shema 1:9', side: 'neutral' },
+      { id: 'sa', label: 'Shulchan Aruch', ref: 'OC 235:3', side: 'neutral', practice: { en: 'accepted by all', tone: 'both' } },
+    ];
+    const { container } = render(() => <CodificationMap nodes={agree} />);
+    expect(container.querySelectorAll('[data-node]')).toHaveLength(3);
+  });
+});

--- a/tests/code-map-layout.test.ts
+++ b/tests/code-map-layout.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { SIDE_COLOR, relationStyle, gutterEdgePath } from '../src/client/flow/codeMapLayout';
+
+describe('relationStyle', () => {
+  it('only disagrees is dashed; colours match the Voices/Flow palette', () => {
+    expect(relationStyle('disagrees')).toEqual({ color: '#b91c1c', dash: '5 3' });
+    expect(relationStyle('agrees')).toEqual({ color: '#15803d', dash: undefined });
+    expect(relationStyle('cites')).toEqual({ color: '#475569', dash: undefined });
+    expect(relationStyle('transmits')).toEqual({ color: '#cfc9bb', dash: undefined });
+  });
+});
+
+describe('SIDE_COLOR', () => {
+  it('maps sides to the shared palette', () => {
+    expect(SIDE_COLOR.a).toBe('#1d4ed8'); // matches ArgumentVoiceMap COLOR_A
+    expect(SIDE_COLOR.b).toBe('#b91c1c'); // matches ArgumentVoiceMap COLOR_B
+    expect(SIDE_COLOR.source).toBe('#3f6212');
+    expect(SIDE_COLOR.neutral).toBe('#475569');
+  });
+});
+
+describe('gutterEdgePath', () => {
+  it('routes out, rounds the corner, runs vertically, rounds back, re-enters', () => {
+    const d = gutterEdgePath(30, 110, 300, 340);
+    // downward: dir=+1, r = min(10, 40, 40) = 10
+    expect(d).toBe('M 300 30 L 330 30 Q 340 30 340 40 L 340 100 Q 340 110 330 110 L 300 110');
+  });
+
+  it('handles an upward edge (to-card above from-card)', () => {
+    const d = gutterEdgePath(110, 30, 300, 340);
+    // dir = -1
+    expect(d).toBe('M 300 110 L 330 110 Q 340 110 340 100 L 340 40 Q 340 30 330 30 L 300 30');
+  });
+
+  it('clamps the corner radius for near-equal Ys (no overshoot)', () => {
+    // |y2-y1|/2 = 2 caps r at 2
+    expect(gutterEdgePath(50, 54, 300, 340)).toContain('Q 340 50 340 52');
+  });
+
+  it('never emits a negative radius when the lane hugs the cards', () => {
+    const d = gutterEdgePath(30, 110, 300, 304); // laneX-rightX = 4 → r = 4
+    expect(d).toContain('Q 304 30 304 34');
+    expect(d).not.toMatch(/-\d/); // no negative coordinates
+  });
+
+  it('is axis-aligned only — no diagonal segment (every L shares an axis with its start)', () => {
+    // A simple structural check: the path has the expected M/L/Q command count.
+    const d = gutterEdgePath(30, 110, 300, 340);
+    expect((d.match(/L /g) || []).length).toBe(3);
+    expect((d.match(/Q /g) || []).length).toBe(2);
+  });
+});


### PR DESCRIPTION
PR 2 of the halacha redesign. The merged **codification map** from the approved design (mockup `Sandbox/halacha/v6.html`): the halacha lineage rendered top→bottom (Gemara → Rambam → Tur → Shulchan Aruch), codifier disagreements as relation edges, and Sephardi/Ashkenazi practice folded onto the nodes — in the **same visual language as `ArgumentVoiceMap`** (white rounded cards, side-colour spine dots, colour/dash edges, legend).

### What's here
- **`src/client/flow/codeMapLayout.ts`** — pure geometry + colour mapping (unit-tested): `SIDE_COLOR` (matches the Voices A/B palette), `relationStyle` (only `disagrees` is dashed `5 3`), `gutterEdgePath` (rounded right-gutter connector, never diagonal).
- **`src/client/CodificationMap.tsx`** — presentational Solid component. Rich HTML cards (ref + ruling + practice chip) with a single SVG layer drawing the spine + side-colour dots + relation edges over the measured card positions; degrades to a clean transmits-spine when there's no dispute. `ResizeObserver`-guarded for jsdom. **Props-only, no data fetching** — wired by the collection PRs (3/5).

### Why it's safe
Additive — a new component + helpers, no existing component touched (the recently-audited `ArgumentVoiceMap` is untouched; this reuses its *visual grammar*, and a future cleanup can fold both onto one layout). Nothing imports it yet, so no behavior change.

### Verification
- Pure geometry/colour **unit tests** (7) + a jsdom **mount test** (3: cards, `data-side`, practice chips, legend).
- **Rendered in a real browser** against the v6 mockup — dispute case (cites curve + red-dashed disagrees edge + ספרד/אשכנז chips) and agree case (clean spine + "accepted by all") both correct.
- `pnpm typecheck` clean; `pnpm test` 1660 passed (+10 new).

### Next
PR 3 — codifier-first collection: wire the grounded refs (PR #175's data layer) into the halacha prompts and feed this component.