### PR TITLE
Tidbit: rank selection toward the human idea, not lomdus

### DIFF
--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -2701,13 +2701,15 @@ CODE_ENRICHMENTS.push(
 
 const TIDBIT_ESSAY_SYSTEM_PROMPT = `You are a sharp Talmud teacher writing ONE "Tidbit" for this daf — a single "did you notice…" worth carrying away. Not a summary, not the background, not the argument outline. You pick the ONE most genuinely interesting, non-obvious thing on THIS page and explain it.
 
-WHAT TO LOOK FOR (pick the strongest ONE; any kind is fine):
-- an aggadah (story) read against the grain — where the obvious moral is a setup for a sharper one;
-- a legal concept with a surprising twist or consequence;
-- a sharp machloket whose ramifications reach real practice (including a Bavli/Yerushalmi or Tanna/Amora fault line) — only if it is genuinely in the materials;
-- a textual point (a variant, a precise word) that changes the stakes;
-- on a dry / technical daf, the one real thing a learner would actually want to know.
-Prefer the non-obvious. Do NOT default to the famous greatest-hits reading when a sharper, true one is available. But never manufacture interest — if the daf is plain, an honest hidden point beats a forced "twist".
+WHAT TO LOOK FOR — in ORDER of preference. Take the highest kind the daf genuinely offers; do not reach down a level when a higher one is sitting right there:
+1. A story or aggadah, or a human moment — people, character, a scene, a striking thing someone said or did.
+2. A surprising idea anyone would find interesting — about people, language, values, history, or the way the law thinks. This INCLUDES practical halacha and real life: what people actually did, a stringency they took on, a custom, a ruling that changes how someone lives. On a dense halachic daf the gold is exactly this kind of human observation — e.g. on the impurity-degrees daf the tidbit is "the gemara is really describing people who held themselves to the Temple's purity standard with no obligation to — extra holiness taken on by choice," NOT the dispute about whether a third degree exists.
+3. A textual point — a variant or a precise word — that changes the stakes.
+4. ONLY if the daf is purely technical and offers nothing above: the single humane point under the halacha, written for someone who does not learn gemara.
+
+NOT the tidbit's job — this belongs to the Bi'yun (a separate, deeper pill): reconstructing a machloket, laying out the rishonim's svaras, who-holds-what, the conceptual fork between Amoraim. If your draft is walking through a dispute between sages or commentaries, you are writing a Bi'yun — stop, back out, and find the human idea instead. Practical halacha is welcome; lamdus is not.
+
+Prefer the non-obvious, but never manufacture interest — if the daf is plain, an honest small point beats a forced "twist".
 
 AIM FOR THE BIGGER IDEA, NOT THE MECHANICS. The best tidbit leaves the reader with a resonant, human idea — something true and a little surprising about Torah, people, law, or how a person lives — not a blow-by-blow reconstruction of who-holds-what. The rich analysis you are given is your INPUT for understanding the daf; it is NOT the thing to report back. Rise above the lomdus to the point it serves.
 - Decisive test, from a real daf about the degrees of ritual impurity: the right tidbit is "ordinary Jews chose to eat their everyday food at the Temple's level of purity, though nothing required it — holiness as something you draw nearer to by choice." The WRONG tidbit reconstructs "Ulla and Rabbah bar bar Chana dispute whether a third degree exists in such food." Same daf — one lands an idea, the other recites a machloket.
@@ -2791,13 +2793,15 @@ You now have the full picture of this daf — its text, commentaries, structure 
 
 const TIDBIT_ESSAY_SYSTEM_PROMPT_HE = `אתה מלמד תורה חד שכותב "Tidbit" אחד לדף הזה — דבר אחד מעניין באמת שכדאי לקחת ממנו. לא סיכום, לא הרקע, ולא מתווה הטיעון. אתה בוחר את הדבר האחד הכי מעניין ולא־מובן־מאליו בדף הזה ומסביר אותו.
 
-מה לחפש (בחר את הדבר החזק ביותר; כל סוג מתאים):
-- אגדה הנקראת כנגד הכיוון המתבקש — שבה המוסר המובן מאליו הוא הכנה לקריאה חדה יותר;
-- מושג הלכתי עם תפנית או השלכה מפתיעה;
-- מחלוקת חדה שהשלכותיה נוגעות למעשה (כולל קו שבר בין בבלי לירושלמי או בין תנא לאמורא) — רק אם היא באמת במקורות;
-- נקודה טקסטואלית (גרסה, מילה מדויקת) שמשנה את המשמעות;
-- בדף יבש/טכני — הדבר האחד האמיתי שלומד היה רוצה לדעת.
-העדף את הלא־מובן־מאליו. אל תברח לקריאה המפורסמת והשחוקה כשיש קריאה חדה ואמיתית יותר. אך לעולם אל תייצר עניין יש מאין — אם הדף פשוט, נקודה נסתרת כנה עדיפה על "תפנית" מאולצת.
+מה לחפש — לפי סדר עדיפות. קח את הסוג הגבוה ביותר שהדף באמת מציע; אל תרד דרגה כשיש דרגה גבוהה יותר ממש לפניך:
+1. סיפור או אגדה, או רגע אנושי — אנשים, אופי, סצנה, דבר בולט שמישהו אמר או עשה.
+2. רעיון מפתיע שכל אדם ימצא מעניין — על בני אדם, שפה, ערכים, היסטוריה, או על אופן החשיבה של ההלכה. זה כולל הלכה למעשה וחיים אמיתיים: מה אנשים באמת עשו, חומרא שקיבלו על עצמם, מנהג, פסק ששינה כיצד מישהו חי. בדף הלכתי צפוף הזהב הוא בדיוק תצפית אנושית כזו — למשל בדף על דרגות הטומאה ה-tidbit הוא "הגמרא בעצם מתארת אנשים שהחמירו על עצמם לטהרת הקודש בלי שום חובה — קדושה יתרה שנטלו מרצון", ולא המחלוקת אם קיים שלישי.
+3. נקודה טקסטואלית — גרסה או מילה מדויקת — שמשנה את המשמעות.
+4. רק אם הדף טכני לחלוטין ואין בו דבר מהנ"ל: הנקודה האנושית האחת שמתחת להלכה, כתובה למי שאינו לומד גמרא.
+
+לא תפקיד ה-tidbit — זה שייך ל"עיון" (פיל נפרד ועמוק): שחזור מחלוקת, פריסת סברות הראשונים, מי־מחזיק־מה, הפיצול הרעיוני בין אמוראים. אם הטיוטה מהלכת דרך מחלוקת בין חכמים או מפרשים, אתה כותב עיון — עצור, צא, ומצא את הרעיון האנושי. הלכה למעשה רצויה; למדנות לא.
+
+העדף את הלא־מובן־מאליו, אך לעולם אל תייצר עניין יש מאין — אם הדף פשוט, נקודה קטנה כנה עדיפה על "תפנית" מאולצת.
 
 כוון לרעיון הגדול, לא למכניקה. ה-Tidbit הטוב משאיר את הקורא עם רעיון מהדהד ואנושי — משהו אמיתי ומעט מפתיע על התורה, על בני אדם, על הדין או על חיי האדם — לא שחזור צעד־אחר־צעד של מי מחזיק מה. הניתוח העשיר שניתן לך הוא הקלט שלך להבנת הדף; הוא אינו הדבר שיש לדווח עליו. עלה מעל הלמדנות אל הנקודה שהיא משרתת.
 - מבחן מכריע, מדף אמיתי על דרגות טומאה: ה-Tidbit הנכון הוא "יהודים פשוטים בחרו לאכול את מאכלם היומיומי בטהרת הקודש, אף שדבר לא חייב זאת — קדושה כדבר שמתקרבים אליו מתוך בחירה". ה-Tidbit השגוי משחזר "עולא ורבה בר בר חנה נחלקו אם יש שלישי במאכל כזה". אותו דף — האחד נוחת על רעיון, השני מדקלם מחלוקת.
@@ -2912,7 +2916,7 @@ CODE_ENRICHMENTS.push(
         // mechanics; the tidbit is the bigger idea, lightly grounded. The deep
         // per-instance analysis is the Bi'yun's job, not the tidbit's.
       ],
-      defHash: 'tidbit.essay-v1', cacheVersion: '8', // v8: drop the per-instance lomdus fanOut — it pulled the tidbit into mechanics; back to the lean v3/v4 to-the-point read (deep analysis is the Bi'yun's job)
+      defHash: 'tidbit.essay-v1', cacheVersion: '9', // v9: ranked WHAT-TO-LOOK-FOR — prefer story/human/idea, practical halacha welcome, but machloket/svara reconstruction belongs to the Bi'yun (less halachic)
       // Pro model: finding the non-obvious reading needs the stronger model.
       // Thinking stays OFF (no reasoningEffort) — the context bundle is large,
       // like daf-background.concepts, and a thinking pass on top risks the

--- a/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
+++ b/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
@@ -48,6 +48,6 @@ exports[`CODE_ENRICHMENTS cache identity > per-enrichment fingerprint is stable 
   "rabbi.relationships@6 mode=augment-content scope=global mark=rabbi schema=rabbi_relationships[teachers,students,debatePartners,family,prose] deps=[]",
   "rabbi.synthesis@12 mode=aggregate scope=local mark=rabbi schema=rabbi_synthesis[synthesis] deps=[gemara|e:rabbi.bio|e:rabbi.philosophy|e:rabbi.relationships|e:rabbi.classification|e:rabbi.geography|e:rabbi.relationships.evidence|e:rabbi.geography.evidence|e:rabbi.location|e:rabbi.identity|m:rabbi|e:daf-background.concepts]",
   "rishonim.synthesis@4 mode=aggregate scope=local mark=rishonim schema=rishonim_synthesis[synthesis] deps=[gemara|m:rishonim]",
-  "tidbit.essay@8 mode=aggregate scope=local mark=tidbit schema=tidbit_essay[flavor,hook,paragraphs,sources,textConfidence,readingConfidence] deps=[gemara|commentaries|context|m:argument|m:rabbi|m:pesukim|m:aggadata|m:halacha|m:places|e:argument-overview.flow|e:argument-overview.synthesis|e:daf-background.concepts]",
+  "tidbit.essay@9 mode=aggregate scope=local mark=tidbit schema=tidbit_essay[flavor,hook,paragraphs,sources,textConfidence,readingConfidence] deps=[gemara|commentaries|context|m:argument|m:rabbi|m:pesukim|m:aggadata|m:halacha|m:places|e:argument-overview.flow|e:argument-overview.synthesis|e:daf-background.concepts]",
 ]
 `;


### PR DESCRIPTION
The `WHAT TO LOOK FOR` list weighted aggadah / legal-concept / machloket **equally**, so on a halacha-heavy masechta (Chullin) the tidbit kept landing on the dispute even after the 'bigger idea' directive. (Confirmed by diffing v1↔v8: the selection list never changed — equal weighting was always the cause, not a regression.)

Re-weight into a strict **preference order** (`cache_version` 8→9):
1. a story / aggadah / human moment;
2. a surprising idea anyone would find interesting — **explicitly including practical halacha and real life** (what people did, a stringency they took on), with the Chullin *"held themselves to Temple-level purity with no obligation"* read as the worked example;
3. a textual point;
4. only on a purely technical daf, the humane point under the halacha.

And an explicit boundary: **machloket / svara / who-holds-what reconstruction is the Bi'yun's job, not the tidbit's** — if the draft is walking a dispute, back out and find the human idea. Practical halacha welcome; lamdus not.

typecheck clean; `pnpm test` green (1754); fingerprint snapshot @9.