### PR TITLE
Yerushalmi card: drop duplicate synthesis, show the real parallel text

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -1895,10 +1895,12 @@ export function aggadataInstance(story: AggadataStory): { fields: Record<string,
 // ===========================================================================
 // Yerushalmi — Bavli↔Yerushalmi parallel sidebar card.
 // ---------------------------------------------------------------------------
-// The card's whole point is the DIFFERENCES between the two Talmuds, so the
-// single custom block leads with a one-line "what they share" summary, then a
-// labeled "Differences" box. The recipe's synthesis section weaves a flowing
-// contrast below. The ref is the Panel title (English / Hebrew).
+// The card's whole point is the DIFFERENCES between the two Talmuds. The diff
+// block leads with a one-line "what they share" summary (when present) and the
+// labeled "Differences" box; the parallel block then shows the ACTUAL Jerusalem
+// Talmud passage (fetched from the daf's cached yerushalmi bundle), collapsed by
+// default. The ref is the Panel title (English / Hebrew). No synthesis — the
+// `differences` field already IS the prose.
 // ===========================================================================
 function YerushalmiDiff(props: SpecialBlockProps): JSX.Element {
   const summary = (): string => (typeof props.instance.fields.summary === 'string' ? props.instance.fields.summary : '');
@@ -1906,7 +1908,7 @@ function YerushalmiDiff(props: SpecialBlockProps): JSX.Element {
   return (
     <>
       <Show when={summary()}>
-        <p style={{ margin: '0 0 0.7rem', color: '#333', 'line-height': 1.55 }}>
+        <p style={{ margin: '0 0 0.7rem', color: '#555', 'line-height': 1.55, 'font-size': '0.86rem' }}>
           <HebraizedWithRabbis text={summary()} />
         </p>
       </Show>
@@ -1921,8 +1923,48 @@ function YerushalmiDiff(props: SpecialBlockProps): JSX.Element {
   );
 }
 
+interface YerushalmiPassage { ref: string; heRef: string; hebrew: string; english: string; }
+async function fetchYerushalmiPassages(key: string): Promise<YerushalmiPassage[]> {
+  const [tractate, page] = key.split('|');
+  const res = await fetch(`/api/yerushalmi/${encodeURIComponent(tractate)}/${encodeURIComponent(page)}`);
+  if (!res.ok) return [];
+  const data = await res.json() as { parallels?: YerushalmiPassage[] };
+  return Array.isArray(data.parallels) ? data.parallels : [];
+}
+
+/** The actual Jerusalem Talmud passage this parallel points at — He + En, from
+ *  the daf's cached yerushalmi bundle (the same text the mark was grounded on).
+ *  Collapsed by default; the differences above are the headline, this is the
+ *  "show me the source" layer. One cached-KV GET per card open. */
+function YerushalmiParallel(props: SpecialBlockProps): JSX.Element {
+  const wantedRef = (): string => (typeof props.instance.fields.yerushalmiRef === 'string' ? props.instance.fields.yerushalmiRef : '');
+  const [passages] = createResource(
+    () => `${props.tractate}|${props.page}`,
+    fetchYerushalmiPassages,
+  );
+  const passage = (): YerushalmiPassage | undefined =>
+    (passages() ?? []).find((p) => p.ref === wantedRef());
+  return (
+    <Show when={passages.loading || passage()}>
+      <SectionCard label="yerushalmi.readParallel" collapsed={true}>
+        <Show when={passage()} fallback={
+          <p style={{ color: '#999', 'font-style': 'italic', margin: 0, 'font-size': '0.82rem' }}>{t('pasuk.loading')}</p>
+        }>
+          {(p) => (
+            <>
+              <HebrewProse text={p().hebrew} size="1rem" color="#222" lineHeight={1.75} margin="0 0 0.5rem" />
+              <p style={{ 'font-size': '0.84rem', color: '#475569', 'line-height': 1.55, margin: 0 }}>{p().english}</p>
+            </>
+          )}
+        </Show>
+      </SectionCard>
+    </Show>
+  );
+}
+
 export const YERUSHALMI_BLOCKS: Record<string, (p: SpecialBlockProps) => JSX.Element> = {
   'yerushalmi-diff': YerushalmiDiff,
+  'yerushalmi-parallel': YerushalmiParallel,
 };
 
 /** The mark-instance shape the yerushalmi extractor emits (mark_input for the

--- a/src/client/i18n.ts
+++ b/src/client/i18n.ts
@@ -571,6 +571,7 @@ const CATALOG = {
 
   // — Yerushalmi body —
   'yerushalmi.differences': { en: 'Differences from the Yerushalmi', he: 'הבדלים מן הירושלמי' },
+  'yerushalmi.readParallel': { en: 'Read the parallel (Yerushalmi)', he: 'קרא את המקבילה (ירושלמי)' },
 
   // — Aggadata body —
   'aggadata.background': { en: 'Background', he: 'רקע' },

--- a/src/lib/sidebar/recipe.ts
+++ b/src/lib/sidebar/recipe.ts
@@ -73,14 +73,15 @@ export const YERUSHALMI_RECIPE: SidebarRecipe = {
   kind: 'yerushalmi',
   markId: 'yerushalmi',
   // Title is the parallel's ref (English / Hebrew "תלמוד ירושלמי …"). The diff
-  // block renders the one-line parallel summary + the substantive Bavli↔
-  // Yerushalmi differences (the card's whole reason to exist); synthesis weaves
-  // a flowing contrast below.
+  // block leads with the substantive Bavli↔Yerushalmi differences (the card's
+  // whole reason to exist); the parallel block then shows the actual Jerusalem
+  // Talmud passage, collapsed. No synthesis — for this mark the `differences`
+  // field IS the prose, so a synthesis paragraph only restated it.
   titleField: 'yerushalmiRef',
   titleHeField: 'yerushalmiRefHe',
   sections: [
     { type: 'special', block: 'yerushalmi-diff' },
-    { type: 'synthesis' },
+    { type: 'special', block: 'yerushalmi-parallel' },
   ],
 };
 

--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -530,36 +530,6 @@ const YERUSHALMI_USER_TEMPLATE_HE = `מסכת: {{tractate}}, דף {{page}}.
 
 זהה את קטעי הבבלי שיש להם מקבילה ישירה בירושלמי והסבר את ההבדלים. החזר JSON לפי הסכמה (instances ריק אם אין מקבילה אמיתית).`;
 
-const YERUSHALMI_SYNTHESIS_SYSTEM_PROMPT = `You are a Talmud scholar. You are given ONE identified Bavli↔Yerushalmi parallel (the Bavli span, its Yerushalmi ref, a one-line summary, and the differences already noted) plus the real parallel Yerushalmi text. Write ONE tight paragraph (2-4 sentences) for a learner who has just read the Bavli sugya: name what the two Talmuds share, then the substantive difference(s) — a different ruling, a different attributed authority, an extra or missing step, a different derivation, or sharper/looser framing. Be concrete and grounded in the provided text; do not invent. Plain words, no academic jargon. Output STRICT JSON only: { "synthesis": "..." }.`;
-
-const YERUSHALMI_SYNTHESIS_USER_TEMPLATE = `Tractate: {{tractate}}, page {{page}}.
-
-The identified parallel (Bavli span + Yerushalmi ref + noted differences):
-{{mark_input}}
-
-Parallel Yerushalmi material (real text):
-{{yerushalmi}}
-
-Bavli source (Hebrew/Aramaic):
-{{gemara_he}}
-
-Write the one-paragraph contrast. Return JSON: { "synthesis": "..." }.`;
-
-const YERUSHALMI_SYNTHESIS_SYSTEM_PROMPT_HE = `אתה תלמיד חכם. ניתנה לך מקבילה אחת שזוהתה בין הבבלי לירושלמי (קטע הבבלי, מראה־מקום הירושלמי, סיכום בשורה אחת, וההבדלים שכבר צוינו) יחד עם טקסט הירושלמי המקביל האמיתי. כתוב פסקה אחת הדוקה (2–4 משפטים) ללומד שזה עתה קרא את סוגיית הבבלי: ציין מה משותף לשני התלמודים, ולאחר מכן את ההבדל(ים) המהותי(ים) — פסיקה שונה, ייחוס לאמורא אחר, שלב נוסף או חסר, דרשה שונה, או ניסוח חד/רופף יותר. היה קונקרטי ומעוגן בטקסט המצורף; אל תמציא. מילים פשוטות, ללא ז'רגון אקדמי. החזר JSON תקני בלבד: { "synthesis": "..." }.`;
-
-const YERUSHALMI_SYNTHESIS_USER_TEMPLATE_HE = `מסכת: {{tractate}}, דף {{page}}.
-
-המקבילה שזוהתה (קטע הבבלי + מראה־מקום הירושלמי + ההבדלים שצוינו):
-{{mark_input}}
-
-חומר ירושלמי מקביל (טקסט אמיתי):
-{{yerushalmi}}
-
-מקור הבבלי (עברית/ארמית):
-{{gemara_he}}
-
-כתוב את פסקת ההשוואה. החזר JSON: { "synthesis": "..." }.`;
-
 
 export const CODE_MARKS: MarkDefinition[] = [
   {
@@ -5754,21 +5724,6 @@ CODE_ENRICHMENTS.push(
       model: ARGUMENT_PRO_MODEL,
       systemPromptHe: AGGADATA_QA_SYSTEM_PROMPT_HE,
       userPromptTemplateHe: AGGADATA_QA_USER_TEMPLATE_HE,
-    },
-  ),
-);
-
-CODE_ENRICHMENTS.push(
-  makeSynthesis(
-    'yerushalmi', 'yerushalmi.synthesis',
-    'One-paragraph contrast of this Bavli span with its Yerushalmi parallel — what they share and how they differ.',
-    YERUSHALMI_SYNTHESIS_SYSTEM_PROMPT, YERUSHALMI_SYNTHESIS_USER_TEMPLATE,
-    {
-      dependencies: ['gemara', 'yerushalmi-text', { mark: 'yerushalmi' }],
-      defHash: 'yerushalmi.synthesis-v1', cacheVersion: '1',
-      model: ARGUMENT_PRO_MODEL,
-      systemPromptHe: YERUSHALMI_SYNTHESIS_SYSTEM_PROMPT_HE,
-      userPromptTemplateHe: YERUSHALMI_SYNTHESIS_USER_TEMPLATE_HE,
     },
   ),
 );

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -6843,6 +6843,29 @@ app.post('/api/admin/translate-bio', async (c) => {
 // show the full quoted verse and let the reader step ± through Tanakh.
 // Sefaria's /api/texts response carries `next` / `prev` strings — we trust
 // those over manually parsing chapter:verse so book boundaries stay correct.
+// Read-only view of the Jerusalem Talmud passages parallel to this daf — the
+// same cached bundle the `yerushalmi` mark was grounded on (mishnah-mapped, see
+// getYerushalmiCached). The reader's Yerushalmi card uses it to show the actual
+// parallel text under the differences. He/En are stripped of Sefaria's footnote
+// markup so the prose reads clean.
+app.get('/api/yerushalmi/:tractate/:page', async (c) => {
+  const tractate = c.req.param('tractate');
+  const page = c.req.param('page');
+  const clean = (s: string): string =>
+    stripHtmlServer(
+      s.replace(/<sup[^>]*>[\s\S]*?<\/sup>/g, '').replace(/<i class="footnote">[\s\S]*?<\/i>/g, ''),
+    ).trim();
+  const bundle = await getYerushalmiCached(c.env.CACHE, tractate, page);
+  return c.json({
+    parallels: bundle.map((y) => ({
+      ref: y.ref,
+      heRef: y.heRef,
+      hebrew: clean(y.hebrew),
+      english: clean(y.english),
+    })),
+  });
+});
+
 app.get('/api/pasuk', async (c) => {
   const ref = c.req.query('ref') ?? '';
   if (!ref || ref.length > 100) return c.json({ error: 'missing or invalid ref' }, 400);

--- a/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
+++ b/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
@@ -48,6 +48,5 @@ exports[`CODE_ENRICHMENTS cache identity > per-enrichment fingerprint is stable 
   "rabbi.synthesis@11 mode=aggregate scope=local mark=rabbi schema=rabbi_synthesis[synthesis] deps=[gemara|e:rabbi.bio|e:rabbi.philosophy|e:rabbi.relationships|e:rabbi.classification|e:rabbi.geography|e:rabbi.relationships.evidence|e:rabbi.geography.evidence|e:rabbi.location|e:rabbi.identity|m:rabbi]",
   "rishonim.synthesis@4 mode=aggregate scope=local mark=rishonim schema=rishonim_synthesis[synthesis] deps=[gemara|m:rishonim]",
   "tidbit.essay@5 mode=aggregate scope=local mark=tidbit schema=tidbit_essay[flavor,hook,paragraphs,sources,textConfidence,readingConfidence] deps=[gemara|commentaries|context|m:argument|m:rabbi|m:pesukim|m:aggadata|m:halacha|m:places|e:argument-overview.flow|e:argument-overview.synthesis|e:daf-background.concepts]",
-  "yerushalmi.synthesis@1 mode=aggregate scope=local mark=yerushalmi schema=yerushalmi_synthesis[synthesis] deps=[gemara|yerushalmi-text|m:yerushalmi]",
 ]
 `;


### PR DESCRIPTION
The card showed the same content twice — the mark's summary+differences AND a synthesis paragraph that restated them. Removes the synthesis section + the now-dead `yerushalmi.synthesis` enrichment/prompts. New structure: **Differences** (headline) + a collapsible **Read the parallel** block rendering the actual Jerusalem Talmud passage (He+En), served read-only from the daf's already-cached `yerushalmi` bundle via a new `GET /api/yerushalmi/:t/:p`. Follow-up to #193/#202.