### PR TITLE
Dev inspector: surface the source TEXTS a piece was generated from

### DIFF
--- a/src/client/InstanceInspectorShelf.tsx
+++ b/src/client/InstanceInspectorShelf.tsx
@@ -56,6 +56,11 @@ interface Props {
   prettyDepLabel: (depId: string) => string;
   renderBody: () => JSX.Element;
   onClose: () => void;
+  /** Source TEXTS that fed the current view's prompt, fetched on demand from
+   *  /api/run-sources (gemara / commentaries / mishna / halacha-refs /
+   *  yerushalmi-text / context). Null while loading; {} when the producer pulls
+   *  no source texts. */
+  sources: Record<string, { chars: number; content: string }> | null;
 }
 
 export default function InstanceInspectorShelf(props: Props) {
@@ -171,6 +176,30 @@ export default function InstanceInspectorShelf(props: Props) {
             <pre style={{ 'white-space': 'pre-wrap', 'font-family': 'ui-monospace, Menlo, monospace', 'font-size': '12px', margin: '0.4rem 0 0', background: '#f8f8f8', padding: '0.6rem', 'border-radius': '3px' }}>
               {JSON.stringify(anchors(), null, 2)}
             </pre>
+          </details>
+        )}</Show>
+
+        {/* source TEXTS fed into the prompt — the daf gemara, commentaries,
+            mishna, halacha refs, Yerushalmi, and aggregated external context
+            that grounded this generation. Fetched on demand (/api/run-sources)
+            so the reader hot path never carries them. Collapsed; each source
+            nested so a large context blob doesn't flood the drawer. The full
+            text went to the LLM; content here is a length-capped preview. */}
+        <Show when={props.sources && Object.keys(props.sources).length > 0 ? props.sources : null}>{(sources) => (
+          <details style={{ 'margin-bottom': '0.5rem' }}>
+            <summary style={{ color: '#666', cursor: 'pointer', 'font-size': '0.78rem' }}>
+              {`sources (texts) — ${Object.keys(sources()).join(', ')}`}
+            </summary>
+            <For each={Object.entries(sources())}>{([name, src]) => (
+              <details style={{ 'margin-top': '0.35rem' }}>
+                <summary style={{ color: '#777', cursor: 'pointer', 'font-size': '0.74rem' }}>
+                  {`${name} · ${src.chars.toLocaleString()} chars`}
+                </summary>
+                <pre style={{ 'white-space': 'pre-wrap', 'font-family': 'ui-monospace, Menlo, monospace', 'font-size': '12px', margin: '0.3rem 0 0', background: '#f8f8f8', padding: '0.6rem', 'border-radius': '3px', 'max-height': '40vh', 'overflow-y': 'auto' }}>
+                  {src.content}
+                </pre>
+              </details>
+            )}</For>
           </details>
         )}</Show>
 

--- a/src/client/MarkEnrichmentCards.tsx
+++ b/src/client/MarkEnrichmentCards.tsx
@@ -529,6 +529,42 @@ export default function MarkEnrichmentCards(props: Props) {
     );
   });
 
+  // Source TEXTS that fed the inspector's current view (gemara / commentaries /
+  // mishna / halacha-refs / yerushalmi-text / aggregated context). Fetched on
+  // demand from the read-only /api/run-sources companion — deliberately NOT a
+  // field on the cached RunResult, since the texts are KB-scale and only the dev
+  // inspector wants them (every reader's card fetch would otherwise carry them).
+  // Re-fetches when the focal view changes; null while loading or closed.
+  const [inspectorSources, setInspectorSources] =
+    createSignal<Record<string, { chars: number; content: string }> | null>(null);
+  createEffect(() => {
+    if (!(devModeActive() && isInspectorOpen())) { setInspectorSources(null); return; }
+    const view = currentView();
+    if (!view) { setInspectorSources(null); return; }
+    const curLang = lang();
+    const inst = props.instance;
+    const tractate = props.tractate;
+    const page = props.page;
+    setInspectorSources(null); // show "loading" on a view switch
+    const controller = new AbortController();
+    onCleanup(() => controller.abort());
+    void fetch('/api/run-sources', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ enrichment_id: view.id, tractate, page, mark_input: inst, lang: curLang }),
+      signal: controller.signal,
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((j) => {
+        if (controller.signal.aborted) return;
+        const sources = j && typeof j === 'object' && 'sources' in j
+          ? (j as { sources: Record<string, { chars: number; content: string }> }).sources
+          : {};
+        setInspectorSources(sources);
+      })
+      .catch(() => { /* inspector just shows no sources */ });
+  });
+
   // Dependencies that fed the current view. For a synthesis-style aggregate
   // the deps are the leaves it consumed (taken from deps_resolved on the
   // run); for a leaf with no upstream deps we surface its own id so the
@@ -751,6 +787,7 @@ export default function MarkEnrichmentCards(props: Props) {
             prettyDepLabel={(depId) => prettyDepLabel(depId, props.markId)}
             renderBody={renderInspectorBody}
             onClose={closeInspector}
+            sources={inspectorSources()}
           />
         </Portal>
       </Show>

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1455,6 +1455,29 @@ interface ResolvedInputs {
   depends: Record<string, unknown>;
   /** Mark instance lists keyed by dep id (returned as anchors_resolved). */
   anchors: Record<string, unknown>;
+  /** Raw source TEXTS fed into the prompt, keyed by source name (gemara,
+   *  commentaries, mishna, halacha-refs, yerushalmi-text, context). Surfaced by
+   *  the read-only /api/run-sources endpoint so the dev inspector shows not just
+   *  which enrichments/marks fed a piece but which TEXTS did — kept OFF the
+   *  cached RunResult so it never bloats the reader hot path. `chars` is the full
+   *  length; `content` is a bounded preview (the full text already went to the
+   *  LLM; only the inspector needs to eyeball it). */
+  sources: Record<string, { chars: number; content: string }>;
+}
+
+/** Bounded preview cap for a source text returned by /api/run-sources — same
+ *  posture as the 2KB resolved-prompt cap, but roomier since a dev may want to
+ *  scan the actual gemara/context that grounded a generation. Keeps a single
+ *  inspector response from shipping the full multi-KB context blob per source. */
+const SOURCE_PREVIEW_CAP = 8000;
+function recordSource(out: ResolvedInputs, name: string, content: unknown): void {
+  if (typeof content !== 'string' || content.length === 0) return;
+  out.sources[name] = {
+    chars: content.length,
+    content: content.length > SOURCE_PREVIEW_CAP
+      ? content.slice(0, SOURCE_PREVIEW_CAP) + `… [+${content.length - SOURCE_PREVIEW_CAP} chars]`
+      : content,
+  };
 }
 
 async function resolveDependencies(
@@ -1465,14 +1488,21 @@ async function resolveDependencies(
   markInput: unknown,
   bypassCache: boolean,
   parentChain: ReadonlySet<string>,
+  /** When true, resolve ONLY the deterministic source-text deps (gemara /
+   *  commentaries / mishna / halacha-refs / yerushalmi-text / context — all
+   *  cached KV reads, no LLM) and skip the `{enrichment}` / `{mark}` deps that
+   *  would trigger generation. Used by the read-only /api/run-sources inspector
+   *  endpoint so opening the dev inspector never re-runs a model. */
+  sourcesOnly = false,
 ): Promise<ResolvedInputs> {
-  const out: ResolvedInputs = { vars: {}, depends: {}, anchors: {} };
+  const out: ResolvedInputs = { vars: {}, depends: {}, anchors: {}, sources: {} };
   if (!dependencies || dependencies.length === 0) {
     // Default behavior: when no dependencies declared, hand the gemara slice
     // through (matches pre-refactor buildDafContext behavior). Removes a
     // foot-gun when porting old extractors that omitted the field.
     const slice = await getGemaraSlice(rc.env, tractate, page, bypassCache);
     Object.assign(out.vars, gemaraSliceToVars(slice));
+    recordSource(out, 'gemara', out.vars.gemara);
     return out;
   }
   // Resolve all dependencies CONCURRENTLY. They're independent (each writes a
@@ -1484,17 +1514,20 @@ async function resolveDependencies(
     if (dep === 'gemara') {
       const slice = await getGemaraSlice(rc.env, tractate, page, bypassCache);
       Object.assign(out.vars, gemaraSliceToVars(slice));
+      recordSource(out, 'gemara', out.vars.gemara);
       return;
     }
     if (dep === 'commentaries') {
       const slice = await getCommentariesSlice(rc.env, tractate, page, bypassCache);
       out.vars.commentaries = commentariesSliceToString(slice);
+      recordSource(out, 'commentaries', out.vars.commentaries);
       return;
     }
     if (dep === 'mishna') {
       const bundle = await getMishnaBundleCached(rc.env.CACHE, tractate, page);
       const filtered = selectMishnaForMark(bundle, markInput);
       out.vars.mishna = mishnaBundleToString(filtered);
+      recordSource(out, 'mishna', out.vars.mishna);
       return;
     }
     if (dep === 'halacha-refs') {
@@ -1503,6 +1536,7 @@ async function resolveDependencies(
       // enrichment SELECTS from real refs instead of recalling citations.
       const bundle = await getHalachaRefsCached(rc.env.CACHE, tractate, page);
       out.vars.halacha_refs = formatGroundedRefsForPrompt(bundle);
+      recordSource(out, 'halacha-refs', out.vars.halacha_refs);
       return;
     }
     if (dep === 'yerushalmi-text') {
@@ -1519,6 +1553,7 @@ async function resolveDependencies(
       ]);
       const notes = daf ? fromDafyomi(daf).filter((i) => i.source === 'dafyomi:yerushalmi') : [];
       out.vars.yerushalmi = formatYerushalmiForPrompt(bundle, curated, notes);
+      recordSource(out, 'yerushalmi-text', out.vars.yerushalmi);
       return;
     }
     if (dep === 'context') {
@@ -1539,13 +1574,20 @@ async function resolveDependencies(
         }));
       const items = await collectContext(rc.env, tractate, page, { sections });
       // Back up the deterministic Revach placer with the cached AI matcher for
-      // any entries it left whole-daf (once per daf; LLM-free on cache hit).
-      await placeRevachWithAi(rc.env, tractate, page, items);
+      // any entries it left whole-daf (once per daf; LLM-free on cache hit). In
+      // the source-only inspector pass, run it cache-only so the preview still
+      // reflects already-cached placements but NEVER triggers the matcher on a
+      // cold daf.
+      await placeRevachWithAi(rc.env, tractate, page, items, sourcesOnly);
       const scoped = contextForAnchor(items, segsFromMarkInput(markInput));
       out.vars.context = formatContextForPrompt(scoped);
+      recordSource(out, 'context', out.vars.context);
       return;
     }
     if (typeof dep === 'object' && dep !== null) {
+      // Inspector source-only pass: skip enrichment/mark deps (they'd trigger
+      // generation); we only want the source TEXTS this producer pulls.
+      if (sourcesOnly) return;
       if ('enrichment' in dep) {
         const depId = dep.enrichment;
         if (parentChain.has(depId)) {
@@ -2851,6 +2893,51 @@ app.post('/api/run', async (c) => {
     : await cacheKeyForRunBody(c.env, job);
   await c.env.ENRICHMENT_QUEUE.send(job);
   return c.json({ status: 'pending', runId: job.runId, cacheKey: cacheKey ?? undefined }, 202);
+});
+
+/**
+ * POST /api/run-sources — read-only companion to /api/run for the dev inspector.
+ * Given a mark/enrichment + daf (+ optional mark_input), resolves ONLY the
+ * source TEXTS that producer feeds into its prompt (gemara / commentaries /
+ * mishna / halacha-refs / yerushalmi-text / aggregated context) and returns them
+ * as `{ sources: { <name>: { chars, content } } }`.
+ *
+ * Deliberately a separate endpoint, NOT a field on the cached RunResult: the
+ * source texts are large (KB-scale each) and would bloat every reader's card
+ * fetch + KV entry for a dev-only view. Here they're computed on demand from the
+ * source slices: NO LLM (the `{enrichment}`/`{mark}` deps are skipped and the
+ * Revach AI matcher runs cache-only) and NO enrichment-result is written. It
+ * does the same deterministic source reads a normal page read does — so a cold
+ * daf populates the shared source-slice cache (gemara/commentary/etc.) on a
+ * miss, exactly as the already-public /api/run would; this is a strict subset of
+ * that endpoint's surface (no model, no studio knobs), so it needs no extra auth.
+ */
+app.post('/api/run-sources', async (c) => {
+  let raw: unknown;
+  try { raw = await c.req.json(); }
+  catch { return c.json({ error: 'invalid JSON' }, 400); }
+  const body = raw as { mark_id?: string; enrichment_id?: string; tractate?: string; page?: string; mark_input?: unknown; lang?: string };
+  if (!body.tractate || !body.page) return c.json({ error: 'tractate and page required' }, 400);
+  if (!body.mark_id && !body.enrichment_id) return c.json({ error: 'mark_id or enrichment_id required' }, 400);
+
+  const def = body.enrichment_id
+    ? await loadEnrichmentDef(c.env, body.enrichment_id)
+    : await loadMarkDef(c.env, body.mark_id!);
+  if (!def) {
+    const what = body.enrichment_id ? `enrichment ${body.enrichment_id}` : `mark ${body.mark_id}`;
+    return c.json({ error: `${what} not found` }, 404);
+  }
+
+  const rc: RunCtx = {
+    env: c.env,
+    url: c.req.url,
+    ctx: c.executionCtx,
+    lang: body.lang === 'he' ? 'he' : 'en',
+  };
+  const inputs = await resolveDependencies(
+    rc, def.dependencies, body.tractate, body.page, body.mark_input, false, new Set(), true,
+  );
+  return c.json({ sources: inputs.sources });
 });
 
 /**

--- a/src/worker/revach-ai-place.ts
+++ b/src/worker/revach-ai-place.ts
@@ -61,6 +61,7 @@ async function getOrCompute(
   tractate: string,
   page: string,
   all: ContextItem[],
+  cacheOnly = false,
 ): Promise<SegMatch[] | null> {
   const cache = env.CACHE;
   const cacheKey = KEY(tractate, page);
@@ -70,6 +71,8 @@ async function getOrCompute(
       if (raw) return JSON.parse(raw) as SegMatch[];
     } catch { /* missing / corrupt → recompute */ }
   }
+  // Inspector source-preview pass: never trigger the LLM matcher on a miss.
+  if (cacheOnly) return null;
   const existing = inflight.get(cacheKey);
   if (existing) return existing;
 
@@ -95,10 +98,15 @@ export async function placeRevachWithAi(
   tractate: string,
   page: string,
   items: ContextItem[],
+  /** When true, apply ONLY already-cached AI placements and never compute fresh
+   *  matches (no LLM). Used by the read-only /api/run-sources inspector pass so a
+   *  preview reflects the real prompt's cached placements without triggering the
+   *  matcher on a cold daf. */
+  cacheOnly = false,
 ): Promise<void> {
   const all = revachItems(items);
   if (all.length === 0) return;
   if (!all.some((i) => i.segs.length === 0)) return; // nothing to fill
-  const matches = await getOrCompute(env, tractate, page, all);
+  const matches = await getOrCompute(env, tractate, page, all, cacheOnly);
   if (matches) applyAiToUnplaced(items, matches);
 }


### PR DESCRIPTION
## What

In dev mode, clicking the **i** on a sidebar card showed which *enrichments/marks* fed a generation (`deps_resolved` / `anchors_resolved`) but **not the source texts** — the daf gemara, commentaries, mishna, halacha refs, Yerushalmi, and aggregated external context that actually grounded the prompt. This adds a **"sources (texts)"** section to the inspector so you can see *everything* that went into generating a given piece, each source collapsed with its full char count and a length-capped preview.

## How

Source texts are KB-scale, so they are **not** added to the cached `RunResult` — that would bloat every reader's card fetch and KV entry for a dev-only view. Instead:

- `resolveDependencies` records each source it pulls into a new `ResolvedInputs.sources` map (`{ chars, content }`, content capped at 8KB).
- A read-only **`POST /api/run-sources`** companion resolves *only* the source deps on demand:
  - skips the `{enrichment}` / `{mark}` deps (no generation),
  - runs the Revach AI matcher **cache-only** (never triggers the LLM matcher on a cold daf),
  
  so it runs no model and writes no enrichment result — a strict subset of the already-public `/api/run` surface (no extra auth needed).
- Client: `MarkEnrichmentCards` fetches sources from the endpoint when the inspector opens (re-fetching per focal view) and passes them to `InstanceInspectorShelf`, which renders them.

## Notes

- The `context` preview matches the real prompt: it applies already-cached Revach placements (cache-only), so it neither diverges from what the model saw nor risks a fresh LLM call.
- Reviewed twice with `codex exec --sandbox read-only`; both findings (hot-path/KV bloat, then preview fidelity + endpoint contract wording) addressed.
- `pnpm typecheck`, `pnpm test` (1754 passing), and `pnpm build` all green.

Not yet verified live in a running browser — happy to do that next.