### PR TITLE
Marks: put the yerushalmi mark back under dev mode

### DIFF
--- a/src/client/MarksRegistryPanel.tsx
+++ b/src/client/MarksRegistryPanel.tsx
@@ -183,7 +183,6 @@ const FORCE_ON_DEFAULTS: { tag: string; ids: string[] }[] = [
   { tag: 'argument-overview-2026-05', ids: ['argument-overview'] },
   { tag: 'daf-background-2026-05', ids: ['daf-background'] },
   { tag: 'tidbit-2026-06', ids: ['tidbit'] },
-  { tag: 'yerushalmi-2026-06', ids: ['yerushalmi'] },
 ];
 
 function readAppliedDefaults(): Set<string> {

--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -797,6 +797,10 @@ export const CODE_MARKS: MarkDefinition[] = [
     dependencies: ['gemara', 'yerushalmi-text'],
     passes: ['anchor-verbatim'],
     status: 'promoted',
+    // Dev-only for now: hidden from readers, surfaces only when dev mode is
+    // active (across the toggle list, rendering, auto-run and first-visit
+    // defaults). Still warmed by yomi-cron so dev views are instant.
+    experimental: true,
     def_hash: 'yerushalmi-llm-v1',
     cache_version: '1',
     source: 'code',


### PR DESCRIPTION
Yerushalmi parallels was turned on for everyone in #201. Pull it back under dev mode for now while keeping Tidbit on by default.

- `code-marks.ts`: mark `yerushalmi` `experimental: true` — hidden from readers, surfaces only when dev mode is active (toggle list, rendering, auto-run, first-visit defaults). Reuses the existing `experimental` flag that already flows registry -> client (`studio-registry.ts:253`).
- `MarksRegistryPanel.tsx`: drop the `yerushalmi-2026-06` `FORCE_ON_DEFAULTS` entry so it no longer auto-enables for new or existing users.
- `yomi-cron` is left untouched — yerushalmi keeps warming daily so dev views stay instant.
- Tidbit is unchanged (promoted + `tidbit-2026-06` force-on), so it remains on by default for everyone.

typecheck clean; 1729 unit tests pass.