### PR TITLE
Yerushalmi: harvest curated Bavli<->Yerushalmi parallels as a source

### DIFF
--- a/scripts/harvest-yerushalmi-parallels.mjs
+++ b/scripts/harvest-yerushalmi-parallels.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * Harvest curated Bavli<->Yerushalmi parallels into a static dataset.
+ *
+ * Source: Sefaria's editorial collection "'The Talmud says': Shared Stories in
+ * the Babylonian and Jerusalem Talmuds" — hand-curated story parallels that the
+ * mishnah-mapping can't find (they're cross-tractate, e.g. Bavli Bava Metzia <->
+ * Yerushalmi Moed Katan). Sefaria's link graph does NOT expose Bavli<->Yerushalmi
+ * parallels (verified: /api/related on Bava Metzia 59a returns zero), so this
+ * curated collection is the only Sefaria-side cross-Talmud data.
+ *
+ * Each collection sheet pairs one Bavli ref with one Yerushalmi ref plus an
+ * editorial title + summary. We freeze the result to JSON so the app has no
+ * runtime dependency on Sefaria for the curated list; re-run to refresh or grow.
+ *
+ *   node scripts/harvest-yerushalmi-parallels.mjs
+ *
+ * Writes src/lib/data/curated-yerushalmi-parallels.json.
+ */
+import { writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const COLLECTION_SLUG = 'the-talmud-says-shared-stories-in-the-babylonian-and-jerusalem-talmuds';
+const OUT = join(dirname(fileURLToPath(import.meta.url)), '..', 'src', 'lib', 'data', 'curated-yerushalmi-parallels.json');
+
+const strip = (s) => (s ?? '').replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim();
+const isYerushalmi = (r) => r.startsWith('Jerusalem Talmud') || r.includes('Yerushalmi');
+
+async function getJson(url) {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`${res.status} ${url}`);
+  return res.json();
+}
+
+async function main() {
+  const col = await getJson(`https://www.sefaria.org/api/collections/${COLLECTION_SLUG}`);
+  const sheets = (col.collection ?? col).sheets ?? [];
+  const parallels = [];
+  for (const meta of sheets) {
+    const sheet = await getJson(`https://www.sefaria.org/api/sheets/${meta.id}`);
+    const refs = (sheet.sources ?? []).map((s) => s.ref).filter(Boolean);
+    const yer = refs.find(isYerushalmi);
+    const bav = refs.find((r) => !isYerushalmi(r));
+    if (!yer || !bav) {
+      console.warn(`  skip sheet ${meta.id} (${strip(sheet.title)}): refs=${JSON.stringify(refs)}`);
+      continue;
+    }
+    parallels.push({
+      bavli: bav,
+      yerushalmi: yer,
+      title: strip(sheet.title),
+      summary: strip(sheet.summary),
+      sheetId: meta.id,
+      url: `https://www.sefaria.org/sheets/${meta.id}`,
+    });
+    console.log(`  + ${bav}  <->  ${yer}  (${strip(sheet.title)})`);
+  }
+  parallels.sort((a, b) => a.bavli.localeCompare(b.bavli));
+  const out = {
+    source: '"The Talmud says": Shared Stories in the Babylonian and Jerusalem Talmuds (Sefaria editorial collection)',
+    sourceUrl: `https://www.sefaria.org/collections/${COLLECTION_SLUG}`,
+    license: 'Sefaria sheets — CC-BY (see Sefaria terms)',
+    count: parallels.length,
+    parallels,
+  };
+  writeFileSync(OUT, JSON.stringify(out, null, 2) + '\n');
+  console.log(`\nwrote ${parallels.length} parallels -> ${OUT}`);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -1924,41 +1924,59 @@ function YerushalmiDiff(props: SpecialBlockProps): JSX.Element {
 }
 
 interface YerushalmiPassage { ref: string; heRef: string; hebrew: string; english: string; }
-async function fetchYerushalmiPassages(key: string): Promise<YerushalmiPassage[]> {
+interface YerushalmiCurated { ref: string; title: string; summary: string; url: string; bavliAnchor: string; hebrew: string; english: string; }
+interface YerushalmiData { parallels: YerushalmiPassage[]; curated: YerushalmiCurated[]; }
+async function fetchYerushalmiData(key: string): Promise<YerushalmiData> {
   const [tractate, page] = key.split('|');
   const res = await fetch(`/api/yerushalmi/${encodeURIComponent(tractate)}/${encodeURIComponent(page)}`);
-  if (!res.ok) return [];
-  const data = await res.json() as { parallels?: YerushalmiPassage[] };
-  return Array.isArray(data.parallels) ? data.parallels : [];
+  if (!res.ok) return { parallels: [], curated: [] };
+  const data = await res.json() as { parallels?: YerushalmiPassage[]; curated?: YerushalmiCurated[] };
+  return { parallels: Array.isArray(data.parallels) ? data.parallels : [], curated: Array.isArray(data.curated) ? data.curated : [] };
 }
 
-/** The actual Jerusalem Talmud passage this parallel points at — He + En, from
- *  the daf's cached yerushalmi bundle (the same text the mark was grounded on).
- *  Collapsed by default; the differences above are the headline, this is the
- *  "show me the source" layer. One cached-KV GET per card open. */
+/** The actual Jerusalem Talmud passage(s) for this daf — He + En, from the daf's
+ *  cached yerushalmi bundle (the same text the mark was grounded on), plus any
+ *  CURATED Bavli<->Yerushalmi parallels (hand-made cross-references, often
+ *  cross-tractate, with an editorial summary + a link to the source). Collapsed
+ *  by default; the differences above are the headline, this is the "show me the
+ *  source" layer. One cached GET per card open. */
 function YerushalmiParallel(props: SpecialBlockProps): JSX.Element {
   const wantedRef = (): string => (typeof props.instance.fields.yerushalmiRef === 'string' ? props.instance.fields.yerushalmiRef : '');
-  const [passages] = createResource(
-    () => `${props.tractate}|${props.page}`,
-    fetchYerushalmiPassages,
-  );
+  const [data] = createResource(() => `${props.tractate}|${props.page}`, fetchYerushalmiData);
   const passage = (): YerushalmiPassage | undefined =>
-    (passages() ?? []).find((p) => p.ref === wantedRef());
+    (data()?.parallels ?? []).find((p) => p.ref === wantedRef());
+  const curated = (): YerushalmiCurated[] => data()?.curated ?? [];
   return (
-    <Show when={passages.loading || passage()}>
-      <SectionCard label="yerushalmi.readParallel" collapsed={true}>
-        <Show when={passage()} fallback={
-          <p style={{ color: '#999', 'font-style': 'italic', margin: 0, 'font-size': '0.82rem' }}>{t('pasuk.loading')}</p>
-        }>
-          {(p) => (
-            <>
-              <HebrewProse text={p().hebrew} size="1rem" color="#222" lineHeight={1.75} margin="0 0 0.5rem" />
-              <p style={{ 'font-size': '0.84rem', color: '#475569', 'line-height': 1.55, margin: 0 }}>{p().english}</p>
-            </>
-          )}
-        </Show>
-      </SectionCard>
-    </Show>
+    <>
+      <Show when={data.loading || passage()}>
+        <SectionCard label="yerushalmi.readParallel" collapsed={true}>
+          <Show when={passage()} fallback={
+            <p style={{ color: '#999', 'font-style': 'italic', margin: 0, 'font-size': '0.82rem' }}>{t('pasuk.loading')}</p>
+          }>
+            {(p) => (
+              <>
+                <HebrewProse text={p().hebrew} size="1rem" color="#222" lineHeight={1.75} margin="0 0 0.5rem" />
+                <p style={{ 'font-size': '0.84rem', color: '#475569', 'line-height': 1.55, margin: 0 }}>{p().english}</p>
+              </>
+            )}
+          </Show>
+        </SectionCard>
+      </Show>
+      <Show when={curated().length > 0}>
+        <SectionCard label="yerushalmi.curatedParallel" collapsed={true}>
+          <For each={curated()}>{(c) => (
+            <div style={{ 'margin-bottom': '0.7rem' }}>
+              <a href={c.url} target="_blank" rel="noopener" style={{ 'font-weight': 600, color: ACCENTS.yerushalmi, 'font-size': '0.9rem', 'text-decoration': 'none' }}>{c.title}</a>
+              <div style={{ 'font-size': '0.7rem', color: '#888', margin: '0.1rem 0 0.3rem' }}>{c.ref}</div>
+              <p style={{ 'font-size': '0.84rem', color: '#444', 'line-height': 1.55, margin: '0 0 0.4rem' }}>{c.summary}</p>
+              <Show when={c.hebrew}>
+                <HebrewProse text={c.hebrew} size="0.95rem" color="#333" lineHeight={1.7} margin="0" />
+              </Show>
+            </div>
+          )}</For>
+        </SectionCard>
+      </Show>
+    </>
   );
 }
 

--- a/src/client/i18n.ts
+++ b/src/client/i18n.ts
@@ -572,6 +572,7 @@ const CATALOG = {
   // — Yerushalmi body —
   'yerushalmi.differences': { en: 'Differences from the Yerushalmi', he: 'הבדלים מן הירושלמי' },
   'yerushalmi.readParallel': { en: 'Read the parallel (Yerushalmi)', he: 'קרא את המקבילה (ירושלמי)' },
+  'yerushalmi.curatedParallel': { en: 'Curated parallel (Sefaria)', he: 'מקבילה נבחרת (ספריא)' },
 
   // — Aggadata body —
   'aggadata.background': { en: 'Background', he: 'רקע' },

--- a/src/lib/data/curated-yerushalmi-parallels.json
+++ b/src/lib/data/curated-yerushalmi-parallels.json
@@ -1,0 +1,48 @@
+{
+  "source": "\"The Talmud says\": Shared Stories in the Babylonian and Jerusalem Talmuds (Sefaria editorial collection)",
+  "sourceUrl": "https://www.sefaria.org/collections/the-talmud-says-shared-stories-in-the-babylonian-and-jerusalem-talmuds",
+  "license": "Sefaria sheets — CC-BY (see Sefaria terms)",
+  "count": 5,
+  "parallels": [
+    {
+      "bavli": "Bava Metzia 59a:12-59b:7",
+      "yerushalmi": "Jerusalem Talmud Moed Katan 3:1:6-10",
+      "title": "Achnai’s Oven and “It is not in the heavens!”",
+      "summary": "Achnai’s Oven exemplifies the Talmud’s revolutionary approach to Jewish legal rulings. Those who study Achnai’s oven are most familiar with the Babylonian Talmud’s (Talmud Bavli) version, but a very different telling appears in the Jerusalem Talmud (Talmud Yerushalmi).",
+      "sheetId": 364518,
+      "url": "https://www.sefaria.org/sheets/364518"
+    },
+    {
+      "bavli": "Moed Katan 20a:10-11",
+      "yerushalmi": "Jerusalem Talmud Moed Katan 3:5:14",
+      "title": "Where does “Shiva” come From?",
+      "summary": "What is the source for the custom to mourn for seven days after burying one’s immediate relative (“shiva”)? The rabbis of the Babylonian and Jerusalem Talmuds take the learner on an adventure to find out.",
+      "sheetId": 366391,
+      "url": "https://www.sefaria.org/sheets/366391"
+    },
+    {
+      "bavli": "Rosh Hashanah 29b:10",
+      "yerushalmi": "Jerusalem Talmud Rosh Hashanah 4:1:2",
+      "title": "No Shofar on Shabbat: Two Approaches",
+      "summary": "Why do you think many communities don’t blow the shofar on Rosh Hashanah when it falls on a Shabbat? The Babylonian and Jerusalem Talmud texts in this sheet present two very different reasons.",
+      "sheetId": 366370,
+      "url": "https://www.sefaria.org/sheets/366370"
+    },
+    {
+      "bavli": "Shabbat 88a:5",
+      "yerushalmi": "Jerusalem Talmud Berakhot 9:5:16",
+      "title": "“They established that which they accepted”: Revelation and Consent",
+      "summary": "From one story in the Babylonian Talmud, the rabbis infer that God forced the Jewish people to accept the Torah. It then uses a verse from the Book of Esther to show that the Jews actually voluntarily accepted the Torah. The Jerusalem Talmud interprets the verse very differently.",
+      "sheetId": 366364,
+      "url": "https://www.sefaria.org/sheets/366364"
+    },
+    {
+      "bavli": "Sukkah 30a:3",
+      "yerushalmi": "Jerusalem Talmud Sukkah 3:1:2",
+      "title": "Who do we harm when we do mitzvot illegally?",
+      "summary": "Can mitzvot be fulfilled when doing so would require someone to transgress? If not, why not? Who do we harm? The Babylonian and Jerusalem Talmuds agree with the principle, but disagree as to who is harmed in such a situation.",
+      "sheetId": 366375,
+      "url": "https://www.sefaria.org/sheets/366375"
+    }
+  ]
+}

--- a/src/lib/yerushalmiParallels.ts
+++ b/src/lib/yerushalmiParallels.ts
@@ -1,0 +1,78 @@
+/**
+ * Curated Bavli<->Yerushalmi parallels — a hand-made cross-Talmud source.
+ *
+ * Sefaria's link graph exposes NO Bavli<->Yerushalmi parallels, and the
+ * mishnah-mapping only finds same-mishnah parallels. This dataset (harvested
+ * from Sefaria's editorial "Shared Stories" collection by
+ * scripts/harvest-yerushalmi-parallels.mjs) captures curated STORY parallels —
+ * often cross-tractate (e.g. Bavli Bava Metzia <-> Yerushalmi Moed Katan) — that
+ * neither of those can surface. Small but high-confidence; grows as we harvest
+ * more sources. Used to ground the `yerushalmi` mark and surface curated links.
+ */
+import data from './data/curated-yerushalmi-parallels.json';
+
+export interface CuratedYerushalmiParallel {
+  /** Bavli ref (Sefaria), e.g. "Bava Metzia 59a:12-59b:7". */
+  bavli: string;
+  /** Yerushalmi ref (Sefaria), e.g. "Jerusalem Talmud Moed Katan 3:1:6-10". */
+  yerushalmi: string;
+  /** Editorial title of the parallel. */
+  title: string;
+  /** Editorial summary of how the two tellings relate / differ. */
+  summary: string;
+  sheetId: number;
+  url: string;
+}
+
+export interface CuratedYerushalmiDataset {
+  source: string;
+  sourceUrl: string;
+  license: string;
+  count: number;
+  parallels: CuratedYerushalmiParallel[];
+}
+
+const DATASET = data as CuratedYerushalmiDataset;
+
+export function curatedYerushalmiDataset(): CuratedYerushalmiDataset {
+  return DATASET;
+}
+
+/** A daf+amud as a sortable int so ranges compare cleanly ("59a"->118,
+ *  "59b"->119, "60a"->120). null if not a daf token. */
+function dafOrd(daf: string): number | null {
+  const m = daf.match(/^(\d+)([ab])$/);
+  if (!m) return null;
+  return parseInt(m[1], 10) * 2 + (m[2] === 'b' ? 1 : 0);
+}
+
+/**
+ * Parse the Bavli side of a curated ref into tractate + inclusive daf range.
+ *   "Bava Metzia 59a:12-59b:7" -> { tractate: 'Bava Metzia', start: '59a', end: '59b' }
+ *   "Rosh Hashanah 29b:10"     -> { tractate: 'Rosh Hashanah', start: '29b', end: '29b' }
+ *   "Moed Katan 20a:10-11"     -> { tractate: 'Moed Katan', start: '20a', end: '20a' }
+ * Returns null if no daf token is present.
+ */
+export function parseBavliRef(ref: string): { tractate: string; start: string; end: string } | null {
+  const m = ref.match(/^(.+?)\s+(\d.*)$/);
+  if (!m) return null;
+  const tractate = m[1].trim();
+  const dafs = m[2].match(/\d+[ab]/g);
+  if (!dafs || dafs.length === 0) return null;
+  return { tractate, start: dafs[0], end: dafs[dafs.length - 1] };
+}
+
+/** Curated parallels whose Bavli ref covers (tractate, page). Tractate must
+ *  match exactly (Sefaria spelling, which the reader also uses). */
+export function curatedParallelsForDaf(tractate: string, page: string): CuratedYerushalmiParallel[] {
+  const want = dafOrd(page);
+  if (want == null) return [];
+  return DATASET.parallels.filter((p) => {
+    const b = parseBavliRef(p.bavli);
+    if (!b || b.tractate !== tractate) return false;
+    const s = dafOrd(b.start);
+    const e = dafOrd(b.end);
+    if (s == null || e == null) return false;
+    return want >= Math.min(s, e) && want <= Math.max(s, e);
+  });
+}

--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -802,7 +802,8 @@ export const CODE_MARKS: MarkDefinition[] = [
     // defaults). Still warmed by yomi-cron so dev views are instant.
     experimental: true,
     def_hash: 'yerushalmi-llm-v1',
-    cache_version: '1',
+    // v2: grounding now also includes curated Bavli<->Yerushalmi parallels.
+    cache_version: '2',
     source: 'code',
     updated_at: NOW,
   },

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -10,6 +10,7 @@ import {
 import { getDafyomiMasechet } from '../lib/sefref/dafyomi/masechtos';
 import { collectContext } from './context-providers';
 import { fromDafyomi } from '../lib/context/fromDafyomi';
+import { curatedParallelsForDaf, type CuratedYerushalmiParallel } from '../lib/yerushalmiParallels';
 import { placeRevachWithAi } from './revach-ai-place';
 import { formatContextForPrompt, contextForAnchor, segsFromMarkInput } from '../lib/context/select';
 import { continuationLink, type FlowEdge } from '../lib/context/link';
@@ -1251,11 +1252,52 @@ function truncateForPrompt(s: string, max: number): string {
  * sentinel when the daf has no Yerushalmi parallel (most of Kodashim/Taharot),
  * so the producer knows the absence is real rather than a fetch gap.
  */
+/** Strip Sefaria footnote markup + tags so a Yerushalmi passage reads clean. */
+function cleanYerushalmiText(s: string): string {
+  return stripHtmlServer(
+    s.replace(/<sup[^>]*>[\s\S]*?<\/sup>/g, '').replace(/<i class="footnote">[\s\S]*?<\/i>/g, ''),
+  ).trim();
+}
+
+/** A curated Bavli<->Yerushalmi parallel for a daf, with the Yerushalmi text
+ *  fetched + its editorial title/summary. The grounding-confidence tier above
+ *  the mishnah-mapping (a human curated this exact cross-reference). */
+interface CuratedYerushalmiPassage {
+  ref: string; title: string; summary: string; url: string; bavliAnchor: string;
+  hebrew: string; english: string;
+}
+
+/** Fetch the Yerushalmi text for curated parallels on a daf (few per daf, often
+ *  0-1). Each failure contributes nothing. */
+async function fetchCuratedYerushalmi(parallels: CuratedYerushalmiParallel[]): Promise<CuratedYerushalmiPassage[]> {
+  const flat = (x: unknown): string => Array.isArray(x) ? x.map(flat).join(' ') : (typeof x === 'string' ? x : '');
+  const out: CuratedYerushalmiPassage[] = [];
+  await Promise.all(parallels.map(async (p) => {
+    try {
+      const res = await sefariaAPI.getText(p.yerushalmi, { context: 0 });
+      out.push({
+        ref: p.yerushalmi, title: p.title, summary: p.summary, url: p.url, bavliAnchor: p.bavli,
+        hebrew: cleanYerushalmiText(flat(res.he)), english: cleanYerushalmiText(flat(res.text)),
+      });
+    } catch { /* skip on fetch failure */ }
+  }));
+  return out;
+}
+
 function formatYerushalmiForPrompt(
   bundle: Awaited<ReturnType<typeof getYerushalmiCached>>,
+  curated: CuratedYerushalmiPassage[],
   notes: ReturnType<typeof fromDafyomi>,
 ): string {
-  const blocks = bundle.map((y) => {
+  // Curated parallels first — a human confirmed this exact cross-reference, so
+  // it's the highest-confidence grounding (and often cross-tractate, which the
+  // mishnah-mapping can't find).
+  const curatedBlocks = curated.map((c) => {
+    const he = truncateForPrompt(c.hebrew, 1600);
+    const en = truncateForPrompt(c.english, 2000);
+    return `[${c.ref}] CONFIRMED curated parallel — "${c.title}" (anchors Bavli ${c.bavliAnchor}). Editorial note: ${c.summary}\nHE: ${he}\nEN: ${en}`.trim();
+  });
+  const mishnahBlocks = bundle.map((y) => {
     const he = truncateForPrompt(stripHtmlServer(y.hebrew), 1400);
     const en = truncateForPrompt(stripHtmlServer(y.english), 1800);
     const range = y.anchorStartSeg === y.anchorEndSeg
@@ -1263,6 +1305,7 @@ function formatYerushalmiForPrompt(
       : `Bavli segments ${y.anchorStartSeg}-${y.anchorEndSeg}`;
     return `[${y.ref}] (parallels ${range}, via ${y.mishnahRef})\nHE: ${he}\nEN: ${en}`.trim();
   });
+  const blocks = [...curatedBlocks, ...mishnahBlocks];
   const noteLines: string[] = [];
   for (const n of notes) {
     const title = n.title?.en || n.title?.he || '';
@@ -1463,16 +1506,19 @@ async function resolveDependencies(
       return;
     }
     if (dep === 'yerushalmi-text') {
-      // The Jerusalem Talmud parallel(s) on the same mishnah (real text, located
-      // via fetchYerushalmiForDaf) plus the dafyomi.co.il Yerushalmi study notes
-      // — so a producer contrasts Bavli vs Yerushalmi against the source rather
-      // than from memory. Each source that fails contributes nothing.
-      const [bundle, daf] = await Promise.all([
+      // Three grounding tiers: (1) curated Bavli<->Yerushalmi parallels a human
+      // confirmed (often cross-tractate — the mishnah-mapping can't find them),
+      // (2) the Jerusalem Talmud parallel(s) on the same mishnah (real text via
+      // fetchYerushalmiForDaf), (3) dafyomi.co.il Yerushalmi study notes — so a
+      // producer contrasts Bavli vs Yerushalmi against the source rather than
+      // from memory. Each source that fails contributes nothing.
+      const [bundle, daf, curated] = await Promise.all([
         getYerushalmiCached(rc.env.CACHE, tractate, page),
         getDafyomiContentCached(rc.env.CACHE, rc.env.ASSETS, tractate, page, {}).catch(() => null),
+        fetchCuratedYerushalmi(curatedParallelsForDaf(tractate, page)),
       ]);
       const notes = daf ? fromDafyomi(daf).filter((i) => i.source === 'dafyomi:yerushalmi') : [];
-      out.vars.yerushalmi = formatYerushalmiForPrompt(bundle, notes);
+      out.vars.yerushalmi = formatYerushalmiForPrompt(bundle, curated, notes);
       return;
     }
     if (dep === 'context') {
@@ -6887,18 +6933,21 @@ app.post('/api/admin/translate-bio', async (c) => {
 app.get('/api/yerushalmi/:tractate/:page', async (c) => {
   const tractate = c.req.param('tractate');
   const page = c.req.param('page');
-  const clean = (s: string): string =>
-    stripHtmlServer(
-      s.replace(/<sup[^>]*>[\s\S]*?<\/sup>/g, '').replace(/<i class="footnote">[\s\S]*?<\/i>/g, ''),
-    ).trim();
-  const bundle = await getYerushalmiCached(c.env.CACHE, tractate, page);
+  const [bundle, curated] = await Promise.all([
+    getYerushalmiCached(c.env.CACHE, tractate, page),
+    fetchCuratedYerushalmi(curatedParallelsForDaf(tractate, page)),
+  ]);
   return c.json({
     parallels: bundle.map((y) => ({
       ref: y.ref,
       heRef: y.heRef,
-      hebrew: clean(y.hebrew),
-      english: clean(y.english),
+      hebrew: cleanYerushalmiText(y.hebrew),
+      english: cleanYerushalmiText(y.english),
     })),
+    // Curated Bavli<->Yerushalmi parallels whose Bavli ref covers this daf —
+    // hand-made cross-references (Sefaria "Shared Stories"), with the real
+    // Yerushalmi text + an editorial summary. Often cross-tractate.
+    curated,
   });
 });
 

--- a/tests/yerushalmi-parallels.test.ts
+++ b/tests/yerushalmi-parallels.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseBavliRef,
+  curatedParallelsForDaf,
+  curatedYerushalmiDataset,
+} from '../src/lib/yerushalmiParallels';
+
+describe('curated Bavli<->Yerushalmi parallels', () => {
+  it('parses single-daf and multi-daf Bavli refs (incl. space-name tractates)', () => {
+    expect(parseBavliRef('Bava Metzia 59a:12-59b:7')).toEqual({ tractate: 'Bava Metzia', start: '59a', end: '59b' });
+    expect(parseBavliRef('Rosh Hashanah 29b:10')).toEqual({ tractate: 'Rosh Hashanah', start: '29b', end: '29b' });
+    expect(parseBavliRef('Moed Katan 20a:10-11')).toEqual({ tractate: 'Moed Katan', start: '20a', end: '20a' });
+    expect(parseBavliRef('Sukkah 30a:3')).toEqual({ tractate: 'Sukkah', start: '30a', end: '30a' });
+  });
+
+  it('matches a daf inside a multi-daf range (Achnai spans 59a-59b)', () => {
+    expect(curatedParallelsForDaf('Bava Metzia', '59a').map((p) => p.sheetId)).toEqual([364518]);
+    expect(curatedParallelsForDaf('Bava Metzia', '59b').map((p) => p.sheetId)).toEqual([364518]);
+    // just outside the range
+    expect(curatedParallelsForDaf('Bava Metzia', '58b')).toEqual([]);
+    expect(curatedParallelsForDaf('Bava Metzia', '60a')).toEqual([]);
+  });
+
+  it('matches single-daf parallels and rejects the wrong amud/tractate', () => {
+    expect(curatedParallelsForDaf('Rosh Hashanah', '29b').map((p) => p.yerushalmi))
+      .toEqual(['Jerusalem Talmud Rosh Hashanah 4:1:2']);
+    expect(curatedParallelsForDaf('Rosh Hashanah', '29a')).toEqual([]);
+    expect(curatedParallelsForDaf('Sukkah', '30a').map((p) => p.sheetId)).toEqual([366375]);
+    // right daf, wrong tractate
+    expect(curatedParallelsForDaf('Berakhot', '30a')).toEqual([]);
+  });
+
+  it('every dataset entry has a Yerushalmi target and a parseable Bavli ref', () => {
+    const ds = curatedYerushalmiDataset();
+    expect(ds.parallels.length).toBe(ds.count);
+    for (const p of ds.parallels) {
+      expect(p.yerushalmi.startsWith('Jerusalem Talmud')).toBe(true);
+      expect(parseBavliRef(p.bavli)).not.toBeNull();
+    }
+  });
+});


### PR DESCRIPTION
Sefaria's link graph exposes **no** Bavli↔Yerushalmi parallels (verified) and the mishnah-mapping only finds same-mishnah ones — so curated cross-tractate story parallels (Achnai: Bavli Bava Metzia ↔ Yerushalmi Moed Katan, etc.) were invisible. This harvests Sefaria's editorial **"Shared Stories"** collection into a static, extensible dataset and surfaces it.

- `scripts/harvest-yerushalmi-parallels.mjs` → `src/lib/data/curated-yerushalmi-parallels.json` (5 pairs, re-runnable to grow)
- `src/lib/yerushalmiParallels.ts`: typed `curatedParallelsForDaf` (ref-parse + daf-range match), unit-tested
- **Worker:** curated pairs feed the `yerushalmi` mark's grounding as the **highest-confidence tier** (real Yerushalmi text + editorial summary); `GET /api/yerushalmi/:t/:p` returns a `curated[]` array; mark `cache_version` 1→2
- **Client:** a "Curated parallel (Sefaria)" card section (title + summary + source link + text)

Foundation for adding more sources later. Follow-up to the Yerushalmi-mark work (#193/#207).