### PR TITLE
Hebraize: swap compound Tosafot names whole (fix mixed-script 'תוספות HaRosh')

### DIFF
--- a/src/client/hebraize.ts
+++ b/src/client/hebraize.ts
@@ -337,6 +337,17 @@ const BARE_HEBRAIZE_NAMES: Record<string, string> = {
   Rashba: 'רשב״א',
   Ritva: 'ריטב״א',
   Rashi: 'רש״י',
+  // Tosafot — compound forms listed alongside the bare word. Longest-first
+  // sort (below) makes the compounds win, so "Tosafot HaRosh" swaps whole
+  // instead of half-translating to "תוספות HaRosh" (one author rendered half
+  // Hebrew, half English). The HaRosh/Rid/Yeshanim suffixes are not bare-list
+  // entries on their own, so without these the second word leaks through.
+  'Tosafot HaRosh': 'תוספות הרא״ש',
+  'Tosfos HaRosh': 'תוספות הרא״ש',
+  'Tosafot Rid': 'תוספות רי״ד',
+  'Tosfos Rid': 'תוספות רי״ד',
+  'Tosafot Yeshanim': 'תוספות ישנים',
+  'Tosfos Yeshanim': 'תוספות ישנים',
   Tosafot: 'תוספות',
   Tosfos: 'תוספות',
   Meiri: 'מאירי',

--- a/tests/hebraize.test.ts
+++ b/tests/hebraize.test.ts
@@ -364,6 +364,12 @@ const BARE_NAMES_SWAP: Array<[string, string]> = [
   ['Rashi explains the gemara',                  'רש״י explains the gemara'],
   ['Tosafot disagree',                           'תוספות disagree'],
   ['Tosfos disagree',                            'תוספות disagree'],
+  // Compound Tosafot names — ONE author each, must swap whole (regression:
+  // a bare "Tosafot" entry alone left the second word as "תוספות HaRosh").
+  ['Tosafot HaRosh asks',                        'תוספות הרא״ש asks'],
+  ['Tosfos HaRosh asks',                         'תוספות הרא״ש asks'],
+  ['per Tosafot Rid',                            'per תוספות רי״ד'],
+  ['the Tosafot Yeshanim note',                  'the תוספות ישנים note'],
   ['the Ramban argues against',                  'the רמב״ן argues against'],
   ['Rashba and Ritva both hold',                 'רשב״א and ריטב״א both hold'],
   ['the Meiri suggests',                         'the מאירי suggests'],
@@ -388,6 +394,38 @@ describe('hebraizeBareNames — authority + work-title swap', () => {
   for (const [input, expected] of BARE_NAMES_SWAP) {
     it(`"${input}" → "${expected}"`, () => {
       expect(hebraizeBareNames(input)).toBe(expected);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// No-mixed-script invariant. A multi-word authority/work name is ONE thing;
+// hebraizing it must swap the WHOLE name, never half (regression: a bare
+// "Tosafot" entry without the compound left "Tosafot HaRosh" → "תוספות
+// HaRosh", one author rendered half Hebrew, half English). Each name below
+// must hebraize with zero Latin letters surviving in the name itself.
+// ---------------------------------------------------------------------------
+const LATIN_LETTER = /[A-Za-zÀ-ſ]/;
+const WHOLE_NAME_HEBRAIZED: string[] = [
+  'Tosafot HaRosh',
+  'Tosfos HaRosh',
+  'Tosafot Rid',
+  'Tosfos Rid',
+  'Tosafot Yeshanim',
+  'Tosfos Yeshanim',
+  'Mishneh Torah',
+  'Shulchan Aruch',
+  'Orach Chaim',
+  'Yoreh Deah',
+  'Even HaEzer',
+  'Choshen Mishpat',
+];
+
+describe('hebraizeBareNames — no half-translated (mixed-script) names', () => {
+  for (const name of WHOLE_NAME_HEBRAIZED) {
+    it(`"${name}" hebraizes whole, leaving no Latin letters`, () => {
+      const out = hebraizeBareNames(name);
+      expect(out).not.toMatch(LATIN_LETTER);
     });
   }
 });


### PR DESCRIPTION
## Bug

In hebraized prose, the one author **Tosafot HaRosh** rendered as `תוספות HaRosh` — half Hebrew, half English. The bare-name pass (`hebraizeBareNames` in `src/client/hebraize.ts`) had `Tosafot` in its whitelist but not the compound `Tosafot HaRosh`, so it swapped only the leading word and left `HaRosh` in Latin script.

## Fix

Register the compound Tosafot names (`HaRosh` / `Rid` / `Yeshanim`, both `Tosafot`/`Tosfos` spellings) in `BARE_HEBRAIZE_NAMES`. The existing longest-first sort makes the compound win over the bare `Tosafot`, so the whole name swaps.

## Regression guard

- Specific cases added to the `BARE_NAMES_SWAP` table (e.g. `Tosafot HaRosh asks` → `תוספות הרא״ש asks`).
- A general **no-mixed-script invariant**: a curated list of compound authority/work names must hebraize whole, leaving zero Latin letters. Reproduces the exact `תוספות HaRosh` failure before the fix.

`pnpm typecheck` and `pnpm test` pass (275 tests).