### PR TITLE
Usage: combine both-zone traffic; serve www.talmud.dev

### DIFF
--- a/src/worker/cf-zone-analytics.ts
+++ b/src/worker/cf-zone-analytics.ts
@@ -1,28 +1,36 @@
 /**
  * App activity (accesses + geography) from Cloudflare's zone HTTP analytics.
- * Every request to the shaunregenbaum.com zone is seen at the CF edge, so its
- * daily-rollup dataset (`httpRequests1dGroups`) gives a true picture of how
- * often the app is hit and from where — without the app logging anything.
+ * Every request to a zone is seen at the CF edge, so its daily-rollup dataset
+ * (`httpRequests1dGroups`) gives a true picture of how often the app is hit and
+ * from where — without the app logging anything.
  *
- * Scope note: the dataset is whole-zone (it has no per-host filter), but
- * talmud.shaunregenbaum.com is ~98% of the zone's traffic, so the figures are
- * effectively the app. `uniques` (deduped daily visitors) is the human-facing
- * "accesses" signal; `requests` is total edge volume and includes bots,
- * crawlers, and assets.
+ * The app is served on two hosts in two zones: talmud.shaunregenbaum.com (the
+ * shaunregenbaum.com zone, where the app is ~98% of traffic) and talmud.dev
+ * (a dedicated zone). CF_ZONE_TAG is a COMMA-SEPARATED list of zone ids; each
+ * is queried independently and the daily rows are merged by date so the Usage
+ * page shows combined app traffic across both domains. (One visitor hitting
+ * both hosts is counted in each zone's `uniques`, so merged "visits" can
+ * slightly double-count cross-domain visitors — acceptable for a traffic gauge;
+ * `requests` is an exact sum.)
  *
- * Requires a Cloudflare API token with "Zone Analytics: Read" on the
- * shaunregenbaum.com zone. The account-scoped CF_ANALYTICS_TOKEN used for AI
- * Gateway cost is NOT enough (it has no zone access). Set a dedicated token:
+ * Requires a Cloudflare API token with "Zone Analytics: Read" on EVERY zone in
+ * CF_ZONE_TAG. The account-scoped CF_ANALYTICS_TOKEN used for AI Gateway cost is
+ * NOT enough (it has no zone access). Set a dedicated token:
  *   wrangler secret put CF_ZONE_ANALYTICS_TOKEN
- * and the zone id (not secret) as a var:  CF_ZONE_TAG = "..."   in wrangler.toml
- * (If you instead broaden CF_ANALYTICS_TOKEN to include Zone Analytics: Read,
- * leave CF_ZONE_ANALYTICS_TOKEN unset — this falls back to it.)
+ * and the zone ids (not secret) as a var:  CF_ZONE_TAG = "id1,id2"  in
+ * wrangler.toml. (If you instead broaden CF_ANALYTICS_TOKEN to include Zone
+ * Analytics: Read on those zones, leave CF_ZONE_ANALYTICS_TOKEN unset — this
+ * falls back to it.)
  *
- * Degrades gracefully exactly like aigw-analytics.ts: a missing token/zone or a
- * failed query returns a { configured/ok: false, error } shape so the dashboard
- * states the problem plainly instead of inventing numbers. The GraphQL field
- * names follow CF's documented zone analytics schema; if one is wrong the query
- * errors and the dashboard surfaces that string verbatim for diagnosis.
+ * Per-zone DEGRADATION: zones are fetched independently, so a zone the token
+ * isn't authorized for (or that errors) is dropped from the merge while the
+ * others still report — the overall result is `ok` as long as at least one zone
+ * succeeds. A combined query (`zoneTag_in`) is deliberately NOT used because CF
+ * fails the WHOLE query if the token lacks any one zone. When some zones fail
+ * the `error` field names them (the dashboard hides it while `ok`, but it's in
+ * the raw payload for diagnosis). A missing token/tag, or ALL zones failing,
+ * returns the { configured/ok: false, error } shape like aigw-analytics.ts so
+ * the dashboard states the problem plainly instead of inventing numbers.
  *
  * NOTE: httpRequests1dGroups is the aggregated (unsampled) daily dataset — no
  * sampleInterval weighting needed. We use it rather than the adaptive dataset
@@ -100,11 +108,48 @@ function ymd(d: Date): string {
   return d.toISOString().slice(0, 10);
 }
 
+// One zone's daily rows over [start, end]. Returns the raw groups so the caller
+// can merge across zones; an error string (instead of throwing) keeps one
+// zone's failure from sinking the others.
+interface ZoneResult {
+  zoneTag: string;
+  ok: boolean;
+  error?: string;
+  groups: DailyGroup[];
+}
+
+async function fetchOneZone(token: string, zoneTag: string, start: string, end: string): Promise<ZoneResult> {
+  try {
+    const res = await fetch(GRAPHQL_URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+      body: JSON.stringify({ query: QUERY, variables: { zoneTag, start, end } }),
+    });
+    if (!res.ok) {
+      return { zoneTag, ok: false, error: `HTTP ${res.status}`, groups: [] };
+    }
+    const json = (await res.json()) as {
+      data?: { viewer?: { zones?: Array<{ httpRequests1dGroups?: DailyGroup[] }> } };
+      errors?: Array<{ message?: string }>;
+    };
+    if (json.errors && json.errors.length > 0) {
+      return { zoneTag, ok: false, error: json.errors.map((e) => e.message).filter(Boolean).join('; ').slice(0, 300), groups: [] };
+    }
+    const zone = json.data?.viewer?.zones?.[0];
+    if (!zone) {
+      return { zoneTag, ok: false, error: 'zone not found (check CF_ZONE_TAG and token zone scope)', groups: [] };
+    }
+    return { zoneTag, ok: true, groups: zone.httpRequests1dGroups ?? [] };
+  } catch (err) {
+    return { zoneTag, ok: false, error: String((err as Error)?.message ?? err).slice(0, 300), groups: [] };
+  }
+}
+
 export async function fetchZoneActivity(env: ZoneEnv, days = 30): Promise<ZoneActivity> {
   const token = env.CF_ZONE_ANALYTICS_TOKEN || env.CF_ANALYTICS_TOKEN;
-  const zoneTag = env.CF_ZONE_TAG;
-  if (!token || !zoneTag) {
-    const missing = [!token && 'CF_ZONE_ANALYTICS_TOKEN', !zoneTag && 'CF_ZONE_TAG']
+  const zoneTags = (env.CF_ZONE_TAG ?? '').split(',').map((s) => s.trim()).filter(Boolean);
+  if (!token || zoneTags.length === 0) {
+    const missing = [!token && 'CF_ZONE_ANALYTICS_TOKEN', zoneTags.length === 0 && 'CF_ZONE_TAG']
       .filter(Boolean)
       .join(', ');
     return { configured: false, ok: false, error: `not configured (missing: ${missing})` };
@@ -112,63 +157,59 @@ export async function fetchZoneActivity(env: ZoneEnv, days = 30): Promise<ZoneAc
 
   const end = new Date();
   const start = new Date(end.getTime() - days * 24 * 60 * 60 * 1000);
-  const variables = { zoneTag, start: ymd(start), end: ymd(end) };
+  const windowStart = ymd(start);
+  const windowEnd = ymd(end);
 
-  try {
-    const res = await fetch(GRAPHQL_URL, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
-      body: JSON.stringify({ query: QUERY, variables }),
-    });
-    if (!res.ok) {
-      return { configured: true, ok: false, error: `HTTP ${res.status}` };
-    }
-    const json = (await res.json()) as {
-      data?: { viewer?: { zones?: Array<{ httpRequests1dGroups?: DailyGroup[] }> } };
-      errors?: Array<{ message?: string }>;
-    };
-    if (json.errors && json.errors.length > 0) {
-      return { configured: true, ok: false, error: json.errors.map((e) => e.message).filter(Boolean).join('; ').slice(0, 300) };
-    }
-    const zone = json.data?.viewer?.zones?.[0];
-    if (!zone) {
-      return { configured: true, ok: false, error: 'zone not found (check CF_ZONE_TAG and token zone scope)' };
-    }
+  // Query each zone independently so an unauthorized/failing zone is dropped
+  // rather than failing the whole request (see header note on per-zone scope).
+  const results = await Promise.all(zoneTags.map((tag) => fetchOneZone(token, tag, windowStart, windowEnd)));
+  const okResults = results.filter((r) => r.ok);
+  const failed = results.filter((r) => !r.ok);
 
-    const groups = zone.httpRequests1dGroups ?? [];
-    const byDay: ZoneDayRow[] = groups.map((g) => ({
-      date: g.dimensions?.date ?? '',
-      requests: g.sum?.requests ?? 0,
-      visits: g.uniq?.uniques ?? 0,
-    }));
+  if (okResults.length === 0) {
+    const err = failed.map((r) => `${r.zoneTag}: ${r.error}`).join('; ').slice(0, 300) || 'all zones failed';
+    return { configured: true, ok: false, error: err };
+  }
 
-    // "From where" aggregates each day's countryMap across the whole window.
-    const countryReq = new Map<string, number>();
-    for (const g of groups) {
+  // Merge daily rows across zones by date (sum requests + visits).
+  const dayReq = new Map<string, number>();
+  const dayVis = new Map<string, number>();
+  const countryReq = new Map<string, number>();
+  for (const r of okResults) {
+    for (const g of r.groups) {
+      const date = g.dimensions?.date ?? '';
+      dayReq.set(date, (dayReq.get(date) ?? 0) + (g.sum?.requests ?? 0));
+      dayVis.set(date, (dayVis.get(date) ?? 0) + (g.uniq?.uniques ?? 0));
       for (const c of g.sum?.countryMap ?? []) {
         const name = c.clientCountryName || '';
         countryReq.set(name, (countryReq.get(name) ?? 0) + (c.requests ?? 0));
       }
     }
-    const byCountry: ZoneCountryRow[] = [...countryReq.entries()]
-      .map(([country, requests]) => ({ country, requests }))
-      .sort((a, b) => b.requests - a.requests)
-      .slice(0, 20);
-
-    return {
-      configured: true,
-      ok: true,
-      windowStart: variables.start,
-      windowEnd: variables.end,
-      byDay,
-      byCountry,
-      totals: {
-        day: summarize(byDay, 1),
-        week: summarize(byDay, 7),
-        month: summarize(byDay, days),
-      },
-    };
-  } catch (err) {
-    return { configured: true, ok: false, error: String((err as Error)?.message ?? err).slice(0, 300) };
   }
+
+  const byDay: ZoneDayRow[] = [...dayReq.keys()]
+    .sort()
+    .map((date) => ({ date, requests: dayReq.get(date) ?? 0, visits: dayVis.get(date) ?? 0 }));
+
+  const byCountry: ZoneCountryRow[] = [...countryReq.entries()]
+    .map(([country, requests]) => ({ country, requests }))
+    .sort((a, b) => b.requests - a.requests)
+    .slice(0, 20);
+
+  return {
+    configured: true,
+    ok: true,
+    // Surface partial failures in the payload for diagnosis (the dashboard hides
+    // `error` while `ok`, but it's visible in the raw JSON / logs).
+    error: failed.length > 0 ? failed.map((r) => `${r.zoneTag}: ${r.error}`).join('; ').slice(0, 300) : undefined,
+    windowStart,
+    windowEnd,
+    byDay,
+    byCountry,
+    totals: {
+      day: summarize(byDay, 1),
+      week: summarize(byDay, 7),
+      month: summarize(byDay, days),
+    },
+  };
 }

--- a/tests/cf-zone-analytics.test.ts
+++ b/tests/cf-zone-analytics.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fetchZoneActivity } from '../src/worker/cf-zone-analytics';
+
+// Build a GraphQL httpRequests1dGroups response for one zone.
+function zoneResponse(rows: Array<{ date: string; requests: number; uniques: number; countries?: Record<string, number> }>) {
+  return {
+    data: {
+      viewer: {
+        zones: [
+          {
+            httpRequests1dGroups: rows.map((r) => ({
+              dimensions: { date: r.date },
+              sum: {
+                requests: r.requests,
+                countryMap: Object.entries(r.countries ?? {}).map(([clientCountryName, requests]) => ({ clientCountryName, requests })),
+              },
+              uniq: { uniques: r.uniques },
+            })),
+          },
+        ],
+      },
+    },
+  };
+}
+
+// Mock fetch keyed by the zoneTag in the request body, so each zone gets its
+// own canned response (or error).
+function mockFetchByZone(byZone: Record<string, unknown | { httpError: number } | { gqlError: string }>) {
+  return vi.fn(async (_url: string, init: { body: string }) => {
+    const tag = JSON.parse(init.body).variables.zoneTag as string;
+    const r = byZone[tag];
+    if (r && typeof r === 'object' && 'httpError' in r) {
+      return { ok: false, status: (r as { httpError: number }).httpError, json: async () => ({}) } as Response;
+    }
+    if (r && typeof r === 'object' && 'gqlError' in r) {
+      return { ok: true, status: 200, json: async () => ({ errors: [{ message: (r as { gqlError: string }).gqlError }] }) } as unknown as Response;
+    }
+    return { ok: true, status: 200, json: async () => r } as unknown as Response;
+  });
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+const TOK = { CF_ZONE_ANALYTICS_TOKEN: 't' };
+
+describe('fetchZoneActivity multi-zone', () => {
+  it('not configured when token or zone tags missing', async () => {
+    expect((await fetchZoneActivity({ CF_ZONE_TAG: 'a,b' })).configured).toBe(false);
+    expect((await fetchZoneActivity({ ...TOK, CF_ZONE_TAG: '' })).configured).toBe(false);
+  });
+
+  it('merges daily rows across two zones by date', async () => {
+    vi.stubGlobal('fetch', mockFetchByZone({
+      A: zoneResponse([{ date: '2026-06-02', requests: 100, uniques: 10, countries: { US: 80, IL: 20 } }]),
+      B: zoneResponse([{ date: '2026-06-02', requests: 5, uniques: 2, countries: { IL: 5 } }]),
+    }));
+    const act = await fetchZoneActivity({ ...TOK, CF_ZONE_TAG: 'A,B' }, 30);
+    expect(act.ok).toBe(true);
+    expect(act.error).toBeUndefined();
+    // same-date rows from both zones collapse to one merged row
+    expect(act.byDay).toHaveLength(1);
+    expect(act.byDay?.[0]).toMatchObject({ date: '2026-06-02', requests: 105, visits: 12 });
+    // countries summed across zones
+    const il = act.byCountry?.find((c) => c.country === 'IL');
+    expect(il?.requests).toBe(25);
+    expect(act.totals?.day.requests).toBe(105);
+  });
+
+  it('drops an unauthorized zone but still reports the authorized one', async () => {
+    vi.stubGlobal('fetch', mockFetchByZone({
+      A: zoneResponse([{ date: '2026-06-02', requests: 100, uniques: 10 }]),
+      B: { gqlError: 'zones [B] are not authorized' },
+    }));
+    const act = await fetchZoneActivity({ ...TOK, CF_ZONE_TAG: 'A,B' }, 30);
+    expect(act.ok).toBe(true);
+    expect(act.totals?.day.requests).toBe(100);
+    // partial failure is surfaced in the payload (dashboard hides it while ok)
+    expect(act.error).toContain('B');
+  });
+
+  it('fails (ok:false) only when every zone fails', async () => {
+    vi.stubGlobal('fetch', mockFetchByZone({
+      A: { httpError: 403 },
+      B: { gqlError: 'not authorized' },
+    }));
+    const act = await fetchZoneActivity({ ...TOK, CF_ZONE_TAG: 'A,B' }, 30);
+    expect(act.configured).toBe(true);
+    expect(act.ok).toBe(false);
+    expect(act.error).toContain('A');
+    expect(act.error).toContain('B');
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -12,10 +12,11 @@ worker_loaders = [{ binding = "LOADER" }]
 # Custom production domains. Both zones must be active on the same Cloudflare
 # account (PropheX) that `wrangler whoami` reports. talmud.dev and
 # talmud.shaunregenbaum.com point at this same worker — identical backend,
-# KV cache, queues, and crons (one deployment, two hostnames).
+# KV cache, queues, and crons (one deployment, three hostnames).
 routes = [
   { pattern = "talmud.shaunregenbaum.com", custom_domain = true },
-  { pattern = "talmud.dev", custom_domain = true }
+  { pattern = "talmud.dev", custom_domain = true },
+  { pattern = "www.talmud.dev", custom_domain = true }
 ]
 
 [assets]
@@ -67,13 +68,18 @@ OPENROUTER_GATEWAY_PROVIDER = "openrouter"
 # ~$70 (entity marks only). Safe to leave at "1" — it's a no-op once latched.
 # To re-run a pass, delete the obs-backfill-cursor:v1 KV key.
 OBSERVATIONS_WARM_SHAS = "1"
-# Zone (shaunregenbaum.com) id for the Usage-page activity tracker. Not secret.
-# Used by src/worker/cf-zone-analytics.ts to query CF zone HTTP analytics
-# (httpRequests1dGroups) for app accesses + country breakdown. The query also
-# needs a token with "Zone Analytics: Read" set as the CF_ZONE_ANALYTICS_TOKEN
-# secret (`wrangler secret put CF_ZONE_ANALYTICS_TOKEN`); it falls back to
-# CF_ANALYTICS_TOKEN if that one is broadened to include zone analytics.
-CF_ZONE_TAG = "4808b439c50e3a42494ae7e0b2fa1bec"
+# Zone ids for the Usage-page activity tracker. Not secret. COMMA-SEPARATED:
+# the app is served on two zones (shaunregenbaum.com + talmud.dev) and
+# src/worker/cf-zone-analytics.ts queries each, then merges the daily rows so
+# Usage shows combined traffic across both domains. Order is
+# shaunregenbaum.com, talmud.dev. Used to query CF zone HTTP analytics
+# (httpRequests1dGroups) for app accesses + country breakdown. The query needs
+# a token with "Zone Analytics: Read" on EVERY listed zone, set as the
+# CF_ZONE_ANALYTICS_TOKEN secret (`wrangler secret put CF_ZONE_ANALYTICS_TOKEN`);
+# it falls back to CF_ANALYTICS_TOKEN if that one is broadened to include zone
+# analytics. A zone the token can't read is dropped from the merge (the others
+# still report); it does not break the page.
+CF_ZONE_TAG = "4808b439c50e3a42494ae7e0b2fa1bec,af7b181368ea154cd40b55404b47d818"
 # LLM spend budget (USD), enforced by src/worker/budget.ts at the runLLM
 # chokepoint. DAILY_BUDGET_USD is a hard ceiling on ALL spend per UTC day (the
 # guard latches a pause at 95% of this to leave headroom for in-flight jobs);


### PR DESCRIPTION
## Combine usage across domains
`CF_ZONE_TAG` is now a **comma-separated** list of zone ids (shaunregenbaum.com + talmud.dev). `cf-zone-analytics.ts` queries each zone independently and merges the daily rows / country breakdown, so the Usage page reports **combined** app traffic across both domains.

- **Per-zone degradation:** a zone the analytics token can't read (or that errors) is dropped from the merge while the others still report. The result is only `ok:false` when *every* zone fails. (A combined `zoneTag_in` query is deliberately avoided — CF fails the whole query if the token lacks any one zone.) Partial failures are captured in the payload `error` field.
- New unit test `tests/cf-zone-analytics.test.ts` covers merge, partial-drop, and all-fail.

## Serve www.talmud.dev
Adds `www.talmud.dev` as a third custom-domain route (its Namecheap parking CNAME was removed) so it serves the app.

## Follow-up (account-owner action, can't be done via API token)
To actually surface talmud.dev's numbers, the `CF_ZONE_ANALYTICS_TOKEN` must be granted **Zone Analytics: Read** on the talmud.dev zone. Until then the page shows shaunregenbaum.com only and silently skips talmud.dev (verified live).

Already deployed; all three domains return 200 and `/api/usage` merges correctly (talmud.dev currently skipped pending the token grant).