### PR TITLE
Deploy: add talmud.dev as a second custom domain

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -9,10 +9,13 @@ compatibility_flags = ["nodejs_compat"]
 # /api request bridge in src/worker/mcp.ts). See @cloudflare/codemode.
 worker_loaders = [{ binding = "LOADER" }]
 
-# Custom production domain. Requires shaunregenbaum.com to be an active zone
-# on the same Cloudflare account (PropheX) that `wrangler whoami` reports.
+# Custom production domains. Both zones must be active on the same Cloudflare
+# account (PropheX) that `wrangler whoami` reports. talmud.dev and
+# talmud.shaunregenbaum.com point at this same worker — identical backend,
+# KV cache, queues, and crons (one deployment, two hostnames).
 routes = [
-  { pattern = "talmud.shaunregenbaum.com", custom_domain = true }
+  { pattern = "talmud.shaunregenbaum.com", custom_domain = true },
+  { pattern = "talmud.dev", custom_domain = true }
 ]
 
 [assets]


### PR DESCRIPTION
Adds `talmud.dev` as an additional `custom_domain` route on the existing `talmud` worker. Both hostnames hit the same backend — same CACHE KV, queues, crons, secrets — so all cached data is served at talmud.dev with no migration.

Already deployed live (both domains return 200; `/api/links` confirms the shared cache serves on talmud.dev). Also removed a leftover Namecheap parking-page A record on the apex that was blocking the custom-domain bind; the email-forwarding MX/TXT records were left intact.