### PR TITLE
Usage page: loading indicator + faster load

### DIFF
--- a/src/client/UsagePage.tsx
+++ b/src/client/UsagePage.tsx
@@ -278,6 +278,20 @@ function fmtTokens(n: number | null | undefined): string {
   return `${(n / 1_000_000).toFixed(2)}M`;
 }
 
+// Small inline spinner reusing the global `daf-spin` keyframe (styles.css).
+function Spinner(props: { size?: string }): JSX.Element {
+  const s = () => props.size ?? '0.8rem';
+  return (
+    <span
+      style={{
+        display: 'inline-block', width: s(), height: s(), 'border-radius': '50%',
+        border: '2px solid #ddd', 'border-top-color': '#4b7bec',
+        animation: 'daf-spin 0.8s linear infinite', 'flex-shrink': 0,
+      }}
+    />
+  );
+}
+
 interface SectionHeadingProps {
   title: string;
   hint?: string;
@@ -987,18 +1001,36 @@ export function UsagePage(): JSX.Element {
   const interval = setInterval(() => { void refetch(); void refetchCache(); }, 30000);
   if (typeof window !== 'undefined') window.addEventListener('beforeunload', () => clearInterval(interval));
 
+  // Any in-flight fetch (initial load OR a background refetch keeping its prior
+  // value). Drives the header spinner so a slow load never looks frozen.
+  const busy = () => data.loading || cacheStats.loading;
+  // First paint: nothing has resolved yet. Show a full loading banner rather
+  // than an empty page while the (sometimes multi-second) endpoints respond.
+  const firstLoad = () => !data() && !cacheStats() && !data.error;
+
   return (
     <main class="page-shell" style={{ '--page-max': '960px', 'font-family': 'system-ui, -apple-system, sans-serif', color: '#222' }}>
       <header class="responsive-row" style={{ 'margin-bottom': '1.2rem' }}>
-        <h1 style={{ margin: 0, 'font-size': '1.4rem' }}>{t('usage.title')}</h1>
+        <h1 style={{ margin: 0, 'font-size': '1.4rem', display: 'flex', 'align-items': 'center', gap: '0.5rem' }}>
+          {t('usage.title')}
+          <Show when={busy()}><Spinner /></Show>
+        </h1>
         <a href="#daf" style={{ color: '#666', 'font-size': '0.85rem', 'text-decoration': 'none' }}>{t('usage.backToDaf')}</a>
         <button
           onClick={() => { void refetch(); void refetchCache(); }}
-          style={{ 'margin-left': 'auto', padding: '0.3rem 0.7rem', border: '1px solid #ddd', 'border-radius': '4px', background: '#fff', cursor: 'pointer', 'font-size': '0.8rem' }}
+          disabled={busy()}
+          style={{ 'margin-left': 'auto', padding: '0.3rem 0.7rem', border: '1px solid #ddd', 'border-radius': '4px', background: '#fff', cursor: busy() ? 'default' : 'pointer', 'font-size': '0.8rem', opacity: busy() ? 0.6 : 1 }}
         >
-          {t('usage.refresh')}
+          {busy() ? t('usage.refreshing') : t('usage.refresh')}
         </button>
       </header>
+
+      <Show when={firstLoad()}>
+        <div style={{ display: 'flex', 'align-items': 'center', gap: '0.6rem', color: '#888', padding: '2rem 0', 'font-size': '0.9rem' }}>
+          <Spinner size="1.1rem" />
+          {t('usage.loading')}
+        </div>
+      </Show>
 
       <Show when={data()}>
         {(d) => (

--- a/src/client/i18n.ts
+++ b/src/client/i18n.ts
@@ -373,6 +373,8 @@ const CATALOG = {
   'usage.title': { en: 'Usage', he: 'שימוש' },
   'usage.backToDaf': { en: '← back to daf', he: '← חזרה לדף' },
   'usage.refresh': { en: 'Refresh', he: 'רענון' },
+  'usage.refreshing': { en: 'Refreshing…', he: 'מרענן…' },
+  'usage.loading': { en: 'Loading usage data…', he: 'טוען נתוני שימוש…' },
   'usage.loadFailed': { en: 'Failed to load: {error}', he: 'הטעינה נכשלה: {error}' },
   'usage.none': { en: 'None.', he: 'אין.' },
   'usage.noDataYet': { en: 'No data yet.', he: 'אין עדיין נתונים.' },

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -3142,7 +3142,26 @@ app.get('/api/admin/cache-stats', async (c) => {
   const cache = c.env.CACHE;
   if (!cache) return c.json({ error: 'no cache binding' }, 503);
   const cached = await readCachedCacheStats(cache);
-  if (cached && isFresh(cached)) return c.json(cached);
+  // Stale-while-revalidate: computeCacheStats scans dozens of KV prefixes and
+  // can take several seconds, so never block a page load on it once we have
+  // ANY cached copy. Serve the cached value immediately; if it's past the 60s
+  // freshness window, recompute in the background so the next load is fresh.
+  // (A cron also refreshes this, so the background recompute is just a backstop
+  // for gaps between cron runs.) Only a true cold miss blocks on the scan.
+  if (cached) {
+    if (!isFresh(cached)) {
+      c.executionCtx.waitUntil((async () => {
+        try {
+          const fresh = await computeCacheStats(cache);
+          await writeCachedCacheStats(cache, fresh);
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.warn('[cache-stats] background refresh failed:', err);
+        }
+      })());
+    }
+    return c.json(cached);
+  }
   const stats = await computeCacheStats(cache);
   await writeCachedCacheStats(cache, stats);
   return c.json(stats);
@@ -3717,8 +3736,48 @@ function percentile(sorted: number[], p: number): number {
 
 app.get('/api/usage', async (c) => {
   const cache = c.env.CACHE;
-  const telRaw = cache ? await cache.get('telemetry:v1:recent') : null;
-  const repRaw = cache ? await cache.get('reports:v1:recent') : null;
+
+  // External analytics, cached 5 min so the 30s dashboard refresh doesn't
+  // hammer the CF analytics API. Closures so they participate in the single
+  // parallel fetch below.
+  const loadAigw = async (): Promise<Awaited<ReturnType<typeof fetchGatewayCost>>> => {
+    if (!cache) return fetchGatewayCost(c.env);
+    const raw = await cache.get('aigw-cost:v1');
+    if (raw) { try { return JSON.parse(raw) as Awaited<ReturnType<typeof fetchGatewayCost>>; } catch { /* recompute */ } }
+    const fresh = await fetchGatewayCost(c.env);
+    c.executionCtx.waitUntil(cache.put('aigw-cost:v1', JSON.stringify(fresh), { expirationTtl: 300 }));
+    return fresh;
+  };
+  const loadActivity = async (): Promise<Awaited<ReturnType<typeof fetchZoneActivity>>> => {
+    if (!cache) return fetchZoneActivity(c.env);
+    const raw = await cache.get('zone-activity:v1');
+    if (raw) { try { return JSON.parse(raw) as Awaited<ReturnType<typeof fetchZoneActivity>>; } catch { /* recompute */ } }
+    const fresh = await fetchZoneActivity(c.env);
+    c.executionCtx.waitUntil(cache.put('zone-activity:v1', JSON.stringify(fresh), { expirationTtl: 300 }));
+    return fresh;
+  };
+
+  // Every source below is independent, and several are full KV-prefix scans
+  // (telemetry, usage rollups, the three observed-entity backlogs). Fetching
+  // them serially made the page wait on the SUM of those scans; fetch them all
+  // concurrently so it waits only on the slowest.
+  const emptyUnknown = { total: 0, sightings: 0, sample: [] as never[] };
+  const [
+    telRaw, repRaw, selfTracked, aiGateway, activity,
+    unknownRabbis, observedPlaces, observedConcepts, jeRaw, lintFailures,
+  ] = await Promise.all([
+    cache ? cache.get('telemetry:v1:recent') : null,
+    cache ? cache.get('reports:v1:recent') : null,
+    cache ? readUsageSummary(cache) : null,
+    loadAigw(),
+    loadActivity(),
+    cache ? listUnknownRabbis(cache) : emptyUnknown,
+    cache ? listObservedPlaces(cache) : emptyUnknown,
+    cache ? listObservedConcepts(cache) : emptyUnknown,
+    cache ? cache.get(RECENT_ERRORS_KEY) : null,
+    readLintFailures(cache),
+  ]);
+
   const telemetry = telRaw ? (JSON.parse(telRaw) as TelemetryRecord[]) : [];
   const reports = repRaw ? (JSON.parse(repRaw) as BugReport[]) : [];
 
@@ -3793,60 +3852,9 @@ app.get('/api/usage', async (c) => {
       mark_id: r.mark_id, enrichment_id: r.enrichment_id,
     }));
 
-  // --- Cost ----------------------------------------------------------------
-  // Self-tracked lifetime totals from the persistent daily rollups, plus the
-  // authoritative AI Gateway figure (cached 5 min so the 30s dashboard refresh
-  // doesn't hammer the CF analytics API).
-  const selfTracked = cache ? await readUsageSummary(cache) : null;
-  let aiGateway: Awaited<ReturnType<typeof fetchGatewayCost>>;
-  if (cache) {
-    const cachedAigw = await cache.get('aigw-cost:v1');
-    let parsed: Awaited<ReturnType<typeof fetchGatewayCost>> | null = null;
-    if (cachedAigw) { try { parsed = JSON.parse(cachedAigw); } catch { parsed = null; } }
-    if (parsed) {
-      aiGateway = parsed;
-    } else {
-      aiGateway = await fetchGatewayCost(c.env);
-      c.executionCtx.waitUntil(cache.put('aigw-cost:v1', JSON.stringify(aiGateway), { expirationTtl: 300 }));
-    }
-  } else {
-    aiGateway = await fetchGatewayCost(c.env);
-  }
-
-  // --- Activity (CF zone analytics) ---------------------------------------
-  // Edge request + country data for the app host, cached 5 min like the AI
-  // Gateway figure so the 30s dashboard refresh doesn't hammer CF analytics.
-  let activity: Awaited<ReturnType<typeof fetchZoneActivity>>;
-  if (cache) {
-    const cachedAct = await cache.get('zone-activity:v1');
-    let parsed: Awaited<ReturnType<typeof fetchZoneActivity>> | null = null;
-    if (cachedAct) { try { parsed = JSON.parse(cachedAct); } catch { parsed = null; } }
-    if (parsed) {
-      activity = parsed;
-    } else {
-      activity = await fetchZoneActivity(c.env);
-      c.executionCtx.waitUntil(cache.put('zone-activity:v1', JSON.stringify(activity), { expirationTtl: 300 }));
-    }
-  } else {
-    activity = await fetchZoneActivity(c.env);
-  }
-
-  // --- Needs-enrichment backlog -------------------------------------------
-  const unknownRabbis = cache ? await listUnknownRabbis(cache) : { total: 0, sightings: 0, sample: [] };
-  const observedPlaces = cache ? await listObservedPlaces(cache) : { total: 0, sightings: 0, sample: [] };
-  const observedConcepts = cache ? await listObservedConcepts(cache) : { total: 0, sightings: 0, sample: [] };
-
   // --- Hard queue-job failures (separate ring buffer from telemetry) -------
   let jobErrors: RecentJobError[] = [];
-  if (cache) {
-    const jeRaw = await cache.get(RECENT_ERRORS_KEY);
-    if (jeRaw) { try { jobErrors = (JSON.parse(jeRaw) as RecentJobError[]).slice(-30).reverse(); } catch { jobErrors = []; } }
-  }
-
-  // --- Capped lint failures (cards that hit MAX_LINT_ATTEMPTS and were pinned
-  // with gloss-style / missing-Hebrew issues still present). Surfaces the cost
-  // sink so a persistently-failing prompt is visible, not silent.
-  const lintFailures: LintFailuresSummary = await readLintFailures(cache);
+  if (jeRaw) { try { jobErrors = (JSON.parse(jeRaw) as RecentJobError[]).slice(-30).reverse(); } catch { jobErrors = []; } }
 
   return c.json({
     telemetry: { perEndpoint, perMark, perEnrichment, recentErrors, totalCount: telemetry.length },


### PR DESCRIPTION
The usage page took several seconds to load with a blank screen and no feedback. This addresses both halves: tell the user something is happening, and make it actually faster.

## Tell the user something's happening
- Header spinner (reusing the global `daf-spin` keyframe) shows whenever a fetch is in flight — initial load or the 30s background refresh.
- A full "Loading usage data…" banner on first paint, instead of an empty page while the (sometimes multi-second) endpoints respond.
- The Refresh button shows "Refreshing…" and disables while busy.

## Make it faster
- **`/api/usage`**: the handler awaited ~10 independent KV operations serially — two ring-buffer gets, the usage-summary scan, the three observed-entity backlog scans, AI Gateway, zone activity, job errors, lint failures — so the page waited on the *sum* of those scans. Folded them into a single `Promise.all`; it now waits only on the slowest. The 5-min SWR caching for AI Gateway / zone activity is preserved (moved into closures).
- **`/api/admin/cache-stats`**: this scans dozens of KV prefixes and can take several seconds. It used to block any load where the 60s cache was stale. Now it's stale-while-revalidate — serve the cached copy immediately and recompute in the background (a cron already refreshes it too, so the background recompute is just a backstop). Only a true cold miss blocks on the scan.

## Verification
- `pnpm typecheck` clean, `pnpm test` 1708 passing.
- Codex read-only review: LGTM, no correctness bugs.