### PR TITLE
Halacha: derivation — 'where it comes from' (reverse Sefaria)

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -12,6 +12,7 @@ import RabbiPlacesTimeline, { type LocationInference } from './RabbiPlacesTimeli
 import ArgumentVoiceMap, { type ArgumentVoicesData } from './ArgumentVoiceMap';
 import CodificationMap from './CodificationMap';
 import { codeMapFromCodification, type CodificationData } from './flow/codeMapLayout';
+import { type DerivationSource } from '../lib/halacha/codifiers';
 import ArgumentNarrative from './ArgumentNarrative';
 import { deriveVoiceEdges } from '../lib/typing/voices';
 import { voicesMapEligible, voicesShowMap, voicesShowFallback } from '../lib/typing/profile';
@@ -1393,6 +1394,63 @@ function HalachaDisputes(props: SpecialBlockProps): JSX.Element {
 }
 
 /** The halacha mark-instance shape (mark_input for the leaves). */
+async function fetchDerivation(args: { tractate: string; page: string; refs: string[] }): Promise<DerivationSource[]> {
+  if (args.refs.length === 0) return [];
+  const qs = args.refs.map((r) => `ref=${encodeURIComponent(r)}`).join('&');
+  const r = await fetch(`/api/derivation/${encodeURIComponent(args.tractate)}/${encodeURIComponent(args.page)}?${qs}`);
+  if (!r.ok) return [];
+  const j = await r.json() as { sources?: DerivationSource[] };
+  return j.sources ?? [];
+}
+
+const DERIVATION_ROLE_LABEL: Record<DerivationSource['role'], string> = {
+  primary: 'primary source', related: 'related', root: 'scriptural root',
+};
+
+// Halacha "where it comes from": the gemara (+ scriptural) sources the codified
+// ruling derives from. Reads the codifier refs off the halacha.codification leaf
+// and fetches the deterministic /api/derivation (reverse Sefaria). The current
+// daf is highlighted — a card belongs to its codified law and surfaces on every
+// daf that is a source for it.
+function HalachaDerivation(props: SpecialBlockProps): JSX.Element {
+  const refs = (): string[] => {
+    const d = props.deps['halacha.codification'] as CodificationData | undefined;
+    if (!d) return [];
+    return [d.mishnehTorah?.ref, d.tur?.ref, d.shulchanAruch?.ref]
+      .filter((r): r is string => typeof r === 'string' && r.trim().length > 0);
+  };
+  const [sources] = createResource(
+    () => ({ tractate: props.tractate, page: props.page, refs: refs() }),
+    fetchDerivation,
+  );
+  return (
+    <Show when={(sources() ?? []).length > 0}>
+      <div style={{ 'margin-top': '0.9rem' }}>
+        <div style={{ 'font-size': '0.7rem', 'text-transform': 'uppercase', 'letter-spacing': '0.08em', color: '#888', 'margin-bottom': '0.5rem' }}>
+          {t('halacha.derivation')}
+        </div>
+        <div style={{ display: 'flex', 'flex-direction': 'column', gap: '0.4rem' }}>
+          <For each={sources()}>{(s) => (
+            <div style={{
+              display: 'flex', 'align-items': 'baseline', gap: '0.5rem',
+              background: s.isCurrent ? '#fdf2f2' : '#fff',
+              border: s.isCurrent ? '1.5px solid #8a2a2b' : '1px solid #e4e0d4',
+              'border-radius': '8px', padding: '0.4rem 0.6rem',
+              'box-shadow': '0 1px 1.4px rgba(58,51,32,0.1)',
+            }}>
+              <span style={{ 'font-family': 'system-ui, -apple-system, sans-serif', 'font-size': '0.82rem', 'font-weight': 600, color: '#2a2723' }}>{s.ref}</span>
+              <span style={{ 'font-family': 'system-ui, -apple-system, sans-serif', 'font-size': '0.62rem', 'text-transform': 'uppercase', 'letter-spacing': '0.04em', color: '#9a958a' }}>{DERIVATION_ROLE_LABEL[s.role]}</span>
+              <Show when={s.isCurrent}>
+                <span style={{ 'margin-left': 'auto', 'font-family': 'system-ui, -apple-system, sans-serif', 'font-size': '0.58rem', 'font-weight': 700, color: '#fff', background: '#8a2a2b', 'border-radius': '3px', padding: '0.05rem 0.3rem', 'flex-shrink': 0 }}>YOU ARE HERE</span>
+              </Show>
+            </div>
+          )}</For>
+        </div>
+      </div>
+    </Show>
+  );
+}
+
 export function halachaInstance(topic: HalachaTopic): { fields: Record<string, unknown>; startSegIdx: number; endSegIdx: number } {
   return {
     startSegIdx: 0,
@@ -1408,6 +1466,7 @@ export function halachaInstance(topic: HalachaTopic): { fields: Record<string, u
 export const HALACHA_BLOCKS: Record<string, (p: SpecialBlockProps) => JSX.Element> = {
   'halacha-codification': HalachaCodification,
   'halacha-practical': HalachaPractical,
+  'halacha-derivation': HalachaDerivation,
   'halacha-disputes': HalachaDisputes,
 };
 

--- a/src/client/i18n.ts
+++ b/src/client/i18n.ts
@@ -515,6 +515,7 @@ const CATALOG = {
 
   // — Halacha body —
   'halacha.codification': { en: 'Codification', he: 'פסיקה' },
+  'halacha.derivation': { en: 'Where it comes from', he: 'מקורות בש״ס' },
   'halacha.practical': { en: 'Practical', he: 'למעשה' },
   'halacha.disputes': { en: 'Disputes', he: 'מחלוקות' },
   // Codification source labels (the פסיקה rows).

--- a/src/lib/sefref/sefaria/client.ts
+++ b/src/lib/sefref/sefaria/client.ts
@@ -502,6 +502,22 @@ class SefariaAPI {
   }
 
   /**
+   * Reverse derivation ("where it comes from"): given a CODE ref (a Mishneh
+   * Torah / Tur / Shulchan Aruch citation), return the Talmud + Tanakh sources
+   * Sefaria links it to — the gemara dapim (and biblical verses) the codified
+   * law rests on. The inverse of `fetchHalachicRefs`. Returns the raw
+   * `{ ref, category }` links; `buildDerivation` (src/lib/halacha/codifiers)
+   * classifies + dedupes them. Returns [] on any fetch error.
+   */
+  async fetchCodeSources(codeRef: string): Promise<Array<{ ref: string; category: string }>> {
+    const related = await this.getRelated(codeRef).catch(() => null);
+    if (!related) return [];
+    return related.links
+      .filter((l) => l.category === 'Talmud' || l.category === 'Tanakh')
+      .map((l) => ({ ref: l.ref, category: l.category }));
+  }
+
+  /**
    * Fetch the Mishnayot that the gemara on this daf is discussing. Sefaria's
    * /api/related surfaces these as `category: "Mishnah"` links — typically
    * 1-2 per daf, with `type: "mishnah in talmud"` marking the canonical

--- a/src/lib/sidebar/recipe.ts
+++ b/src/lib/sidebar/recipe.ts
@@ -96,6 +96,10 @@ export const HALACHA_RECIPE: SidebarRecipe = {
     // codifier dispute now lives in the map; synthesis still weaves the rest.
     { type: 'special', block: 'halacha-codification', deps: ['halacha.codification'] },
     { type: 'special', block: 'halacha-practical', deps: ['halacha.practical'] },
+    // "Where it comes from": the gemara sources the codified law derives from
+    // (deterministic reverse Sefaria, /api/derivation), reading the codifier
+    // refs off the codification leaf — so it depends on halacha.codification.
+    { type: 'special', block: 'halacha-derivation', deps: ['halacha.codification'] },
   ],
 };
 

--- a/src/worker/cache-keys.ts
+++ b/src/worker/cache-keys.ts
@@ -231,6 +231,11 @@ export function keyForRishonim(tractate: string, page: string): string {
 export function keyForHalachaRefs(tractate: string, page: string): string {
   return `halacha-refs:v2:${tractate}:${page}`;
 }
+/** Reverse derivation: the Talmud/Tanakh sources a CODE ref (Mishneh Torah /
+ *  Tur / Shulchan Aruch citation) links back to. Keyed by the raw code ref. */
+export function keyForCodeSources(codeRef: string): string {
+  return `code-sources:v1:${codeRef}`;
+}
 export function keyForDafTopics(tractate: string, page: string): string {
   return `daf-topics:v1:${tractate}:${page}`;
 }

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -12,7 +12,7 @@ import { collectContext } from './context-providers';
 import { placeRevachWithAi } from './revach-ai-place';
 import { formatContextForPrompt, contextForAnchor, segsFromMarkInput } from '../lib/context/select';
 import { continuationLink, type FlowEdge } from '../lib/context/link';
-import { formatGroundedRefsForPrompt } from '../lib/halacha/codifiers';
+import { formatGroundedRefsForPrompt, buildDerivation } from '../lib/halacha/codifiers';
 import { dafSpine } from '../lib/context/spine';
 import { dafLinks } from '../lib/context/dafLinks';
 import { producerNodesFrom, reverseDependencyIndex, transitiveDependents } from '../lib/registry/depGraph';
@@ -23,6 +23,7 @@ import {
   getSefariaPageCached,
   getRishonimCached,
   getHalachaRefsCached,
+  getCodeSourcesCached,
   getSaCommentaryCached,
   getDafTopicsCached,
   getMishnaBundleCached,
@@ -866,6 +867,21 @@ async function readFlowConnections(env: Bindings, tractate: string, page: string
 // first real CONSUMER of src/lib/context/link.ts — assembled by the pure
 // `dafLinks`. Best-effort per source: a cold/failed source contributes nothing
 // rather than failing the whole response.
+// Halacha "where it comes from": the gemara sources a codified ruling derives
+// from. Deterministic — reverse Sefaria /api/related on the code ref, classified
+// + deduped by buildDerivation, with the current daf marked. Read-only, no LLM.
+// Accepts one or more `ref` query params (the codifier refs the card already
+// holds), merges their sources.
+app.get('/api/derivation/:tractate/:page', async (c) => {
+  const tractate = c.req.param('tractate');
+  const page = c.req.param('page');
+  const refs = c.req.queries('ref') ?? [];
+  if (refs.length === 0) return c.json({ sources: [] });
+  const linkLists = await Promise.all(refs.map((r) => getCodeSourcesCached(c.env.CACHE, r)));
+  const sources = buildDerivation(linkLists.flat(), { tractate, page });
+  return c.json({ sources });
+});
+
 app.get('/api/links/:tractate/:page', async (c) => {
   const tractate = c.req.param('tractate');
   const page = c.req.param('page');

--- a/src/worker/source-cache.ts
+++ b/src/worker/source-cache.ts
@@ -31,7 +31,7 @@ import {
 import type { DafyomiDaf } from '../lib/sefref/dafyomi/schema';
 import {
   keyForDafyomi, keyForHebrewBooks, keyForSefariaBundle, keyForSefariaSegments,
-  keyForRishonim, keyForHalachaRefs, keyForDafTopics, keyForMishnaBundle, keyForSaCommentary,
+  keyForRishonim, keyForHalachaRefs, keyForCodeSources, keyForDafTopics, keyForMishnaBundle, keyForSaCommentary,
 } from './cache-keys';
 import { scrapeDafyomiLive } from './dafyomi-live';
 
@@ -177,6 +177,24 @@ export async function getHalachaRefsCached(
     return data;
   } catch {
     return {};
+  }
+}
+
+/** Reverse derivation: the Talmud/Tanakh sources a code ref links back to,
+ *  cached by the raw code ref. Feeds the halacha "where it comes from" view. */
+export async function getCodeSourcesCached(
+  cache: KVNamespace | undefined,
+  codeRef: string,
+): Promise<Array<{ ref: string; category: string }>> {
+  const key = keyForCodeSources(codeRef);
+  const hit = await readCache<Array<{ ref: string; category: string }>>(cache, key);
+  if (hit) return hit;
+  try {
+    const data = await sefariaAPI.fetchCodeSources(codeRef);
+    await writeCache(cache, key, data);
+    return data;
+  } catch {
+    return [];
   }
 }
 

--- a/tests/client/halacha-body.test.tsx
+++ b/tests/client/halacha-body.test.tsx
@@ -50,11 +50,12 @@ describe('Halacha recipe card', () => {
     expect(buttons.some((b) => b.textContent?.includes(t('qa.questions')))).toBe(false);
   });
 
-  it('declares synthesis + the codification (map) and practical blocks, no qa', () => {
+  it('declares synthesis + codification (map), practical, derivation; no qa', () => {
     // The standalone disputes block is retired — the Mechaber/Rema split now
-    // lives in the codification map (see codeMapFromCodification).
+    // lives in the codification map (see codeMapFromCodification). Derivation
+    // ("where it comes from") reads the codifier refs off halacha.codification.
     const blocks = HALACHA_RECIPE.sections.flatMap((s) => (s.type === 'special' ? [s.block] : []));
-    expect(blocks).toEqual(['halacha-codification', 'halacha-practical']);
+    expect(blocks).toEqual(['halacha-codification', 'halacha-practical', 'halacha-derivation']);
     expect(HALACHA_RECIPE.sections[0].type).toBe('synthesis');
     expect(HALACHA_RECIPE.sections.some((s) => s.type === 'qa')).toBe(false);
     // Every declared block is registered.


### PR DESCRIPTION
PR 4 of the halacha redesign — the **"Where it comes from"** layer: the cross-Shas gemara (+ scriptural) sources a codified ruling derives from, with the current daf marked. **Deterministic — no LLM** (the inverse of the daf→codifiers link, straight from Sefaria), so it's unaffected by provider state.

### What's here
- **`fetchCodeSources(codeRef)`** (sefaria client): reverse `/api/related` on a code ref → its `Talmud`/`Tanakh` links. Cached via `getCodeSourcesCached` + `keyForCodeSources`.
- **`GET /api/derivation/:t/:p?ref=...&ref=...`**: merges the reverse sources for the codifier refs and runs `buildDerivation` (#175) → `{ sources }` with the current daf flagged. Read-only.
- **`HalachaDerivation`** client block: reads the codifier refs off the `halacha.codification` leaf, fetches `/api/derivation`, renders the source list (primary / related / scriptural-root; current daf highlighted in burgundy). Wired into `HALACHA_RECIPE` after practical; i18n `halacha.derivation` ("Where it comes from").

### Verified upstream
Reverse derivation was probed live earlier (e.g. MT Reading the Shema 1:9 → Berakhot 2a + Shabbat 34b/Pesachim 94a; SA CM 3:1 → Sanhedrin 2a/2b/3a + RH 25b + Tanakh). `buildDerivation` (dedup, role assignment, current-daf marking) is unit-tested in #175.

### Review / tests
Codex-reviewed (no issues). `pnpm typecheck` clean; `pnpm test` 1688 passed.