### PR TITLE
Tidbit: build from the per-instance halacha/pesukim/aggadata analysis

### DIFF
--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -2740,12 +2740,18 @@ Sages on this daf:
 
 Verses (pesukim) cited on this daf:
 {{anchors.pesukim}}
+Verse analysis — the app's own reading of each cited pasuk (how the gemara uses it, where it lands):
+{{depends.pesukim.synthesis}}
 
 Aggadic stories on this daf:
 {{anchors.aggadata}}
+Story analysis — the app's own reading of each aggadah (what it does in its sugya, the central tension):
+{{depends.aggadata.synthesis}}
 
 Halachic topics on this daf:
 {{anchors.halacha}}
+Halachic analysis — the app's own reading of each topic (where it sits in the codes, the live dispute, practical upshot):
+{{depends.halacha.synthesis}}
 
 Places on this daf:
 {{anchors.places}}
@@ -2824,12 +2830,18 @@ const TIDBIT_ESSAY_USER_TEMPLATE_HE = `מסכת: {{tractate}}, דף {{page}}.
 
 פסוקים המצוטטים בדף זה:
 {{anchors.pesukim}}
+ניתוח הפסוקים — קריאת האפליקציה לכל פסוק מצוטט (כיצד הגמרא משתמשת בו ולאן הוא מגיע):
+{{depends.pesukim.synthesis}}
 
 אגדות בדף זה:
 {{anchors.aggadata}}
+ניתוח האגדות — קריאת האפליקציה לכל אגדה (תפקידה בסוגיה והמתח המרכזי):
+{{depends.aggadata.synthesis}}
 
 נושאי הלכה בדף זה:
 {{anchors.halacha}}
+ניתוח ההלכה — קריאת האפליקציה לכל נושא (מיקומו בפוסקים, המחלוקת החיה, ההשלכה המעשית):
+{{depends.halacha.synthesis}}
 
 מקומות בדף זה:
 {{anchors.places}}
@@ -2868,8 +2880,15 @@ CODE_ENRICHMENTS.push(
         { enrichment: 'argument-overview.flow' },
         { enrichment: 'argument-overview.synthesis' },
         { enrichment: 'daf-background.concepts' },
+        // fanOut: the app's OWN per-instance analysis for every story, verse,
+        // and halachic topic on the daf — not just the mark anchors above. This
+        // is the richest layer, so the tidbit reads the same readings the
+        // aggadata / pesukim / halacha cards show.
+        { enrichment: 'aggadata.synthesis', fanOut: true },
+        { enrichment: 'pesukim.synthesis', fanOut: true },
+        { enrichment: 'halacha.synthesis', fanOut: true },
       ],
-      defHash: 'tidbit.essay-v1', cacheVersion: '5', // v5: use the daf's background glossary as the authoritative Hebrew-term set in prose
+      defHash: 'tidbit.essay-v1', cacheVersion: '6', // v6: + fanOut aggadata/pesukim/halacha syntheses (the app's own per-instance analysis)
       // Pro model: finding the non-obvious reading needs the stronger model.
       // Thinking stays OFF (no reasoningEffort) — the context bundle is large,
       // like daf-background.concepts, and a thinking pass on top risks the

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1511,6 +1511,32 @@ async function resolveDependencies(
           out.depends[depId] = { error: 'not found' };
           return;
         }
+        // fanOut: run this per-instance enrichment for EVERY instance of its
+        // target mark and expose the array. Lets a whole-daf consumer (the
+        // tidbit) pull in every story's / verse's / topic's analysis. Each
+        // instance run resolves its own deps + scopes its context, and is
+        // cache-keyed per instance — so on a warmed daf these are all hits.
+        if ((dep as { fanOut?: boolean }).fanOut) {
+          const markDef = await loadMarkDef(rc.env, depDef.mark);
+          if (!markDef) { out.depends[depId] = { error: `mark ${depDef.mark} not found` }; return; }
+          let instances: unknown[] = [];
+          try {
+            const markRes = await runMarkOnce(rc, markDef, tractate, page, bypassCache);
+            const parsed = markRes.parsed as { instances?: unknown[] } | null;
+            instances = Array.isArray(parsed?.instances) ? parsed.instances : [];
+          } catch (err) {
+            out.depends[depId] = { error: String((err as Error)?.message ?? err) };
+            return;
+          }
+          const results = await Promise.all(instances.map(async (inst) => {
+            try {
+              const r = await runEnrichmentOnce(rc, depDef, tractate, page, inst, bypassCache, undefined, parentChain);
+              return r.parsed ?? r.content;
+            } catch { return null; }
+          }));
+          out.depends[depId] = results.filter((x) => x != null);
+          return;
+        }
         try {
           const result = await runEnrichmentOnce(rc, depDef, tractate, page, markInput, bypassCache, undefined, parentChain);
           out.depends[depId] = result.parsed ?? result.content;

--- a/src/worker/studio-schema.ts
+++ b/src/worker/studio-schema.ts
@@ -353,7 +353,12 @@ export type EnrichmentDependency =
   | 'context'
   | 'halacha-refs'
   | 'yerushalmi-text'
-  | { enrichment: string }
+  // `{ enrichment: id }` resolves the dep for the CONSUMER's own instance.
+  // `fanOut: true` instead runs a PER-INSTANCE enrichment for EVERY instance of
+  // its target mark on the daf and exposes the array under {{depends.<id>}} —
+  // the way a whole-daf consumer (e.g. the tidbit) pulls in every story's /
+  // verse's / topic's analysis, not just one.
+  | { enrichment: string; fanOut?: boolean }
   | { mark: string };
 
 // ===========================================================================

--- a/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
+++ b/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
@@ -47,6 +47,6 @@ exports[`CODE_ENRICHMENTS cache identity > per-enrichment fingerprint is stable 
   "rabbi.relationships@6 mode=augment-content scope=global mark=rabbi schema=rabbi_relationships[teachers,students,debatePartners,family,prose] deps=[]",
   "rabbi.synthesis@12 mode=aggregate scope=local mark=rabbi schema=rabbi_synthesis[synthesis] deps=[gemara|e:rabbi.bio|e:rabbi.philosophy|e:rabbi.relationships|e:rabbi.classification|e:rabbi.geography|e:rabbi.relationships.evidence|e:rabbi.geography.evidence|e:rabbi.location|e:rabbi.identity|m:rabbi|e:daf-background.concepts]",
   "rishonim.synthesis@4 mode=aggregate scope=local mark=rishonim schema=rishonim_synthesis[synthesis] deps=[gemara|m:rishonim]",
-  "tidbit.essay@5 mode=aggregate scope=local mark=tidbit schema=tidbit_essay[flavor,hook,paragraphs,sources,textConfidence,readingConfidence] deps=[gemara|commentaries|context|m:argument|m:rabbi|m:pesukim|m:aggadata|m:halacha|m:places|e:argument-overview.flow|e:argument-overview.synthesis|e:daf-background.concepts]",
+  "tidbit.essay@6 mode=aggregate scope=local mark=tidbit schema=tidbit_essay[flavor,hook,paragraphs,sources,textConfidence,readingConfidence] deps=[gemara|commentaries|context|m:argument|m:rabbi|m:pesukim|m:aggadata|m:halacha|m:places|e:argument-overview.flow|e:argument-overview.synthesis|e:daf-background.concepts|e*:aggadata.synthesis|e*:pesukim.synthesis|e*:halacha.synthesis]",
 ]
 `;

--- a/tests/code-enrichments-snapshot.test.ts
+++ b/tests/code-enrichments-snapshot.test.ts
@@ -18,7 +18,7 @@ function fingerprint(e: (typeof CODE_ENRICHMENTS)[number]): string {
   const name = schema?.name ?? '-';
   const required = (schema?.schema?.required ?? []).join(',');
   const deps = (e.dependencies ?? [])
-    .map((d) => (typeof d === 'string' ? d : 'enrichment' in d ? `e:${d.enrichment}` : `m:${d.mark}`))
+    .map((d) => (typeof d === 'string' ? d : 'enrichment' in d ? `${(d as { fanOut?: boolean }).fanOut ? 'e*' : 'e'}:${d.enrichment}` : `m:${d.mark}`))
     .join('|');
   return `${e.id}@${e.cache_version} mode=${e.mode} scope=${e.scope} mark=${e.target_mark} schema=${name}[${required}] deps=[${deps}]`;
 }


### PR DESCRIPTION
Requested: feed the tidbit more context — the halachot, pesukim, and aggadot. It already had the *mark anchors* (the list of stories/verses/topics); this gives it the app's **own per-instance analysis** of each.

**New primitive — opt-in fan-out dependency.** The resolver runs an `{ enrichment }` dep against the *consumer's* instance, so a whole-daf consumer (the tidbit) couldn't pull a per-instance enrichment across all instances. `{ enrichment: id, fanOut: true }` now: loads the enrichment's target mark → runs it to get every instance → runs the enrichment per instance → exposes the array under `{{depends.<id>}}`. `parentChain` is threaded so cycle detection holds (Codex-confirmed).

**Tidbit** (`cache_version` 5→6): added `aggadata.synthesis`, `pesukim.synthesis`, `halacha.synthesis` as fan-out deps; EN+HE templates surface each as a labeled analysis block. On a warmed daf these are cache hits — the prefetch warms the per-section syntheses first, and the tidbit is generated last, so it reads the same readings the cards show.

Snapshot fingerprint serializes fan-out deps as `e*:<id>`. Codex: looks correct, no bugs. typecheck clean; `pnpm test` green (1729); dep-graph-validate passes (no cycle).