### PR TITLE
Tidbit: underline background terms with tooltips

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -1181,12 +1181,12 @@ function TidbitEssayView(parsed: Record<string, unknown>): JSX.Element {
       </Show>
       <Show when={hook}>
         <p style={{ margin: '0 0 0.85rem', 'font-size': '1.02rem', 'line-height': 1.4, 'font-weight': 600, color: '#1f1b18' }}>
-          <Hebraized text={hook} />
+          <HebraizedWithRabbis text={hook} />
         </p>
       </Show>
       <For each={paragraphs}>{(p) => (
         <p style={{ margin: '0 0 0.7rem', 'font-size': '0.92rem', 'line-height': 1.62, color: '#2b2622' }}>
-          <Hebraized text={p} />
+          <HebraizedWithRabbis text={p} />
         </p>
       )}</For>
       <Show when={sources.length > 0}>


### PR DESCRIPTION
Render the tidbit hook + paragraphs through `HebraizedWithRabbis` instead of plain `Hebraized`.

The tidbit sidebar already mounts inside `ConceptLinkProvider` (matcher built from the daf's `daf-background.concepts`) and `RabbiLinkProvider`, so this reuses the existing concept-tooltip + rabbi-link layer: **background terms in the essay get an underline + gloss tooltip**, matching the other sidebar prose. Pure client render change — no enrichment or cache change.

typecheck clean; `pnpm test` green (1721).