### PR TITLE
Turn the yerushalmi mark on by default

### DIFF
--- a/src/client/MarksRegistryPanel.tsx
+++ b/src/client/MarksRegistryPanel.tsx
@@ -183,6 +183,7 @@ const FORCE_ON_DEFAULTS: { tag: string; ids: string[] }[] = [
   { tag: 'argument-overview-2026-05', ids: ['argument-overview'] },
   { tag: 'daf-background-2026-05', ids: ['daf-background'] },
   { tag: 'tidbit-2026-06', ids: ['tidbit'] },
+  { tag: 'yerushalmi-2026-06', ids: ['yerushalmi'] },
 ];
 
 function readAppliedDefaults(): Set<string> {


### PR DESCRIPTION
Adds a `FORCE_ON_DEFAULTS` entry (`yerushalmi-2026-06`) so the yerushalmi mark turns ON for existing users with a saved toggle set (applied once; a later explicit toggle-off still sticks). New users already get it via the first-visit 'enable all promoted marks' default. Follow-up to #193/#200.