### PR TITLE
Halacha: shape-aware practical + wider codification gutter

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -1,4 +1,4 @@
-import { For, Show, createEffect, createMemo, createResource, createSignal, onCleanup, type JSX } from 'solid-js';
+import { For, Show, Switch, Match, createEffect, createMemo, createResource, createSignal, onCleanup, type JSX } from 'solid-js';
 import type { Section, Rabbi, HalachaTopic, AggadataStory, Pasuk } from './shapes';
 import { GENERATION_BY_ID, generationLabelHe, type GenerationId } from './generations';
 import type { IdentifiedRabbi } from './dafContext';
@@ -1283,12 +1283,36 @@ export const RABBI_BLOCKS: Record<string, (p: SpecialBlockProps) => JSX.Element>
 //         Disputes card (rendered only when non-empty).
 // ===========================================================================
 
+interface PracticalRow { when: string; value: string }
 interface PracticalData {
-  lechatchila: string;
-  bedieved: string;
-  appliesWhen: string[];
-  exceptions: string[];
-  prose: string;
+  shape: 'best-fallback' | 'statement' | 'taxonomy';
+  best: string;
+  fallback: string;
+  statement: string;
+  rows: PracticalRow[];
+  note: string;
+}
+/** Old practical shape, still served during the cache-bump stale window
+ *  (stale-while-revalidate). Normalized into the new shape so the card renders
+ *  cleanly until the v5 value lands. */
+interface PracticalLegacy {
+  lechatchila?: string; bedieved?: string;
+  appliesWhen?: string[]; exceptions?: string[]; prose?: string;
+}
+function normalizePractical(raw: unknown): PracticalData | undefined {
+  const d = raw as Partial<PracticalData> & PracticalLegacy | undefined;
+  if (!d) return undefined;
+  if (typeof d.shape === 'string') return d as PracticalData;
+  // Legacy → best-fallback, dropping the retired appliesWhen pills; the most
+  // important old exception becomes the single note.
+  if (typeof d.prose === 'string' || typeof d.lechatchila === 'string') {
+    return {
+      shape: 'best-fallback',
+      best: d.lechatchila ?? '', fallback: d.bedieved ?? '', statement: '', rows: [],
+      note: (d.exceptions ?? []).filter(Boolean)[0] ?? '',
+    };
+  }
+  return undefined;
 }
 interface DisputePosition { voice: string; position: string; }
 interface DisputeItem {
@@ -1332,69 +1356,61 @@ function HalachaCodification(props: SpecialBlockProps): JSX.Element {
   );
 }
 
-// Halacha practical guidance: lechatchila / bedieved + applies-when / exceptions.
-function HalachaPractical(props: SpecialBlockProps): JSX.Element {
-  const practical = (): PracticalData | undefined => {
-    const d = props.deps['halacha.practical'] as PracticalData | undefined;
-    return d && typeof d.prose === 'string' ? d : undefined;
-  };
+// Shape-aware practical "what to do": best/fallback rows, a single statement
+// line, or a case→answer map — chosen by `shape`. Plain English leads, Hebrew
+// term as a tag. The old applies-when / exceptions pill lists are retired (an
+// optional single `note` carries the one key caveat).
+const PRACTICAL_LABEL_STYLE: JSX.CSSProperties = {
+  'font-size': '0.65rem', color: '#999', 'text-transform': 'uppercase',
+  'letter-spacing': '0.06em', 'margin-bottom': '0.15rem',
+};
+const PRACTICAL_TEXT_STYLE: JSX.CSSProperties = { 'font-size': '0.88rem', color: '#222', 'line-height': 1.5 };
+
+function PracticalLine(props: { heTag: string; label: string; text: string }): JSX.Element {
   return (
-      <Show when={practical()}>
-        {(pr) => (
-          <SectionCard label="halacha.practical" inspect={{ instanceKey: props.instanceKey, leafId: 'halacha.practical' }}>
-            <Show when={pr().lechatchila}>
-              <div style={{ 'margin-bottom': '0.4rem' }}>
-                <div style={{ 'font-size': '0.65rem', color: '#999', 'text-transform': 'uppercase', 'letter-spacing': '0.06em', 'margin-bottom': '0.15rem' }}>
-                  <span lang="he" dir="ltr" style={{ 'font-family': '"Mekorot Vilna", serif', 'font-size': '0.85rem', 'text-transform': 'none', color: '#666' }}>לכתחילה</span>
-                  <span style={{ 'margin-left': '0.35rem' }}>{t('halacha.lechatchila')}</span>
-                </div>
-                <div style={{ 'font-size': '0.88rem', color: '#222', 'line-height': 1.5 }}>
-                  <HebraizedWithRabbis text={pr().lechatchila} />
-                </div>
+    <div style={{ 'margin-bottom': '0.4rem' }}>
+      <div style={PRACTICAL_LABEL_STYLE}>
+        <span lang="he" dir="ltr" style={{ 'font-family': '"Mekorot Vilna", serif', 'font-size': '0.85rem', 'text-transform': 'none', color: '#666' }}>{props.heTag}</span>
+        <span style={{ 'margin-left': '0.35rem' }}>{props.label}</span>
+      </div>
+      <div style={PRACTICAL_TEXT_STYLE}><HebraizedWithRabbis text={props.text} /></div>
+    </div>
+  );
+}
+
+function HalachaPractical(props: SpecialBlockProps): JSX.Element {
+  const practical = (): PracticalData | undefined => normalizePractical(props.deps['halacha.practical']);
+  return (
+    <Show when={practical()}>
+      {(pr) => (
+        <SectionCard label="halacha.practical" inspect={{ instanceKey: props.instanceKey, leafId: 'halacha.practical' }}>
+          <Switch>
+            <Match when={pr().shape === 'best-fallback'}>
+              <Show when={pr().best}><PracticalLine heTag="לכתחילה" label={t('halacha.lechatchila')} text={pr().best} /></Show>
+              <Show when={pr().fallback}><PracticalLine heTag="בדיעבד" label={t('halacha.bedieved')} text={pr().fallback} /></Show>
+            </Match>
+            <Match when={pr().shape === 'taxonomy'}>
+              <div style={{ display: 'grid', 'grid-template-columns': 'auto 1fr', 'column-gap': '0.6rem', 'row-gap': '0.3rem', 'align-items': 'baseline' }}>
+                <For each={pr().rows}>{(row) => (
+                  <>
+                    <div style={{ 'font-size': '0.82rem', color: '#555', 'line-height': 1.4 }}><Hebraized text={row.when} capitalize /></div>
+                    <div style={{ 'font-size': '0.85rem', color: '#161616', 'font-weight': 500, 'line-height': 1.4 }}><Hebraized text={row.value} /></div>
+                  </>
+                )}</For>
               </div>
-            </Show>
-            <Show when={pr().bedieved}>
-              <div style={{ 'margin-bottom': '0.4rem' }}>
-                <div style={{ 'font-size': '0.65rem', color: '#999', 'text-transform': 'uppercase', 'letter-spacing': '0.06em', 'margin-bottom': '0.15rem' }}>
-                  <span lang="he" dir="ltr" style={{ 'font-family': '"Mekorot Vilna", serif', 'font-size': '0.85rem', 'text-transform': 'none', color: '#666' }}>בדיעבד</span>
-                  <span style={{ 'margin-left': '0.35rem' }}>{t('halacha.bedieved')}</span>
-                </div>
-                <div style={{ 'font-size': '0.88rem', color: '#222', 'line-height': 1.5 }}>
-                  <HebraizedWithRabbis text={pr().bedieved} />
-                </div>
-              </div>
-            </Show>
-            <Show when={pr().appliesWhen.length > 0}>
-              <div style={{ 'margin-bottom': '0.4rem' }}>
-                <div style={{ 'font-size': '0.65rem', color: '#999', 'text-transform': 'uppercase', 'letter-spacing': '0.06em', 'margin-bottom': '0.15rem' }}>{t('halacha.appliesWhen')}</div>
-                <div style={{ display: 'flex', 'flex-wrap': 'wrap', gap: '0.3rem' }}>
-                  <For each={pr().appliesWhen}>{(item) => (
-                    <span style={{
-                      'font-size': '0.75rem', padding: '0.15rem 0.5rem',
-                      background: '#fff', border: '1px solid #e5e3dc',
-                      'border-radius': '999px', color: '#444',
-                    }}><Hebraized text={item} capitalize /></span>
-                  )}</For>
-                </div>
-              </div>
-            </Show>
-            <Show when={pr().exceptions.length > 0}>
-              <div style={{ 'margin-bottom': '0.4rem' }}>
-                <div style={{ 'font-size': '0.65rem', color: '#999', 'text-transform': 'uppercase', 'letter-spacing': '0.06em', 'margin-bottom': '0.15rem' }}>{t('halacha.exceptions')}</div>
-                <div style={{ display: 'flex', 'flex-wrap': 'wrap', gap: '0.3rem' }}>
-                  <For each={pr().exceptions}>{(item) => (
-                    <span style={{
-                      'font-size': '0.75rem', padding: '0.15rem 0.5rem',
-                      background: '#fef3c7', border: '1px solid #fde68a',
-                      'border-radius': '999px', color: '#92400e',
-                    }}><Hebraized text={item} capitalize /></span>
-                  )}</For>
-                </div>
-              </div>
-            </Show>
-          </SectionCard>
-        )}
-      </Show>
+            </Match>
+            <Match when={pr().shape === 'statement'}>
+              <div style={PRACTICAL_TEXT_STYLE}><HebraizedWithRabbis text={pr().statement} /></div>
+            </Match>
+          </Switch>
+          <Show when={pr().note}>
+            <div style={{ 'margin-top': '0.5rem', 'font-size': '0.8rem', color: '#6b5e3a', background: '#fcf7ea', border: '1px solid #ecdfbe', 'border-radius': '5px', padding: '0.4rem 0.55rem', 'line-height': 1.45 }}>
+              <span style={{ 'font-weight': 600 }}>{t('halacha.note')}: </span><HebraizedWithRabbis text={pr().note} />
+            </div>
+          </Show>
+        </SectionCard>
+      )}
+    </Show>
   );
 }
 

--- a/src/client/CodificationMap.tsx
+++ b/src/client/CodificationMap.tsx
@@ -42,7 +42,9 @@ const LEGEND_LABEL: Record<RelationKind, string> = {
 };
 
 const SPINE_X = 18;       // left-gutter x of the spine + dots
-const GUTTER = 22;        // right gutter width for relation lanes
+// Wide right gutter so the relation connectors have room to bow out clearly
+// (narrows the cards, which is the intent — the lines need the space).
+const GUTTER = 46;        // right gutter width for relation lanes
 const LANE_STEP = 9;      // x between parallel relation lanes
 
 export default function CodificationMap(props: Props): JSX.Element {

--- a/src/client/i18n.ts
+++ b/src/client/i18n.ts
@@ -517,6 +517,7 @@ const CATALOG = {
   // — Halacha body —
   'halacha.codification': { en: 'Codification', he: 'פסיקה' },
   'halacha.derivation': { en: 'Where it comes from', he: 'מקורות בש״ס' },
+  'halacha.note': { en: 'Note', he: 'הערה' },
   'halacha.practical': { en: 'Practical', he: 'למעשה' },
   'halacha.disputes': { en: 'Disputes', he: 'מחלוקות' },
   // Codification source labels (the פסיקה rows).

--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -3637,24 +3637,29 @@ Rules:
 ${HEBREW_GLOSS_STYLE}`;
 
 
-const HALACHA_PRACTICAL_SYSTEM_PROMPT = `You are a scholar of halacha and practical psak. Given ONE halachic topic surfaced on a daf, describe the PRACTICAL application of the settled halacha — what someone has to actually do, when it applies, and what the common edge cases are.
+const HALACHA_PRACTICAL_SYSTEM_PROMPT = `You are a scholar of halacha and practical psak. Given ONE halachic topic surfaced on a daf, state the PRACTICAL bottom line — what a person actually does — in the SHAPE that fits the ruling. Plain English first; the Hebrew term is a tag, not the main word.
 
-Output STRICT JSON only:
+First choose the shape:
+- "best-fallback" — a timing / measure rule with a לכתחילה ideal AND a בדיעבד fallback (e.g. say the evening שמע before חצות; after the fact it still counts until dawn).
+- "statement" — a single action, prohibition, or structural requirement with NO meaningful best/fallback split (e.g. "Don't carry between domains on שבת"; "A monetary case is judged by three").
+- "taxonomy" — a mapping of case → answer (e.g. each food → its ברכה).
+
+Output STRICT JSON only — fill ONLY the fields for the chosen shape, leave the others as "" or []:
 
 {
-  "lechatchila": "1-2 sentences: how the halacha is performed lechatchila (ideal-case). What's the standard practice?",
-  "bedieved":    "1 sentence on the bedieved (after-the-fact) standard, when applicable. Empty string if no lechatchila/bedieved distinction.",
-  "appliesWhen": ["Short bullet phrases — 2-4 items — naming the situations when this halacha is triggered (e.g. 'eating bread', 'after dark', 'in a public domain')."],
-  "exceptions":  ["Short bullet phrases — 0-3 items — naming common exceptions or edge cases ('a sick person is exempt', 'on Shabbat the rule changes', etc.). Empty array if none."],
-  "prose": "ONE short paragraph (2-3 sentences) on how the rule plays out today — what the typical person does, what trips them up, any standard halachic threshold the gemara introduced that still governs practice."
+  "shape": "best-fallback" | "statement" | "taxonomy",
+  "best":      "best-fallback ONLY. ONE sentence: the ideal practice, plain words first. e.g. 'Say it before halachic midnight (חצות).'",
+  "fallback":  "best-fallback ONLY. ONE sentence: the after-the-fact standard. e.g. 'Any time until dawn (עלות השחר) still counts.' Empty if there is genuinely no fallback.",
+  "statement": "statement ONLY. ONE plain sentence of what to do / not do / the requirement.",
+  "rows":      [ { "when": "the case, plain (e.g. 'Tree fruit')", "value": "the answer (e.g. 'בורא פרי העץ')" } ],
+  "note":      "OPTIONAL single plain-language heads-up or exception (e.g. 'A sick person is exempt'). Empty when none — do NOT pad."
 }
 
 Rules:
-- The "lechatchila" field must describe the standard live practice (the לכתחילה standard), not the gemara's hypothetical. If the practice still tracks the gemara's plain conclusion, say so concretely.
-- The "bedieved" field is for the after-the-fact (בדיעבד) standard: did the act count, what do you do retroactively, etc. Empty string when there is no such distinction.
-- appliesWhen / exceptions are SHORT scannable phrases (not sentences), each STARTING WITH A CAPITAL LETTER when they begin in English ("Locking a door on שבת", "A sick person is exempt").
-- appliesWhen / exceptions follow the SAME HEBREW_GLOSS_STYLE as the prose — they are short, but they are NOT a plain-English exception. Hebraize the always-list terms here exactly as you would in prose: write "Locking a door on שבת", "Designated before שבת", "In בית דין", and Form A for any technical term with no clean English word ("A bolt never prepared is מוקצה (set aside)"). The chips must read consistently with the lechatchila / bedieved / prose fields — one convention across the whole card.
-- NO puff. NO jargon: "transmitter" not "tradent". Across ALL text fields (chips included), follow the HEBREW_GLOSS_STYLE rules below — every use of שבת / לכתחילה / בדיעבד / רוב / etc. MUST appear with the Hebrew script (Form A or Form B), never as bare transliteration or bare English.
+- Choose exactly ONE shape and fill only its fields. Do NOT invent a בדיעבד fallback to fill best-fallback — if there's no real after-the-fact distinction, use "statement".
+- "note" is ONE short plain sentence, not a list — the most important single caveat, or "" if none. (The old chip lists are retired.)
+- Plain English leads; attach the Hebrew term once, glossed, per the style below ("before halachic midnight (חצות)", not "חצות (midnight)").
+- NO puff. NO jargon: "transmitter" not "tradent".
 
 ${HEBREW_GLOSS_STYLE}`;
 
@@ -3786,22 +3791,27 @@ const HALACHA_CODIFICATION_SYSTEM_PROMPT_HE = `אתה תלמיד חכם הבקי
 
 ${HEBREW_NATIVE_STYLE}`;
 
-const HALACHA_PRACTICAL_SYSTEM_PROMPT_HE = `אתה תלמיד חכם הבקיא בהלכה ובפסק מעשי. בהינתן נושא הלכתי אחד שעלה בדף, תאר את היישום המעשי של ההלכה הפסוקה — מה צריך לעשות בפועל, מתי זה חל, ומהם מקרי הקצה הנפוצים.
+const HALACHA_PRACTICAL_SYSTEM_PROMPT_HE = `אתה תלמיד חכם הבקיא בהלכה ובפסק מעשי. בהינתן נושא הלכתי אחד שעלה בדף, נסח את השורה התחתונה המעשית — מה האדם עושה בפועל — בצורה (shape) המתאימה לאופי ההלכה.
 
-החזר JSON תקין בלבד:
+תחילה בחר את הצורה:
+- "best-fallback" — דין של זמן / שיעור שיש בו לכתחילה וגם בדיעבד (למשל קריאת שמע של ערבית לכתחילה לפני חצות; בדיעבד עד עלות השחר).
+- "statement" — מעשה יחיד, איסור, או דרישה מבנית ללא חלוקת לכתחילה/בדיעבד משמעותית (למשל "אין מוציאין מרשות לרשות בשבת"; "דיני ממונות בשלשה").
+- "taxonomy" — מיפוי של מקרה ← תשובה (למשל כל מאכל ← הברכה שלו).
+
+החזר JSON תקין בלבד — מלא רק את השדות של הצורה שבחרת, השאר את האחרים כ-"" או []:
 
 {
-  "lechatchila": "1-2 משפטים: כיצד מקיימים את ההלכה לכתחילה. מהי הנהגה הסטנדרטית?",
-  "bedieved":    "משפט אחד על דין הבדיעבד, היכן שרלוונטי. מחרוזת ריקה אם אין הבחנת לכתחילה/בדיעבד.",
-  "appliesWhen": ["ביטויים קצרים — 2-4 פריטים — הנוקבים במצבים שבהם הלכה זו מופעלת (למשל 'אכילת לחם', 'לאחר רדת הלילה', 'ברשות הרבים')."],
-  "exceptions":  ["ביטויים קצרים — 0-3 פריטים — הנוקבים בחריגים נפוצים או מקרי קצה ('חולה פטור', 'בשבת הדין משתנה'). מערך ריק אם אין."],
-  "prose": "פסקה קצרה אחת (2-3 משפטים) על אופן יישום הכלל כיום — מה האדם הטיפוסי עושה, מה מכשיל אותו, וכל סף הלכתי שהגמרא הציגה ועדיין שולט בהלכה למעשה."
+  "shape": "best-fallback" | "statement" | "taxonomy",
+  "best":      "ל-best-fallback בלבד. משפט אחד: ההנהגה האידיאלית.",
+  "fallback":  "ל-best-fallback בלבד. משפט אחד: דין הבדיעבד. ריק אם אין באמת בדיעבד.",
+  "statement": "ל-statement בלבד. משפט אחד פשוט של מה לעשות / לא לעשות / הדרישה.",
+  "rows":      [ { "when": "המקרה (למשל 'פרי העץ')", "value": "התשובה (למשל 'בורא פרי העץ')" } ],
+  "note":      "אופציונלי: הערה/חריג יחיד וקצר ('חולה פטור'). ריק כשאין — אל תמלא לחינם."
 }
 
 כללים:
-- שדה "lechatchila" חייב לתאר את ההנהגה החיה הסטנדרטית (סטנדרט הלכתחילה), לא היפותזה של הגמרא. אם ההלכה למעשה עדיין הולכת אחר מסקנת הגמרא הפשוטה, אמור זאת באופן קונקרטי.
-- שדה "bedieved" הוא לדין הבדיעבד: האם המעשה נחשב, מה עושים למפרע, וכו'. מחרוזת ריקה כשאין הבחנה כזו.
-- appliesWhen / exceptions הם ביטויים קצרים, לא משפטים. המשתמש סורק אותם.
+- בחר צורה אחת בלבד ומלא רק את שדותיה. אל תמציא בדיעבד כדי למלא best-fallback — אם אין הבחנה אמיתית, השתמש ב-"statement".
+- "note" הוא משפט יחיד קצר, לא רשימה — החריג החשוב ביותר, או "". (רשימות התגיות הישנות בוטלו.)
 - ללא מליצה.
 
 ${HEBREW_NATIVE_STYLE}`;
@@ -3888,13 +3898,13 @@ CODE_ENRICHMENTS.push(
   ),
   makeEnrichment(
     'halacha', 'halacha.practical', 'Practical',
-    'Lechatchila/bedieved, when the halacha applies, common exceptions, modern practice prose.',
+    'Shape-aware "what to do": best/fallback, a single statement, or a case→answer map, plus one optional note.',
     HALACHA_PRACTICAL_SYSTEM_PROMPT, HALACHA_LEAF_USER_TEMPLATE, HALACHA_PRACTICAL_OUTPUT_SCHEMA,
     {
       mode: 'augment-content', scope: 'local',
       dependencies: ['gemara'],
       passes: ['hebrew-gloss'],
-      defHash: 'halacha.practical-v4', cacheVersion: '4',
+      defHash: 'halacha.practical-v5', cacheVersion: '5',
       systemPromptHe: HALACHA_PRACTICAL_SYSTEM_PROMPT_HE,
       userPromptTemplateHe: HALACHA_LEAF_USER_TEMPLATE_HE,
     },

--- a/src/worker/output-schemas.ts
+++ b/src/worker/output-schemas.ts
@@ -194,9 +194,18 @@ export const HALACHA_DISPUTES_OUTPUT_SCHEMA = responseFormat('halacha_disputes',
     settled: z.string(),
   })),
 }));
+// Shape-aware practical "what to do": the render is chosen by `shape`.
+//   best-fallback → best (לכתחילה) + fallback (בדיעבד) lines (timing/measure rules)
+//   statement     → one plain line (a prohibition, action, or requirement)
+//   taxonomy      → a case→value map (e.g. food → bracha)
+// `note` is an optional single plain-language heads-up (retires the pill lists).
 export const HALACHA_PRACTICAL_OUTPUT_SCHEMA = responseFormat('halacha_practical', z.object({
-  lechatchila: z.string(), bedieved: z.string(),
-  appliesWhen: z.array(z.string()), exceptions: z.array(z.string()), prose: z.string(),
+  shape: z.enum(['best-fallback', 'statement', 'taxonomy']),
+  best: z.string(),
+  fallback: z.string(),
+  statement: z.string(),
+  rows: z.array(z.object({ when: z.string(), value: z.string() })),
+  note: z.string(),
 }));
 export const HALACHA_SYNTHESIS_OUTPUT_SCHEMA = responseFormat('halacha_synthesis', single('synthesis'));
 

--- a/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
+++ b/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
@@ -22,7 +22,7 @@ exports[`CODE_ENRICHMENTS cache identity > per-enrichment fingerprint is stable 
   "daf-background.synthesis@6 mode=aggregate scope=local mark=daf-background schema=daf_background_synthesis[synthesis] deps=[gemara|context|e:daf-background.concepts]",
   "halacha.codification@4 mode=augment-content scope=local mark=halacha schema=halacha_codification[mishnehTorah,tur,shulchanAruch,rema,prose] deps=[gemara|halacha-refs]",
   "halacha.disputes@3 mode=augment-content scope=local mark=halacha schema=halacha_disputes[disputes] deps=[gemara]",
-  "halacha.practical@4 mode=augment-content scope=local mark=halacha schema=halacha_practical[lechatchila,bedieved,appliesWhen,exceptions,prose] deps=[gemara]",
+  "halacha.practical@5 mode=augment-content scope=local mark=halacha schema=halacha_practical[shape,best,fallback,statement,rows,note] deps=[gemara]",
   "halacha.synthesis@4 mode=aggregate scope=local mark=halacha schema=halacha_synthesis[synthesis] deps=[gemara|e:halacha.codification|e:halacha.practical|e:halacha.disputes]",
   "pesukim.landing@2 mode=augment-content scope=local mark=pesukim schema=pesukim_landing[landing] deps=[gemara|m:rabbi]",
   "pesukim.mechanism@2 mode=augment-content scope=local mark=pesukim schema=pesukim_mechanism[mechanism] deps=[gemara|commentaries]",

--- a/tests/fixtures/output-schemas/HALACHA_PRACTICAL_OUTPUT_SCHEMA.json
+++ b/tests/fixtures/output-schemas/HALACHA_PRACTICAL_OUTPUT_SCHEMA.json
@@ -5,32 +5,51 @@
     "type": "object",
     "additionalProperties": false,
     "required": [
-      "lechatchila",
-      "bedieved",
-      "appliesWhen",
-      "exceptions",
-      "prose"
+      "shape",
+      "best",
+      "fallback",
+      "statement",
+      "rows",
+      "note"
     ],
     "properties": {
-      "lechatchila": {
+      "shape": {
+        "type": "string",
+        "enum": [
+          "best-fallback",
+          "statement",
+          "taxonomy"
+        ]
+      },
+      "best": {
         "type": "string"
       },
-      "bedieved": {
+      "fallback": {
         "type": "string"
       },
-      "appliesWhen": {
+      "statement": {
+        "type": "string"
+      },
+      "rows": {
         "type": "array",
         "items": {
-          "type": "string"
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "when",
+            "value"
+          ],
+          "properties": {
+            "when": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            }
+          }
         }
       },
-      "exceptions": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
-      },
-      "prose": {
+      "note": {
         "type": "string"
       }
     }

--- a/tests/hebrew-terms.test.ts
+++ b/tests/hebrew-terms.test.ts
@@ -116,16 +116,6 @@ describe('halacha.practical prompt — always-list wiring', () => {
   });
 });
 
-describe('halacha.practical prompt — chip convention (uniform Form A)', () => {
-  it('requires capitalized chip phrases', () => {
-    expect(practicalSys).toMatch(/STARTING WITH A CAPITAL LETTER/);
-  });
-  it('makes chips follow the SAME gloss style as the prose', () => {
-    expect(practicalSys).toMatch(/SAME HEBREW_GLOSS_STYLE as the prose/);
-    expect(practicalSys).toMatch(/NOT a plain-English exception/);
-  });
-  it('applies the gloss style across ALL text fields, chips included', () => {
-    expect(practicalSys).toMatch(/Across ALL text fields \(chips included\)/);
-    expect(practicalSys).toMatch(/STYLE — Hebrew \+ English mixing/);
-  });
-});
+// The applies-when / exceptions chip lists were retired in the shape-aware
+// practical reshape (best-fallback | statement | taxonomy + one optional note),
+// so the old "uniform Form A chip convention" prompt rules no longer exist.


### PR DESCRIPTION
PR 5 of the halacha redesign — the **"What to do"** reshape you flagged at the start, plus a map-gutter tweak.

### Shape-aware practical
The practical guidance no longer forces every halacha into `lechatchila`/`bedieved` + the wrapping **applies-when / exceptions pill lists**. The enrichment picks the **shape** that fits the ruling and the card renders accordingly:
- **`best-fallback`** → Best (לכתחילה) + Fallback (בדיעבד) lines
- **`statement`** → one plain line (a prohibition / action / requirement — no fake fallback)
- **`taxonomy`** → a case→answer map (e.g. food → ברכה)

…plus **one optional plain-language `note`** (the yellow pill lists collapse to the single key caveat). Plain English leads; the Hebrew term is a tag.

- `output-schemas`: `HALACHA_PRACTICAL_OUTPUT_SCHEMA` → `{shape,best,fallback,statement,rows,note}`; parity fixture regenerated.
- `code-marks`: rewritten practical prompt (EN+HE) that **chooses a shape**; `cacheVersion` 4→5.
- client: shape-aware `HalachaPractical` (`Switch` on shape) + a **normalizer** that maps the OLD shape during the stale-while-revalidate window so nothing breaks mid-rollout; pill renders retired. i18n `halacha.note`.

### Map gutter (design feedback)
`CodificationMap` right gutter 22→46 so the relation connectors bow out clearly — narrows the cards, per the screenshot note. Verified in the standalone demo.

### Tests
Retired the obsolete chip-convention prompt assertions; snapshot + parity fixture updated. `pnpm typecheck` clean; `pnpm test` 1688 passed. Generation-only (regen on demand under `cache_version` 5).