### PR TITLE
Halacha: clickable Talmudic-source rows + dispute prompt fix

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -12,7 +12,7 @@ import RabbiPlacesTimeline, { type LocationInference } from './RabbiPlacesTimeli
 import ArgumentVoiceMap, { type ArgumentVoicesData } from './ArgumentVoiceMap';
 import CodificationMap from './CodificationMap';
 import { codeMapFromCodification, SIDE_COLOR, type CodificationData } from './flow/codeMapLayout';
-import { type DerivationSource } from '../lib/halacha/codifiers';
+import { type DerivationSource, parseBavliRef } from '../lib/halacha/codifiers';
 import ArgumentNarrative from './ArgumentNarrative';
 import { deriveVoiceEdges } from '../lib/typing/voices';
 import { voicesMapEligible, voicesShowMap, voicesShowFallback } from '../lib/typing/profile';
@@ -1486,6 +1486,24 @@ const DERIVATION_ROLE_LABEL: Record<DerivationSource['role'], string> = {
   primary: 'primary source', related: 'related', root: 'scriptural root',
 };
 
+// `parseBavliRef` (imported from lib/halacha/codifiers) turns a Bavli source
+// ref into the tractate + page this reader navigates by. Tanakh roots and
+// Yerushalmi refs return null — not dapim here — so they stay non-clickable.
+
+// Same `?tractate=&page=` URL contract the overview cross-references use. The
+// href is real (middle-click / open-in-new-tab work); onClick keeps the SPA
+// navigation in the common case.
+function dafHref(target: { tractate: string; page: string }): string {
+  const u = new URL(window.location.href);
+  u.searchParams.set('tractate', target.tractate);
+  u.searchParams.set('page', target.page);
+  u.hash = '';
+  return u.pathname + u.search;
+}
+function navigateToDaf(target: { tractate: string; page: string }): void {
+  window.location.href = dafHref(target);
+}
+
 // Halacha "where it comes from": the gemara (+ scriptural) sources the codified
 // ruling derives from. Reads the codifier refs off the halacha.codification leaf
 // and fetches the deterministic /api/derivation (reverse Sefaria). The current
@@ -1509,21 +1527,42 @@ function HalachaDerivation(props: SpecialBlockProps): JSX.Element {
           {t('halacha.derivation')}
         </div>
         <div style={{ display: 'flex', 'flex-direction': 'column', gap: '0.4rem' }}>
-          <For each={sources()}>{(s) => (
-            <div style={{
+          <For each={sources()}>{(s) => {
+            // Bavli sources (other than the current daf) navigate to that daf.
+            const target = s.kind === 'bavli' && !s.isCurrent ? parseBavliRef(s.ref) : null;
+            const rowStyle: JSX.CSSProperties = {
               display: 'flex', 'align-items': 'baseline', gap: '0.5rem',
               background: s.isCurrent ? '#fdf2f2' : '#fff',
               border: s.isCurrent ? '1.5px solid #8a2a2b' : '1px solid #e4e0d4',
               'border-radius': '8px', padding: '0.4rem 0.6rem',
               'box-shadow': '0 1px 1.4px rgba(58,51,32,0.1)',
-            }}>
-              <span style={{ 'font-family': 'system-ui, -apple-system, sans-serif', 'font-size': '0.82rem', 'font-weight': 600, color: '#2a2723' }}>{s.ref}</span>
-              <span style={{ 'font-family': 'system-ui, -apple-system, sans-serif', 'font-size': '0.62rem', 'text-transform': 'uppercase', 'letter-spacing': '0.04em', color: '#9a958a' }}>{DERIVATION_ROLE_LABEL[s.role]}</span>
-              <Show when={s.isCurrent}>
-                <span style={{ 'margin-left': 'auto', 'font-family': 'system-ui, -apple-system, sans-serif', 'font-size': '0.58rem', 'font-weight': 700, color: '#fff', background: '#8a2a2b', 'border-radius': '3px', padding: '0.05rem 0.3rem', 'flex-shrink': 0 }}>YOU ARE HERE</span>
+              'text-decoration': 'none', cursor: target ? 'pointer' : 'default',
+            };
+            const inner = (
+              <>
+                <span style={{ 'font-family': 'system-ui, -apple-system, sans-serif', 'font-size': '0.82rem', 'font-weight': 600, color: '#2a2723' }}>{s.ref}</span>
+                <span style={{ 'font-family': 'system-ui, -apple-system, sans-serif', 'font-size': '0.62rem', 'text-transform': 'uppercase', 'letter-spacing': '0.04em', color: '#9a958a' }}>{DERIVATION_ROLE_LABEL[s.role]}</span>
+                <Show when={s.isCurrent}>
+                  <span style={{ 'margin-left': 'auto', 'font-family': 'system-ui, -apple-system, sans-serif', 'font-size': '0.58rem', 'font-weight': 700, color: '#fff', background: '#8a2a2b', 'border-radius': '3px', padding: '0.05rem 0.3rem', 'flex-shrink': 0 }}>YOU ARE HERE</span>
+                </Show>
+                <Show when={target}>
+                  <span aria-hidden="true" style={{ 'margin-left': 'auto', color: '#b8b2a4', 'font-size': '0.95rem', 'line-height': 1, 'flex-shrink': 0 }}>›</span>
+                </Show>
+              </>
+            );
+            return (
+              <Show when={target} fallback={<div style={rowStyle}>{inner}</div>}>
+                <a
+                  href={dafHref(target!)}
+                  onClick={(e) => { e.preventDefault(); navigateToDaf(target!); }}
+                  title={t('overview.goToDaf', { daf: s.ref })}
+                  style={rowStyle}
+                  onMouseEnter={(e) => { e.currentTarget.style.borderColor = '#8a2a2b'; e.currentTarget.style.background = '#fbf6f6'; }}
+                  onMouseLeave={(e) => { e.currentTarget.style.borderColor = '#e4e0d4'; e.currentTarget.style.background = '#fff'; }}
+                >{inner}</a>
               </Show>
-            </div>
-          )}</For>
+            );
+          }}</For>
         </div>
       </div>
     </Show>

--- a/src/lib/halacha/codifiers.ts
+++ b/src/lib/halacha/codifiers.ts
@@ -186,6 +186,26 @@ export function baseDafRef(ref: string): string {
   return m ? m[1] : r.replace(/:\d+(?:-\d+)?$/, '');
 }
 
+/**
+ * Inverse of `baseDafRef`: split a Bavli base ref ("Berakhot 31a", "Bava Metzia
+ * 59b") into the tractate + page the in-app reader navigates by. The tractate
+ * may be several words (Rosh Hashanah, Moed Katan, Avodah Zarah), so the daf
+ * (\d+[ab]) is the anchor and everything before it is the tractate, VERBATIM.
+ *
+ * Deliberately does NO spelling normalization: the tractate is whatever the
+ * source ref spelled. Callers navigate only when that string matches an app
+ * tractate slug (the Sefaria-derived refs match for all of Shas today). If a
+ * future source spells a tractate differently, this is the seam where a
+ * normalization map would slot in — see tests/halacha-codifiers.test.ts.
+ *
+ * Returns null for anything that isn't a "<words> <daf>" Bavli ref (Tanakh
+ * verses, Yerushalmi chapter:halacha refs), which aren't dapim in this reader.
+ */
+export function parseBavliRef(ref: string): { tractate: string; page: string } | null {
+  const m = (ref ?? '').trim().match(/^(.+?)\s+(\d+[ab])$/);
+  return m ? { tractate: m[1], page: m[2] } : null;
+}
+
 export type DerivationRole = 'primary' | 'related' | 'root';
 
 export interface DerivationSource {

--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -3702,7 +3702,7 @@ Output STRICT JSON only:
 Rules:
 - present=false is the COMMON case. Most topics are settled. Set present=false (and leave the other fields empty/[]) unless there is a real dispute that changes practice. DO NOT fabricate a dispute to fill the field.
 - GROUND it in the inputs. Use the codification trail's Rema entry for the Mechaber/Rema split, and the study-aid context's poskim notes for Acharonim positions — do not invent voices or refs not supported by the inputs.
-- "side": put the two camps on a=blue / b=neutral consistently (e.g. Mechaber=a, Rema=b); a citing/neutral voice is "neutral".
+- "side": put the two opposing camps on "a" vs "b" consistently (e.g. Mechaber=a, Rema=b); a citing or background voice is "neutral".
 - "sephardi"/"ashkenazi" are the practical consequence — fill them only when the split is genuinely along community lines (Mechaber/Rema, Ashkenaz/Sefarad); otherwise leave empty and rely on "settled".
 - NO puff.
 
@@ -3872,7 +3872,7 @@ const HALACHA_DISPUTE_SYSTEM_PROMPT_HE = `אתה תלמיד חכם הבקיא ב
 כללים:
 - present=false הוא המקרה הנפוץ. רוב הנושאים מיושבים. קבע present=false (והשאר את השאר ריק/[]) אלא אם יש מחלוקת אמיתית המשנה את ההלכה למעשה. אל תמציא מחלוקת.
 - בסס על הקלט. השתמש בערך הרמ"א שבשלשלת הפסיקה לחילוק מחבר/רמ"א, ובהערות הפוסקים שבהקשר לעמדות האחרונים — אל תמציא קולות או מראי מקום שאינם נתמכים בקלט.
-- "side": שים את שני המחנות על a / b באופן עקבי (למשל מחבר=a, רמ"א=b); קול מצטט/ניטרלי הוא "neutral".
+- "side": שים את שני המחנות החולקים על "a" מול "b" באופן עקבי (למשל מחבר=a, רמ"א=b); קול מצטט או רקע הוא "neutral".
 - "sephardi"/"ashkenazi" — מלא רק כשהפיצול הוא באמת לפי עדות; אחרת השאר ריק והסתמך על "settled".
 - ללא מליצה.
 

--- a/tests/halacha-codifiers.test.ts
+++ b/tests/halacha-codifiers.test.ts
@@ -2,9 +2,10 @@ import { describe, it, expect } from 'vitest';
 import {
   classifyCodifier, buildCodificationChain, hasCodification, CODIFIERS,
   classifyShasSource, baseDafRef, buildDerivation, formatGroundedRefsForPrompt,
-  type RelatedLink,
+  parseBavliRef, type RelatedLink,
 } from '../src/lib/halacha/codifiers';
 import type { HalachicRefBundle } from '../src/lib/sefref/sefaria/client';
+import { TRACTATE_OPTIONS } from '../src/lib/sefref/tractates';
 
 // Fixtures below are the SHAPES observed live from Sefaria (/api/related):
 // index_titles like "Mishneh Torah, Reading the Shema", "Tur, Orach Chayim",
@@ -159,5 +160,57 @@ describe('buildDerivation', () => {
     const d = buildDerivation(links);
     expect(d.some((s) => s.ref.startsWith('Rashi'))).toBe(false);
     expect(d.every((s) => !s.isCurrent)).toBe(true);
+  });
+});
+
+describe('parseBavliRef — derivation refs → in-app navigation', () => {
+  it('splits single- and multi-word tractates off the daf', () => {
+    expect(parseBavliRef('Berakhot 31a')).toEqual({ tractate: 'Berakhot', page: '31a' });
+    expect(parseBavliRef('Niddah 66a')).toEqual({ tractate: 'Niddah', page: '66a' });
+    // The daf (\d+[ab]) is the anchor, so multi-word tractates stay intact.
+    expect(parseBavliRef('Bava Metzia 59b')).toEqual({ tractate: 'Bava Metzia', page: '59b' });
+    expect(parseBavliRef('Rosh Hashanah 16a')).toEqual({ tractate: 'Rosh Hashanah', page: '16a' });
+    expect(parseBavliRef('Avodah Zarah 18a')).toEqual({ tractate: 'Avodah Zarah', page: '18a' });
+    expect(parseBavliRef('Moed Katan 28a')).toEqual({ tractate: 'Moed Katan', page: '28a' });
+  });
+
+  it('returns null for non-Bavli refs (Tanakh roots, Yerushalmi, junk)', () => {
+    expect(parseBavliRef('Leviticus 19:5')).toBeNull();
+    expect(parseBavliRef('Jerusalem Talmud Berakhot 1:1:1')).toBeNull();
+    expect(parseBavliRef('Berakhot 2a:3')).toBeNull(); // segment-precise, not a base daf
+    expect(parseBavliRef('')).toBeNull();
+  });
+
+  // The claim under test: a derivation ref navigates cleanly only when its
+  // tractate spelling matches an app URL slug. Today every Bavli tractate the
+  // app serves is spelled the same way Sefaria spells it, so a "<slug> <daf>"
+  // ref round-trips straight back to a navigable slug — no normalization map
+  // needed.
+  const APP_SLUGS = new Set(TRACTATE_OPTIONS.map((o) => o.value));
+
+  it('round-trips every app tractate slug to a navigable target', () => {
+    for (const slug of APP_SLUGS) {
+      const parsed = parseBavliRef(`${slug} 5b`);
+      expect(parsed).toEqual({ tractate: slug, page: '5b' });
+      // The parsed tractate is a real app slug → goToDaf lands on a real page.
+      expect(APP_SLUGS.has(parsed!.tractate)).toBe(true);
+    }
+  });
+
+  it('does NOT normalize spelling — a variant tractate parses but is not navigable', () => {
+    // If a future source spelled a tractate differently than the app slug
+    // (these are NOT in TRACTATE_OPTIONS), parseBavliRef still returns the
+    // tractate VERBATIM — and that verbatim string is not a known slug, so
+    // navigation would miss. This is exactly the seam a normalization map fills.
+    for (const variant of ['Avoda Zara 18a', 'Rosh HaShana 16a', 'Beitza 4a', 'Eiruvin 13b']) {
+      const parsed = parseBavliRef(variant)!;
+      expect(parsed).not.toBeNull();
+      expect(APP_SLUGS.has(parsed.tractate)).toBe(false); // would 404 until normalized
+    }
+    // Sanity: the canonical spellings these mimic ARE valid slugs.
+    expect(APP_SLUGS.has('Avodah Zarah')).toBe(true);
+    expect(APP_SLUGS.has('Rosh Hashanah')).toBe(true);
+    expect(APP_SLUGS.has('Beitzah')).toBe(true);
+    expect(APP_SLUGS.has('Eruvin')).toBe(true);
   });
 });


### PR DESCRIPTION
Integrates a parallel agent's local-only commit (rescued so it isn't lost) plus a small follow-up fix.

### Clickable Talmudic-source rows (cherry-picked from the other agent's `ec45755`)
The derivation "Talmudic sources" rows now **navigate**: each Bavli source links to that daf via the `?tractate=&page=` contract (current daf stays marked-but-inert; Tanakh roots + Yerushalmi stay plain, since they aren't dapim in this reader). `parseBavliRef` moves into `lib/halacha/codifiers` (pure, beside its inverse `baseDafRef`) and is unit-tested — every app tractate slug round-trips, including multi-word (Bava Metzia / Rosh Hashanah / Avodah Zarah).

### Dispute prompt fix (Codex follow-up to #188)
The `halacha.dispute` prompt said "a=blue / b=neutral", but the b side renders red and neutral is its own value — reworded to opposing camps "a" vs "b". Prompt-only; no schema/cache change.

`pnpm typecheck` clean; `pnpm test` 1696 passed.