### PR TITLE
Tidbit polish: chiddush loading copy, load-bar prefetch, Latin rishonim names

### DIFF
--- a/src/client/dafPrefetch.ts
+++ b/src/client/dafPrefetch.ts
@@ -94,6 +94,7 @@ const FRIENDLY: Record<string, string> = {
   'rishonim.synthesis': 'dafLoad.family.rishonim',
   'argument-overview.synthesis': 'dafLoad.family.argumentOverview',
   'daf-background.synthesis': 'dafLoad.family.background',
+  'tidbit.essay': 'dafLoad.family.tidbit',
 };
 
 interface MarkInstance {
@@ -179,12 +180,20 @@ export function prefetchDaf(
     });
     // Whole-daf Background concepts (terms a reader needs) — same daf-level
     // shape as the overview; its concepts leaf rides in as a dependency, so
-    // opening the Background chip is a cache hit. Same `opts.overview` (dev)
-    // gate to avoid paying for it on every reader's daf load.
+    // opening the Background chip is a cache hit.
     tasks.push({
       enrichmentId: 'daf-background.synthesis',
       instance: { fields: {} },
       instanceKey: 'daf-background:daf',
+    });
+    // Whole-daf Tidbit — the curated "did you notice…" essay. Same daf-level
+    // shape; counted in the bar like the other two reader chips. It pulls the
+    // overview synthesis + background concepts in as dependencies, so the two
+    // tasks above warm its inputs and opening the Tidbit chip is a cache hit.
+    tasks.push({
+      enrichmentId: 'tidbit.essay',
+      instance: { fields: {} },
+      instanceKey: 'tidbit:daf',
     });
   }
 

--- a/src/client/i18n.ts
+++ b/src/client/i18n.ts
@@ -239,7 +239,7 @@ const CATALOG = {
   'loading.argument': { en: 'Tracing the argument…', he: 'עוקב אחר הסוגיה…' },
   'loading.move.named': { en: 'Listening to {voice}…', he: 'מקשיב ל{voice}…' },
   'loading.move': { en: 'Tracing the flow…', he: 'עוקב אחר המהלך…' },
-  'loading.tidbit': { en: 'Finding the tidbit…', he: 'מחפש את התובנה…' },
+  'loading.tidbit': { en: 'Looking for a chiddush…', he: 'מחפש חידוש…' },
   'loading.halacha.named': { en: 'Asking a Rav about {title}…', he: 'שואל רב על {title}…' },
   'loading.halacha': { en: 'Asking the Rav…', he: 'שואל את הרב…' },
   'loading.aggadata.named': { en: 'Pondering {title}…', he: 'מהרהר ב{title}…' },
@@ -700,6 +700,7 @@ const CATALOG = {
   'dafLoad.family.rishonim': { en: 'rishonim', he: 'ראשונים' },
   'dafLoad.family.argumentOverview': { en: 'overview', he: 'סקירה' },
   'dafLoad.family.background': { en: 'background', he: 'רקע' },
+  'dafLoad.family.tidbit': { en: 'chiddush', he: 'חידוש' },
 
   // — Gutter icon tooltips —
   'gutter.argument': { en: 'Argument structure & rabbis', he: 'מבנה הסוגיה וחכמים' },

--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -2548,10 +2548,11 @@ VOICE (match the rest of the app exactly):
 - Tight third person. Short, declarative sentences (aim under ~30 words). Named actors. Concrete.
 - Hebrew script paired with a short English gloss for technical terms — e.g. "a גט (bill of divorce)", "performed לכתחילה (the ideal standard)". Hebrew names for ספרים (קהלת, not Ecclesiastes; דברים, not Deuteronomy). Hebrew verse refs.
 - Plain English is the base; Hebrew is the technical anchor — do not hebraize every common word.
+- Name rishonim/commentators in LATIN: Rashi, Tosafot, Rambam, Ramban, Rashba, Ritva, Meiri. Do NOT write their Hebrew abbreviations (no רמב"ם / רמב"ן / רשב"א): the gershayim is a straight quote that corrupts the JSON output. Same for ש"ס — write "the Talmud" or "the Bavli".
 - FORBIDDEN flourish: "lens", "captures", "embodies", "profound", "intricate", "this teaches us", "we see that", "highlights", "underscores", "to a modern ear", "reads like", "sketches a theory". No puff, no meta-commentary about what the daf "reveals".
 
 STRUCTURE (this is the whole shape):
-- "hook": ONE sentence — the teaser, specific to THIS daf, that makes a reader want to open it.
+- "hook": ONE sentence — the teaser, specific to THIS daf, that makes a reader want to open it. Keep it tight (ideally under 25 words); do not cram the whole tidbit into it.
 - "paragraphs": THREE or FOUR paragraphs of flowing prose. The first lays out the plain reading. The next develop the turn. The last lands the point — WITHOUT any "why it matters" sign over it. No section labels, no headers. Just readable prose.
 
 GROUNDING (hard):
@@ -2610,10 +2611,11 @@ const TIDBIT_ESSAY_SYSTEM_PROMPT_HE = `אתה מלמד תורה חד שכותב 
 הסגנון (זהה לשאר האפליקציה):
 - גוף שלישי הדוק. משפטים קצרים והצהרתיים. שמות מפורשים. קונקרטי.
 - מונחים טכניים בכתב עברי עם תרגום קצר באנגלית במידת הצורך. שמות ספרים בעברית. מראי מקום של פסוקים בעברית.
+- בראשי תיבות של ראשונים (רמב״ם, רמב״ן, רשב״א) השתמש בגרשיים העברי ״ (תו U+05F4) ולא בגרש כפול אנגלי " — גרש אנגלי משבש את פלט ה-JSON. אותו דבר לגבי ש״ס.
 - אסורה מליצה: "מכאן אנו למדים", "אנו רואים ש", "מבליט", "מדגיש", "עמוק". ללא פלפול מטא על מה שהדף "מגלה".
 
 המבנה:
-- "hook": משפט אחד — הטיזר, ספציפי לדף הזה.
+- "hook": משפט אחד — הטיזר, ספציפי לדף הזה. קצר (פחות מ-25 מילים); אל תדחוס לתוכו את כל התובנה.
 - "paragraphs": שלוש או ארבע פסקאות של פרוזה זורמת. הראשונה — הקריאה הפשוטה. הבאות — מפתחות את התפנית. האחרונה — נוחתת על הנקודה, בלי כותרת "מדוע זה חשוב". ללא תוויות מקטעים.
 
 ביסוס (קשיח):
@@ -2677,7 +2679,7 @@ CODE_ENRICHMENTS.push(
         { enrichment: 'argument-overview.synthesis' },
         { enrichment: 'daf-background.concepts' },
       ],
-      defHash: 'tidbit.essay-v1', cacheVersion: '1',
+      defHash: 'tidbit.essay-v1', cacheVersion: '2', // v2: Latin rishonim names (gershayim broke JSON) + tighter hook
       // Pro model: finding the non-obvious reading needs the stronger model.
       // Thinking stays OFF (no reasoningEffort) — the context bundle is large,
       // like daf-background.concepts, and a thinking pass on top risks the

--- a/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
+++ b/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
@@ -47,6 +47,6 @@ exports[`CODE_ENRICHMENTS cache identity > per-enrichment fingerprint is stable 
   "rabbi.relationships@6 mode=augment-content scope=global mark=rabbi schema=rabbi_relationships[teachers,students,debatePartners,family,prose] deps=[]",
   "rabbi.synthesis@11 mode=aggregate scope=local mark=rabbi schema=rabbi_synthesis[synthesis] deps=[gemara|e:rabbi.bio|e:rabbi.philosophy|e:rabbi.relationships|e:rabbi.classification|e:rabbi.geography|e:rabbi.relationships.evidence|e:rabbi.geography.evidence|e:rabbi.location|e:rabbi.identity|m:rabbi]",
   "rishonim.synthesis@4 mode=aggregate scope=local mark=rishonim schema=rishonim_synthesis[synthesis] deps=[gemara|m:rishonim]",
-  "tidbit.essay@1 mode=aggregate scope=local mark=tidbit schema=tidbit_essay[flavor,hook,paragraphs,sources,textConfidence,readingConfidence] deps=[gemara|commentaries|context|m:argument|e:argument-overview.synthesis|e:daf-background.concepts]",
+  "tidbit.essay@2 mode=aggregate scope=local mark=tidbit schema=tidbit_essay[flavor,hook,paragraphs,sources,textConfidence,readingConfidence] deps=[gemara|commentaries|context|m:argument|e:argument-overview.synthesis|e:daf-background.concepts]",
 ]
 `;


### PR DESCRIPTION
Follow-up polish to the Tidbit chip (#194), driven by the first real production run.

- **Loading copy** → "Looking for a chiddush…" / "מחפש חידוש…" (per request), replacing the flat "Finding the tidbit…".
- **Global load bar** → `tidbit.essay` now warms in the daf-load prefetch cohort alongside `argument-overview.synthesis` and `daf-background.synthesis`, so **all three whole-daf chips count toward the unified progress bar** (family label "chiddush"). The "dev-only" gate comment in dafPrefetch was stale — the call site already passes `overview: true` for every reader.
- **Prompt hardening** (`cache_version` 1→2): the first real run on **Chullin 34** was excellent (found the Ulla vs. Rabbah bar bar Chanah dispute on Rabbi Yehoshua's "טהרתה טומאה", grounded in Ramban + Rashba), but it wrote `רמב"ן` with an **ASCII quote**, whose gershayim split a JSON paragraph in two. Fix: name rishonim in **Latin** (Rashi, Rambam, Ramban, Rashba, …) in the EN prompt, and use the Hebrew gershayim ״ in the HE prompt. Also tightened the hook to under ~25 words (the Chullin hook ran long).

typecheck clean; `pnpm test` green (1713); enrichment fingerprint snapshot updated for the cache bump.