### PR TITLE
Bi'yun: a whole-daf deep-dive chip for the rishonim's problem

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -140,7 +140,8 @@ export type SidebarContent =
   | { kind: 'rishonim'; instance: RishonimInstance; index: number }
   | { kind: 'argument-overview' }
   | { kind: 'daf-background' }
-  | { kind: 'tidbit' };
+  | { kind: 'tidbit' }
+  | { kind: 'biyun' };
 
 export interface ArgumentSidebarProps {
   content: SidebarContent | null;
@@ -1225,6 +1226,9 @@ function TidbitEssayView(parsed: Record<string, unknown>): JSX.Element {
 // per-mark renderer seam in MarkEnrichmentCards (so caching/polling/telemetry
 // stay shared) rather than the deps_resolved channel.
 registerMarkRenderer('tidbit', TidbitEssayView);
+// Bi'yun reuses the same essay renderer (its output has no `flavor`, so the
+// flavor tag simply doesn't render); only the panel accent + title differ.
+registerMarkRenderer('biyun', TidbitEssayView);
 
 function TidbitBody(props: { tractate: string; page: string }): JSX.Element {
   return (
@@ -1233,6 +1237,20 @@ function TidbitBody(props: { tractate: string; page: string }): JSX.Element {
         markId="tidbit"
         instance={{ fields: {} }}
         instanceKey={`${props.tractate}/${props.page}/tidbit`}
+        tractate={props.tractate}
+        page={props.page}
+      />
+    </Panel>
+  );
+}
+
+function BiyunBody(props: { tractate: string; page: string }): JSX.Element {
+  return (
+    <Panel accent={ACCENTS.biyun} title={t('biyun.title')}>
+      <Synthesis
+        markId="biyun"
+        instance={{ fields: {} }}
+        instanceKey={`${props.tractate}/${props.page}/biyun`}
         tractate={props.tractate}
         page={props.page}
       />
@@ -2351,6 +2369,10 @@ export function ArgumentSidebar(props: ArgumentSidebarProps): JSX.Element {
 
             <Show when={c().kind === 'tidbit'}>
               <TidbitBody tractate={props.tractate} page={props.page} />
+            </Show>
+
+            <Show when={c().kind === 'biyun'}>
+              <BiyunBody tractate={props.tractate} page={props.page} />
             </Show>
 
         </aside>

--- a/src/client/DafViewer.tsx
+++ b/src/client/DafViewer.tsx
@@ -825,6 +825,7 @@ export default function DafViewer(): JSX.Element {
     if (c.kind === 'argument-overview') return t('overview.chip');
     if (c.kind === 'daf-background') return t('background.chip');
     if (c.kind === 'tidbit') return t('tidbit.chip');
+    if (c.kind === 'biyun') return t('biyun.chip');
     return 'Back';
   };
   const sidebarKey = (c: SidebarContent): string => {
@@ -840,6 +841,7 @@ export default function DafViewer(): JSX.Element {
     if (c.kind === 'argument-overview') return 'argument-overview';
     if (c.kind === 'daf-background') return 'daf-background';
     if (c.kind === 'tidbit') return 'tidbit';
+    if (c.kind === 'biyun') return 'biyun';
     return 'unknown';
   };
 
@@ -854,6 +856,7 @@ export default function DafViewer(): JSX.Element {
     if (id === 'argument-overview') setSidebar({ kind: 'argument-overview' });
     else if (id === 'daf-background') setSidebar({ kind: 'daf-background' });
     else if (id === 'tidbit') setSidebar({ kind: 'tidbit' });
+    else if (id === 'biyun') setSidebar({ kind: 'biyun' });
   };
   // Set by ArgumentSidebar when the user clicks an argument-move card. Paints
   // a yellow band over the move's segment range in the main daf text. When
@@ -2128,6 +2131,7 @@ export default function DafViewer(): JSX.Element {
     if (s.kind === 'argument-overview') return 'argument-overview';
     if (s.kind === 'daf-background') return 'daf-background';
     if (s.kind === 'tidbit') return 'tidbit';
+    if (s.kind === 'biyun') return 'biyun';
     return `${s.kind}:${s.index}`;
   });
 
@@ -2931,6 +2935,7 @@ export default function DafViewer(): JSX.Element {
             const label = () => m.id === 'argument-overview' ? t('overview.chip')
               : m.id === 'daf-background' ? t('background.chip')
               : m.id === 'tidbit' ? t('tidbit.chip')
+              : m.id === 'biyun' ? t('biyun.chip')
               : m.id;
             const active = () => sidebar()?.kind === m.id;
             return (

--- a/src/client/MarkEnrichmentCards.tsx
+++ b/src/client/MarkEnrichmentCards.tsx
@@ -592,6 +592,9 @@ export default function MarkEnrichmentCards(props: Props) {
     if (props.markId === 'tidbit') {
       return t('loading.tidbit');
     }
+    if (props.markId === 'biyun') {
+      return t('loading.biyun');
+    }
     return t('loading.default');
   };
 

--- a/src/client/MarksRegistryPanel.tsx
+++ b/src/client/MarksRegistryPanel.tsx
@@ -183,6 +183,7 @@ const FORCE_ON_DEFAULTS: { tag: string; ids: string[] }[] = [
   { tag: 'argument-overview-2026-05', ids: ['argument-overview'] },
   { tag: 'daf-background-2026-05', ids: ['daf-background'] },
   { tag: 'tidbit-2026-06', ids: ['tidbit'] },
+  { tag: 'biyun-2026-06', ids: ['biyun'] },
   { tag: 'yerushalmi-2026-06', ids: ['yerushalmi'] },
 ];
 

--- a/src/client/MobileShelf.tsx
+++ b/src/client/MobileShelf.tsx
@@ -177,5 +177,6 @@ function labelForSidebar(s: SidebarContent | null): string {
     case 'argument-overview': return 'Overview';
     case 'daf-background': return 'Background';
     case 'tidbit': return 'Tidbit';
+    case 'biyun': return "Bi'yun";
   }
 }

--- a/src/client/dafPrefetch.ts
+++ b/src/client/dafPrefetch.ts
@@ -95,6 +95,7 @@ const FRIENDLY: Record<string, string> = {
   'argument-overview.synthesis': 'dafLoad.family.argumentOverview',
   'daf-background.synthesis': 'dafLoad.family.background',
   'tidbit.essay': 'dafLoad.family.tidbit',
+  'biyun.essay': 'dafLoad.family.biyun',
 };
 
 interface MarkInstance {
@@ -194,6 +195,14 @@ export function prefetchDaf(
       enrichmentId: 'tidbit.essay',
       instance: { fields: {} },
       instanceKey: 'tidbit:daf',
+    });
+    // Whole-daf Bi'yun — the deep rishonim dive. Same daf-level shape; counted
+    // in the bar. Heaviest of the chips (it fans out the per-segment rishonim
+    // analysis), so it warms last in the cohort and the bar reflects it.
+    tasks.push({
+      enrichmentId: 'biyun.essay',
+      instance: { fields: {} },
+      instanceKey: 'biyun:daf',
     });
   }
 

--- a/src/client/i18n.ts
+++ b/src/client/i18n.ts
@@ -175,6 +175,7 @@ const CATALOG = {
   'sidebar.kind.argument-overview': { en: 'Overview', he: 'סקירה' },
   'sidebar.kind.daf-background': { en: 'Background', he: 'רקע' },
   'sidebar.kind.tidbit': { en: 'Tidbit', he: 'תובנה' },
+  'sidebar.kind.biyun': { en: "Bi'yun", he: 'עיון' },
 
   // — Whole-daf argument overview —
   'overview.chip': { en: 'Overview', he: 'סקירה' },
@@ -217,6 +218,9 @@ const CATALOG = {
   // — Whole-daf Tidbit (one curated "did you notice…" reading) —
   'tidbit.chip': { en: 'Tidbit', he: 'תובנה' },
   'tidbit.title': { en: 'Tidbit', he: 'תובנה' },
+  // — Whole-daf Bi'yun (deep dive into a rishonim problem) —
+  'biyun.chip': { en: "Bi'yun", he: 'עיון' },
+  'biyun.title': { en: "Bi'yun", he: 'עיון' },
   'tidbit.empty': { en: 'No tidbit for this daf yet.', he: 'אין עדיין תובנה לדף זה.' },
   'tidbit.sources': { en: 'Sources', he: 'מקורות' },
   'tidbit.flavor.aggadah': { en: 'Aggadah', he: 'אגדה' },
@@ -241,6 +245,7 @@ const CATALOG = {
   'loading.move.named': { en: 'Listening to {voice}…', he: 'מקשיב ל{voice}…' },
   'loading.move': { en: 'Tracing the flow…', he: 'עוקב אחר המהלך…' },
   'loading.tidbit': { en: 'Looking for a chiddush…', he: 'מחפש חידוש…' },
+  'loading.biyun': { en: 'Learning it through…', he: 'מעיין בסוגיה…' },
   'loading.halacha.named': { en: 'Asking a Rav about {title}…', he: 'שואל רב על {title}…' },
   'loading.halacha': { en: 'Asking the Rav…', he: 'שואל את הרב…' },
   'loading.aggadata.named': { en: 'Pondering {title}…', he: 'מהרהר ב{title}…' },
@@ -706,6 +711,7 @@ const CATALOG = {
   'dafLoad.family.argumentOverview': { en: 'overview', he: 'סקירה' },
   'dafLoad.family.background': { en: 'background', he: 'רקע' },
   'dafLoad.family.tidbit': { en: 'chiddush', he: 'חידוש' },
+  'dafLoad.family.biyun': { en: 'bi\'yun', he: 'עיון' },
 
   // — Gutter icon tooltips —
   'gutter.argument': { en: 'Argument structure & rabbis', he: 'מבנה הסוגיה וחכמים' },

--- a/src/client/sidebar/primitives.tsx
+++ b/src/client/sidebar/primitives.tsx
@@ -32,6 +32,7 @@ export const ACCENTS = {
   'argument-overview': '#8a2a2b',
   'daf-background': '#8a6d3b',
   tidbit: '#2f6b66',
+  biyun: '#3f4ea0',
   halacha: '#1e40af',
   aggadata: '#7c3aed',
   yerushalmi: '#0f766e',
@@ -52,6 +53,7 @@ export function kindLabelKey(kind: SidebarKind): CatalogKey {
     case 'argument-overview': return 'sidebar.kind.argument-overview';
     case 'daf-background': return 'sidebar.kind.daf-background';
     case 'tidbit': return 'sidebar.kind.tidbit';
+    case 'biyun': return 'sidebar.kind.biyun';
     case 'halacha': return 'sidebar.kind.halacha';
     case 'aggadata': return 'sidebar.kind.aggadata';
     case 'yerushalmi': return 'sidebar.kind.yerushalmi';

--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -79,6 +79,7 @@ import {
   RISHONIM_SYNTHESIS_OUTPUT_SCHEMA,
   YERUSHALMI_OUTPUT_SCHEMA,
   TIDBIT_ESSAY_OUTPUT_SCHEMA,
+  BIYUN_ESSAY_OUTPUT_SCHEMA,
   proseSchema,
 } from './output-schemas';
 import { AGGADATA_RECIPE, PASUK_RECIPE, HALACHA_RECIPE, RISHONIM_RECIPE, RABBI_RECIPE, YERUSHALMI_RECIPE } from '../lib/sidebar/recipe';
@@ -675,6 +676,29 @@ export const CODE_MARKS: MarkDefinition[] = [
     },
     status: 'promoted',
     def_hash: 'tidbit-v1',
+    cache_version: '1',
+    source: 'code',
+    updated_at: NOW,
+  },
+  {
+    id: 'biyun',
+    label: "Bi'yun",
+    description: "Whole-daf עיון: a deep dive into ONE halachic/conceptual problem on the daf that the rishonim are wrestling with — the difficulty, the competing approaches, what's at stake. The lomdus counterpart to the Tidbit. Grounded on the full daf + commentaries + the rishonim/argument/halacha analysis it depends on.",
+    category: 'canon',
+    // Reader-facing whole-daf chip, sibling of the tidbit. Same deterministic
+    // anchorless instance carrying the chip + biyun.essay enrichment.
+    anchor: 'whole-daf',
+    render: {
+      kind: 'chip',
+      color: '#3f4ea0',
+      position: 'header',
+    },
+    extractor: {
+      kind: 'computed',
+      fn: 'whole-daf-instance',
+    },
+    status: 'promoted',
+    def_hash: 'biyun-v1',
     cache_version: '1',
     source: 'code',
     updated_at: NOW,
@@ -2906,6 +2930,182 @@ CODE_ENRICHMENTS.push(
       model: ARGUMENT_PRO_MODEL,
       systemPromptHe: TIDBIT_ESSAY_SYSTEM_PROMPT_HE,
       userPromptTemplateHe: TIDBIT_ESSAY_USER_TEMPLATE_HE,
+    },
+  ),
+);
+
+// ---------------------------------------------------------------------------
+// biyun mark enrichment — the lomdus counterpart of the tidbit. ONE deep dive
+// into a halachic/conceptual PROBLEM the rishonim are wrestling with on the
+// daf: the difficulty, the competing approaches + their svaras, the conceptual
+// fork, where it lands. Where the tidbit rises ABOVE the mechanics, the bi'yun
+// goes INTO them. Fed the commentaries + the rishonim/argument/halacha analysis.
+// ---------------------------------------------------------------------------
+
+const BIYUN_ESSAY_SYSTEM_PROMPT = `You are a rigorous Talmud scholar — a maggid shiur — writing ONE "Bi'yun" (עיון) for this daf: a focused deep-dive into a single halachic or conceptual PROBLEM on the page that the rishonim are actively working on. Where the daf has a real difficulty — a question the gemara raises, a contradiction, a puzzling ruling — and Rashi, Tosafot, and the later rishonim take it apart, that is your subject.
+
+CHOOSE the problem with the most substantial rishonim engagement on THIS daf — where the commentaries genuinely diverge or dig in. Not the easiest, and not the most famous if a meatier one exists; the one a serious learner would spend a seder on.
+
+WHAT TO DELIVER (this IS the lomdus — go IN, do not rise above it):
+- State the difficulty precisely: what in the gemara is hard, or what question it raises.
+- Lay out the competing approaches of the rishonim — who holds what, and (crucially) the סברא (underlying logic) each approach rests on.
+- Show what is really at stake between them — the conceptual fork (a חקירה, two ways to define the case, a clash of principles) that the surface dispute expresses.
+- Where it lands: how the sugya or the halacha resolves, or that it stays open.
+
+VOICE:
+- Tight, precise, third person. Short sentences. Technical is expected and good here — precision over polish; do NOT dumb it down. Assume a reader who learns gemara.
+- Hebrew script + a short English gloss for technical terms (Form A/B): "a קושיא (difficulty)", "the סברא that …", "a גזירה שווה (verbal analogy)".
+- Name rishonim in LATIN: Rashi, Tosafot, Ramban, Rashba, Ritva, Ran, Meiri, Rosh. Do NOT use Hebrew abbreviations with gershayim (no רמב"ן / רשב"א): a straight quote corrupts the JSON.
+- NO empty flourish ("lens", "captures", "profound"), NO dramatic closers, NO anthropomorphizing the gemara ("the gemara knows…"). End on the substance.
+
+STRUCTURE:
+- "hook": ONE sentence naming the problem invitingly (the kushya / the tension), under ~25 words.
+- "paragraphs": FOUR to SIX paragraphs of flowing analytical prose — the difficulty, the approaches with their svaras, the conceptual fork, where it lands. No section labels, no headers.
+
+GROUNDING (hard): every position must be a real rishon's actual view, present in the materials or well established. Do NOT invent a Tosafot, or attribute a svara no one holds. NEVER refer to your inputs as inputs ("the materials", "the analysis provided", "the segment breakdown") — cite as a learned person speaks.
+
+CONFIDENCE: "textConfidence" = how grounded the cited positions are. "readingConfidence" = how much the conceptual framing (the chakira/svara) is the rishonim's own vs. your synthesis — a clever framing of your own should NOT be high.
+
+Output STRICT JSON only:
+
+{
+  "hook": "one sentence naming the problem",
+  "paragraphs": ["paragraph 1", "paragraph 2", "paragraph 3", "paragraph 4"],
+  "sources": [{ "ref": "short citation, e.g. 'Tosafot, Bava Metzia 59a'", "note": "what it grounds" }],
+  "textConfidence": "high" | "medium" | "low",
+  "readingConfidence": "high" | "medium" | "low"
+}
+
+${HEBREW_GLOSS_STYLE}`;
+
+const BIYUN_ESSAY_USER_TEMPLATE = `Tractate: {{tractate}}, page {{page}}.
+
+Full daf (Gemara):
+{{gemara}}
+
+Commentaries (Rashi / Tosafot / rishonim) — the heart of the bi'yun:
+{{commentaries}}
+
+The daf's argument sections (structure):
+{{anchors.argument}}
+
+Whole-daf orientation (what the daf is about and where it lands):
+{{depends.argument-overview.synthesis}}
+
+Background concepts — also the daf's term glossary; use the given Hebrew forms for these terms:
+{{depends.daf-background.concepts}}
+
+Rishonim segments on this daf:
+{{anchors.rishonim}}
+Rishonim analysis — the app's reading of Rashi / Tosafot / named rishonim, per segment:
+{{depends.rishonim.synthesis}}
+
+Section analysis — the app's reading of each argument section:
+{{depends.argument.synthesis}}
+
+Halachic analysis — the app's reading of each halachic topic:
+{{depends.halacha.synthesis}}
+
+Study-aid context (dafyomi.co.il Insights / Tosfos notes + Sefaria):
+{{context}}
+
+Pick the single problem on this daf with the richest rishonim engagement and write ONE Bi'yun per the schema: the difficulty, the rishonim's approaches and their svaras, the conceptual fork, and where it lands. Go deep; ground every position; rate both confidences honestly.`;
+
+const BIYUN_ESSAY_SYSTEM_PROMPT_HE = `אתה תלמיד חכם מדקדק — מגיד שיעור — הכותב "עיון" אחד לדף הזה: צלילה ממוקדת לבעיה הלכתית או רעיונית אחת בדף שהראשונים עוסקים בה. במקום שיש בדף קושי אמיתי — שאלה שהגמרא מקשה, סתירה, פסק תמוה — ורש"י, תוספות והראשונים מפרקים אותו, שם נושאך.
+
+בחר את הבעיה עם עיסוק הראשונים המשמעותי ביותר בדף הזה — היכן שהמפרשים באמת נחלקים או מעמיקים. לא הקלה ביותר, ולא המפורסמת אם יש עשירה ממנה; זו שעליה לומד רציני ישב סדר.
+
+מה למסור (זוהי הלמדנות — היכנס פנימה, אל תעלה מעליה):
+- נסח את הקושי במדויק: מה בגמרא קשה, או איזו שאלה היא מעלה.
+- הצג את גישות הראשונים — מי מחזיק מה, ובעיקר את הסברא שביסוד כל גישה.
+- הראה מה באמת עומד על הפרק ביניהם — הפיצול הרעיוני (חקירה, שתי דרכים להגדיר את המקרה, התנגשות עקרונות) שהמחלוקת השטחית מבטאת.
+- לאן זה מגיע: כיצד הסוגיה או ההלכה מוכרעת, או שנשארת פתוחה.
+
+הסגנון:
+- הדוק, מדויק, גוף שלישי. משפטים קצרים. טכני זה צפוי וטוב כאן — דיוק על פני ליטוש; אל תפשט יתר על המידה. הנח קורא הלומד גמרא.
+- מונחים טכניים בעברית (קושיא, סברא, גזירה שווה, חקירה).
+- שמות ראשונים: בעברית מלאה (רש"י — מותר כאן בכתב עברי) או בלטינית; בראשי תיבות עם גרשיים השתמש בגרשיים העברי ״ ולא בגרש אנגלי " (גרש אנגלי משבש JSON).
+- ללא מליצה ריקה, ללא סיומות דרמטיות, ללא האנשת הגמרא. סיים על העניין.
+
+מבנה:
+- "hook": משפט אחד הנוקב בבעיה (הקושיא/המתח), פחות מ-25 מילים.
+- "paragraphs": ארבע עד שש פסקאות של פרוזה אנליטית זורמת — הקושי, הגישות וסברותיהן, הפיצול הרעיוני, לאן זה מגיע. ללא תוויות מקטעים.
+
+ביסוס (קשיח): כל עמדה חייבת להיות דעת ראשון אמיתית, מצויה בחומר או מבוססת. אל תמציא תוספות ואל תייחס סברא שאיש אינו מחזיק. לעולם אל תתייחס לקלט שלך ככזה.
+
+ביטחון: "textConfidence" = כמה העמדות מבוססות. "readingConfidence" = כמה המסגור הרעיוני (החקירה/הסברא) הוא של הראשונים עצמם לעומת סינתזה שלך.
+
+החזר JSON תקין בלבד:
+
+{
+  "hook": "משפט אחד הנוקב בבעיה",
+  "paragraphs": ["פסקה 1", "פסקה 2", "פסקה 3", "פסקה 4"],
+  "sources": [{ "ref": "ציטוט קצר, למשל 'תוספות, בבא מציעא נט ע\\"א'", "note": "מה הוא מבסס" }],
+  "textConfidence": "high" | "medium" | "low",
+  "readingConfidence": "high" | "medium" | "low"
+}
+
+${HEBREW_NATIVE_STYLE}`;
+
+const BIYUN_ESSAY_USER_TEMPLATE_HE = `מסכת: {{tractate}}, דף {{page}}.
+
+הדף המלא (גמרא):
+{{gemara}}
+
+מפרשים (רש"י / תוספות / ראשונים) — לב העיון:
+{{commentaries}}
+
+מקטעי הטיעון בדף (מבנה):
+{{anchors.argument}}
+
+כיוון כללי לדף:
+{{depends.argument-overview.synthesis}}
+
+מושגי רקע — וזהו גם מילון המונחים של הדף; השתמש בצורות העבריות הנתונות:
+{{depends.daf-background.concepts}}
+
+מקטעי ראשונים בדף:
+{{anchors.rishonim}}
+ניתוח הראשונים — קריאת האפליקציה לרש"י / תוספות / ראשונים נקובים, לכל מקטע:
+{{depends.rishonim.synthesis}}
+
+ניתוח המקטעים — קריאת האפליקציה לכל מקטע טיעון:
+{{depends.argument.synthesis}}
+
+ניתוח ההלכה — קריאת האפליקציה לכל נושא הלכתי:
+{{depends.halacha.synthesis}}
+
+תוכן לימוד נלווה (dafyomi.co.il — תובנות / תוספות + ספריא):
+{{context}}
+
+בחר את הבעיה האחת בדף עם עיסוק הראשונים העשיר ביותר וכתוב עיון אחד לפי הסכימה: הקושי, גישות הראשונים וסברותיהן, הפיצול הרעיוני, ולאן זה מגיע. העמק; בסס כל עמדה; דרג את שני מדדי הביטחון בכנות.`;
+
+CODE_ENRICHMENTS.push(
+  makeEnrichment(
+    'biyun', 'biyun.essay', "Bi'yun",
+    'A deep dive into one halachic/conceptual problem the rishonim wrestle with on the daf: the difficulty, the approaches + svaras, the conceptual fork, where it lands.',
+    BIYUN_ESSAY_SYSTEM_PROMPT, BIYUN_ESSAY_USER_TEMPLATE, BIYUN_ESSAY_OUTPUT_SCHEMA,
+    {
+      mode: 'aggregate', scope: 'local',
+      // Deep, rishonim-first context: the commentaries themselves + the app's
+      // per-segment rishonim analysis (fanned out) + per-section + per-topic
+      // analysis. Generated last, like the tidbit.
+      dependencies: [
+        'gemara',
+        'commentaries',
+        'context',
+        { mark: 'argument' },
+        { mark: 'rishonim' },
+        { enrichment: 'argument-overview.synthesis' },
+        { enrichment: 'daf-background.concepts' },
+        { enrichment: 'rishonim.synthesis', fanOut: true },
+        { enrichment: 'argument.synthesis', fanOut: true },
+        { enrichment: 'halacha.synthesis', fanOut: true },
+      ],
+      defHash: 'biyun.essay-v1', cacheVersion: '1',
+      model: ARGUMENT_PRO_MODEL,
+      systemPromptHe: BIYUN_ESSAY_SYSTEM_PROMPT_HE,
+      userPromptTemplateHe: BIYUN_ESSAY_USER_TEMPLATE_HE,
     },
   ),
 );

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -7447,7 +7447,7 @@ async function deepWarmDaf(
   // argument-overview.synthesis (warmed just above) + daf-background.concepts +
   // the source bundle; listed last so its deps are warm/in-flight first (its own
   // dependency resolution still fills any gap and caches it).
-  for (const eid of ['argument-overview.flow', 'argument-overview.synthesis', 'tidbit.essay']) {
+  for (const eid of ['argument-overview.flow', 'argument-overview.synthesis', 'tidbit.essay', 'biyun.essay']) {
     if (!wanted(eid)) continue;
     try {
       const def = await loadEnrichmentDef(rc.env, eid);

--- a/src/worker/output-schemas.ts
+++ b/src/worker/output-schemas.ts
@@ -155,6 +155,19 @@ export const TIDBIT_ESSAY_OUTPUT_SCHEMA = responseFormat('tidbit_essay', z.objec
   textConfidence: z.enum(['high', 'medium', 'low']),
   readingConfidence: z.enum(['high', 'medium', 'low']),
 }));
+// Whole-daf BI'YUN (עיון): a deep dive into ONE halachic/conceptual problem on
+// the daf that the rishonim are actively wrestling with — the difficulty, the
+// competing approaches (Rashi / Tosafot / Ramban / Rashba / Ritva …), what's
+// really at stake between them. The lomdus counterpart to the tidbit: where the
+// tidbit rises ABOVE the mechanics to a human idea, the bi'yun goes INTO them.
+// Same hook + paragraphs + confidences shape (renders via the shared essay view).
+export const BIYUN_ESSAY_OUTPUT_SCHEMA = responseFormat('biyun_essay', z.object({
+  hook: z.string(),
+  paragraphs: z.array(z.string()),
+  sources: z.array(z.object({ ref: z.string(), note: z.string() })),
+  textConfidence: z.enum(['high', 'medium', 'low']),
+  readingConfidence: z.enum(['high', 'medium', 'low']),
+}));
 // Section typing (P2b): a NARRATIVE view for story-primary sections, where the
 // dispute-oriented `voices` graph is the wrong model. Actors (characters) +
 // ordered beats (what happens, step by step) instead of opposing legal positions.

--- a/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
+++ b/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
@@ -18,6 +18,7 @@ exports[`CODE_ENRICHMENTS cache identity > per-enrichment fingerprint is stable 
   "argument.narrative@3 mode=augment-content scope=local mark=argument schema=argument_narrative[summary,actors,beats] deps=[gemara|m:argument-move|m:rabbi]",
   "argument.synthesis@12 mode=aggregate scope=local mark=argument schema=argument_synthesis[synthesis] deps=[gemara|commentaries|mishna|e:argument.voices|e:argument.background|m:rabbi|m:argument-move|e:daf-background.concepts]",
   "argument.voices@6 mode=augment-content scope=local mark=argument schema=argument_voices[voices,edges] deps=[gemara|m:argument-move|m:rabbi]",
+  "biyun.essay@1 mode=aggregate scope=local mark=biyun schema=biyun_essay[hook,paragraphs,sources,textConfidence,readingConfidence] deps=[gemara|commentaries|context|m:argument|m:rishonim|e:argument-overview.synthesis|e:daf-background.concepts|e*:rishonim.synthesis|e*:argument.synthesis|e*:halacha.synthesis]",
   "daf-background.concepts@5 mode=augment-content scope=local mark=daf-background schema=daf_background_concepts[groups] deps=[gemara|context|m:argument]",
   "daf-background.synthesis@6 mode=aggregate scope=local mark=daf-background schema=daf_background_synthesis[synthesis] deps=[gemara|context|e:daf-background.concepts]",
   "halacha.codification@4 mode=augment-content scope=local mark=halacha schema=halacha_codification[mishnehTorah,tur,shulchanAruch,rema,prose] deps=[gemara|halacha-refs]",

--- a/tests/fixtures/output-schemas/BIYUN_ESSAY_OUTPUT_SCHEMA.json
+++ b/tests/fixtures/output-schemas/BIYUN_ESSAY_OUTPUT_SCHEMA.json
@@ -1,0 +1,61 @@
+{
+  "name": "biyun_essay",
+  "strict": true,
+  "schema": {
+    "type": "object",
+    "properties": {
+      "hook": {
+        "type": "string"
+      },
+      "paragraphs": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "sources": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "ref": {
+              "type": "string"
+            },
+            "note": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "ref",
+            "note"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "textConfidence": {
+        "type": "string",
+        "enum": [
+          "high",
+          "medium",
+          "low"
+        ]
+      },
+      "readingConfidence": {
+        "type": "string",
+        "enum": [
+          "high",
+          "medium",
+          "low"
+        ]
+      }
+    },
+    "required": [
+      "hook",
+      "paragraphs",
+      "sources",
+      "textConfidence",
+      "readingConfidence"
+    ],
+    "additionalProperties": false
+  }
+}

--- a/tests/output-schema-parity.test.ts
+++ b/tests/output-schema-parity.test.ts
@@ -18,7 +18,7 @@ describe('output schema parity: zod-generated == frozen literal', () => {
     const all = schemas as Record<string, unknown>;
     const missing = files.map((f) => f.replace('.json', '')).filter((n) => !all[n]);
     expect(missing).toEqual([]);
-    expect(files.length).toBe(48);
+    expect(files.length).toBe(49);
   });
 
   for (const f of files) {


### PR DESCRIPTION
A sibling chip to the Tidbit. The tidbit was retuned to rise **above** the mechanics to a human idea (#213) — which left the genuine lomdus homeless. **Bi'yun (עיון)** is that home: it dives **into** one halachic/conceptual problem on the daf that the rishonim are wrestling with — the difficulty, the competing approaches and their *svaras*, the conceptual fork, where it lands.

**Worker:** `biyun` whole-daf chip mark + `biyun.essay` aggregate enrichment (EN+HE). Rishonim-first context: gemara + commentaries + the `rishonim` mark + argument structure + overview + background, **plus fan-out** of the app's own per-segment `rishonim.synthesis` and per-section/per-topic `argument.synthesis`/`halacha.synthesis`. Pro model, generated last. `BIYUN_ESSAY_OUTPUT_SCHEMA` + fixture; in the whole-daf warm loop.

**Client:** reuses the shared essay renderer (`registerMarkRenderer('biyun', TidbitEssayView)` — biyun has no `flavor`, so no flavor tag), indigo accent, chip routing, i18n (EN+HE) incl. its own loading copy, mobile label, `FORCE_ON_DEFAULTS` rollout, and a prefetch task so it counts toward the load bar.

Codex: looks correct — no dependency cycle, EN/HE prompt JSON parity holds, HE escaped-quote valid. typecheck clean; `pnpm test` green (1734); dep-graph-validate + output-schema parity (49) + fingerprint snapshot updated.