### PR TITLE
Halacha: ground codification refs + render the codifier lineage map

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -10,6 +10,8 @@ import RabbiLineageTree, { type RelationshipsData, type RelationshipsEvidence } 
 import { type GeographyData, type GeographyEvidence } from './RabbiGeographyCard';
 import RabbiPlacesTimeline, { type LocationInference } from './RabbiPlacesTimeline';
 import ArgumentVoiceMap, { type ArgumentVoicesData } from './ArgumentVoiceMap';
+import CodificationMap from './CodificationMap';
+import { codeMapFromCodification, type CodificationData } from './flow/codeMapLayout';
 import ArgumentNarrative from './ArgumentNarrative';
 import { deriveVoiceEdges } from '../lib/typing/voices';
 import { voicesMapEligible, voicesShowMap, voicesShowFallback } from '../lib/typing/profile';
@@ -1068,71 +1070,6 @@ function DafBackgroundBody(props: { tractate: string; page: string }): JSX.Eleme
   );
 }
 
-function sefariaUrl(source: 'mishnehTorah' | 'shulchanAruch' | 'rema', ref: string): string | null {
-  const trimmed = ref.trim();
-  if (source === 'mishnehTorah') {
-    return `https://www.sefaria.org/search?q=${encodeURIComponent('Mishneh Torah ' + trimmed)}`;
-  }
-  const match = trimmed.match(/^(Orach(?:\s+)?(?:Ch|H)(?:aim|ayyim)?|Yoreh\s+De'?ah|Even\s+Ha'?Ezer|Choshen\s+Mishpat)\s+(\d+):(\d+)/i);
-  if (match) {
-    const sectionMap: Record<string, string> = {
-      orachchaim: 'Orach_Chayyim', orachchayyim: 'Orach_Chayyim', orachhaim: 'Orach_Chayyim',
-      yorehdeah: 'Yoreh_De%27ah', evenhaezer: 'Even_HaEzer', choshenmishpat: 'Choshen_Mishpat',
-    };
-    const normalized = match[1].toLowerCase().replace(/\s+/g, '').replace(/'/g, '');
-    const section = sectionMap[normalized];
-    if (section) {
-      const prefix = source === 'rema' ? 'Mappah' : 'Shulchan_Arukh';
-      return `https://www.sefaria.org/${prefix}%2C_${section}.${match[2]}.${match[3]}`;
-    }
-  }
-  return `https://www.sefaria.org/search?q=${encodeURIComponent(trimmed)}`;
-}
-
-function RulingRow(props: {
-  source: 'mishnehTorah' | 'shulchanAruch' | 'rema';
-  label: string;
-  color: string;
-  ruling?: { ref: string; summary: string };
-}): JSX.Element {
-  return (
-    <Show when={props.ruling}>
-      {(r) => {
-        const url = sefariaUrl(props.source, r().ref);
-        return (
-          <div style={{
-            padding: '0.55rem 0.7rem',
-            background: '#fafaf7',
-            border: '1px solid #eae8e0',
-            'border-radius': '4px',
-            'margin-bottom': '0.45rem',
-          }}>
-            <div style={{
-              'font-size': '0.68rem',
-              'text-transform': 'uppercase',
-              'letter-spacing': '0.06em',
-              'font-weight': 600,
-              color: props.color,
-              'margin-bottom': '0.25rem',
-            }}>
-              {props.label}
-            </div>
-            <div style={{ 'font-weight': 500, color: '#333', 'margin-bottom': '0.2rem', 'font-size': '0.85rem' }}>
-              <a href={url ?? '#'} target="_blank" rel="noopener noreferrer"
-                 style={{ color: props.color, 'text-decoration': 'none' }}>
-                {r().ref} ↗
-              </a>
-            </div>
-            <div style={{ color: '#555', 'line-height': 1.45, 'font-size': '0.85rem' }}>
-              <HebraizedWithRabbis text={r().summary} />
-            </div>
-          </div>
-        );
-      }}
-    </Show>
-  );
-}
-
 interface PasukDetail {
   ref: string;
   heRef: string | null;
@@ -1306,14 +1243,6 @@ export const RABBI_BLOCKS: Record<string, (p: SpecialBlockProps) => JSX.Element>
 //         Disputes card (rendered only when non-empty).
 // ===========================================================================
 
-interface CodificationRuling { ref: string; ruling: string; }
-interface CodificationData {
-  mishnehTorah: CodificationRuling | null;
-  tur: CodificationRuling | null;
-  shulchanAruch: CodificationRuling | null;
-  rema: CodificationRuling | null;
-  prose: string;
-}
 interface PracticalData {
   lechatchila: string;
   bedieved: string;
@@ -1330,61 +1259,36 @@ interface DisputeItem {
 }
 interface DisputesData { disputes: DisputeItem[]; }
 
-// Halacha codification: structured ruling rows (Mishneh Torah / Tur / Shulchan
-// Aruch / Rema). A NAMED special block reading the halacha.codification leaf.
+// Halacha codification: the codifier lineage as a CodificationMap — Gemara →
+// Rambam → Tur → Shulchan Aruch, with a present Rema folded in as the
+// Mechaber/Rema disagree edge. A NAMED special block reading the
+// halacha.codification leaf (the {mishnehTorah,tur,shulchanAruch,rema,prose}
+// shape) and mapping it via codeMapFromCodification.
 function HalachaCodification(props: SpecialBlockProps): JSX.Element {
   const codification = (): CodificationData | undefined => {
     const d = props.deps['halacha.codification'] as CodificationData | undefined;
     return d && typeof d.prose === 'string' ? d : undefined;
   };
+  const map = () => {
+    const cod = codification();
+    return cod ? codeMapFromCodification(cod, `${props.tractate} ${props.page}`) : null;
+  };
   return (
-      <Show when={codification()}>
-        {(cod) => (
-          <div style={{ 'margin-top': '0.9rem' }}>
-            <div style={{
-              'font-size': '0.7rem', 'text-transform': 'uppercase',
-              'letter-spacing': '0.08em', color: '#888', 'margin-bottom': '0.5rem',
-              display: 'flex', 'align-items': 'center', gap: '0.4rem',
-            }}>
-              <span>{t('halacha.codification')}</span>
-              <InspectDot instanceKey={props.instanceKey} leafId="halacha.codification" style={{ 'margin-left': 'auto' }} />
-            </div>
-            <RulingRow
-              source="mishnehTorah" label={t('source.mishnehTorah')} color="#8a2a2b"
-              ruling={cod().mishnehTorah ? { ref: cod().mishnehTorah!.ref, summary: cod().mishnehTorah!.ruling } : undefined}
-            />
-            <Show when={cod().tur}>
-              {(tur) => (
-                <div style={{
-                  padding: '0.55rem 0.7rem', background: '#fafaf7',
-                  border: '1px solid #eae8e0', 'border-radius': '4px',
-                  'margin-bottom': '0.45rem',
-                }}>
-                  <div style={{
-                    'font-size': '0.68rem', 'text-transform': 'uppercase',
-                    'letter-spacing': '0.06em', 'font-weight': 600, color: '#a16207',
-                    'margin-bottom': '0.25rem',
-                  }}>{t('source.tur')}</div>
-                  <div style={{ 'font-weight': 500, color: '#333', 'margin-bottom': '0.2rem', 'font-size': '0.85rem' }}>
-                    {tur().ref}
-                  </div>
-                  <div style={{ color: '#555', 'line-height': 1.45, 'font-size': '0.85rem' }}>
-                    <HebraizedWithRabbis text={tur().ruling} />
-                  </div>
-                </div>
-              )}
-            </Show>
-            <RulingRow
-              source="shulchanAruch" label={t('source.shulchanAruch')} color="#1e40af"
-              ruling={cod().shulchanAruch ? { ref: cod().shulchanAruch!.ref, summary: cod().shulchanAruch!.ruling } : undefined}
-            />
-            <RulingRow
-              source="rema" label={t('source.rema')} color="#7c3aed"
-              ruling={cod().rema ? { ref: cod().rema!.ref, summary: cod().rema!.ruling } : undefined}
-            />
+    <Show when={map()}>
+      {(m) => (
+        <div style={{ 'margin-top': '0.9rem', position: 'relative' }}>
+          <div style={{
+            'font-size': '0.7rem', 'text-transform': 'uppercase',
+            'letter-spacing': '0.08em', color: '#888', 'margin-bottom': '0.5rem',
+            display: 'flex', 'align-items': 'center', gap: '0.4rem',
+          }}>
+            <span>{t('halacha.codification')}</span>
+            <InspectDot instanceKey={props.instanceKey} leafId="halacha.codification" style={{ 'margin-left': 'auto' }} />
           </div>
-        )}
-      </Show>
+          <CodificationMap nodes={m().nodes} edges={m().edges} />
+        </div>
+      )}
+    </Show>
   );
 }
 

--- a/src/client/CodificationMap.tsx
+++ b/src/client/CodificationMap.tsx
@@ -18,32 +18,10 @@
 import { For, Show, createSignal, onMount, onCleanup, type JSX } from 'solid-js';
 import {
   SIDE_COLOR, relationStyle, gutterEdgePath,
-  type NodeSide, type RelationKind,
+  type NodeSide, type RelationKind, type CodeMapNode, type CodeMapEdge,
 } from './flow/codeMapLayout';
 
-/** One node in the lineage (a codifier, or the gemara source at the top). */
-export interface CodeMapNode {
-  /** Stable id; relation edges reference these. */
-  id: string;
-  /** Authority handle shown bold (e.g. "Rambam", "Shulchan Aruch", "Gemara"). */
-  label: string;
-  /** Citation shown in link-blue next to the label (e.g. "OC 235:3"). */
-  ref?: string;
-  /** A short, plain ruling line under the heading. */
-  ruling?: string;
-  /** Small uppercase tag after the label (e.g. "source"). */
-  era?: string;
-  /** Dispute side → badge / spine-dot colour. */
-  side: NodeSide;
-  /** Optional practice chip (Sephardi / Ashkenazi / accepted-by-all). */
-  practice?: { en: string; he?: string; tone: 'sef' | 'ashk' | 'both' };
-}
-
-export interface CodeMapEdge {
-  from: string;
-  to: string;
-  kind: RelationKind;
-}
+export type { CodeMapNode, CodeMapEdge } from './flow/codeMapLayout';
 
 interface Props {
   nodes: CodeMapNode[];

--- a/src/client/flow/codeMapLayout.ts
+++ b/src/client/flow/codeMapLayout.ts
@@ -60,3 +60,84 @@ export function gutterEdgePath(y1: number, y2: number, rightX: number, laneX: nu
     `L ${rightX} ${y2}`,
   ].join(' ');
 }
+
+// ---------------------------------------------------------------------------
+// Map model + mapper from the codification enrichment shape
+// ---------------------------------------------------------------------------
+
+/** One node in the lineage (a codifier, or the gemara source at the top). */
+export interface CodeMapNode {
+  id: string;
+  /** Authority handle shown bold (e.g. "Rambam", "Shulchan Aruch", "Gemara"). */
+  label: string;
+  /** Citation shown in link-blue (e.g. "OC 235:3"). */
+  ref?: string;
+  /** A short, plain ruling line under the heading. */
+  ruling?: string;
+  /** Small uppercase tag after the label (e.g. "source"). */
+  era?: string;
+  /** Dispute side → badge / spine-dot colour. */
+  side: NodeSide;
+  /** Optional practice chip (Sephardi / Ashkenazi / accepted-by-all). */
+  practice?: { en: string; he?: string; tone: 'sef' | 'ashk' | 'both' };
+}
+
+export interface CodeMapEdge {
+  from: string;
+  to: string;
+  kind: RelationKind;
+}
+
+/** The codification enrichment's current output shape (one ruling per codifier).
+ *  `rema` non-null encodes the Mechaber/Rema divergence. */
+export interface CodificationRuling { ref: string; ruling: string }
+export interface CodificationData {
+  mishnehTorah: CodificationRuling | null;
+  tur: CodificationRuling | null;
+  shulchanAruch: CodificationRuling | null;
+  rema: CodificationRuling | null;
+  prose: string;
+}
+
+const hasRef = (r: CodificationRuling | null | undefined): r is CodificationRuling =>
+  !!r && typeof r.ref === 'string' && r.ref.trim().length > 0;
+
+/**
+ * Build the codification map from the enrichment output: a gemara source node
+ * on top, then the present codifiers in lineage order (Rambam → Tur → Shulchan
+ * Aruch). When Rema diverges, it becomes a second side-B node bracketed to the
+ * Shulchan Aruch (side A) by a `disagrees` edge — the Mechaber/Rema split folded
+ * into the lineage. The gemara→first-codifier edge is `cites`; the rest of the
+ * spine is `transmits`.
+ */
+export function codeMapFromCodification(
+  d: CodificationData,
+  dafRef: string,
+): { nodes: CodeMapNode[]; edges: CodeMapEdge[] } {
+  const nodes: CodeMapNode[] = [{ id: 'gemara', label: 'Gemara', ref: dafRef, era: 'source', side: 'source' }];
+  const edges: CodeMapEdge[] = [];
+  // The Mechaber/Rema split only makes sense when the Shulchan Aruch is present
+  // (Rema glosses it). A Rema without an SA node has nothing to disagree with.
+  const disputed = hasRef(d.rema) && hasRef(d.shulchanAruch);
+  const spine: Array<[keyof CodificationData, string]> = [
+    ['mishnehTorah', 'Rambam'],
+    ['tur', 'Tur'],
+    ['shulchanAruch', disputed ? 'Mechaber' : 'Shulchan Aruch'],
+  ];
+  let prev = 'gemara';
+  let firstCodifier = true;
+  for (const [key, label] of spine) {
+    const r = d[key] as CodificationRuling | null;
+    if (!hasRef(r)) continue;
+    const side: NodeSide = disputed && key === 'shulchanAruch' ? 'a' : 'neutral';
+    nodes.push({ id: key, label, ref: r.ref, ruling: r.ruling, side });
+    edges.push({ from: prev, to: key, kind: firstCodifier ? 'cites' : 'transmits' });
+    prev = key;
+    firstCodifier = false;
+  }
+  if (disputed) {
+    nodes.push({ id: 'rema', label: 'Rema', ref: d.rema!.ref, ruling: d.rema!.ruling, side: 'b' });
+    edges.push({ from: 'shulchanAruch', to: 'rema', kind: 'disagrees' });
+  }
+  return { nodes, edges };
+}

--- a/src/lib/halacha/codifiers.ts
+++ b/src/lib/halacha/codifiers.ts
@@ -129,6 +129,31 @@ export function hasCodification(bundle: HalachicRefBundle | undefined): boolean 
   return buildCodificationChain(bundle, { includeSecondary: true }).length > 0;
 }
 
+function truncate(s: string | undefined, n = 360): string {
+  const t = (s ?? '').trim();
+  return t.length > n ? `${t.slice(0, n - 1)}…` : t;
+}
+
+/**
+ * Format the grounded codifier refs (with their real Hebrew/English text) for
+ * the codification PROMPT, so the LLM SELECTS from real Sefaria refs instead of
+ * recalling citations. One block per codifier, its refs listed with capped
+ * snippets. Empty-bundle dapim get an explicit marker (the prompt then knows
+ * there is nothing to codify).
+ */
+export function formatGroundedRefsForPrompt(bundle: HalachicRefBundle | undefined): string {
+  const chain = buildCodificationChain(bundle, { includeSecondary: true });
+  if (!chain.length) return '(no codifier links found for this daf)';
+  return chain.map((node) => {
+    const refs = node.refs.map((r) => {
+      const he = truncate(r.hebrew);
+      const en = truncate(r.english);
+      return `  - ${r.ref}${he ? `\n    HE: ${he}` : ''}${en ? `\n    EN: ${en}` : ''}`;
+    }).join('\n');
+    return `${node.label}:\n${refs}`;
+  }).join('\n\n');
+}
+
 // ---------------------------------------------------------------------------
 // Derivation (reverse: code → gemara sources, "where it comes from")
 // ---------------------------------------------------------------------------

--- a/src/lib/sidebar/recipe.ts
+++ b/src/lib/sidebar/recipe.ts
@@ -91,9 +91,11 @@ export const HALACHA_RECIPE: SidebarRecipe = {
   titleHeField: 'topicHe',
   sections: [
     { type: 'synthesis' },
+    // Codification renders as the CodificationMap (lineage + the Mechaber/Rema
+    // disagree edge), so the standalone disputes block is retired — the common
+    // codifier dispute now lives in the map; synthesis still weaves the rest.
     { type: 'special', block: 'halacha-codification', deps: ['halacha.codification'] },
     { type: 'special', block: 'halacha-practical', deps: ['halacha.practical'] },
-    { type: 'special', block: 'halacha-disputes', deps: ['halacha.disputes'] },
   ],
 };
 

--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -3593,6 +3593,26 @@ English translation:
 
 Produce the requested output per the schema.`;
 
+// Codification gets an extra GROUNDED-REFS block: the real Mishneh Torah / Tur /
+// Shulchan Aruch refs (with text) Sefaria links to this daf, so the model
+// SELECTS a real ref rather than recalling one. Separate from the shared leaf
+// template (which practical/disputes still use without the refs block).
+const HALACHA_CODIFICATION_USER_TEMPLATE = `Tractate: {{tractate}}, page {{page}}.
+
+Halacha topic identified on this daf:
+{{mark_input}}
+
+Grounded codifier references — real Sefaria refs (with text) that cite THIS daf. SELECT from these; do not invent refs not listed here:
+{{halacha_refs}}
+
+Hebrew/Aramaic source for the daf:
+{{gemara_he}}
+
+English translation:
+{{gemara_en}}
+
+Produce the requested output per the schema.`;
+
 const HALACHA_CODIFICATION_SYSTEM_PROMPT = `You are a scholar of halacha. Given ONE halachic topic surfaced on a daf, produce the canonical codification trail: what Mishneh Torah, Tur, Shulchan Aruch, and Rema rule on this exact topic.
 
 Output STRICT JSON only:
@@ -3606,6 +3626,8 @@ Output STRICT JSON only:
 }
 
 Rules:
+- GROUND every ref. You are given a "Grounded codifier references" block listing the real Sefaria refs (with their text) that cite this daf. For Mishneh Torah, Tur, and Shulchan Aruch: SELECT the ref from that block and base the ruling on the text shown there. If one of those three is absent from the block, return null for it — DO NOT invent or recall a ref that is not listed.
+- Rema is the EXCEPTION: Sefaria folds Rema's glosses into the Shulchan Aruch, so Rema will NOT appear as its own entry in the block. Supply Rema (using the Shulchan Aruch's siman:seif as its ref) ONLY when he explicitly disagrees with, qualifies, or adds Ashkenazi minhag to the Mechaber's ruling on THIS topic — otherwise null.
 - ref MUST be a real, citable reference (sefer + hilchot + chapter:halacha for Mishneh Torah; siman[:seif] for Tur/Shulchan Aruch/Rema). If you cannot supply a real ref with confidence, return null for that codifier — DO NOT invent references.
 - For each non-null entry, the ruling MUST genuinely match what the codifier says on THIS topic, not a general gloss.
 - Rema is only non-null when he explicitly disagrees, qualifies, or adds Ashkenazi minhag to the Mechaber's ruling. If Rema agrees silently, leave it null.
@@ -3725,6 +3747,22 @@ const HALACHA_LEAF_USER_TEMPLATE_HE = `מסכת: {{tractate}}, דף {{page}}.
 
 הפק את הפלט המבוקש לפי הסכימה.`;
 
+const HALACHA_CODIFICATION_USER_TEMPLATE_HE = `מסכת: {{tractate}}, דף {{page}}.
+
+נושא הלכתי שזוהה בדף זה:
+{{mark_input}}
+
+מראי מקום מבוססים של הפוסקים — מראי מקום אמיתיים מספריא (עם טקסט) המפנים לדף זה. בחר מתוכם; אל תמציא מראי מקום שאינם ברשימה:
+{{halacha_refs}}
+
+מקור עברי/ארמי לדף:
+{{gemara_he}}
+
+תרגום אנגלי:
+{{gemara_en}}
+
+הפק את הפלט המבוקש לפי הסכימה.`;
+
 const HALACHA_CODIFICATION_SYSTEM_PROMPT_HE = `אתה תלמיד חכם הבקיא בהלכה. בהינתן נושא הלכתי אחד שעלה בדף, הפק את שלשלת הפסיקה הקנונית: מה משנה תורה, הטור, השולחן ערוך והרמ"א פוסקים בנושא המדויק הזה.
 
 החזר JSON תקין בלבד:
@@ -3738,6 +3776,8 @@ const HALACHA_CODIFICATION_SYSTEM_PROMPT_HE = `אתה תלמיד חכם הבקי
 }
 
 כללים:
+- בסס כל מראה מקום. ניתן לך בלוק "מראי מקום מבוססים של הפוסקים" המפרט את מראי המקום האמיתיים מספריא (עם הטקסט) המפנים לדף זה. עבור משנה תורה, הטור, והשולחן ערוך: בחר את מראה המקום מתוך הבלוק הזה ובסס את הפסק על הטקסט המוצג שם. אם אחד משלושת אלה אינו מופיע בבלוק, החזר null עבורו — אל תמציא ואל תשלוף מראה מקום שאינו ברשימה.
+- הרמ"א הוא יוצא הדופן: ספריא משלבת את הגהות הרמ"א בתוך השולחן ערוך, ולכן הרמ"א לא יופיע כערך נפרד בבלוק. ספק את הרמ"א (תוך שימוש בסימן:סעיף של השולחן ערוך כמראה המקום שלו) רק כאשר הוא חולק במפורש, מסייג, או מוסיף מנהג אשכנז לפסק המחבר בנושא הזה — אחרת null.
 - ref חייב להיות מראה מקום אמיתי וניתן לציטוט (ספר + הלכות + פרק:הלכה למשנה תורה; סימן[:סעיף] לטור/שו"ע/רמ"א). אם אינך יכול לספק מראה מקום אמיתי בביטחון, החזר null לאותו פוסק — אל תמציא מראי מקום.
 - עבור כל ערך שאינו null, ה-ruling חייב להתאים באמת למה שהפוסק אומר בנושא הזה, לא להגהה כללית.
 - הרמ"א אינו null רק כשהוא חולק במפורש, מסייג, או מוסיף מנהג אשכנז לפסק המחבר. אם הרמ"א מסכים בשתיקה, השאר null.
@@ -3834,14 +3874,16 @@ CODE_ENRICHMENTS.push(
   makeEnrichment(
     'halacha', 'halacha.codification', 'Codification',
     'Mishneh Torah / Tur / Shulchan Aruch / Rema rulings on this topic, with refs and a prose trail.',
-    HALACHA_CODIFICATION_SYSTEM_PROMPT, HALACHA_LEAF_USER_TEMPLATE, HALACHA_CODIFICATION_OUTPUT_SCHEMA,
+    HALACHA_CODIFICATION_SYSTEM_PROMPT, HALACHA_CODIFICATION_USER_TEMPLATE, HALACHA_CODIFICATION_OUTPUT_SCHEMA,
     {
       mode: 'augment-content', scope: 'local',
-      dependencies: ['gemara'],
+      // 'halacha-refs' feeds the real Sefaria codifier refs (with text) into the
+      // prompt so refs are GROUNDED (selected) rather than recalled.
+      dependencies: ['gemara', 'halacha-refs'],
       passes: ['hebrew-gloss'],
-      defHash: 'halacha.codification-v3', cacheVersion: '3',
+      defHash: 'halacha.codification-v4', cacheVersion: '4',
       systemPromptHe: HALACHA_CODIFICATION_SYSTEM_PROMPT_HE,
-      userPromptTemplateHe: HALACHA_LEAF_USER_TEMPLATE_HE,
+      userPromptTemplateHe: HALACHA_CODIFICATION_USER_TEMPLATE_HE,
     },
   ),
   makeEnrichment(

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -12,6 +12,7 @@ import { collectContext } from './context-providers';
 import { placeRevachWithAi } from './revach-ai-place';
 import { formatContextForPrompt, contextForAnchor, segsFromMarkInput } from '../lib/context/select';
 import { continuationLink, type FlowEdge } from '../lib/context/link';
+import { formatGroundedRefsForPrompt } from '../lib/halacha/codifiers';
 import { dafSpine } from '../lib/context/spine';
 import { dafLinks } from '../lib/context/dafLinks';
 import { producerNodesFrom, reverseDependencyIndex, transitiveDependents } from '../lib/registry/depGraph';
@@ -1386,6 +1387,14 @@ async function resolveDependencies(
       const bundle = await getMishnaBundleCached(rc.env.CACHE, tractate, page);
       const filtered = selectMishnaForMark(bundle, markInput);
       out.vars.mishna = mishnaBundleToString(filtered);
+      return;
+    }
+    if (dep === 'halacha-refs') {
+      // Grounded codifier refs (Mishneh Torah / Tur / Shulchan Aruch) that
+      // Sefaria links to this daf, with their real text — so the codification
+      // enrichment SELECTS from real refs instead of recalling citations.
+      const bundle = await getHalachaRefsCached(rc.env.CACHE, tractate, page);
+      out.vars.halacha_refs = formatGroundedRefsForPrompt(bundle);
       return;
     }
     if (dep === 'context') {

--- a/src/worker/studio-registry.ts
+++ b/src/worker/studio-registry.ts
@@ -214,13 +214,13 @@ function validateEnrichmentDependencies(input: unknown): { ok: true; deps: Enric
   if (!Array.isArray(input)) return { ok: false, error: 'dependencies must be an array' };
   const out: EnrichmentDependency[] = [];
   for (const e of input) {
-    if (e === 'gemara' || e === 'commentaries') { out.push(e); continue; }
+    if (e === 'gemara' || e === 'commentaries' || e === 'mishna' || e === 'context' || e === 'halacha-refs') { out.push(e); continue; }
     if (e && typeof e === 'object') {
       const o = e as { mark?: unknown; enrichment?: unknown };
       if (typeof o.mark === 'string') { out.push({ mark: o.mark }); continue; }
       if (typeof o.enrichment === 'string') { out.push({ enrichment: o.enrichment }); continue; }
     }
-    return { ok: false, error: 'each dep must be "gemara" | "commentaries" | { mark: string } | { enrichment: string }' };
+    return { ok: false, error: 'each dep must be "gemara" | "commentaries" | "mishna" | "context" | "halacha-refs" | { mark: string } | { enrichment: string }' };
   }
   return { ok: true, deps: out };
 }

--- a/src/worker/studio-schema.ts
+++ b/src/worker/studio-schema.ts
@@ -329,6 +329,8 @@ export type Extractor = LLMExtractor | SefariaExtractor | ComputedExtractor | Ma
 //   'context'            → {{context}}  (aggregated external context for the
 //                          daf: dafyomi.co.il Points/Halacha/Charts + Sefaria,
 //                          grouped plain text via collectContext)
+//   'halacha-refs'       → {{halacha_refs}}  (grounded Mishneh Torah / Tur /
+//                          Shulchan Aruch refs + text Sefaria links to this daf)
 //   { enrichment: id }   → {{depends.<id>}}    (recursively resolved)
 //   { mark: id }         → {{anchors.<id>}}    (mark extractor for same daf)
 //
@@ -343,6 +345,7 @@ export type EnrichmentDependency =
   | 'commentaries'
   | 'mishna'
   | 'context'
+  | 'halacha-refs'
   | { enrichment: string }
   | { mark: string };
 

--- a/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
+++ b/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
@@ -20,7 +20,7 @@ exports[`CODE_ENRICHMENTS cache identity > per-enrichment fingerprint is stable 
   "argument.voices@6 mode=augment-content scope=local mark=argument schema=argument_voices[voices,edges] deps=[gemara|m:argument-move|m:rabbi]",
   "daf-background.concepts@5 mode=augment-content scope=local mark=daf-background schema=daf_background_concepts[groups] deps=[gemara|context|m:argument]",
   "daf-background.synthesis@6 mode=aggregate scope=local mark=daf-background schema=daf_background_synthesis[synthesis] deps=[gemara|context|e:daf-background.concepts]",
-  "halacha.codification@3 mode=augment-content scope=local mark=halacha schema=halacha_codification[mishnehTorah,tur,shulchanAruch,rema,prose] deps=[gemara]",
+  "halacha.codification@4 mode=augment-content scope=local mark=halacha schema=halacha_codification[mishnehTorah,tur,shulchanAruch,rema,prose] deps=[gemara|halacha-refs]",
   "halacha.disputes@3 mode=augment-content scope=local mark=halacha schema=halacha_disputes[disputes] deps=[gemara]",
   "halacha.practical@4 mode=augment-content scope=local mark=halacha schema=halacha_practical[lechatchila,bedieved,appliesWhen,exceptions,prose] deps=[gemara]",
   "halacha.synthesis@4 mode=aggregate scope=local mark=halacha schema=halacha_synthesis[synthesis] deps=[gemara|e:halacha.codification|e:halacha.practical|e:halacha.disputes]",

--- a/tests/client/halacha-body.test.tsx
+++ b/tests/client/halacha-body.test.tsx
@@ -50,9 +50,11 @@ describe('Halacha recipe card', () => {
     expect(buttons.some((b) => b.textContent?.includes(t('qa.questions')))).toBe(false);
   });
 
-  it('declares synthesis + the three custom blocks (codification / practical / disputes), no qa', () => {
+  it('declares synthesis + the codification (map) and practical blocks, no qa', () => {
+    // The standalone disputes block is retired — the Mechaber/Rema split now
+    // lives in the codification map (see codeMapFromCodification).
     const blocks = HALACHA_RECIPE.sections.flatMap((s) => (s.type === 'special' ? [s.block] : []));
-    expect(blocks).toEqual(['halacha-codification', 'halacha-practical', 'halacha-disputes']);
+    expect(blocks).toEqual(['halacha-codification', 'halacha-practical']);
     expect(HALACHA_RECIPE.sections[0].type).toBe('synthesis');
     expect(HALACHA_RECIPE.sections.some((s) => s.type === 'qa')).toBe(false);
     // Every declared block is registered.

--- a/tests/code-map-layout.test.ts
+++ b/tests/code-map-layout.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { SIDE_COLOR, relationStyle, gutterEdgePath } from '../src/client/flow/codeMapLayout';
+import {
+  SIDE_COLOR, relationStyle, gutterEdgePath,
+  codeMapFromCodification, type CodificationData,
+} from '../src/client/flow/codeMapLayout';
+
+const ruling = (ref: string) => ({ ref, ruling: `ruling for ${ref}` });
+const baseCod = (over: Partial<CodificationData> = {}): CodificationData => ({
+  mishnehTorah: null, tur: null, shulchanAruch: null, rema: null, prose: 'p', ...over,
+});
 
 describe('relationStyle', () => {
   it('only disagrees is dashed; colours match the Voices/Flow palette', () => {
@@ -48,5 +56,49 @@ describe('gutterEdgePath', () => {
     const d = gutterEdgePath(30, 110, 300, 340);
     expect((d.match(/L /g) || []).length).toBe(3);
     expect((d.match(/Q /g) || []).length).toBe(2);
+  });
+});
+
+describe('codeMapFromCodification', () => {
+  it('builds the gemara→Rambam→Tur→SA spine with cites then transmits, all neutral when undisputed', () => {
+    const { nodes, edges } = codeMapFromCodification(baseCod({
+      mishnehTorah: ruling('Krias Shema 1:9'), tur: ruling('OC 235'), shulchanAruch: ruling('OC 235:3'),
+    }), 'Berakhot 2a');
+    expect(nodes.map((n) => n.id)).toEqual(['gemara', 'mishnehTorah', 'tur', 'shulchanAruch']);
+    expect(nodes[0]).toMatchObject({ label: 'Gemara', ref: 'Berakhot 2a', side: 'source', era: 'source' });
+    expect(nodes.find((n) => n.id === 'shulchanAruch')).toMatchObject({ label: 'Shulchan Aruch', side: 'neutral' });
+    expect(edges).toEqual([
+      { from: 'gemara', to: 'mishnehTorah', kind: 'cites' },
+      { from: 'mishnehTorah', to: 'tur', kind: 'transmits' },
+      { from: 'tur', to: 'shulchanAruch', kind: 'transmits' },
+    ]);
+  });
+
+  it('folds a present Rema into a side-B node with a disagrees edge; SA becomes Mechaber/side-A', () => {
+    const { nodes, edges } = codeMapFromCodification(baseCod({
+      mishnehTorah: ruling('Berakhot 8:1'), tur: ruling('OC 202'), shulchanAruch: ruling('OC 202:1'), rema: ruling('OC 202:1'),
+    }), 'Berakhot 35a');
+    expect(nodes.find((n) => n.id === 'shulchanAruch')).toMatchObject({ label: 'Mechaber', side: 'a' });
+    expect(nodes.find((n) => n.id === 'rema')).toMatchObject({ label: 'Rema', side: 'b', ref: 'OC 202:1' });
+    expect(edges).toContainEqual({ from: 'shulchanAruch', to: 'rema', kind: 'disagrees' });
+  });
+
+  it('skips absent codifiers; the first present one is cited from the gemara', () => {
+    const { nodes, edges } = codeMapFromCodification(baseCod({ shulchanAruch: ruling('YD 87:1') }), 'Chullin 113b');
+    expect(nodes.map((n) => n.id)).toEqual(['gemara', 'shulchanAruch']);
+    expect(edges).toEqual([{ from: 'gemara', to: 'shulchanAruch', kind: 'cites' }]);
+  });
+
+  it('does not fold in a Rema that has no Shulchan Aruch to gloss (no orphan disagree edge)', () => {
+    const { nodes, edges } = codeMapFromCodification(baseCod({
+      mishnehTorah: ruling('Hil. X 1:1'), rema: ruling('OC 99:1'),
+    }), 'Gittin 2a');
+    expect(nodes.map((n) => n.id)).toEqual(['gemara', 'mishnehTorah']); // no rema node
+    expect(edges.some((e) => e.to === 'rema')).toBe(false);
+  });
+
+  it('ignores a ruling with a blank ref', () => {
+    const { nodes } = codeMapFromCodification(baseCod({ mishnehTorah: { ref: '  ', ruling: 'x' } }), 'Shabbat 2a');
+    expect(nodes.map((n) => n.id)).toEqual(['gemara']);
   });
 });

--- a/tests/dep-graph-validate.test.ts
+++ b/tests/dep-graph-validate.test.ts
@@ -3,7 +3,8 @@ import { producerNodesFrom, validateProducerGraph } from '../src/lib/registry/de
 import { CODE_MARKS, CODE_ENRICHMENTS } from '../src/worker/code-marks';
 
 // Source inputs are the non-producer leaves a dependency may point at.
-const SOURCES = new Set(['gemara', 'commentaries', 'context', 'mishna']);
+// 'halacha-refs' feeds grounded codifier refs into halacha.codification.
+const SOURCES = new Set(['gemara', 'commentaries', 'context', 'mishna', 'halacha-refs']);
 
 describe('validateProducerGraph — unit', () => {
   it('flags a dependency on a nonexistent producer/source as dangling', () => {

--- a/tests/halacha-codifiers.test.ts
+++ b/tests/halacha-codifiers.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   classifyCodifier, buildCodificationChain, hasCodification, CODIFIERS,
-  classifyShasSource, baseDafRef, buildDerivation,
+  classifyShasSource, baseDafRef, buildDerivation, formatGroundedRefsForPrompt,
   type RelatedLink,
 } from '../src/lib/halacha/codifiers';
 import type { HalachicRefBundle } from '../src/lib/sefref/sefaria/client';
@@ -85,6 +85,30 @@ describe('buildCodificationChain', () => {
     expect(hasCodification(aggadic)).toBe(false);
     expect(hasCodification(bundle)).toBe(true);
     expect(hasCodification(undefined)).toBe(false);
+  });
+});
+
+describe('formatGroundedRefsForPrompt', () => {
+  it('lists allowlisted codifiers with their refs + capped snippets, in lineage order', () => {
+    const out = formatGroundedRefsForPrompt({
+      'Tur, Orach Chayim': [{ ref: 'Tur, Orach Chayim 235', hebrew: 'זמן קריאת שמע', english: 'The time for Shema' }],
+      'Mishneh Torah, Reading the Shema': [{ ref: 'Mishneh Torah, Reading the Shema 1:9', hebrew: 'מצאת הכוכבים', english: 'From nightfall' }],
+      'Sefer Yereim': [{ ref: 'Sefer Yereim 300:1', hebrew: 'x', english: 'y' }], // noise, dropped
+    });
+    // Mishneh Torah (order 1) precedes Tur (order 2); noise excluded.
+    expect(out.indexOf('Mishneh Torah')).toBeLessThan(out.indexOf('Tur'));
+    expect(out).not.toContain('Sefer Yereim');
+    expect(out).toContain('Mishneh Torah, Reading the Shema 1:9');
+    expect(out).toContain('HE: מצאת הכוכבים');
+    expect(out).toContain('EN: The time for Shema');
+  });
+
+  it('caps long snippets and marks an empty bundle', () => {
+    expect(formatGroundedRefsForPrompt({})).toBe('(no codifier links found for this daf)');
+    const long = 'א'.repeat(800);
+    const out = formatGroundedRefsForPrompt({ 'Shulchan Arukh, Orach Chayim': [{ ref: 'OC 235:1', hebrew: long, english: '' }] });
+    expect(out).toContain('…');
+    expect(out.length).toBeLessThan(long.length);
   });
 });
 


### PR DESCRIPTION
PR 3 of the halacha redesign — the **codification axis, end to end** (generation-only; no mass re-warm). Builds on the data layer (#175) and the component (#177).

### Worker — refs are GROUNDED, not recalled
- New **`halacha-refs` enrichment dependency**: feeds the real Sefaria Mishneh Torah / Tur / Shulchan Aruch refs (with their text) that cite the daf into the codification prompt, via `formatGroundedRefsForPrompt` over #175's `buildCodificationChain`. The prompt now **selects from that block** instead of recalling citations.
- **Rema carve-out** (caught in review): Sefaria folds Rema into the SA, so it won't appear in the grounded block — the prompt supplies Rema (using the SA's siman:seif) only when he genuinely diverges, so the Mechaber/Rema edge survives.
- Dedicated `HALACHA_CODIFICATION_USER_TEMPLATE` (EN+HE) carrying `{{halacha_refs}}`; codification `cacheVersion` 3→4. **Output schema unchanged** (so synthesis/practical untouched).
- `halacha-refs` added to `EnrichmentDependency` + the studio validator (which had also drifted from `mishna`/`context`).

### Client — the codification block becomes the CodificationMap
- `codeMapFromCodification` maps the existing `{mishnehTorah,tur,shulchanAruch,rema}` shape to the lineage (Gemara → Rambam → Tur → Shulchan Aruch), folding a present **Rema** in as the Mechaber/Rema **disagree edge** (only when the SA is present).
- `HalachaCodification` now renders `CodificationMap`; the `RulingRow` stack + `sefariaUrl` are retired. The **standalone disputes recipe block is dropped** — the common codifier split lives in the map; synthesis still weaves the rest.
- Backward-compatible: the mapper consumes the same shape already cached, so the new map renders from existing data too; new generation just sharpens the refs.

### Scope / next
Generation-only — cards regenerate on demand under the new `cache_version`. The shape-aware **practical** reshape (best/fallback) + the richer **dispute object** (with dafyomi poskim) + **derivation** ("where it comes from") are the follow-up PRs.

### Tests
Reviewed with Codex (3 findings fixed: Rema grounding, rema-without-SA edge, studio validator). Pure logic unit-tested (codifiers, prompt formatter, mapper); `pnpm typecheck` clean; `pnpm test` 1670 passed.