### PR TITLE
Client: calm 'try again later' message on AI-provider outages

### DIFF
--- a/src/client/MarkEnrichmentCards.tsx
+++ b/src/client/MarkEnrichmentCards.tsx
@@ -25,7 +25,7 @@ import { trackAI } from './aiActivity';
 import InstanceInspectorShelf from './InstanceInspectorShelf';
 import {
   RequestQueue, QUEUE_PRIORITY, runResultCache, runCacheKey, isAbort,
-  PAUSED_ERROR, isPausedBody,
+  PAUSED_ERROR, isPausedBody, isServiceUnavailableError,
   type RunResult,
 } from './enrichmentQueue';
 import { lang, t } from './i18n';
@@ -608,13 +608,17 @@ export default function MarkEnrichmentCards(props: Props) {
     }
     if (r.kind === 'error') {
       const paused = r.error === PAUSED_ERROR;
+      const unavailable = !paused && isServiceUnavailableError(r.error);
+      // Both paused and provider-outage are calm, expected states — amber, plain
+      // text, localized. A genuine bug (parse/schema/unknown) stays loud (red mono).
+      const calm = paused || unavailable;
       return (
         <div style={{
-          color: paused ? '#a16207' : '#c00',
-          'font-family': paused ? 'inherit' : 'monospace',
+          color: calm ? '#a16207' : '#c00',
+          'font-family': calm ? 'inherit' : 'monospace',
           'font-size': '0.78rem', padding: '0.4rem 0',
         }}>
-          {paused ? t('qa.error.paused') : r.error}
+          {paused ? t('qa.error.paused') : unavailable ? t('enrich.error.unavailable') : r.error}
         </div>
       );
     }

--- a/src/client/QAPanel.tsx
+++ b/src/client/QAPanel.tsx
@@ -32,7 +32,7 @@ import { Hebraized } from './Hebraized';
 import { hebraize } from './hebraize';
 import { trackAI } from './aiActivity';
 import { lang, t } from './i18n';
-import { PAUSED_ERROR, isPausedBody, isPausedError } from './enrichmentQueue';
+import { PAUSED_ERROR, isPausedBody, isPausedError, isServiceUnavailableError } from './enrichmentQueue';
 
 export interface QAPanelProps {
   /** Mark id — drives which `<mark>.suggested-questions` + `<mark>.qa`
@@ -301,7 +301,11 @@ export default function QAPanel(props: QAPanelProps): JSX.Element {
         }).catch(() => { /* swallow */ });
       }
     } catch (err) {
-      const msg = isPausedError(err) ? t('qa.error.paused') : String((err as Error)?.message ?? err);
+      const msg = isPausedError(err)
+        ? t('qa.error.paused')
+        : isServiceUnavailableError(err)
+          ? t('enrich.error.unavailable')
+          : String((err as Error)?.message ?? err);
       setOpenAnswers((m) => ({ ...m, [key]: { state: 'error', error: msg } }));
     }
   };
@@ -320,7 +324,9 @@ export default function QAPanel(props: QAPanelProps): JSX.Element {
         ? t('qa.error.paused')
         : reply.rateLimited
           ? t('qa.error.rateLimit')
-          : reply.error);
+          : isServiceUnavailableError(reply.error)
+            ? t('enrich.error.unavailable')
+            : reply.error);
       return;
     }
     // Optimistically prepend to registry so it appears immediately, then

--- a/src/client/enrichmentQueue.ts
+++ b/src/client/enrichmentQueue.ts
@@ -61,6 +61,24 @@ export function isPausedError(err: unknown): boolean {
   return (err as { message?: string } | null)?.message === PAUSED_ERROR;
 }
 
+// A transient AI-provider failure (auth rejected, provider down, gateway 5xx,
+// timed-out job) — distinct from a code bug. The provider/model is unreachable,
+// so the honest, calm message is "try again later" rather than a raw stack.
+// Matches the worker's runLLM error strings (llm-error.ts) + the client's own
+// poll timeout. Deliberately narrow: a parse/schema/validation error is a real
+// bug and should still surface loudly.
+const SERVICE_UNAVAILABLE_RE =
+  /openrouter|user not found|no endpoints|HTTP\s*40[13]\b|HTTP\s*5\d\d\b|InferenceUpstreamError|timed out|fetch failed|network|temporarily unavailable|AiError|budget exhausted/i;
+
+/** True when an error string / Error signals the AI service is unavailable
+ *  (provider auth/outage/timeout) rather than a genuine bug. Excludes the
+ *  budget-pause sentinel, which has its own dedicated message. */
+export function isServiceUnavailableError(err: unknown): boolean {
+  const msg = typeof err === 'string' ? err : (err as { message?: string } | null)?.message;
+  if (!msg || msg === PAUSED_ERROR) return false;
+  return SERVICE_UNAVAILABLE_RE.test(msg);
+}
+
 // ---------------------------------------------------------------------------
 // Client-side result cache
 // ---------------------------------------------------------------------------

--- a/src/client/i18n.ts
+++ b/src/client/i18n.ts
@@ -704,6 +704,10 @@ const CATALOG = {
     en: 'AI generation is paused for now to keep this project sustainable. Please try again tomorrow.',
     he: 'יצירת התוכן בבינה מלאכותית מושהית כעת כדי לשמור על קיימות הפרויקט. נא לנסות שוב מחר.',
   },
+  'enrich.error.unavailable': {
+    en: 'AI generation is temporarily unavailable. Please try again later or tomorrow.',
+    he: 'יצירת התוכן בבינה מלאכותית אינה זמינה כרגע. נא לנסות שוב מאוחר יותר או מחר.',
+  },
 } satisfies Record<string, Entry>;
 
 /** Every known catalog key. Lets UI props (e.g. section labels) demand a real

--- a/tests/enrichment-queue.test.ts
+++ b/tests/enrichment-queue.test.ts
@@ -1,5 +1,29 @@
 import { describe, it, expect } from 'vitest';
-import { RequestQueue, QUEUE_PRIORITY, isAbort } from '../src/client/enrichmentQueue';
+import { RequestQueue, QUEUE_PRIORITY, isAbort, isServiceUnavailableError, PAUSED_ERROR } from '../src/client/enrichmentQueue';
+
+describe('isServiceUnavailableError', () => {
+  it('flags AI-provider outages / timeouts (calm "try later" states)', () => {
+    for (const m of [
+      'OpenRouter HTTP 401: {"error":{"message":"User not found.","code":401}}',
+      'OpenRouter HTTP 503',
+      'no endpoints found',
+      'job abc timed out after 90s',
+      'fetch failed',
+      'InferenceUpstreamError',
+    ]) {
+      expect(isServiceUnavailableError(m)).toBe(true);
+      expect(isServiceUnavailableError(new Error(m))).toBe(true);
+    }
+  });
+
+  it('does NOT flag real bugs or the budget-pause sentinel', () => {
+    expect(isServiceUnavailableError('schema validation failed: missing field "ref"')).toBe(false);
+    expect(isServiceUnavailableError('parse_error: unexpected token')).toBe(false);
+    expect(isServiceUnavailableError(PAUSED_ERROR)).toBe(false);
+    expect(isServiceUnavailableError('')).toBe(false);
+    expect(isServiceUnavailableError(null)).toBe(false);
+  });
+});
 
 // A manually-resolved promise so tests can control exactly when a task
 // finishes and observe queue scheduling deterministically.


### PR DESCRIPTION
When an enrichment / Q&A run fails because the AI provider is unreachable — auth rejected (e.g. `OpenRouter HTTP 401: User not found`), gateway 5xx, no endpoints, or the client's poll timed out — the cards showed a **raw red error string** or just spun. These are expected, transient states, not bugs, and should read calmly.

### Changes (client-only)
- **`isServiceUnavailableError`** (`enrichmentQueue.ts`): classifies provider-outage / timeout error strings. Deliberately narrow — excludes the budget-pause sentinel (its own message) and genuine parse/schema/validation bugs, which still surface loudly in red monospace.
- **`enrich.error.unavailable`** (i18n, en+he): "AI generation is temporarily unavailable. Please try again later or tomorrow."
- **`MarkEnrichmentCards` + `QAPanel`** render a provider outage like the existing budget pause: amber, plain text, localized.

### Why
Surfaces the outage honestly instead of a raw stack, and pairs with the existing budget-pause UX. (Prompted by a real prod incident: a revoked OpenRouter key returned 401 for every enrichment; stale-while-revalidate masked it server-side, but any cold card showed the raw 401.)

### Tests
`isServiceUnavailableError` unit-tested (flags 401/5xx/no-endpoints/timeout/fetch-failed; does NOT flag schema bugs or the pause sentinel). `pnpm typecheck` clean; `pnpm test` 1688 passed.