### PR TITLE
Prose: use the daf's background glossary as the authoritative Hebrew-term set

### DIFF
--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -896,7 +896,8 @@ ${alwaysHebraizeBlock()}
     GOOD: "the gemara uses 'הוצאו' (they were brought out) to describe…"
     GOOD: "the term 'אמר' indicates direct attribution"
   If you don't remember the Hebrew/Aramaic verbatim, paraphrase in English instead of writing the transliteration in quotes. NEVER fake a verbatim quote with transliteration.
-- Plain English is the BASE; Hebrew script is the technical anchor. Don't pile Hebrew script on every common word — only where the term is genuinely the technical concept.`;
+- Plain English is the BASE; Hebrew script is the technical anchor. Don't pile Hebrew script on every common word — only where the term is genuinely the technical concept.
+- THE DAF'S OWN GLOSSARY IS AUTHORITATIVE. If the prompt gives you this daf's background terms (each an English label + its Hebrew + a gloss), treat that list as the definitive set of terms to show in Hebrew here. Whenever your prose uses one of them, write it in Form A/B using EXACTLY that Hebrew spelling — e.g. given "Tevul Yom / טבול יום", write "טבול יום (one who immersed that day)" rather than "tevul yom" or English alone; given "Midnight / חצות", write "חצות (halakhic midnight)". This keeps the prose consistent with the glossary the reader sees on the daf and lets each term carry its own tooltip.`;
 
 /**
  * Hebrew-output style guide — the lang='he' counterpart of HEBREW_GLOSS_STYLE.
@@ -919,7 +920,8 @@ const HEBREW_NATIVE_STYLE = `סגנון — כתיבה בעברית (החל בא
 - שדה המבקש במפורש שם באנגלית (למשל "name": "Conventional English name") — מלא אותו באנגלית כנדרש. שדה מקביל "nameHe" — מלא בעברית.
 - ציטוטי excerpt מן הדף נשארים בעברית/ארמית מילה במילה כפי שהם בדף, ללא שינוי.
 - הימנע ממליצות ריקות ומשפה מנופחת. אל תכתוב: "תמצית", "מבעד לעדשה של", "מגלם", "עומק רוחני", "ביטוי מובהק", "רגישות עמוקה", "שואף בעקביות", "טבוע בו". כתוב משפטי נושא-נשוא-מושא ענייניים עם עובדות קונקרטיות (תקופה, אזור, שמות חכמים, שיטות).
-- עברית היא שפת הבסיס; אין צורך לפזר מילים לועזיות או תעתיקים.`;
+- עברית היא שפת הבסיס; אין צורך לפזר מילים לועזיות או תעתיקים.
+- מילון הדף הוא סמכותי. אם הקלט כולל את מונחי הרקע של הדף (תווית באנגלית + עברית + הסבר לכל אחד), התייחס לרשימה כקבוצת המונחים המוסמכת: בכל פעם שהפרוזה נוקטת באחד מהם, כתוב אותו בדיוק באותה צורה עברית שניתנה (למשל "טבול יום", "חצות", "תרומה"). כך הפרוזה עקבית עם מילון הרקע שהקורא רואה בדף.`;
 
 
 // rabbi.bio — DAF-AGNOSTIC general biography. Same regardless of which daf
@@ -2746,7 +2748,7 @@ How those sections relate (the flow graph: continues / resolves / depends-on / p
 Whole-daf orientation (what the daf is about and where it lands):
 {{depends.argument-overview.synthesis}}
 
-Background concepts a reader needs going in:
+Background concepts a reader needs going in — this is also THE DAF'S TERM GLOSSARY: when your prose uses any term below, write it in the given Hebrew form (Form A/B) using exactly that spelling:
 {{depends.daf-background.concepts}}
 
 Sages on this daf:
@@ -2830,7 +2832,7 @@ const TIDBIT_ESSAY_USER_TEMPLATE_HE = `מסכת: {{tractate}}, דף {{page}}.
 כיוון כללי לדף (על מה הדף ולאן הוא מגיע):
 {{depends.argument-overview.synthesis}}
 
-מושגי רקע שהקורא צריך:
+מושגי רקע שהקורא צריך — וזהו גם מילון המונחים של הדף: בכל פעם שהפרוזה נוקטת מונח מהרשימה, כתוב אותו בצורתו העברית הנתונה בדיוק:
 {{depends.daf-background.concepts}}
 
 חכמים בדף זה:
@@ -2883,7 +2885,7 @@ CODE_ENRICHMENTS.push(
         { enrichment: 'argument-overview.synthesis' },
         { enrichment: 'daf-background.concepts' },
       ],
-      defHash: 'tidbit.essay-v1', cacheVersion: '4', // v4: short clean source refs (name+place only) + ban internal-input language ("the materials", "segment breakdown", line numbers)
+      defHash: 'tidbit.essay-v1', cacheVersion: '5', // v5: use the daf's background glossary as the authoritative Hebrew-term set in prose
       // Pro model: finding the non-obvious reading needs the stronger model.
       // Thinking stays OFF (no reasoningEffort) — the context bundle is large,
       // like daf-background.concepts, and a thinking pass on top risks the

--- a/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
+++ b/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
@@ -47,7 +47,7 @@ exports[`CODE_ENRICHMENTS cache identity > per-enrichment fingerprint is stable 
   "rabbi.relationships@6 mode=augment-content scope=global mark=rabbi schema=rabbi_relationships[teachers,students,debatePartners,family,prose] deps=[]",
   "rabbi.synthesis@11 mode=aggregate scope=local mark=rabbi schema=rabbi_synthesis[synthesis] deps=[gemara|e:rabbi.bio|e:rabbi.philosophy|e:rabbi.relationships|e:rabbi.classification|e:rabbi.geography|e:rabbi.relationships.evidence|e:rabbi.geography.evidence|e:rabbi.location|e:rabbi.identity|m:rabbi]",
   "rishonim.synthesis@4 mode=aggregate scope=local mark=rishonim schema=rishonim_synthesis[synthesis] deps=[gemara|m:rishonim]",
-  "tidbit.essay@4 mode=aggregate scope=local mark=tidbit schema=tidbit_essay[flavor,hook,paragraphs,sources,textConfidence,readingConfidence] deps=[gemara|commentaries|context|m:argument|m:rabbi|m:pesukim|m:aggadata|m:halacha|m:places|e:argument-overview.flow|e:argument-overview.synthesis|e:daf-background.concepts]",
+  "tidbit.essay@5 mode=aggregate scope=local mark=tidbit schema=tidbit_essay[flavor,hook,paragraphs,sources,textConfidence,readingConfidence] deps=[gemara|commentaries|context|m:argument|m:rabbi|m:pesukim|m:aggadata|m:halacha|m:places|e:argument-overview.flow|e:argument-overview.synthesis|e:daf-background.concepts]",
   "yerushalmi.synthesis@1 mode=aggregate scope=local mark=yerushalmi schema=yerushalmi_synthesis[synthesis] deps=[gemara|yerushalmi-text|m:yerushalmi]",
 ]
 `;


### PR DESCRIPTION
Driven by the observation that `daf-background.concepts` already defines the daf's key terms with English label + Hebrew + gloss (Tevul Yom/טבול יום, Midnight/חצות, Terumah/תרומה, …) — exactly the set worth showing in Hebrew in English prose. Requested to apply **everywhere**, not just the tidbit.

- **Shared `HEBREW_GLOSS_STYLE` / `HEBREW_NATIVE_STYLE`** (embedded by ~38 prose enrichments): when the prompt includes the daf's background terms, treat that list as authoritative and write each in its given Hebrew form (Form A/B), exact spelling. **Conditional** — a no-op for enrichments not yet fed the glossary, so it's safe to land everywhere and activates as each gets the dep. Bonus: keeps prose consistent with the on-page glossary and makes the concept-tooltip underline layer match reliably.
- **`tidbit.essay`** (`cache_version` 4→5): its background-concepts block is now explicitly labeled the daf's term glossary to draw Hebrew from.

No fingerprint-snapshot churn for the other 37 (the snapshot keys on version/schema/deps, not prompt text); their recipe_hash drifts and regenerates under stale-while-revalidate — no forced mass re-warm.

Also confirmed live: the v4 source-citation fix works — Berakhot 3 now shows `Maharsha, Berakhot 3b` (clean), explanation on hover.

typecheck clean; `pnpm test` green (1721); fingerprint snapshot @5.