### PR TITLE
Dafyomi: parse the Yerushalmi 'Point by Point' pages (Bavli↔Yerushalmi parallels)

### DIFF
--- a/src/lib/sefref/dafyomi/parse/index.ts
+++ b/src/lib/sefref/dafyomi/parse/index.ts
@@ -13,6 +13,7 @@ import { parseBackground } from './background.ts';
 import { parseReview } from './review.ts';
 import { parseHebCharts } from './hebcharts.ts';
 import { parseRevach } from './revach.ts';
+import { parseYerushalmi } from './yerushalmi.ts';
 import type {
   DafyomiContentType, DafyomiAmudContent, DafyomiBody, DafyomiEntry, DafyomiPointsEntry,
 } from '../schema.ts';
@@ -70,9 +71,9 @@ export function parseDafyomiContent(type: DafyomiContentType, html: string): Par
       break;
     }
     case 'yerushalmi': {
-      const { a } = parseIndentedEntries(content);
-      blocks = [mk('a', { type, entries: a }, true)];
-      if (a.length === 0) warnings.push('no yerushalmi entries parsed');
+      const entries = parseYerushalmi(content);
+      blocks = [mk('a', { type, entries }, true)];
+      if (entries.length === 0) warnings.push('no yerushalmi entries parsed');
       break;
     }
     case 'points': {

--- a/src/lib/sefref/dafyomi/parse/yerushalmi.ts
+++ b/src/lib/sefref/dafyomi/parse/yerushalmi.ts
@@ -1,0 +1,146 @@
+/**
+ * @fileoverview Yerushalmi "Point by Point Outline" parser.
+ *
+ * dafyomi.co.il publishes, per Bavli daf, a "Yerushalmi to Match <daf>" page —
+ * the parallel Yerushalmi material with an English point-by-point outline
+ * alongside the Hebrew Yerushalmi text, and an explicit Yerushalmi ref per
+ * point (often cross-tractate, e.g. Bavli Chullin -> Yerushalmi Terumos).
+ *
+ * The DOM is the shared indented-entry idiom (`div.subject` + `div.indent1..3`
+ * with `span.nm` / `span.cl`), but with two twists the generic parser mishandles:
+ *   1. the Hebrew is interleaved as `div.indent1heb` / `indent2heb` / `indent3heb`
+ *      (NOT `ptshebtext`), and `levelOfClass('indent1heb')` returns null (word
+ *      boundary), so the generic parser DROPS it; and
+ *   2. each subject carries the parallel Yerushalmi ref in a `span.source`.
+ * This dedicated parser pairs the He/En and captures the ref into `entry.refs`.
+ */
+
+import {
+  elementChildren, isAmudBreak, levelOfClass, markerOf, labelOf,
+  bodyText, text, txt, collapse, type HTMLElement,
+} from './common.ts';
+import type { DafyomiEntry, DafyomiRef } from '../schema.ts';
+
+// Hebrew source divs on the yerushalmi page (interleaved before each English
+// entry). `ptshebtext`/`subjectheb` are kept for parity with the generic idiom.
+const HEB_CLASS = /\b(indent[123]heb|subjectheb|ptshebtext)\b/;
+
+/** Strip leading Vilna / Oz-VeHadar daf markers like
+ *  "[דף א עמוד א] [דף א עמוד א (עוז והדר)]" off a Hebrew line. */
+function stripDafMarkers(he: string): string {
+  return he.replace(/^(?:\s*\[[^\]]*\]\s*)+/, '').trim();
+}
+
+/**
+ * Parse a subject's "(Yerushalmi [Tractate] [Perek N] [Halachah M] Daf Xa)"
+ * source span into a structured ref. `detail` carries "perek:halachah" (when
+ * both are present) so a consumer can build a Sefaria
+ * "Jerusalem Talmud <tractate> <perek>:<halachah>" ref; `page` is the Vilna daf.
+ * `tractate` is set only when the source names a DIFFERENT Yerushalmi tractate
+ * (the cross-tractate case); otherwise it's the daf's own masechet.
+ */
+export function parseYerushalmiRef(src: string): DafyomiRef | null {
+  const m = src.match(
+    /Yerushalmi\s+(?:([A-Z][A-Za-z']+)\s+)?(?:Perek\s+(\d+)\s+)?(?:Halachah\s+(\d+)\s+)?Daf\s+(\d+[ab])/,
+  );
+  if (!m) return null;
+  const [, tractate, perek, halachah, daf] = m;
+  const ref: DafyomiRef = { raw: collapse(m[0]), kind: 'yerushalmi', page: daf };
+  if (tractate) ref.tractate = tractate;
+  if (perek && halachah) ref.detail = `${perek}:${halachah}`;
+  else if (halachah) ref.detail = `Halachah ${halachah}`;
+  return ref;
+}
+
+/**
+ * Parse a "Yerushalmi to Match" page's `#content` into entries. Each `subject`
+ * is a top-level point (with the parallel Yerushalmi ref in `refs`); the
+ * lettered `indentN` entries nest beneath it, each carrying paired English
+ * (`body.en`) + Hebrew (`body.he`) text. Whole-daf (amud breaks ignored).
+ */
+export function parseYerushalmi(content: HTMLElement): DafyomiEntry[] {
+  const top: DafyomiEntry[] = [];
+  let curTop: DafyomiEntry | null = null;
+  const stack: DafyomiEntry[] = [];
+  let pendingHe: string | null = null;
+
+  const deepest = (): DafyomiEntry | null => stack[stack.length - 1] ?? curTop;
+
+  for (const el of elementChildren(content)) {
+    if (isAmudBreak(el)) continue; // yerushalmi pages are a single whole-daf unit
+    const cls = el.getAttribute('class') ?? '';
+    if (/\bmaseches(heb)?line\b/.test(cls)) continue; // masechet-name header
+
+    if (HEB_CLASS.test(cls)) {
+      const t = stripDafMarkers(text(el));
+      if (t) pendingHe = pendingHe ? `${pendingHe} ${t}` : t;
+      continue;
+    }
+
+    const level = levelOfClass(cls);
+    if (level == null) continue;
+    const isHeading = /\bsubject\b/.test(cls);
+    const marker = markerOf(el);
+    const label = labelOf(el);
+
+    if (isHeading) {
+      const srcEl = el.querySelector('.source');
+      const ref = srcEl ? parseYerushalmiRef(text(srcEl)) : null;
+      let title = bodyText(el, marker);
+      if (srcEl) title = title.replace(text(srcEl), '').replace(/\s*\(\s*\)\s*$/, '').trim();
+      curTop = { marker, level: 0, title: txt(title, pendingHe ?? undefined), body: {}, children: [] };
+      if (ref) curTop.refs = [ref];
+      pendingHe = null;
+      top.push(curTop);
+      stack.length = 0;
+      stack[0] = curTop;
+      continue;
+    }
+
+    if (!marker) {
+      // Continuation paragraph: fold into the deepest open entry.
+      const tgt = deepest();
+      const body = bodyText(el, undefined, label);
+      if (tgt) {
+        if (body) tgt.body.en = tgt.body.en ? `${tgt.body.en}\n${body}` : body;
+        if (pendingHe) tgt.body.he = tgt.body.he ? `${tgt.body.he} ${pendingHe}` : pendingHe;
+      } else if (body || pendingHe) {
+        curTop = { level: 0, label, body: txt(body, pendingHe ?? undefined), children: [] };
+        top.push(curTop);
+        stack.length = 0;
+        stack[0] = curTop;
+      }
+      pendingHe = null;
+      continue;
+    }
+
+    const entry: DafyomiEntry = {
+      marker,
+      level,
+      label,
+      body: txt(bodyText(el, marker, label), pendingHe ?? undefined),
+    };
+    pendingHe = null;
+
+    if (level === 0) {
+      curTop = entry;
+      curTop.children = [];
+      top.push(curTop);
+      stack.length = 0;
+      stack[0] = curTop;
+      continue;
+    }
+
+    const parent = stack[level - 1] ?? curTop;
+    if (parent) {
+      parent.children = parent.children ?? [];
+      parent.children.push(entry);
+    } else {
+      top.push(entry);
+    }
+    stack[level] = entry;
+    stack.length = level + 1;
+  }
+
+  return top;
+}

--- a/src/lib/sefref/dafyomi/schema.ts
+++ b/src/lib/sefref/dafyomi/schema.ts
@@ -22,7 +22,7 @@ export type { DafyomiContentType };
  *  Tzomes)"). Best-effort structuring; `raw` is always the verbatim text. */
 export interface DafyomiRef {
   raw: string;
-  kind?: 'gemara' | 'mishnah' | 'rashi' | 'tosfos' | 'pasuk' | 'rambam' | 'shulchanAruch' | 'rishon' | 'acharon' | 'other';
+  kind?: 'gemara' | 'mishnah' | 'rashi' | 'tosfos' | 'pasuk' | 'rambam' | 'shulchanAruch' | 'rishon' | 'acharon' | 'yerushalmi' | 'other';
   /** Resolved app tractate value when a cross-reference is recognizable. */
   tractate?: string;
   /** Resolved daf-amud (e.g. "76a") when present. */

--- a/tests/dafyomi-parse.test.ts
+++ b/tests/dafyomi-parse.test.ts
@@ -144,6 +144,35 @@ describe('revach parser', () => {
   });
 });
 
+describe('yerushalmi parser ("Yerushalmi to Match" pages)', () => {
+  it('pairs He+En and extracts the parallel Yerushalmi ref (Berakhot 2 -> JT Berakhot 1:1)', () => {
+    const r = parseDafyomiContent('yerushalmi', fixture('berachos-yerushalmi-002.htm'));
+    expect(r.parseWarnings).toEqual([]);
+    expect(r.blocks).toHaveLength(1);
+    expect(r.blocks[0].wholeDaf).toBe(true);
+    const body = r.blocks[0].body;
+    if (body.type !== 'yerushalmi') throw new Error('wrong body type');
+    expect(body.entries.length).toBeGreaterThan(0);
+    const point = body.entries[0];
+    expect(point.title?.en).toBe("THE TIME FOR KERI'AS SHMA AT NIGHT");
+    // the parallel Yerushalmi ref, captured with perek:halachah for a Sefaria map
+    expect(point.refs?.[0]).toMatchObject({ kind: 'yerushalmi', detail: '1:1', page: '1a' });
+    // first lettered child carries paired English + Hebrew
+    const child = point.children?.[0];
+    expect(child?.body.en).toContain('when do we recite');
+    expect(child?.body.he).toContain('מאימתי קורין');
+  });
+
+  it('captures CROSS-TRACTATE parallels (Bavli Chullin 76 -> Yerushalmi Terumos 4:1)', () => {
+    const r = parseDafyomiContent('yerushalmi', fixture('chulin-yerushalmi-076.htm'));
+    const body = r.blocks[0].body;
+    if (body.type !== 'yerushalmi') throw new Error('wrong body type');
+    expect(body.entries[0].refs?.[0]).toMatchObject({
+      kind: 'yerushalmi', tractate: 'Terumos', detail: '4:1', page: '18a',
+    });
+  });
+});
+
 describe('buildRevachUrl', () => {
   it('builds the memdb URL for a masechet with a known tid (no zero-padding)', () => {
     const m = getDafyomiMasechet('Chullin')!;

--- a/tests/fixtures/dafyomi/berachos-yerushalmi-002.htm
+++ b/tests/fixtures/dafyomi/berachos-yerushalmi-002.htm
@@ -1,0 +1,240 @@
+﻿<!DOCTYPE HTML>
+<html lang="en">
+<head>
+<!--85:8  12/03/24-->
+<!--hr84.1-->    
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<!-- The above 3 meta tags *must* come first in the head -->
+<!-- no remmed css links allowed -->
+
+
+<meta name="Keywords" content="Gemara, Talmud, Dafyomi, Daf Yomi, Yerushalmi">
+
+<title>POINT BY POINT OUTLINES OF THE YERUSHALMI - BERACHOS 2</title>
+
+<!--BKMRK1-->
+
+
+
+<link href="../../headerset.css" rel="stylesheet" type="text/css">
+<link href="../../footerset.css" rel="stylesheet" type="text/css">
+<link href="../../content_outline.css" rel="stylesheet" type="text/css">
+<link href="../../content_yerushalmi.css" rel="stylesheet" type="text/css">
+<link rel="shortcut icon" href="http://www.dafyomi.co.il/kih_icon_clear.ico">
+<!--BKMRK2-->
+</head>
+
+<body>
+<div id="yer">
+<div id="wrapper">
+    
+    <div id="header">    
+        <div class="horiz_rule"></div>
+        <div class="title">POINT BY POINT OUTLINES<br class="smallbreak"> OF THE YERUSHALMI</div>
+
+<div class="headerdedication">THE NEFF FAMILY<br />
+ <b>MASECHES BERACHOS</b><!--2026_06 missing the file content.html --></div>
+<div class="headerspecialsection"><br />
+<!--2026_06 missing the file content.html --></div>
+
+  
+        <img class="kih_logo" src="http://www.dafyomi.co.il/kih-logo-tiny.gif" alt="Kollel Iyun Hadaf">
+<div class="headerline">prepared by Rabbi Pesach Feldman<br class="smallbreak"> of Kollel Iyun Hadaf, Yerushalayim</div>
+<div class="email"><a href="mailto:daf@dafyomi.co.il">daf@dafyomi.co.il</a>, <a href="https://dafyomi.co.il">www.dafyomi.co.il</a> </div>
+<div class="roshkollel">Rosh Kollel: Rabbi Mordecai Kornfeld</div>
+
+        <div class="horiz_rule"></div>
+
+
+        <div id="nav">
+<!--prevdaf1-->
+            <div class="left"><a href="../../nidah/yerushalmi/ni-yr-073.htm"><img src="http://www.dafyomi.co.il/left.gif" alt="Previous"></a></div>
+<!--prevdaf2-->
+
+
+   <div class="daf"><p class="tomatch">Yerushalmi to Match</p>Berachos 2</div>
+
+
+
+
+<!--nextdaf1-->
+            <div class="right"><a href="br-yr-003.htm"><img src="http://www.dafyomi.co.il/right.gif" alt="Next"></a></div>
+<!--nextdaf2-->
+        </div>  <!-- end #nav1 -->
+
+
+
+     
+
+<!--askkollel1-->
+        <div class="clear"></div>
+        <div class="ask">
+            <a href="http://www.dafyomi.co.il/askollel.htm">
+                <img src="http://www.dafyomi.co.il/quest-mark.gif" alt="Ask the Kollel">
+                <br><span>Ask the<br>Kollel</span>
+            </a>
+        </div>
+<!--askkollel2--> 
+    </div>  
+
+
+ 
+   <!-- end #header -->
+    <div class="clear"></div>
+
+<div class="dedicationbox"><br><u>PAST CYCLE DEDICATION</u><br><br>BERACHOS 2-3 - The first two Dafim in Shas, the start of the 12th Dafyomi cycle, have been dedicated anonymously by a reader in Switzerland. </div>    
+<!--ADVERTTEXT-->
+    
+	    <div id="content">
+
+<div id="msch-br" class="masecheshebline">מסכת ברכות</div>
+<div id="msc-br" class="masechesline">MASECHES BERACHOS</div>
+<div  id="tbr0021" class="subject"><span id="phbr01.01"></span><span class="nm">1)</span><p> THE TIME FOR KERI'AS SHMA AT NIGHT <span class="source">(Yerushalmi Perek 1 Halachah 1 Daf 1a)</span></p></div>
+<div  id="hbr0021a" class="indent1heb"><p><span id="dvbr001a" class="vl">[דף א עמוד א]</span> <span id="dobr001a" class="oz">[דף א עמוד א (עוז והדר)]</span> מתני' מאימתי קורין את שמע בערבין</p></div>
+<div  id="ebr0021a" class="indent1"><span class="nm">(a)</span><p><span class="cl">	(Mishnah) Question:</span> From (and until) when do we recite Keri'as Shma at night?</p></div>
+<div  id="hbr0021b" class="indent1heb"><p>משעה שהכהנים נכנסין לוכל בתרומתן עד סוף האשמורת הראשונה דברי ר"א.</p></div>
+<div  id="ebr0021b" class="indent1"><span class="nm">(b)</span><p><span class="cl">	Answer #1 (R. Eliezer):</span> The Mitzvah is from the time when Kohanim enter to eat their Terumah, until the end of the first Mishmar (these will be explained).</p></div>
+<div  id="hbr0021c" class="indent1heb"><p>וחכמים אומרים עד חצות.</p></div>
+<div  id="ebr0021c" class="indent1"><span class="nm">(c)</span><p><span class="cl">	Answer #2 (Chachamim):</span> It is until midnight.</p></div>
+<div  id="hbr0021d" class="indent1heb"><p>ר"ג אומר עד שיעלה עמוד השחר.</p></div>
+<div  id="ebr0021d" class="indent1"><span class="nm">(d)</span><p><span class="cl">	Answer #3 (R. Gamliel):</span> It is until dawn.</p></div>
+<div  id="hbr0021e" class="indent1heb"><p>מעשה ובאו בניו מבית המשתה ואמרו לו לא קרינו את שמע</p></div>
+<div  id="ebr0021e" class="indent1"><span class="nm">(e)</span><p>	A case occurred in which R. Gamliel's sons came home from a wedding after midnight. They told him, we did not recite Shma.</p></div>
+<div  id="hbr0021e1" class="indent2heb"><p>אמר להן אם לא עלה עמוד השחר חייבין אתם לקרות.</p></div>
+<div  id="ebr0021e1" class="indent2"><span class="nm">1.</span><p><span class="cl">	R. Gamliel:</span> If dawn did not come, you are obligated to recite [it now];</p></div>
+<div  id="hbr0021e2" class="indent2heb"><p>ולא זו בלבד אמרו אלא כל שאמרו חכמים עד חצות <span id="dobr001b" class="oz">[דף א עמוד ב (עוז והדר)]</span> מצותן עד שיעלה עמוד השחר.</p></div>
+<div  id="ebr0021e2" class="indent2"><span class="nm">2.</span><p>	Not only this (is until dawn). Rather, wherever Chachamim said "until midnight," the (Torah) Mitzvah is until dawn:</p></div>
+<div  id="hbr0021e2i" class="indent3heb"><p>הקטר חלבים ואיברים מצותן עד שיעלה עמוד השחר.</p></div>
+<div  id="ebr0021e2i" class="indent3"><span class="nm">i.</span><p>	Burning [on the Mizbe'ach] Chelev (of Korbanos) and limbs (of an Olah), their Mitzvah is until dawn;</p></div>
+<div  id="hbr0021e2ii" class="indent3heb"><p>כל הנאכלין ליום אחד מצותן עד שיעלה עמוד השחר.</p></div>
+<div  id="ebr0021e2ii" class="indent3"><span class="nm">ii.</span><p>	All Korbanos that may be eaten for one day [and a night], their Mitzvah is until dawn.</p></div>
+<div  id="hbr0021e3" class="indent2heb"><p>אם כן למה אמרו חכמים עד חצות</p></div>
+<div  id="ebr0021e3" class="indent2"><span class="nm">3.</span><p><span class="cl">	Question:</span> If so, why did Chachamim say "until midnight"?</p></div>
+<div  id="hbr0021e4" class="indent2heb"><p>כדי להרחיק את האדם מן העבירה:</p></div>
+<div  id="ebr0021e4" class="indent2"><span class="nm">4.</span><p><span class="cl">	Answer:</span> This is to distance people from transgression (lest dawn arrive before one performs the Mitzvah).</p></div>
+<div  id="hbr0021f" class="indent1heb"><p>גמ' אנן תנינן משעה שהכהנים נכנסין לוכל בתרומתן.</p></div>
+<div  id="ebr0021f" class="indent1"><span class="nm">(f)</span><p><span class="cl">	(Gemara):</span> Our Mishnah teaches 'from the time when Kohanim enter to eat their Terumah.'</p></div>
+<div  id="hbr0021g" class="indent1heb"><p>תני רבי חייא משעה שדרך בני אדם נכנסין לאכול פיתן בלילי שבת.</p></div>
+<div  id="ebr0021g" class="indent1"><span class="nm">(g)</span><p><span class="cl">	(R. Chiya - Beraisa):</span> It is the time when people enter to eat their bread on Shabbos night.</p></div>
+<div  id="hbr0021h" class="indent1heb"><p>ותני עלה קרובים דבריהן להיות שוין.</p></div>
+<div  id="ebr0021h" class="indent1"><span class="nm">(h)</span><p><span class="cl">	(Beraisa):</span> Their words are close to the same.</p></div>
+<div  id="hbr0021i" class="indent1heb"><p><span id="dvbr001b" class="vl">[דף א עמוד ב]</span> <span id="dobr002a" class="oz">[דף ב עמוד א (עוז והדר)]</span> איתא חמי משעה שהכהנים נכנסין לוכל בתרומתן יממא הוא ועם כוכביא הוא משעה שדרך בני אדם נכנסין לאכול פתן בלילי שבת שעה ותרתי ליליא הוא ואת אמרת קרובים דבריהן להיות שוין</p></div>
+<div  id="ebr0021i" class="indent1"><span class="nm">(i)</span><p><span class="cl">	Question:</span> When Kohanim enter to eat Terumah is [right after the end of the] day. It is once the stars come out. The time when people enter to eat their bread on Shabbos night is [one or two] hours into the night, and you say that t<b>heir words </b>are close to the same?!</p></div>
+<div  id="hbr0021j" class="indent1heb"><p>אמר רבי יוסי תיפתר באילין כופרניא דקיקייא דאורחיהון מסתלקא עד דהוא יממא דצדי לון מיקמי חיותא.</p></div>
+<div  id="ebr0021j" class="indent1"><span class="nm">(j)</span><p><span class="cl">	Answer (R. Yosi):</span> [R. Chiya] discusses people of small villages. They leave [the Beis ha'Keneses in the field] while it is still day, due to [fear of] Chayos that lie in ambush.</p></div>
+<div  id="hbr0021k" class="indent1heb"><p>תני הקורא קודם לכן לא יצא ידי חובתו</p></div>
+<div  id="ebr0021k" class="indent1"><span class="nm">(k)</span><p><span class="cl">	(Beraisa):</span> One who reads before this, he did not fulfill his obligation.</p></div>
+<div  id="hbr0021l" class="indent1heb"><p>אם כן למה קורין אותה בבית הכנסת</p></div>
+<div  id="ebr0021l" class="indent1"><span class="nm">(l)</span><p><span class="cl">	Question:</span> If so, why do people read it in the Beis ha'Keneses [before this]?</p></div>
+<div  id="hbr0021m" class="indent1heb"><p>אמר רבי יוסי אין קורין אותה בבית הכנסת בשביל לצאת ידי חובתו אלא כדי לעמוד בתפילה מתוך דבר של תורה.</p></div>
+<div  id="ebr0021m" class="indent1"><span class="nm">(m)</span><p><span class="cl">	Answer (R. Yosi):</span> They do not read it in the Beis ha'Keneses to fulfill their obligation, rather, in order to enter Tefilah (Shemoneh Esre) amidst Divrei Torah.</p></div>
+<div  id="hbr0021n" class="indent1heb"><p>ר' זעירא בשם רב ירמיה ספק בירך על מזונו ספק לא בירך צריך לברך דכתיב [דברים ח י] ואכלת ושבעת וברכת.</p></div>
+<div  id="ebr0021n" class="indent1"><span class="nm">(n)</span><p><span class="cl">	(R. Ze'ira citing R. Yirmeyah):</span> If it is a Safek whether one blessed on his food or did not bless, he must bless, for it says "v'Achalta v'Savata u'Verachta" (it is a Torah Mitzvah);</p></div>
+<div  id="hbr0021o" class="indent1heb"><p>ספק התפלל ספק לא התפלל אל יתפלל</p></div>
+<div  id="ebr0021o" class="indent1"><span class="nm">(o)</span><p>	If it is a Safek whether one prayed or did not pray, he does not pray (Tefilah is mid'Rabanan).</p></div>
+<div  id="hbr0021o1" class="indent2heb"><p>ודלא כרבי יוחנן דא"ר יוחנן ולואי שיתפלל אדם כל היום כולו</p></div>
+<div  id="ebr0021o1" class="indent2"><span class="nm">1.</span><p>	This is unlike R. Yochanan, for R. Yochanan said, 'if only a person would pray the entire day!'</p></div>
+<div  id="hbr0021o2" class="indent2heb"><p>למה שאין תפילה מפסדת.</p></div>
+<div  id="ebr0021o2" class="indent2"><span class="nm">2.</span><p>	What is the reason? There is no loss in Tefilah (it is request; there is no concern for Brachah l'Vatalah).</p></div>
+<div  id="hbr0021p" class="indent1heb"><p>ספק קרא ספק לא קרא</p></div>
+<div  id="ebr0021p" class="indent1"><span class="nm">(p)</span><p><span class="cl">	Question:</span> If it is a Safek whether he recited or did not recite [what is the law? <b>CHAREDIM</b> - he is unsure whether Keri'as Shma is mid'Oraisa or mid'Rabanan.]</p></div>
+<div  id="hbr0021q" class="indent1heb"><p>נישמעינה מן הדא <span id="dobr002b" class="oz">[דף ב עמוד ב (עוז והדר)]</span> הקורא קודם לכן לא יצא ידי חובתו</p></div>
+<div  id="ebr0021q" class="indent1"><span class="nm">(q)</span><p><span class="cl">	Answer:</span> We learn from [the above Beraisa]. One who reads before this, he did not fulfill his obligation.</p></div>
+<div  id="hbr0021q1" class="indent2heb"><p>וקודם לכן לאו ספק הוא ואת אמרת צריך לקרות הדא אמרה ספק קרא ספק לא קרא צריך לקרות.</p></div>
+<div  id="ebr0021q1" class="indent2"><span class="nm">1.</span><p>	Before this (Bein ha'Shemashos), is it not a Safek? (If it is day, he was not Yotzei. If it is night, he was Yotzei.) And you say that [he was not Yotzei, and] he must recite [again]! This shows that if it is a Safek whether or not he recited, he must recite.</p></div>
+<div  id="hbr0021r" class="indent1heb"><p>סימן לדבר משיצאו הכוכבים. ואף על פי שאין ראיה לדבר זכר לדבר [נחמיה ד טו] ואנחנו עושים במלאכה וחציים מחזיקים ברמחים מעלות השחר עד צאת הכוכבים וכתיב [שם טז] והיה לנו הלילה למשמר והיום למלאכה.</p></div>
+<div  id="ebr0021r" class="indent1"><span class="nm">(r)</span><p><span class="cl">	(Beraisa):</span> A sign [of when day ends] is Tzeis ha'Kochavim.<b> Even though there is </b>not a proof, there is a hint to this - "va'Anachnu Osim ba'Melachah v'Chetzyam Machazikim b'Ramachim me'Alos ha'Shachar Ad Tzeis ha'Kochavim" (they worked from dawn until Tzeis ha'Kochavim), and it says "v'Hayu Lanu ha'Lailah Mishmar veha'Yom Melachah."</p></div>
+   </div> <!-- End #content -->
+<!--ftr82.1-->
+    <div class="navlinks">
+<!--nextdaf1-->
+        <div class="nextdaf">
+            <p><a href="br-yr-003.htm"><img src="http://www.dafyomi.co.il/right.gif" alt="Next"></a></p>
+        </div>
+<!--nextdaf2-->
+  
+
+
+<div class="indexlink"><a href="https://dafyomi.co.il/section.php?gid=1&amp;sid=17">Yerushalmi Outlines for<br class="smallbreak"> Maseches Berachos</a></div>
+ 
+
+<div class="homepagelink"><a href="https://dafyomi.co.il/gemara.php?gid=1">Homepage for Maseches<br class="smallbreak"> Berachos</a></div>
+ 
+     
+
+   <div class="dafhomelink"><a href="http://www.dafyomi.co.il/index.htm" target="_parent">
+            <img src="http://www.dafyomi.co.il/kih-logo-tiny.gif" alt="Dafyomi Advancement Forum homepage">
+            <br>D.A.F. Homepage</a>
+        </div>   
+    </div> <!-- End navlinks -->
+
+
+<!--HR3-->
+    <div class="horiz_rule"></div>
+
+    <div class="resources">
+
+            <h2>OTHER D.A.F. RESOURCES<br class="smallbreak"> ON THIS DAF</h2>
+
+        <ul>
+ <li><a href="../insites/br-dt-002.htm">Insights to<br>the Daf</a>
+<li><a href="../backgrnd/br-in-002.htm">Background<br>to the Daf</a>
+<li><a href="../review/br-rg-002.htm">Review<br>Questions</a>
+<li><a href="../points/br-ps-002.htm">Point by<br>Point</a>
+
+</ul>
+<ul>
+<li><a href="../halachah/br-hl-002.htm">Halachah<br>Outlines</a>
+<li><a href="../tosfos/br-ts-002.htm">Tosfos<br>Outlines</a>
+<!-- <li><a href="../agadah/br-ag-002.htm">Agadah<br>Outlines</a> -->
+<li><a href="https://dafyomi.co.il/section.php?gid=1&amp;sid=5">English<br>Charts</a></li>
+<li><a href="../../memdb/revdaf.php?tid=1&amp;id=002">Revach<br>l'Daf</a>
+
+</ul>
+<ul>
+<li><a href="../quiz/br-qz-002.htm">Review<br>Quiz</a>
+<li class="liheb"><a href="../hebcharts/br-tl-002.htm">טבלאות<br>בעברית</a>
+<li class="liheb"><a href="https://dafyomi.co.il/berachos/yosefdas/bera-yd-002.pdf">יוסף<br>דעת</a>
+<li class="liheb"><a href="https://dafyomi.co.il/berachos/chidon/br-cd-alla.htm?daf=002#d002">חידונים<br>על הדף</a>
+
+</ul>
+<ul>
+<li class="liheb"><a href="https://dafyomi.co.il/galei_link.php?gid=1&daf=002">גלי<br>מסכתא</a>
+<li><a href="https://dafyomi.co.il/discuss_daf.php?gid=1&amp;sid=20&daf=002&n=0">Discuss<br>the Daf</a>
+<li><a href="https://dafyomi.co.il/members/shiurim/?meseches=berachos">Video/Audio<br>Lectures</a></li>
+
+        </ul>
+    </div>  
+<!--HR4--> <!-- end .resources -->
+
+    <div class="horiz_rule"></div>
+    
+    <div id="footer">
+        <ul>
+            <li><a href="http://www.dafyomi.co.il/new_gemara_picker.php">Other Masechtos</a></li>
+            <li><a href="https://gem.godaddy.com/signups/92631be18f7a4611948240bd55782374/join">Join Mailing Lists</a></li>
+        </ul>
+        <ul>
+            <li><a href="http://www.dafyomi.co.il/askollel.htm">Ask the Kollel</a></li>
+            <li><a href="http://www.dafyomi.co.il/calendars/calendar.htm" target="_parent">Dafyomi Calendar</a></li>
+        </ul>
+        <ul>
+            <li><a href="http://www.dafyomi.co.il/index_heb.htm" class="chomerbivrit">חומר בעברית</a></li>
+            <li><a href="http://www.dafyomi.co.il/sponsors.htm">Donations</a></li>
+         </ul>
+        <ul>
+             <li><a href="http://www.dafyomi.co.il/fanmail.htm">Feedback</a></li>
+             <li><a href="http://www.dafyomi.co.il/central.htm">Dafyomi Links</a></li>
+        </ul>
+    </div> <!-- End #footer -->
+    
+</div>  <!-- End #wrapper -->
+</div>  
+</body>
+</html>
+
+
+
+<!--2026_06 missing the file content.html -->

--- a/tests/fixtures/dafyomi/chulin-yerushalmi-076.htm
+++ b/tests/fixtures/dafyomi/chulin-yerushalmi-076.htm
@@ -1,0 +1,239 @@
+﻿<!DOCTYPE HTML>
+<html lang="en">
+<head>
+<!--86:14  03/23/26-->
+<!--hr84.1-->    
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<!-- The above 3 meta tags *must* come first in the head -->
+<!-- no remmed css links allowed -->
+
+
+<meta name="Keywords" content="Gemara, Talmud, Dafyomi, Daf Yomi, Yerushalmi">
+
+<title>POINT BY POINT OUTLINES OF THE YERUSHALMI - CHULIN 76</title>
+
+<!--BKMRK1-->
+
+
+
+<link href="../../headerset.css" rel="stylesheet" type="text/css">
+<link href="../../footerset.css" rel="stylesheet" type="text/css">
+<link href="../../content_outline.css" rel="stylesheet" type="text/css">
+<link href="../../content_yerushalmi.css" rel="stylesheet" type="text/css">
+<link rel="shortcut icon" href="http://www.dafyomi.co.il/kih_icon_clear.ico">
+<!--BKMRK2-->
+</head>
+
+<body>
+<div id="yer">
+<div id="wrapper">
+    
+    <div id="header">    
+        <div class="horiz_rule"></div>
+        <div class="title">POINT BY POINT OUTLINES<br class="smallbreak"> OF THE YERUSHALMI</div>
+
+<div class="headerdedication"><br />
+ <b>MASECHES CHULIN</b><!--2026_06 missing the file content.html --></div>
+<div class="headerspecialsection"><span class="type ddc-undermaseches">Sponsored by Dr. Lindsay and Rivka Rosenwald<br />
+in honor of David Halevy Rosenwald</span><!--2026_06 missing the file content.html --></div>
+
+  
+        <img class="kih_logo" src="http://www.dafyomi.co.il/kih-logo-tiny.gif" alt="Kollel Iyun Hadaf">
+<div class="headerline">prepared by Rabbi Moshe Dovid Cohen<br class="smallbreak"> of Kollel Iyun Hadaf, Yerushalayim</div>
+<div class="email"><a href="mailto:daf@dafyomi.co.il">daf@dafyomi.co.il</a>, <a href="https://dafyomi.co.il">www.dafyomi.co.il</a> </div>
+<div class="roshkollel">Rosh Kollel: Rabbi Mordecai Kornfeld</div>
+
+        <div class="horiz_rule"></div>
+
+
+        <div id="nav">
+<!--prevdaf1-->
+            <div class="left"><a href="ch-yr-075.htm"><img src="http://www.dafyomi.co.il/left.gif" alt="Previous"></a></div>
+<!--prevdaf2-->
+
+
+   <div class="daf"><p class="tomatch">Yerushalmi to Match</p>Chulin 76</div>
+
+
+
+
+<!--nextdaf1-->
+            <div class="right"><a href="ch-yr-077.htm"><img src="http://www.dafyomi.co.il/right.gif" alt="Next"></a></div>
+<!--nextdaf2-->
+        </div>  <!-- end #nav1 -->
+
+
+
+     
+
+<!--askkollel1-->
+        <div class="clear"></div>
+        <div class="ask">
+            <a href="http://www.dafyomi.co.il/askollel.htm">
+                <img src="http://www.dafyomi.co.il/quest-mark.gif" alt="Ask the Kollel">
+                <br><span>Ask the<br>Kollel</span>
+            </a>
+        </div>
+<!--askkollel2--> 
+    </div>  
+
+
+ 
+   <!-- end #header -->
+    <div class="clear"></div>
+
+<div class="dedicationbox"> </div>    
+<!--ADVERTTEXT-->
+    
+	    <div id="content">
+
+<div id="prk4ss" class="perekline">PEREK HAMAFRISH</div>
+<div  id="tch0761" class="subject"><span id="phss04.01"></span><span class="nm">1)</span><p> PARTIALLY SEPARATED TERUMAH AND MA'ASROS <span class="source">(Yerushalmi Terumos Perek 4 Halachah 1 Daf 18a)</span></p></div>
+<div  id="hch0761a" class="indent1heb"><p>משנה המפריש מקצת תרומה ומעשרות מוציא ממנו תרומה עליו אבל לא למקום אחר</p></div>
+<div  id="ech0761a" class="indent1"><span class="nm">(a)</span><p><span class="cl"> (Mishnah):</span> One who partially separated Terumah and Ma'asros (i.e. less than the required amount); he should remove the rest of it from the same pile, but he may not separate from it for a pile elsewhere.</p></div>
+<div  id="hch0761b" class="indent1heb"><p>ר''מ אומר אף מוציא הוא למקום אחר תרומות ומעשרות:</p></div>
+<div  id="ech0761b" class="indent1"><span class="nm">(b)</span><p><span class="cl"> (R. Meir):</span> He may even separate from it for a pile elsewhere.</p></div>
+<div  id="hch0761c" class="indent1heb"><p><span id="doss033a" class="oz">[דף לג עמוד א (עוז והדר)]</span> גמרא המפריש מקצת תרומות ומעשרות. מתני' כשהפריש ודעתו להפריש</p></div>
+<div  id="ech0761c" class="indent1"><span class="nm">(c)</span><p><span class="cl"> (Gemara):</span> 'One who partially separated Terumah and Ma'asros...' The Mishnah is discussing when he separated with intent to further separate.</p></div>
+<div  id="hch0761d" class="indent1heb"><p>ר' שמואל <span id="dvss018b" class="vl">[דף יח עמוד ב]</span> בשם ר' זעירא מתני' בסתם</p></div>
+<div  id="ech0761d" class="indent1"><span class="nm">(d)</span><p><span class="cl"> (R. Shmuel citing R. Zeira):</span> The Mishnah's case is even when he didn't have that intent.</p></div>
+<div  id="hch0761e" class="indent1heb"><p>אמר רבי מנא קומי ר' יודן מה ופליג</p></div>
+<div  id="ech0761e" class="indent1"><span class="nm">(e)</span><p><span class="cl"> (R. Mana to R. Yudan):</span> Is R. Shmuel disagreeing with the Gemara's previous statement?</p></div>
+<div  id="hch0761f" class="indent1heb"><p>א''ל סתמא בשהפריש ודעתו להפריש</p></div>
+<div  id="ech0761f" class="indent1"><span class="nm">(f)</span><p><span class="cl"> (R. Yudan to R. Mana):</span> R. Shmuel reasons that even if he didn't have specific intent, it is as if he did.</p></div>
+<div  id="hch0761g" class="indent1heb"><p>מה בין מוציא ממנו עליו למוציא ממנו למקום אחר</p></div>
+<div  id="ech0761g" class="indent1"><span class="nm">(g)</span><p><span class="cl"> Question:</span> What's the difference whether he separates from it for itself or for elsewhere?</p></div>
+<div  id="hch0761h" class="indent1heb"><p>בשעה שהוא מוציא ממנו עליו כל הטבל עלה בידו ובשעה שהוא מוציא ממנו למקום אחר מזה ומזה עלה בידו</p></div>
+<div  id="ech0761h" class="indent1"><span class="nm">(h)</span><p><span class="cl"> Answer:</span> When he separates from it for itself, we assume that all of the produce that came to his hand was from the Tevel (since it's viewed as a continuation of his earlier separation). But when he separates for elsewhere, he is assumed to have taken both Tevel and Chulin (since the earlier separation was already completed).</p></div>
+<div  id="hch0761i" class="indent1heb"><p>וקשיא נטל להוציא ממנו עליו כל הטבל עלה בידו ונמלך להוציא ממנו על מקום אחר מזה ומזה עלה בידו נטל להוציא ממנו על מקום אחר מזה ומזה עלה בידו ונמלך להוציא ממנו עליו כל הטבל עלה בידו</p></div>
+<div  id="ech0761i" class="indent1"><span class="nm">(i)</span><p><span class="cl"> Rebuttal:</span> When he took it in his hand to add to his earlier separation, we assume that he only took out Tevel. But if, when it was now in his hand, he instead decided to use it as Terumah for elsewhere, should we be concerned that he has both Tevel and Chulin in his hand? And when he took it to separate for elsewhere (and we are concerned that he has a mixture of Tevel and Chulin), but then he decided to use it for itself, should we now say that he only has Tevel in his hand?</p></div>
+<div  id="hch0761i1" class="indent2heb"><p>פיחת כל הטבל עלה בידו הוסיף מזה ומזה עלה בידו</p></div>
+<div  id="ech0761i1" class="indent2"><span class="nm">1.</span><p>  And if, when he separated the first time, he gave less than he usually gives and he then came a second time to complete his separation, we say that he took only the Tevel in his hand; but when he separated the second time and ultimately gave more than he usually gives, do we also say that he has Chulin in his hand?</p></div>
+<div  id="hch0761j" class="indent1heb"><p><span id="doss033b" class="oz">[דף לג עמוד ב (עוז והדר)]</span> אף בטועה כן היה סבור שהוא חייב שתי סאין ואינו חייב אלא אחת</p></div>
+<div  id="ech0761j" class="indent1"><span class="nm">(j)</span><p><span class="cl"> Question:</span> If he mistakenly thought that he needed to add another two Se'ah of Terumah but he only needed to add one, do we also say that since he intended the second Se'ah to also be Terumah, he would have taken from the Tevel and he can now use it for elsewhere?</p></div>
+<div  id="hch0761k" class="indent1heb"><p>ר' אימי בשם ריש לקיש אותה הסאה שהוא מוסיף עושה אותה תרומה על מקום אחר</p></div>
+<div  id="ech0761k" class="indent1"><span class="nm">(k)</span><p><span class="cl"> (R. Imi citing Reish Lakish):</span> That Se'ah could be used Terumah for elsewhere.</p></div>
+<div  id="hch0761l" class="indent1heb"><p>והתנינן אבל לא על מקום אחר</p></div>
+<div  id="ech0761l" class="indent1"><span class="nm">(l)</span><p><span class="cl"> Question:</span> But the Mishnah taught, 'but not for elsewhere'?</p></div>
+<div  id="hch0761m" class="indent1heb"><p>תיפתר במרבה בתרומה</p></div>
+<div  id="ech0761m" class="indent1"><span class="nm">(m)</span><p><span class="cl"> Answer:</span> That is referring to adding on more Terumah than he usually gives.</p></div>
+<div  id="hch0761n" class="indent1heb"><p>ניחא במרבה בתרומה ובמעשרות לא תני ר''ש בן לקיש מעשרות</p></div>
+<div  id="ech0761n" class="indent1"><span class="nm">(n)</span><p><span class="cl"> Question:</span> This is understandable for Terumah, but (one is not permitted to add extra) Maaser?! Doesn't Reish Lakish agree that Mishnah's text includes the case of Ma'asros?</p></div>
+<div  id="hch0761o" class="indent1heb"><p><span id="dvss019a" class="vl">[דף יט עמוד א]</span> אלא טעמא דר''ש בן לקיש מכיון דו אמר כל הטבל עלה בידו מה בין מוציא ממנו עליו מה בין מוציא ממנו למקום אחר</p></div>
+<div  id="ech0761o" class="indent1"><span class="nm">(o)</span><p> Rather, Reish Lakish reasons that when we say that only Tevel came to his hand, it makes no difference whether he separates from it for itself or for elsewhere.</p></div>
+<div  id="hch0761p" class="indent1heb"><p><span id="doss034a" class="oz">[דף לד עמוד א (עוז והדר)]</span> מיי כדון</p></div>
+<div  id="ech0761p" class="indent1"><span class="nm">(p)</span><p><span class="cl"> Question:</span> Then how do you explain the Mishnah's words 'but not for elsewhere'?</p></div>
+<div  id="hch0761q" class="indent1heb"><p>כשנתקן רובו של כרי</p></div>
+<div  id="ech0761q" class="indent1"><span class="nm">(q)</span><p><span class="cl"> Answer:</span> Originally he separated from most of the pile (which on a Torah level means that the minority of Tevel becomes annulled in the majority of Chulin). However, the Rabbis decreed that it is not annulled, but permitted separating from the same pile, but not for other produce that has a Torah obligation.</p></div>
+<div  id="hch0761r" class="indent1heb"><p>(לא נתקן רובו של כרי) פלוגתא דחזקיה ורבי יוחנן</p></div>
+<div  id="ech0761r" class="indent1"><span class="nm">(r)</span><p> There is a dispute between Chizkiyah and R. Yochanan...</p></div>
+<div  id="hch0761r1" class="indent2heb"><p>דאמר ריש לקיש בשם חזקיה טבל בטל ברוב</p></div>
+<div  id="ech0761r1" class="indent2"><span class="nm">1.</span><p><span class="cl"> (Reish Lakish citing Chizkiyah):</span> (On a Torah level) Tevel is annulled in the majority.</p></div>
+<div  id="hch0761r2" class="indent2heb"><p>ור' יוחנן אמר אין הטבל בטל ברוב מכיון שנתן דעתו להפריש נסתיימה כל חיטה וחיטה במקומה</p></div>
+<div  id="ech0761r2" class="indent2"><span class="nm">2.</span><p><span class="cl"> (R. Yochanan):</span> It's not annulled - since he could separate Terumah from the Tevel part to also make it Chulin, it is as if he is able to identify each wheat kernel of Tevel.</p></div>
+<div  id="hch0761s" class="indent1heb"><p>ואית דבעי מימר כהדא דתני רבי אליעזר בן יעקב דתני ראב''י אינו מוציא לא עליו ולא על מקום אחר</p></div>
+<div  id="ech0761s" class="indent1"><span class="nm">(s)</span><p> Some (wish to differentiate between when he separated for most of the pile and when he did it for less than half) by explaining like the teaching of R. Eliezer ben Yaakov (who disagreed with our Mishnah) - he said that if one partially separated Terumos and Ma'asros, he may not separate from it, whether for itself or for another pile. (We are concerned that when he takes some of the pile to separate for the rest or for elsewhere, he might take from produce that is already Chulin.)</p></div>
+<div  id="hch0761t" class="indent1heb"><p>עד כדון לא נתקן רובה של כרי נתקן רובה של כרי</p></div>
+<div  id="ech0761t" class="indent1"><span class="nm">(t)</span><p><span class="cl"> Question:</span> Perhaps R. Eliezer ben Yaakov was only discussing one who didn't yet separate for most of the pile (since on a Torah level he must still separate), but if he did (so the obligation is now only Rabbinic), perhaps he would not have said it...</p></div>
+<div  id="hch0761u" class="indent1heb"><p><span id="doss034b" class="oz">[דף לד עמוד ב (עוז והדר)]</span> וייבא כהדא היו לפניו ב' כריים א' הפריש ממנו מקצת תרומות ומעשרות וא' הפריש ממנו מקצת תרומות ומעשרות מהו שיתרום מזה על זה</p></div>
+<div  id="ech0761u" class="indent1"><span class="nm">(u)</span><p><span class="cl"> Answer:</span> Learn from this question - if a person had two piles in front of him and from each one he partially separated Terumos and Ma'asros, may he now separate from one for the other?</p></div>
+<div  id="hch0761v" class="indent1heb"><p>תלמידוי דרבי חייא רובא שאלון לר' חייא רובא אמר לון הכסיל חובק את ידיו ואוכל את בשרו</p></div>
+<div  id="ech0761v" class="indent1"><span class="nm">(v)</span><p> The students of R. Chiya asked him this question and he answered with the pasuk (Koheles 4:5), "The fool folds his arms and eats his flesh''.(He ruled like R. Eliezer ben Yaakov and he does not differentiate between having separated for the majority or the minority of the pile.)</p></div>
+<div  id="hch0761w" class="indent1heb"><p>ר' לעזר בשם ר' חייא רבה אין תורמין ולא מעשרין מזה על זה:</p></div>
+<div  id="ech0761w" class="indent1"><span class="nm">(w)</span><p><span class="cl"> (R. Elazar citing R. Chiya the Great):</span> It's only for the second pile that he may not separate from the first pile, but he may separate for it itself (as he follows the first Tana).</p></div>
+
+   </div> <!-- End #content -->
+<!--ftr86.1-->
+    <div class="navlinks">
+<!--nextdaf1-->
+        <div class="nextdaf">
+            <p><a href="ch-yr-077.htm"><img src="http://www.dafyomi.co.il/right.gif" alt="Next"></a></p>
+        </div>
+<!--nextdaf2-->
+  
+
+
+<div class="indexlink"><a href="https://dafyomi.co.il/section.php?gid=33&amp;sid=17">Yerushalmi Outlines for<br class="smallbreak"> Maseches Chulin</a></div>
+ 
+
+<div class="homepagelink"><a href="https://dafyomi.co.il/gemara.php?gid=33">Homepage for Maseches<br class="smallbreak"> Chulin</a></div>
+ 
+
+<!--FINDER-->     
+
+   <div class="dafhomelink"><a href="http://www.dafyomi.co.il/index.htm" target="_parent">
+            <img src="http://www.dafyomi.co.il/kih-logo-tiny.gif" alt="Dafyomi Advancement Forum homepage">
+            <br>D.A.F. Homepage</a>
+        </div>   
+    </div> <!-- End navlinks -->
+
+
+<!--HR3-->
+    <div class="horiz_rule"></div>
+
+    <div class="resources">
+
+            <h2>OTHER D.A.F. RESOURCES<br class="smallbreak"> ON THIS DAF</h2>
+
+        <ul>
+ <li><a href="../insites/ch-dt-076.htm">Insights to<br>the Daf</a></li>
+<li><a href="../backgrnd/ch-in-076.htm">Background<br>to the Daf</a></li>
+<li><a href="../review/ch-rg-076.htm">Review<br>Questions</a></li>
+<li><a href="../points/ch-ps-076.htm">Point by<br>Point</a></li>
+
+</ul>
+<ul>
+<li><a href="../halachah/ch-hl-076.htm">Halachah<br>Outlines</a></li>
+<li><a href="../tosfos/ch-ts-076.htm">Tosfos<br>Outlines</a></li>
+<!-- <li><a href="../agadah/ch-ag-076.htm">Agadah<br>Outlines</a></li> -->
+<li><a href="https://dafyomi.co.il/section.php?gid=33&amp;sid=5">English<br>Charts</a></li>
+<li><a href="../../memdb/revdaf.php?tid=31&amp;id=076">Revach<br>l'Daf</a></li>
+
+</ul>
+<ul>
+<li><a href="../quiz/ch-qz-076.htm">Review<br>Quiz</a></li>
+<li class="liheb"><a href="../hebcharts/ch-tl-076.htm">טבלאות<br>בעברית</a></li>
+<li class="liheb"><a href="https://dafyomi.co.il/chulin/yosefdas/chul-yd-076.pdf">יוסף<br>דעת</a></li>
+<li class="liheb"><a href="https://dafyomi.co.il/chulin/chidon/ch-cd-alla.htm?daf=076#d076">חידונים<br>על הדף</a></li>
+
+</ul>
+<ul>
+<li class="liheb"><a href="https://dafyomi.co.il/galei_link.php?gid=33&daf=076">גלי<br>מסכתא</a></li>
+<li><a href="https://dafyomi.co.il/discuss_daf.php?gid=33&amp;sid=20&daf=076&n=0">Discuss<br>the Daf</a></li>
+<li><a href="https://dafyomi.co.il/members/shiurim/?meseches=chulin">Video/Audio<br>Lectures</a></li>
+
+        </ul>
+    </div>  
+<!--HR4--> <!-- end .resources -->
+
+    <div class="horiz_rule"></div>
+    
+    <div id="footer">
+        <ul>
+            <li><a href="http://www.dafyomi.co.il/new_gemara_picker.php">Other Masechtos</a></li>
+            <li><a href="https://gem.godaddy.com/signups/92631be18f7a4611948240bd55782374/join">Join Mailing Lists</a></li>
+        </ul>
+        <ul>
+            <li><a href="http://www.dafyomi.co.il/askollel.htm">Ask the Kollel</a></li>
+            <li><a href="http://www.dafyomi.co.il/calendars/calendar.htm" target="_parent">Dafyomi Calendar</a></li>
+        </ul>
+        <ul>
+            <li><a href="http://www.dafyomi.co.il/index_heb.htm" class="chomerbivrit">חומר בעברית</a></li>
+            <li><a href="http://www.dafyomi.co.il/sponsors.htm">Donations</a></li>
+         </ul>
+        <ul>
+             <li><a href="http://www.dafyomi.co.il/fanmail.htm">Feedback</a></li>
+             <li><a href="http://www.dafyomi.co.il/central.htm">Dafyomi Links</a></li>
+        </ul>
+    </div> <!-- End #footer -->
+    
+</div>  <!-- End #wrapper -->
+</div>  
+</body>
+</html>
+
+
+
+<!--2026_06 missing the file content.html -->


### PR DESCRIPTION
The dafyomi `yerushalmi` content type was routed to the generic indented-entry parser, which **drops the Hebrew** (interleaved as `div.indentNheb`, which `levelOfClass` skips on a word boundary) and **ignores the per-point Yerushalmi ref** (`span.source`) — so the block came out empty everywhere in our cache.

These pages are **"Yerushalmi to Match \<Bavli daf\>"**: the parallel Yerushalmi material for each Bavli daf — an English **point-by-point outline** + paired **Hebrew** + an explicit **Yerushalmi ref** per point, often **cross-tractate** (Bavli Chullin → Yerushalmi Terumos). A dedicated `parse/yerushalmi.ts` pairs He/En and captures the ref (`perek:halachah` → a Sefaria `Jerusalem Talmud P:H` map; `tractate` set on the cross-tractate case). Adds `'yerushalmi'` to `DafyomiRef.kind`.

**Coverage (live, Berakhot): all 63 dapim have content; 148 outline points, every one with a Yerushalmi ref.** vs. the 5 curated Sefaria pairs Shas-wide.

Tests + fixtures for Berakhot 2 (self) and the cross-tractate Chullin 76 case.

Follow-ups (not in this PR, per plan): bump `keyForDafyomi` to re-warm the now-parseable yerushalmi blocks Shas-wide; surface this as the primary Bavli↔Yerushalmi parallel + digestible-outline source in the card.