### PR TITLE
Tidbit: stop Hebrew citations scrambling in bidi render

### DIFF
--- a/src/client/Hebraized.tsx
+++ b/src/client/Hebraized.tsx
@@ -19,17 +19,38 @@ import { hebraize, unresolvedParens, hebraizeLLM, capitalizeFirst, stripEchoPare
 // by the bidi algorithm into a scrambled mix.
 // Explicit ranges (not literal chars — a composed char like יִ would silently
 // blow the range open). Geresh/gershayim (׳/״) and maqaf (־) stay
-// inside a run (Hebrew abbreviations/compounds); ASCII quotes/parens stay out so
-// they keep their English position.
-const HE_RUN = /([\u0590-\u05FF\uFB1D-\uFB4F](?:[\u0590-\u05FF\uFB1D-\uFB4F\u05BE\u05F3\u05F4 -]*[\u0590-\u05FF\uFB1D-\uFB4F\u05F3\u05F4])?)/g;
+// inside a run (Hebrew abbreviations/compounds).
+//
+// ASCII straight quotes (' ") are ALSO kept inside a run when they sit BETWEEN
+// Hebrew letters: the LLM routinely writes Hebrew abbreviations with ASCII
+// gershayim/geresh instead of the Hebrew glyphs (\u05D1\u05E7"\u05E9 for \u05D1\u05E7\u05F4\u05E9, \u05E8' for \u05E8\u05F3), and
+// quotes a multi-word Aramaic citation. If those internal quotes split the run,
+// each fragment becomes its own <bdi> with a stray LTR quote between them, and
+// the bidi algorithm scrambles the visual order (observed: a Ritva citation
+// rendering as `'\u05D1\u05E7` \u2026 `),` mid-sentence). They live in the CONNECTOR class
+// only, never the boundary classes, so a run still has to END on a Hebrew
+// letter / geresh / gershayim \u2014 a trailing/closing quote and an English `'s`
+// after a Hebrew word both stay OUT, keeping their English position.
+const HE_RUN = /([\u0590-\u05FF\uFB1D-\uFB4F](?:[\u0590-\u05FF\uFB1D-\uFB4F\u05BE\u05F3\u05F4'" -]*[\u0590-\u05FF\uFB1D-\uFB4F\u05F3\u05F4])?)/g;
 const isHe = (s: string): boolean => /[\u0590-\u05FF\uFB1D-\uFB4F]/.test(s);
+
+/** Split mixed Hebrew/English text into alternating runs, flagging which are
+ *  Hebrew/Aramaic. Each Hebrew run gets bidi-isolated by the caller. Pure +
+ *  exported so the run boundaries (the part that scrambles when wrong) are
+ *  unit-testable without rendering. */
+export function bidiSegments(text: string): { text: string; he: boolean }[] {
+  // String.split with a capturing group alternates non-match / match.
+  return text
+    .split(HE_RUN)
+    .filter((part) => part !== '')
+    .map((part) => ({ text: part, he: isHe(part) }));
+}
 
 /** Render mixed Hebrew/English text with each Hebrew run bidi-isolated, so the
  *  surrounding English punctuation doesn't get reordered into a scramble. */
 export function BidiText(props: { text: string }): JSX.Element {
-  // String.split with a capturing group alternates non-match / match.
-  const parts = createMemo(() => props.text.split(HE_RUN));
-  return <For each={parts()}>{(part) => (isHe(part) ? <bdi>{part}</bdi> : <>{part}</>)}</For>;
+  const parts = createMemo(() => bidiSegments(props.text));
+  return <For each={parts()}>{(part) => (part.he ? <bdi>{part.text}</bdi> : <>{part.text}</>)}</For>;
 }
 
 export function Hebraized(props: { text: string | undefined | null; capitalize?: boolean }): JSX.Element {

--- a/tests/prose-bidi.test.ts
+++ b/tests/prose-bidi.test.ts
@@ -1,5 +1,39 @@
 import { describe, it, expect } from 'vitest';
 import { stripEchoParens } from '../src/client/hebraize';
+import { bidiSegments } from '../src/client/Hebraized';
+
+// The Hebrew/Aramaic runs that BidiText wraps in <bdi>. Wrong boundaries are
+// exactly what scrambles the visual order, so assert them directly.
+const heRuns = (s: string): string[] => bidiSegments(s).filter((p) => p.he).map((p) => p.text);
+
+describe('bidiSegments — keep a quoted Hebrew/Aramaic citation in one bidi run', () => {
+  it('keeps an internal ASCII gershayim abbreviation intact (the Ritva scramble)', () => {
+    // Before the fix, the ASCII " inside בק"ש split this into `בק` + `ש של…`,
+    // and the bidi algorithm reordered it into the broken `'בק … ),` render.
+    const para = `The ריטב״א makes this explicit: 'בק"ש של ערבית זמנה תלוי בשכיבה (in the evening Shema), the obligation`;
+    expect(heRuns(para)).toEqual(['ריטב״א', 'בק"ש של ערבית זמנה תלוי בשכיבה']);
+  });
+
+  it('keeps a geresh abbreviation (ר\' יוחנן) as one run', () => {
+    expect(heRuns("quoting ר' יוחנן on the matter")).toEqual(["ר' יוחנן"]);
+  });
+
+  it('does NOT swallow an English apostrophe-s after a Hebrew word', () => {
+    // The run must end on a Hebrew letter, so `'s` (Latin) stays outside.
+    expect(heRuns("the verse's בשכבך describes")).toEqual(['בשכבך']);
+    expect(heRuns("Rabbi עקיבא's view")).toEqual(['עקיבא']);
+  });
+
+  it('keeps a closing ASCII quote OUT of the run (it keeps its English position)', () => {
+    // A wrapped Aramaic quote: the run is the Hebrew inside, the quotes flank it.
+    expect(heRuns("It insists: 'שמע מינה שעורא דעני לחוד וקודם.' The dispute"))
+      .toEqual(['שמע מינה שעורא דעני לחוד וקודם']);
+  });
+
+  it('leaves pure-English text with no bidi runs (no spurious isolation)', () => {
+    expect(heRuns("but to 'the time of lying down.'")).toEqual([]);
+  });
+});
 
 describe('stripEchoParens — drop redundant all-Hebrew gloss parentheticals', () => {
   it('drops an all-Hebrew paren right after a Hebrew term (the broken case)', () => {


### PR DESCRIPTION
## The bug

On Berakhot 2b the Tidbit chip rendered a Ritva citation as broken prose — `The ריטב״א makes this explicit: 'בק` … `), in the evening Shema…` — the Hebrew quote scrambled mid-sentence (see the screenshot the report came from).

## Root cause

`BidiText` isolates each Hebrew/Aramaic run in a `<bdi>` so surrounding English punctuation keeps its LTR position. But `HE_RUN` only kept Hebrew geresh/gershayim (`׳`/`״`) inside a run — **ASCII** straight quotes were left out. The LLM routinely writes Hebrew abbreviations with ASCII gershayim/geresh (`בק"ש`, `ר'`) and wraps Aramaic citations in ASCII quotes. An internal `"` then split one Hebrew run into two `<bdi>` fragments with a stray LTR quote between them, and the bidi algorithm reordered the lot into a scramble.

Reproduced exactly: `בק"ש של ערבית זמנה תלוי בשכיבה` split into `בק` + `ש של ערבית…` (3 runs incl. `ריטב״א`); after the fix it stays one run.

## The fix

Add ASCII `'` and `"` to the run's **connector** class only (never the boundary classes), so they're kept inside a run when flanked by Hebrew, but a run still must **end** on a Hebrew letter / geresh / gershayim. That means:
- `בק"ש`, `ר' יוחנן`, a quoted multi-word Aramaic citation → one clean `<bdi>`.
- An English `'s` after a Hebrew word (`the verse's בשכבך`, `עקיבא's`) and a closing quote → stay **out**, keeping their English position (verified in tests).

Fixes all existing + future cached Tidbits at render time — no regeneration needed. `bidiSegments()` is extracted as a pure export so the run boundaries (the thing that scrambles when wrong) are unit-tested directly.

## Verification
- `pnpm test` — 1726 pass (5 new bidi cases incl. the Ritva scramble + the `'s`/closing-quote non-regressions).
- `pnpm typecheck` — clean.