### PR TITLE
Tidbit: a whole-daf "did you notice…" chip

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -23,7 +23,7 @@ import { dafRefHe, pageLabelHe } from '../lib/sefref/tractates';
 import { selectSectionMoves } from '../lib/argumentMoves';
 import { t, lang } from './i18n';
 import { ACCENTS, HE_FONT, HebrewProse, Panel, QASection, SectionCard, Synthesis, SidebarPanelFromHint, SidebarCardFromHint, setActiveCard, kindLabelKey, type SidebarHint, type SidebarRecipe, type SpecialBlockProps } from './sidebar/primitives';
-import { InspectDot } from './MarkEnrichmentCards';
+import { InspectDot, registerMarkRenderer } from './MarkEnrichmentCards';
 // Recipes now live in the shared lib (carried on the worker mark def too).
 // Re-exported so existing importers (CARD_DEFS, tests) keep their `from
 // './ArgumentSidebar'` path.
@@ -138,7 +138,8 @@ export type SidebarContent =
   | { kind: 'voice-group'; group: { name: string; nameHe: string; bio: string } }
   | { kind: 'rishonim'; instance: RishonimInstance; index: number }
   | { kind: 'argument-overview' }
-  | { kind: 'daf-background' };
+  | { kind: 'daf-background' }
+  | { kind: 'tidbit' };
 
 export interface ArgumentSidebarProps {
   content: SidebarContent | null;
@@ -1106,6 +1107,127 @@ function DafBackgroundBody(props: { tractate: string; page: string }): JSX.Eleme
           {t('background.empty')}
         </HebrewProse>
       </Show>
+    </Panel>
+  );
+}
+
+// ===========================================================================
+// Tidbit body
+// -----------
+// The whole-daf "did you notice…" chip. One curated reading: a hook + 3-4
+// flowing paragraphs, a flavor tag, the sources it rests on, and two honest
+// confidence dots (TEXT grounding vs. how editorial the READING is). The essay
+// is the tidbit.essay aggregate's OWN parsed output, so it renders via the
+// registered mark renderer (registerMarkRenderer below) rather than the deps
+// channel the other *Body components use.
+// ===========================================================================
+
+const TIDBIT_FLAVOR_KEY = {
+  aggadah: 'tidbit.flavor.aggadah',
+  'legal-concept': 'tidbit.flavor.legal-concept',
+  machloket: 'tidbit.flavor.machloket',
+  textual: 'tidbit.flavor.textual',
+  'hidden-point': 'tidbit.flavor.hidden-point',
+} as const;
+
+const TIDBIT_CONF_KEY = {
+  high: 'tidbit.conf.high',
+  medium: 'tidbit.conf.medium',
+  low: 'tidbit.conf.low',
+} as const;
+
+type TidbitConfLevel = keyof typeof TIDBIT_CONF_KEY;
+
+function tidbitConfColor(level: TidbitConfLevel): string {
+  return level === 'high' ? '#3f6b3a' : level === 'medium' ? '#a9802f' : '#9c4a1f';
+}
+
+function TidbitConf(props: { label: string; level: string }): JSX.Element {
+  const lvl = (): TidbitConfLevel =>
+    props.level === 'high' || props.level === 'medium' ? props.level : 'low';
+  return (
+    <span style={{ display: 'inline-flex', 'align-items': 'center', gap: '0.3rem' }}>
+      <span>{props.label}</span>
+      <span style={{
+        display: 'inline-block', width: '0.5rem', height: '0.5rem',
+        'border-radius': '50%', 'background-color': tidbitConfColor(lvl()),
+      }} />
+      <span>{t(TIDBIT_CONF_KEY[lvl()])}</span>
+    </span>
+  );
+}
+
+interface TidbitSource { ref?: string; note?: string }
+
+function TidbitEssayView(parsed: Record<string, unknown>): JSX.Element {
+  const str = (v: unknown): string => (typeof v === 'string' ? v : '');
+  const flavor = str(parsed.flavor);
+  const hook = str(parsed.hook);
+  const paragraphs = Array.isArray(parsed.paragraphs)
+    ? (parsed.paragraphs as unknown[]).filter((p): p is string => typeof p === 'string')
+    : [];
+  const sources = Array.isArray(parsed.sources) ? (parsed.sources as TidbitSource[]) : [];
+  const textConf = str(parsed.textConfidence);
+  const readingConf = str(parsed.readingConfidence);
+  const flavorKey = TIDBIT_FLAVOR_KEY[flavor as keyof typeof TIDBIT_FLAVOR_KEY];
+  return (
+    <div>
+      <Show when={flavorKey}>
+        <div style={{
+          'font-size': '0.66rem', 'letter-spacing': '0.12em', 'text-transform': 'uppercase',
+          'font-weight': 700, color: ACCENTS.tidbit, 'margin-bottom': '0.5rem',
+        }}>{t(flavorKey!)}</div>
+      </Show>
+      <Show when={hook}>
+        <p style={{ margin: '0 0 0.85rem', 'font-size': '1.02rem', 'line-height': 1.4, 'font-weight': 600, color: '#1f1b18' }}>
+          <Hebraized text={hook} />
+        </p>
+      </Show>
+      <For each={paragraphs}>{(p) => (
+        <p style={{ margin: '0 0 0.7rem', 'font-size': '0.92rem', 'line-height': 1.62, color: '#2b2622' }}>
+          <Hebraized text={p} />
+        </p>
+      )}</For>
+      <Show when={sources.length > 0}>
+        <div style={{ display: 'flex', 'flex-wrap': 'wrap', gap: '0.35rem', 'margin-top': '0.75rem' }}>
+          <For each={sources}>{(s) => (
+            <span title={str(s.note)} style={{
+              'font-size': '0.7rem', 'font-family': 'ui-monospace, monospace',
+              background: '#f1ece0', border: '1px solid #e0d4ba', 'border-radius': '5px',
+              padding: '0.1rem 0.45rem', color: '#574e45',
+            }}>{str(s.ref)}</span>
+          )}</For>
+        </div>
+      </Show>
+      <Show when={textConf || readingConf}>
+        <div style={{
+          display: 'flex', 'flex-wrap': 'wrap', gap: '1.1rem', 'margin-top': '0.75rem',
+          'padding-top': '0.55rem', 'border-top': '1px solid #eee',
+          'font-size': '0.66rem', 'font-family': 'ui-monospace, monospace', color: '#9a8d76',
+        }}>
+          <Show when={textConf}><TidbitConf label={t('tidbit.conf.text')} level={textConf} /></Show>
+          <Show when={readingConf}><TidbitConf label={t('tidbit.conf.reading')} level={readingConf} /></Show>
+        </div>
+      </Show>
+    </div>
+  );
+}
+
+// The essay is the tidbit.essay aggregate's own output → render it via the
+// per-mark renderer seam in MarkEnrichmentCards (so caching/polling/telemetry
+// stay shared) rather than the deps_resolved channel.
+registerMarkRenderer('tidbit', TidbitEssayView);
+
+function TidbitBody(props: { tractate: string; page: string }): JSX.Element {
+  return (
+    <Panel accent={ACCENTS.tidbit} title={t('tidbit.title')}>
+      <Synthesis
+        markId="tidbit"
+        instance={{ fields: {} }}
+        instanceKey={`${props.tractate}/${props.page}/tidbit`}
+        tractate={props.tractate}
+        page={props.page}
+      />
     </Panel>
   );
 }
@@ -2120,6 +2242,10 @@ export function ArgumentSidebar(props: ArgumentSidebarProps): JSX.Element {
 
             <Show when={c().kind === 'daf-background'}>
               <DafBackgroundBody tractate={props.tractate} page={props.page} />
+            </Show>
+
+            <Show when={c().kind === 'tidbit'}>
+              <TidbitBody tractate={props.tractate} page={props.page} />
             </Show>
 
         </aside>

--- a/src/client/DafViewer.tsx
+++ b/src/client/DafViewer.tsx
@@ -777,6 +777,7 @@ export default function DafViewer(): JSX.Element {
     if (c.kind === 'rishonim') return `Rishonim · seg ${c.instance.segIdx + 1}`;
     if (c.kind === 'argument-overview') return t('overview.chip');
     if (c.kind === 'daf-background') return t('background.chip');
+    if (c.kind === 'tidbit') return t('tidbit.chip');
     return 'Back';
   };
   const sidebarKey = (c: SidebarContent): string => {
@@ -790,6 +791,7 @@ export default function DafViewer(): JSX.Element {
     if (c.kind === 'rishonim') return `rishonim:${c.instance.segIdx}`;
     if (c.kind === 'argument-overview') return 'argument-overview';
     if (c.kind === 'daf-background') return 'daf-background';
+    if (c.kind === 'tidbit') return 'tidbit';
     return 'unknown';
   };
 
@@ -803,6 +805,7 @@ export default function DafViewer(): JSX.Element {
   const openChip = (id: string) => {
     if (id === 'argument-overview') setSidebar({ kind: 'argument-overview' });
     else if (id === 'daf-background') setSidebar({ kind: 'daf-background' });
+    else if (id === 'tidbit') setSidebar({ kind: 'tidbit' });
   };
   // Set by ArgumentSidebar when the user clicks an argument-move card. Paints
   // a yellow band over the move's segment range in the main daf text. When
@@ -2023,6 +2026,7 @@ export default function DafViewer(): JSX.Element {
     if (s.kind === 'voice-group') return `voice-group:${s.group.name}`;
     if (s.kind === 'argument-overview') return 'argument-overview';
     if (s.kind === 'daf-background') return 'daf-background';
+    if (s.kind === 'tidbit') return 'tidbit';
     return `${s.kind}:${s.index}`;
   });
 
@@ -2803,6 +2807,7 @@ export default function DafViewer(): JSX.Element {
             // language it first rendered in.
             const label = () => m.id === 'argument-overview' ? t('overview.chip')
               : m.id === 'daf-background' ? t('background.chip')
+              : m.id === 'tidbit' ? t('tidbit.chip')
               : m.id;
             const active = () => sidebar()?.kind === m.id;
             return (

--- a/src/client/MarkEnrichmentCards.tsx
+++ b/src/client/MarkEnrichmentCards.tsx
@@ -277,9 +277,17 @@ interface Props {
   }) => void;
 }
 
-// Pluggable per-enrichment renderers can be registered here in the future.
-// For now we use the generic ParsedFieldView (below) which renders any
-// parsed JSON nicely by inferring field types from key names.
+// Pluggable per-mark renderers for the primary (aggregate) card body. When a
+// mark registers one, its parsed JSON is rendered by that component instead of
+// the generic ParsedFieldView — the seam for bespoke layouts (e.g. the Tidbit
+// essay) without each mark reimplementing the run/cache/poll plumbing. Bodies
+// register from their own module at import time (no circular dependency: this
+// file never imports them back).
+export type EnrichmentRenderer = (parsed: Record<string, unknown>) => JSX.Element;
+const MARK_RENDERERS: Record<string, EnrichmentRenderer> = {};
+export function registerMarkRenderer(markId: string, render: EnrichmentRenderer): void {
+  MARK_RENDERERS[markId] = render;
+}
 
 export default function MarkEnrichmentCards(props: Props) {
   const [defs] = createResource(fetchEnrichments);
@@ -581,6 +589,9 @@ export default function MarkEnrichmentCards(props: Props) {
     if (props.markId === 'rishonim') {
       return t('loading.rishonim');
     }
+    if (props.markId === 'tidbit') {
+      return t('loading.tidbit');
+    }
     return t('loading.default');
   };
 
@@ -624,7 +635,10 @@ export default function MarkEnrichmentCards(props: Props) {
     }
     const result = r.result;
     if (result.parsed && typeof result.parsed === 'object') {
-      return <ParsedFieldView parsed={result.parsed as Record<string, unknown>} />;
+      const parsed = result.parsed as Record<string, unknown>;
+      const custom = MARK_RENDERERS[props.markId];
+      if (custom) return custom(parsed);
+      return <ParsedFieldView parsed={parsed} />;
     }
     return (
       <p style={{ margin: 0, 'font-size': '0.92rem', 'line-height': 1.6, color: '#222' }}>

--- a/src/client/MarksRegistryPanel.tsx
+++ b/src/client/MarksRegistryPanel.tsx
@@ -182,6 +182,7 @@ const DEFAULTS_APPLIED_KEY = 'marks-registry:defaults-applied:v1';
 const FORCE_ON_DEFAULTS: { tag: string; ids: string[] }[] = [
   { tag: 'argument-overview-2026-05', ids: ['argument-overview'] },
   { tag: 'daf-background-2026-05', ids: ['daf-background'] },
+  { tag: 'tidbit-2026-06', ids: ['tidbit'] },
 ];
 
 function readAppliedDefaults(): Set<string> {

--- a/src/client/MobileShelf.tsx
+++ b/src/client/MobileShelf.tsx
@@ -174,5 +174,6 @@ function labelForSidebar(s: SidebarContent | null): string {
     case 'rishonim': return 'Rishonim';
     case 'argument-overview': return 'Overview';
     case 'daf-background': return 'Background';
+    case 'tidbit': return 'Tidbit';
   }
 }

--- a/src/client/i18n.ts
+++ b/src/client/i18n.ts
@@ -173,6 +173,7 @@ const CATALOG = {
   'sidebar.kind.rabbi': { en: 'Rabbi', he: 'חכם' },
   'sidebar.kind.argument-overview': { en: 'Overview', he: 'סקירה' },
   'sidebar.kind.daf-background': { en: 'Background', he: 'רקע' },
+  'sidebar.kind.tidbit': { en: 'Tidbit', he: 'תובנה' },
 
   // — Whole-daf argument overview —
   'overview.chip': { en: 'Overview', he: 'סקירה' },
@@ -211,6 +212,22 @@ const CATALOG = {
   'background.cat.legal-concepts': { en: 'Legal concepts', he: 'מושגים הלכתיים' },
   'background.cat.realia': { en: 'Everyday life', he: 'מציאות' },
   'background.cat.assumed-prior': { en: 'Assumed background', he: 'רקע מוקדם' },
+
+  // — Whole-daf Tidbit (one curated "did you notice…" reading) —
+  'tidbit.chip': { en: 'Tidbit', he: 'תובנה' },
+  'tidbit.title': { en: 'Tidbit', he: 'תובנה' },
+  'tidbit.empty': { en: 'No tidbit for this daf yet.', he: 'אין עדיין תובנה לדף זה.' },
+  'tidbit.sources': { en: 'Sources', he: 'מקורות' },
+  'tidbit.flavor.aggadah': { en: 'Aggadah', he: 'אגדה' },
+  'tidbit.flavor.legal-concept': { en: 'Legal concept', he: 'מושג הלכתי' },
+  'tidbit.flavor.machloket': { en: 'Machloket', he: 'מחלוקת' },
+  'tidbit.flavor.textual': { en: 'Textual', he: 'נוסח' },
+  'tidbit.flavor.hidden-point': { en: 'Hidden point', he: 'נקודה נסתרת' },
+  'tidbit.conf.text': { en: 'text', he: 'טקסט' },
+  'tidbit.conf.reading': { en: 'reading', he: 'קריאה' },
+  'tidbit.conf.high': { en: 'high', he: 'גבוה' },
+  'tidbit.conf.medium': { en: 'medium', he: 'בינוני' },
+  'tidbit.conf.low': { en: 'low', he: 'נמוך' },
   // — Common —
   'common.open': { en: 'Open {name}', he: 'פתיחת {name}' },
   'common.close': { en: 'Close', he: 'סגירה' },
@@ -222,6 +239,7 @@ const CATALOG = {
   'loading.argument': { en: 'Tracing the argument…', he: 'עוקב אחר הסוגיה…' },
   'loading.move.named': { en: 'Listening to {voice}…', he: 'מקשיב ל{voice}…' },
   'loading.move': { en: 'Tracing the flow…', he: 'עוקב אחר המהלך…' },
+  'loading.tidbit': { en: 'Finding the tidbit…', he: 'מחפש את התובנה…' },
   'loading.halacha.named': { en: 'Asking a Rav about {title}…', he: 'שואל רב על {title}…' },
   'loading.halacha': { en: 'Asking the Rav…', he: 'שואל את הרב…' },
   'loading.aggadata.named': { en: 'Pondering {title}…', he: 'מהרהר ב{title}…' },

--- a/src/client/sidebar/primitives.tsx
+++ b/src/client/sidebar/primitives.tsx
@@ -31,6 +31,7 @@ export const ACCENTS = {
   argument: '#8a2a2b',
   'argument-overview': '#8a2a2b',
   'daf-background': '#8a6d3b',
+  tidbit: '#2f6b66',
   halacha: '#1e40af',
   aggadata: '#7c3aed',
   pesuk: '#9a3412',
@@ -49,6 +50,7 @@ export function kindLabelKey(kind: SidebarKind): CatalogKey {
     case 'argument': return 'sidebar.kind.argument';
     case 'argument-overview': return 'sidebar.kind.argument-overview';
     case 'daf-background': return 'sidebar.kind.daf-background';
+    case 'tidbit': return 'sidebar.kind.tidbit';
     case 'halacha': return 'sidebar.kind.halacha';
     case 'aggadata': return 'sidebar.kind.aggadata';
     case 'pesuk': return 'sidebar.kind.pesuk';

--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -77,6 +77,7 @@ import {
   RABBI_RELATIONSHIPS_OUTPUT_SCHEMA,
   RABBI_SYNTHESIS_OUTPUT_SCHEMA,
   RISHONIM_SYNTHESIS_OUTPUT_SCHEMA,
+  TIDBIT_ESSAY_OUTPUT_SCHEMA,
   proseSchema,
 } from './output-schemas';
 import { AGGADATA_RECIPE, PASUK_RECIPE, HALACHA_RECIPE, RISHONIM_RECIPE, RABBI_RECIPE } from '../lib/sidebar/recipe';
@@ -562,6 +563,32 @@ export const CODE_MARKS: MarkDefinition[] = [
     },
     status: 'promoted',
     def_hash: 'daf-background-v1',
+    cache_version: '1',
+    source: 'code',
+    updated_at: NOW,
+  },
+  {
+    id: 'tidbit',
+    label: 'Tidbit',
+    description: 'Whole-daf "did you notice…": ONE curated, genuinely interesting thing about this daf — an aggadah read against the grain, a legal concept with a twist, a sharp machloket, a textual point, or a hidden point inside a dry sugya. Grounded on the full daf + commentaries + study context + the overview & background it depends on.',
+    category: 'canon',
+    // Reader-facing whole-daf chip, like the overview/background pills. The
+    // deterministic single anchorless instance carries the chip + the
+    // tidbit.essay enrichment; no LLM at the mark layer. (Promotion is a
+    // judgement call — once a benchmark over a fixed daf set exists, gate it on
+    // that; for now it ships visible so the reading can be evaluated in situ.)
+    anchor: 'whole-daf',
+    render: {
+      kind: 'chip',
+      color: '#2f6b66',
+      position: 'header',
+    },
+    extractor: {
+      kind: 'computed',
+      fn: 'whole-daf-instance',
+    },
+    status: 'promoted',
+    def_hash: 'tidbit-v1',
     cache_version: '1',
     source: 'code',
     updated_at: NOW,
@@ -2493,6 +2520,171 @@ CODE_ENRICHMENTS.push(
       model: ARGUMENT_FLASH_MODEL,
       systemPromptHe: DAF_BACKGROUND_SYNTHESIS_SYSTEM_PROMPT_HE,
       userPromptTemplateHe: DAF_BACKGROUND_SYNTHESIS_USER_TEMPLATE_HE,
+    },
+  ),
+);
+
+// ---------------------------------------------------------------------------
+// tidbit mark enrichment — ONE curated "did you notice…" essay for the whole
+// daf: the single most interesting, non-obvious thing on the page, as a hook +
+// 3-4 flowing paragraphs. Deliberately NOT the background (prerequisites) or the
+// overview (structure) — it is a reading. Fed a generous context bundle (full
+// daf + commentaries + study aids + the overview & background it builds on) so
+// it genuinely understands the daf before choosing. Two honest confidences:
+// TEXT (grounding) vs READING (how editorial the framing is).
+// ---------------------------------------------------------------------------
+
+const TIDBIT_ESSAY_SYSTEM_PROMPT = `You are a sharp Talmud teacher writing ONE "Tidbit" for this daf — a single "did you notice…" worth carrying away. Not a summary, not the background, not the argument outline. You pick the ONE most genuinely interesting, non-obvious thing on THIS page and explain it.
+
+WHAT TO LOOK FOR (pick the strongest ONE; any kind is fine):
+- an aggadah (story) read against the grain — where the obvious moral is a setup for a sharper one;
+- a legal concept with a surprising twist or consequence;
+- a sharp machloket whose ramifications reach real practice (including a Bavli/Yerushalmi or Tanna/Amora fault line) — only if it is genuinely in the materials;
+- a textual point (a variant, a precise word) that changes the stakes;
+- on a dry / technical daf, the one real thing a learner would actually want to know.
+Prefer the non-obvious. Do NOT default to the famous greatest-hits reading when a sharper, true one is available. But never manufacture interest — if the daf is plain, an honest hidden point beats a forced "twist".
+
+VOICE (match the rest of the app exactly):
+- Tight third person. Short, declarative sentences (aim under ~30 words). Named actors. Concrete.
+- Hebrew script paired with a short English gloss for technical terms — e.g. "a גט (bill of divorce)", "performed לכתחילה (the ideal standard)". Hebrew names for ספרים (קהלת, not Ecclesiastes; דברים, not Deuteronomy). Hebrew verse refs.
+- Plain English is the base; Hebrew is the technical anchor — do not hebraize every common word.
+- FORBIDDEN flourish: "lens", "captures", "embodies", "profound", "intricate", "this teaches us", "we see that", "highlights", "underscores", "to a modern ear", "reads like", "sketches a theory". No puff, no meta-commentary about what the daf "reveals".
+
+STRUCTURE (this is the whole shape):
+- "hook": ONE sentence — the teaser, specific to THIS daf, that makes a reader want to open it.
+- "paragraphs": THREE or FOUR paragraphs of flowing prose. The first lays out the plain reading. The next develop the turn. The last lands the point — WITHOUT any "why it matters" sign over it. No section labels, no headers. Just readable prose.
+
+GROUNDING (hard):
+- Every factual claim must rest on the materials provided (the daf, its commentaries, the study context, the overview/background) or on well-established fact. Do NOT invent stories, positions, sources, manuscript variants, or a Yerushalmi/Rishon view that is not real.
+- "sources": list the concrete sources the Tidbit rests on (e.g. "Gittin 68b", "Rambam, Hilchot Gerushin 2:20", "Kohelet 1:12"), each with a short note of what it grounds.
+
+CONFIDENCE (be honest — a human reviewer reads this):
+- "textConfidence": how well the FACTUAL claims are grounded in the daf's text/sources. high = stated directly; medium = a fair inference; low = a stretch.
+- "readingConfidence": how editorial the INTERPRETATION is. high = the daf or a commentary says the surprising thing itself; medium = a fair reading; low = your own bold framing. A bold against-the-grain reading should NOT be high.
+
+Output STRICT JSON only:
+
+{
+  "flavor": "aggadah" | "legal-concept" | "machloket" | "textual" | "hidden-point",
+  "hook": "one sentence",
+  "paragraphs": ["paragraph 1", "paragraph 2", "paragraph 3"],
+  "sources": [{ "ref": "source reference", "note": "what it grounds" }],
+  "textConfidence": "high" | "medium" | "low",
+  "readingConfidence": "high" | "medium" | "low"
+}
+
+${HEBREW_GLOSS_STYLE}`;
+
+const TIDBIT_ESSAY_USER_TEMPLATE = `Tractate: {{tractate}}, page {{page}}.
+
+Full daf (Gemara):
+{{gemara}}
+
+Commentaries (Rashi / Tosafot / rishonim):
+{{commentaries}}
+
+The daf's argument sections (structure, for your orientation):
+{{anchors.argument}}
+
+Whole-daf orientation (what the daf is about and where it lands):
+{{depends.argument-overview.synthesis}}
+
+Background concepts a reader needs going in:
+{{depends.daf-background.concepts}}
+
+Study-aid context (dafyomi.co.il Insights / Points / Halacha / Yerushalmi / Tosfos notes + Sefaria cross-references):
+{{context}}
+
+Write ONE Tidbit for this daf per the schema: the single most interesting, non-obvious thing on the page, as a hook plus three or four flowing paragraphs. Ground every claim in the materials above, and rate both confidences honestly.`;
+
+const TIDBIT_ESSAY_SYSTEM_PROMPT_HE = `אתה מלמד תורה חד שכותב "Tidbit" אחד לדף הזה — דבר אחד מעניין באמת שכדאי לקחת ממנו. לא סיכום, לא הרקע, ולא מתווה הטיעון. אתה בוחר את הדבר האחד הכי מעניין ולא־מובן־מאליו בדף הזה ומסביר אותו.
+
+מה לחפש (בחר את הדבר החזק ביותר; כל סוג מתאים):
+- אגדה הנקראת כנגד הכיוון המתבקש — שבה המוסר המובן מאליו הוא הכנה לקריאה חדה יותר;
+- מושג הלכתי עם תפנית או השלכה מפתיעה;
+- מחלוקת חדה שהשלכותיה נוגעות למעשה (כולל קו שבר בין בבלי לירושלמי או בין תנא לאמורא) — רק אם היא באמת במקורות;
+- נקודה טקסטואלית (גרסה, מילה מדויקת) שמשנה את המשמעות;
+- בדף יבש/טכני — הדבר האחד האמיתי שלומד היה רוצה לדעת.
+העדף את הלא־מובן־מאליו. אל תברח לקריאה המפורסמת והשחוקה כשיש קריאה חדה ואמיתית יותר. אך לעולם אל תייצר עניין יש מאין — אם הדף פשוט, נקודה נסתרת כנה עדיפה על "תפנית" מאולצת.
+
+הסגנון (זהה לשאר האפליקציה):
+- גוף שלישי הדוק. משפטים קצרים והצהרתיים. שמות מפורשים. קונקרטי.
+- מונחים טכניים בכתב עברי עם תרגום קצר באנגלית במידת הצורך. שמות ספרים בעברית. מראי מקום של פסוקים בעברית.
+- אסורה מליצה: "מכאן אנו למדים", "אנו רואים ש", "מבליט", "מדגיש", "עמוק". ללא פלפול מטא על מה שהדף "מגלה".
+
+המבנה:
+- "hook": משפט אחד — הטיזר, ספציפי לדף הזה.
+- "paragraphs": שלוש או ארבע פסקאות של פרוזה זורמת. הראשונה — הקריאה הפשוטה. הבאות — מפתחות את התפנית. האחרונה — נוחתת על הנקודה, בלי כותרת "מדוע זה חשוב". ללא תוויות מקטעים.
+
+ביסוס (קשיח):
+- כל טענה עובדתית חייבת להישען על החומר שסופק או על עובדה מבוססת. אל תמציא סיפורים, עמדות, מקורות, גרסאות, או דעת ירושלמי/ראשון שאינה אמיתית.
+- "sources": רשום את המקורות הקונקרטיים שעליהם ה-Tidbit נשען, כל אחד עם הערה קצרה על מה הוא מבסס.
+
+ביטחון (בכנות — אדם קורא זאת):
+- "textConfidence": כמה הטענות העובדתיות מבוססות בטקסט. high = נאמר במפורש; medium = הסקה הוגנת; low = מתיחה.
+- "readingConfidence": כמה הפרשנות עריכתית. high = הדף או מפרש אומרים זאת בעצמם; medium = קריאה הוגנת; low = מסגור נועז משלך. קריאה נועזת כנגד הכיוון אסור שתהיה high.
+
+החזר JSON תקין בלבד:
+
+{
+  "flavor": "aggadah" | "legal-concept" | "machloket" | "textual" | "hidden-point",
+  "hook": "משפט אחד",
+  "paragraphs": ["פסקה 1", "פסקה 2", "פסקה 3"],
+  "sources": [{ "ref": "מראה מקום", "note": "מה הוא מבסס" }],
+  "textConfidence": "high" | "medium" | "low",
+  "readingConfidence": "high" | "medium" | "low"
+}
+
+${HEBREW_NATIVE_STYLE}`;
+
+const TIDBIT_ESSAY_USER_TEMPLATE_HE = `מסכת: {{tractate}}, דף {{page}}.
+
+הדף המלא (גמרא):
+{{gemara}}
+
+מפרשים (רש"י / תוספות / ראשונים):
+{{commentaries}}
+
+מקטעי הטיעון בדף (מבנה, לכיוונך):
+{{anchors.argument}}
+
+כיוון כללי לדף (על מה הדף ולאן הוא מגיע):
+{{depends.argument-overview.synthesis}}
+
+מושגי רקע שהקורא צריך:
+{{depends.daf-background.concepts}}
+
+תוכן לימוד נלווה (dafyomi.co.il — תובנות / נקודות / הלכה / ירושלמי / תוספות + הפניות ספריא):
+{{context}}
+
+כתוב Tidbit אחד לדף הזה לפי הסכימה: הדבר האחד הכי מעניין ולא־מובן־מאליו בדף, כטיזר ושלוש או ארבע פסקאות זורמות. בסס כל טענה בחומר שלמעלה, ודרג את שני מדדי הביטחון בכנות.`;
+
+CODE_ENRICHMENTS.push(
+  makeEnrichment(
+    'tidbit', 'tidbit.essay', 'Tidbit',
+    'One curated "did you notice…" essay for the whole daf: the single most interesting thing on it, as a hook + 3-4 flowing paragraphs, grounded in the daf + commentaries + study context.',
+    TIDBIT_ESSAY_SYSTEM_PROMPT, TIDBIT_ESSAY_USER_TEMPLATE, TIDBIT_ESSAY_OUTPUT_SCHEMA,
+    {
+      mode: 'aggregate', scope: 'local',
+      // A generous context bundle so the model truly understands the daf before
+      // choosing: full text + Rashi/Tosafot + the argument structure + the
+      // whole-daf orientation + the background concepts + dafyomi study aids.
+      dependencies: [
+        'gemara',
+        'commentaries',
+        'context',
+        { mark: 'argument' },
+        { enrichment: 'argument-overview.synthesis' },
+        { enrichment: 'daf-background.concepts' },
+      ],
+      defHash: 'tidbit.essay-v1', cacheVersion: '1',
+      // Pro model: finding the non-obvious reading needs the stronger model.
+      // Thinking stays OFF (no reasoningEffort) — the context bundle is large,
+      // like daf-background.concepts, and a thinking pass on top risks the
+      // OpenRouter cap. Revisit reasoningEffort if quality calls for it.
+      model: ARGUMENT_PRO_MODEL,
+      systemPromptHe: TIDBIT_ESSAY_SYSTEM_PROMPT_HE,
+      userPromptTemplateHe: TIDBIT_ESSAY_USER_TEMPLATE_HE,
     },
   ),
 );

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -7258,7 +7258,12 @@ async function deepWarmDaf(
   // shows as its own singleton sugya. The one-time global sweep left gaps and
   // never ran for new daf-yomi dapim, so warm it here. Keyed on the canonical
   // whole-daf instance { fields: {} } to match the client.
-  for (const eid of ['argument-overview.flow', 'argument-overview.synthesis']) {
+  //
+  // tidbit.essay is the curated whole-daf "did you notice…" chip. It depends on
+  // argument-overview.synthesis (warmed just above) + daf-background.concepts +
+  // the source bundle; listed last so its deps are warm/in-flight first (its own
+  // dependency resolution still fills any gap and caches it).
+  for (const eid of ['argument-overview.flow', 'argument-overview.synthesis', 'tidbit.essay']) {
     if (!wanted(eid)) continue;
     try {
       const def = await loadEnrichmentDef(rc.env, eid);

--- a/src/worker/output-schemas.ts
+++ b/src/worker/output-schemas.ts
@@ -128,6 +128,21 @@ export const DAF_BACKGROUND_CONCEPTS_OUTPUT_SCHEMA = responseFormat('daf_backgro
     })),
   })),
 }));
+// Whole-daf TIDBIT: one curated "did you notice…" essay surfacing the single
+// most interesting thing on the daf — an aggadah read against the grain, a legal
+// concept with a twist, a sharp machloket, a textual point, or a hidden point
+// inside a dry/technical daf. Output is a hook + 3-4 flowing paragraphs (no
+// section labels). Two confidences: how well the claims are grounded in the
+// daf's TEXT vs. how editorial the READING (interpretive framing) is — a bold
+// reading should carry a lower readingConfidence. Drives the whole-daf Tidbit chip.
+export const TIDBIT_ESSAY_OUTPUT_SCHEMA = responseFormat('tidbit_essay', z.object({
+  flavor: z.enum(['aggadah', 'legal-concept', 'machloket', 'textual', 'hidden-point']),
+  hook: z.string(),
+  paragraphs: z.array(z.string()),
+  sources: z.array(z.object({ ref: z.string(), note: z.string() })),
+  textConfidence: z.enum(['high', 'medium', 'low']),
+  readingConfidence: z.enum(['high', 'medium', 'low']),
+}));
 // Section typing (P2b): a NARRATIVE view for story-primary sections, where the
 // dispute-oriented `voices` graph is the wrong model. Actors (characters) +
 // ordered beats (what happens, step by step) instead of opposing legal positions.

--- a/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
+++ b/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
@@ -47,5 +47,6 @@ exports[`CODE_ENRICHMENTS cache identity > per-enrichment fingerprint is stable 
   "rabbi.relationships@6 mode=augment-content scope=global mark=rabbi schema=rabbi_relationships[teachers,students,debatePartners,family,prose] deps=[]",
   "rabbi.synthesis@11 mode=aggregate scope=local mark=rabbi schema=rabbi_synthesis[synthesis] deps=[gemara|e:rabbi.bio|e:rabbi.philosophy|e:rabbi.relationships|e:rabbi.classification|e:rabbi.geography|e:rabbi.relationships.evidence|e:rabbi.geography.evidence|e:rabbi.location|e:rabbi.identity|m:rabbi]",
   "rishonim.synthesis@4 mode=aggregate scope=local mark=rishonim schema=rishonim_synthesis[synthesis] deps=[gemara|m:rishonim]",
+  "tidbit.essay@1 mode=aggregate scope=local mark=tidbit schema=tidbit_essay[flavor,hook,paragraphs,sources,textConfidence,readingConfidence] deps=[gemara|commentaries|context|m:argument|e:argument-overview.synthesis|e:daf-background.concepts]",
 ]
 `;

--- a/tests/fixtures/output-schemas/TIDBIT_ESSAY_OUTPUT_SCHEMA.json
+++ b/tests/fixtures/output-schemas/TIDBIT_ESSAY_OUTPUT_SCHEMA.json
@@ -1,0 +1,72 @@
+{
+  "name": "tidbit_essay",
+  "strict": true,
+  "schema": {
+    "type": "object",
+    "properties": {
+      "flavor": {
+        "type": "string",
+        "enum": [
+          "aggadah",
+          "legal-concept",
+          "machloket",
+          "textual",
+          "hidden-point"
+        ]
+      },
+      "hook": {
+        "type": "string"
+      },
+      "paragraphs": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "sources": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "ref": {
+              "type": "string"
+            },
+            "note": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "ref",
+            "note"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "textConfidence": {
+        "type": "string",
+        "enum": [
+          "high",
+          "medium",
+          "low"
+        ]
+      },
+      "readingConfidence": {
+        "type": "string",
+        "enum": [
+          "high",
+          "medium",
+          "low"
+        ]
+      }
+    },
+    "required": [
+      "flavor",
+      "hook",
+      "paragraphs",
+      "sources",
+      "textConfidence",
+      "readingConfidence"
+    ],
+    "additionalProperties": false
+  }
+}

--- a/tests/output-schema-parity.test.ts
+++ b/tests/output-schema-parity.test.ts
@@ -18,7 +18,7 @@ describe('output schema parity: zod-generated == frozen literal', () => {
     const all = schemas as Record<string, unknown>;
     const missing = files.map((f) => f.replace('.json', '')).filter((n) => !all[n]);
     expect(missing).toEqual([]);
-    expect(files.length).toBe(47);
+    expect(files.length).toBe(48);
   });
 
   for (const f of files) {


### PR DESCRIPTION
## What

A third whole-daf chip beside **Overview** and **Background**: a **Tidbit** — one curated, genuinely interesting reading of the daf. Not a summary and not the prerequisites; a "did you notice…". It picks the single most interesting, non-obvious thing on the page:

- an aggadah read against the grain (the obvious moral is a setup for a sharper one),
- a legal concept with a surprising twist,
- a sharp machloket whose ramifications reach practice (incl. a Bavli/Yerushalmi or Tanna/Amora fault line),
- a textual point that changes the stakes,
- or, on a dry/technical daf, the one real thing a learner would actually want to know.

Output is a **hook + 3–4 flowing paragraphs** (no section labels), the **sources** it rests on, and **two honest confidence dots**: `text` (how grounded the claims are) vs `reading` (how editorial the framing is) — a bold against-the-grain reading carries a lower `reading`.

## How

Architecturally identical to the existing `daf-background` / `argument-overview` chips (whole-daf, single anchorless instance, no LLM at the mark layer).

**Worker**
- `tidbit` chip mark + `tidbit.essay` aggregate enrichment (EN + HE prompts in the app's voice).
- Fed a generous context bundle so it understands the daf before choosing: `gemara · commentaries · context · {mark:argument} · {enrichment:argument-overview.synthesis} · {enrichment:daf-background.concepts}`. Pro model, thinking off (the bundle is large, like `daf-background.concepts`).
- `TIDBIT_ESSAY_OUTPUT_SCHEMA` + golden fixture.
- Added to the whole-daf deep-warm loop, so the daf-yomi pre-warm covers it.

**Client**
- A **per-mark renderer seam** in `MarkEnrichmentCards` (the documented future hook): a mark can render its own aggregate output with a bespoke layout instead of the generic field dump, while reusing the shared run/cache/poll plumbing.
- `TidbitBody` renders the essay; chip routing in `DafViewer`, the `tidbit` accent + kind, i18n (EN + HE), mobile label, and the `FORCE_ON_DEFAULTS` rollout entry so existing users get the chip.

## Notes
- `pnpm typecheck` clean; `pnpm test` green (1713). Updated the enrichment fingerprint snapshot + the output-schema parity count/fixture.
- Reviewed with `codex exec --sandbox read-only` — it caught the missing `FORCE_ON_DEFAULTS` entry (now added).
- **Promotion** is a judgement call: the mark ships `promoted` so the reading can be evaluated in situ; once a benchmark over a fixed daf set exists, gate promotion on that.