### PR TITLE
Overview maps: show a loading state until the flow resolves

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -738,6 +738,17 @@ export function groupSectionsBySugya(sectionCount: number, connections: FlowConn
   return groups;
 }
 
+/** What the overview's maps region should render. A map is a flow graph whose
+ *  edges are the daf's connections; before the flow enrichment resolves there
+ *  are no connections, so rendering the maps then would show disconnected,
+ *  link-less nodes. Gate on resolution: 'loading' until the flow resolves,
+ *  'ready' after (a daf may legitimately resolve to zero edges), 'empty' when
+ *  the daf has no sections at all. Pure + exported for tests. */
+export function mapsState(sectionCount: number, flowResolved: boolean): 'empty' | 'loading' | 'ready' {
+  if (sectionCount <= 0) return 'empty';
+  return flowResolved ? 'ready' : 'loading';
+}
+
 /** A link from the unified link layer (GET /api/links). Minimal client shape. */
 interface DafLinkLite {
   via: string;
@@ -761,11 +772,16 @@ function ArgumentOverviewBody(props: {
 }): JSX.Element {
   const [connections, setConnections] = createSignal<FlowConnection[]>([]);
   const [active, setActive] = createSignal<number | null>(null);
+  // Has the daf-level flow enrichment resolved yet? Until it has, we have no
+  // connections, so the maps would render as disconnected, link-less nodes —
+  // we show a loading state instead (see `mapsState`).
+  const [flowResolved, setFlowResolved] = createSignal(false);
 
   createEffect(() => {
     void `${props.tractate}/${props.page}`;
     setConnections([]);
     setActive(null);
+    setFlowResolved(false);
     props.onHighlightRange?.(null);
   });
 
@@ -786,6 +802,9 @@ function ArgumentOverviewBody(props: {
   const handleResolved = (r: { deps_resolved?: Record<string, unknown>; anchors_resolved?: Record<string, unknown> }) => {
     const flow = r.deps_resolved?.['argument-overview.flow'] as { connections?: FlowConnection[] } | undefined;
     if (flow && Array.isArray(flow.connections)) setConnections(flow.connections);
+    // The synthesis has resolved (a daf can legitimately have zero flow edges):
+    // the maps may now render, link-less or not.
+    setFlowResolved(true);
   };
 
   // Split the daf's sections into discussion maps. With no flow yet (cold), each
@@ -905,7 +924,26 @@ function ArgumentOverviewBody(props: {
       >
         {/* One flow-graph map per discussion. Multiple maps = multiple sugyot on
             the daf; the cross-page flags show where a discussion runs past the
-            page break. */}
+            page break. Until the flow resolves we have no connections, so we
+            show a loading state rather than disconnected, link-less nodes. */}
+        <Show
+          when={mapsState(props.sections.length, flowResolved()) === 'ready'}
+          fallback={
+            <div style={{
+              display: 'flex', 'align-items': 'center', gap: '0.6rem',
+              padding: '0.7rem 0.2rem', color: '#666', 'font-size': '0.82rem',
+              'font-style': 'italic',
+            }}>
+              <span style={{
+                display: 'inline-block', width: '0.85rem', height: '0.85rem',
+                'border-radius': '50%',
+                border: '2px solid #d6d3d1', 'border-top-color': '#8a2a2b',
+                animation: 'daf-spin 0.8s linear infinite', 'flex-shrink': 0,
+              }} />
+              {t('overview.mapping')}
+            </div>
+          }
+        >
         <For each={groups()}>{(grp) => {
           const hasFirst = grp.includes(0);
           const hasLast = grp.includes(props.sections.length - 1);
@@ -936,6 +974,7 @@ function ArgumentOverviewBody(props: {
             </div>
           );
         }}</For>
+        </Show>
       </Show>
       <Show when={hasConnections()}>
         <div style={{ 'margin-top': '0.7rem', 'border-top': '1px solid #f0f0f0', 'padding-top': '0.55rem' }}>

--- a/src/client/i18n.ts
+++ b/src/client/i18n.ts
@@ -188,6 +188,7 @@ const CATALOG = {
   'overview.crossRefs': { en: 'Cross-references', he: 'הפניות' },
   'overview.connections': { en: 'Connections', he: 'קשרים' },
   'overview.withinFlow': { en: 'within-daf flow', he: 'מהלך פנימי בדף' },
+  'overview.mapping': { en: 'Mapping the discussion…', he: 'ממפה את הסוגיה…' },
   'overview.goToDaf': { en: 'Go to {daf}', he: 'מעבר ל{daf}' },
   'overview.openArgument': { en: 'Open the full argument →', he: 'פתח את הסוגיה המלאה ←' },
   // Link-relation labels (the unified link layer, src/lib/context/link.ts).

--- a/tests/maps-loading-state.test.ts
+++ b/tests/maps-loading-state.test.ts
@@ -1,0 +1,31 @@
+/**
+ * mapsState (ArgumentSidebar): the overview's flow-graph maps must NOT render
+ * until the daf-level flow enrichment has resolved. Before resolution there are
+ * no connections, so the maps would show as disconnected, link-less nodes — a
+ * "map without its links". The gate shows a loading state instead. This locks
+ * that gate against regression.
+ */
+import { describe, it, expect } from 'vitest';
+import { mapsState } from '../src/client/ArgumentSidebar';
+
+describe('mapsState — maps wait for the flow to resolve', () => {
+  it('is loading while the flow has not resolved (no links yet)', () => {
+    // The bug: sections exist, so the maps used to render immediately — as
+    // disconnected nodes — before any connections arrived. Must be loading.
+    expect(mapsState(6, false)).toBe('loading');
+    expect(mapsState(1, false)).toBe('loading');
+  });
+
+  it('is ready once the flow resolves — even with zero edges', () => {
+    // A daf can legitimately have no flow edges; resolution (not edge count)
+    // is what unblocks the maps.
+    expect(mapsState(6, true)).toBe('ready');
+    expect(mapsState(1, true)).toBe('ready');
+  });
+
+  it('is empty when the daf has no sections, regardless of resolution', () => {
+    expect(mapsState(0, false)).toBe('empty');
+    expect(mapsState(0, true)).toBe('empty');
+    expect(mapsState(-1, true)).toBe('empty');
+  });
+});


### PR DESCRIPTION
## Problem

While the daf-level `argument-overview.flow` enrichment is still loading, the whole-daf overview drew its flow-graph maps immediately from the argument sections. With no connections yet, `groupSectionsBySugya` puts each section in its own group, so the maps rendered as a stack of disconnected, link-less node boxes — a "map without its links" (see the synthesis spinner still spinning at the top while the maps below already show).

## Fix

Gate the maps on flow resolution. A new `flowResolved` signal flips true when the synthesis `onResolved` fires (a daf may legitimately resolve to zero edges). Until then the maps region shows a calm "Mapping the discussion…" loading row instead of the link-less nodes. The gating rule is extracted into a pure, exported `mapsState(sectionCount, flowResolved)` predicate.

## Tests

`tests/maps-loading-state.test.ts` locks the gate: `loading` before resolution (the regression), `ready` after (even with zero edges), `empty` for a daf with no sections.

`pnpm typecheck` + full `pnpm test` (1691 tests) green.