### PR TITLE
Yerushalmi: align the dafyomi outline to Bavli segments + surface in the card

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -1943,13 +1943,34 @@ function YerushalmiDiff(props: SpecialBlockProps): JSX.Element {
 
 interface YerushalmiPassage { ref: string; heRef: string; hebrew: string; english: string; }
 interface YerushalmiCurated { ref: string; title: string; summary: string; url: string; bavliAnchor: string; hebrew: string; english: string; }
-interface YerushalmiData { parallels: YerushalmiPassage[]; curated: YerushalmiCurated[]; }
+interface YerushalmiOutlinePoint {
+  topic: string; yerushalmiRef?: string; refRaw?: string;
+  marker?: string; label?: string; he: string; en: string;
+  segIdx?: number; excerpt?: string; score?: number;
+}
+interface YerushalmiData { parallels: YerushalmiPassage[]; curated: YerushalmiCurated[]; outline: YerushalmiOutlinePoint[]; }
 async function fetchYerushalmiData(key: string): Promise<YerushalmiData> {
   const [tractate, page] = key.split('|');
   const res = await fetch(`/api/yerushalmi/${encodeURIComponent(tractate)}/${encodeURIComponent(page)}`);
-  if (!res.ok) return { parallels: [], curated: [] };
-  const data = await res.json() as { parallels?: YerushalmiPassage[]; curated?: YerushalmiCurated[] };
-  return { parallels: Array.isArray(data.parallels) ? data.parallels : [], curated: Array.isArray(data.curated) ? data.curated : [] };
+  if (!res.ok) return { parallels: [], curated: [], outline: [] };
+  const data = await res.json() as { parallels?: YerushalmiPassage[]; curated?: YerushalmiCurated[]; outline?: YerushalmiOutlinePoint[] };
+  return {
+    parallels: Array.isArray(data.parallels) ? data.parallels : [],
+    curated: Array.isArray(data.curated) ? data.curated : [],
+    outline: Array.isArray(data.outline) ? data.outline : [],
+  };
+}
+
+/** Group the flat aligned outline into topic sections (consecutive points share
+ *  a topic + Yerushalmi ref). The Sefaria deep-link comes from the first point. */
+function groupYerushalmiOutline(points: YerushalmiOutlinePoint[]): Array<{ topic: string; ref?: string; points: YerushalmiOutlinePoint[] }> {
+  const groups: Array<{ topic: string; ref?: string; points: YerushalmiOutlinePoint[] }> = [];
+  for (const p of points) {
+    const last = groups[groups.length - 1];
+    if (last && last.topic === p.topic) last.points.push(p);
+    else groups.push({ topic: p.topic, ref: p.yerushalmiRef, points: [p] });
+  }
+  return groups;
 }
 
 /** The actual Jerusalem Talmud passage(s) for this daf — He + En, from the daf's
@@ -1964,8 +1985,43 @@ function YerushalmiParallel(props: SpecialBlockProps): JSX.Element {
   const passage = (): YerushalmiPassage | undefined =>
     (data()?.parallels ?? []).find((p) => p.ref === wantedRef());
   const curated = (): YerushalmiCurated[] => data()?.curated ?? [];
+  const outlineGroups = () => groupYerushalmiOutline(data()?.outline ?? []);
   return (
     <>
+      {/* The dafyomi "Yerushalmi to Match" outline — the digestible parallel.
+          Each point is tagged with the Bavli segment it parallels (§N) so the
+          reader sees WHICH PART has a parallel; unanchored points are the
+          divergent Yerushalmi gemara. */}
+      <Show when={outlineGroups().length > 0}>
+        <SectionCard label="yerushalmi.outline">
+          <For each={outlineGroups()}>{(g) => (
+            <div style={{ 'margin-bottom': '0.7rem' }}>
+              <div style={{ display: 'flex', 'align-items': 'baseline', gap: '0.4rem', 'flex-wrap': 'wrap', 'margin-bottom': '0.25rem' }}>
+                <span style={{ 'font-weight': 600, color: ACCENTS.yerushalmi, 'font-size': '0.84rem' }}>{g.topic}</span>
+                <Show when={g.ref}>
+                  <a href={`https://www.sefaria.org/${encodeURIComponent(g.ref!.replace(/ /g, '_'))}`} target="_blank" rel="noopener"
+                     style={{ 'font-size': '0.68rem', color: '#888', 'text-decoration': 'none' }}>{g.ref} ↗</a>
+                </Show>
+              </div>
+              <For each={g.points}>{(p) => (
+                <Show when={p.en}>
+                  <div style={{ display: 'flex', gap: '0.4rem', 'margin-bottom': '0.2rem', 'align-items': 'baseline' }}>
+                    <Show when={p.segIdx != null} fallback={<span style={{ width: '1.6rem', 'flex-shrink': 0 }} />}>
+                      <span title={p.excerpt} style={{
+                        'flex-shrink': 0, 'font-size': '0.6rem', 'font-weight': 600, padding: '0.05rem 0.3rem',
+                        background: 'rgba(15,118,110,.12)', color: ACCENTS.yerushalmi, 'border-radius': '3px', 'white-space': 'nowrap',
+                      }}>§{(p.segIdx ?? 0) + 1}</span>
+                    </Show>
+                    <span style={{ 'font-size': '0.82rem', color: '#333', 'line-height': 1.5 }}>
+                      <Show when={p.label}><b style={{ color: '#555' }}>{p.label} </b></Show>{p.en}
+                    </span>
+                  </div>
+                </Show>
+              )}</For>
+            </div>
+          )}</For>
+        </SectionCard>
+      </Show>
       <Show when={data.loading || passage()}>
         <SectionCard label="yerushalmi.readParallel" collapsed={true}>
           <Show when={passage()} fallback={

--- a/src/client/i18n.ts
+++ b/src/client/i18n.ts
@@ -578,6 +578,7 @@ const CATALOG = {
   'yerushalmi.differences': { en: 'Differences from the Yerushalmi', he: 'הבדלים מן הירושלמי' },
   'yerushalmi.readParallel': { en: 'Read the parallel (Yerushalmi)', he: 'קרא את המקבילה (ירושלמי)' },
   'yerushalmi.curatedParallel': { en: 'Curated parallel (Sefaria)', he: 'מקבילה נבחרת (ספריא)' },
+  'yerushalmi.outline': { en: 'Yerushalmi parallel (§ = aligned Bavli segment)', he: 'מקבילה בירושלמי (§ = קטע בבלי מקביל)' },
 
   // — Aggadata body —
   'aggadata.background': { en: 'Background', he: 'רקע' },

--- a/src/lib/yerushalmiAlign.ts
+++ b/src/lib/yerushalmiAlign.ts
@@ -1,0 +1,146 @@
+/**
+ * Align dafyomi.co.il "Yerushalmi to Match" outline points to the Bavli daf's
+ * actual segments — i.e. identify WHICH PART of the Bavli has a Yerushalmi
+ * parallel, deterministically.
+ *
+ * The outline points carry the YERUSHALMI text, not the Bavli text, so we can't
+ * match them directly. But the genuinely-parallel material is the shared layer —
+ * the Mishnah (verbatim in both), quoted baraitot, biblical citations — so a
+ * point that shares a long verbatim phrase with a Bavli segment is anchored to
+ * it; points whose Yerushalmi text diverges (the gemara discussion) stay
+ * unanchored. Precision over recall: a wrong anchor is worse than none.
+ *
+ * The matcher is the n-gram / longest-common-run local alignment the research
+ * recommended, run point↔segment over normalized Hebrew (nikud/punct stripped).
+ */
+import { normalizeHebrew, buildVerbatimGrid } from './place/verbatim.ts';
+import type { DafyomiEntry, DafyomiRef } from './sefref/dafyomi/schema.ts';
+
+/** Minimum shared contiguous normalized-word run to assert a parallel anchor. */
+export const MIN_SHARED_RUN = 3;
+
+export interface YerushalmiOutlinePoint {
+  /** The parent point's English topic heading. */
+  topic: string;
+  /** Sefaria ref of the parallel ("Jerusalem Talmud Berakhot 1:1") when the
+   *  dafyomi ref resolves to a perek:halachah; else undefined. */
+  yerushalmiRef?: string;
+  /** Raw dafyomi citation ("Yerushalmi Perek 1 Halachah 1 Daf 1a"). */
+  refRaw?: string;
+  marker?: string;
+  label?: string;
+  he: string;
+  en: string;
+  /** Bavli segment this point parallels (verbatim shared phrase), if any. */
+  segIdx?: number;
+  /** The shared verbatim Bavli phrase (for highlighting), original spelling. */
+  excerpt?: string;
+  /** Shared-run length in normalized words (confidence). */
+  score?: number;
+}
+
+// dafyomi (Ashkenazi) -> Sefaria Yerushalmi tractate spelling, for the
+// cross-tractate refs (e.g. Bavli Chullin -> Yerushalmi Terumot). Same-tractate
+// refs use the daf's own masechet, which already matches Sefaria.
+const YERU_TRACTATE_ALIAS: Record<string, string> = {
+  Terumos: 'Terumot', Maasros: 'Maasrot', "Maaser": 'Maaser Sheni', Sheviis: 'Sheviit',
+  Bikurim: 'Bikkurim', Challah: 'Challah', Orlah: 'Orlah', Demai: 'Demai', Peah: 'Peah',
+  Shabbos: 'Shabbat', Beitzah: 'Beitzah', Pesachim: 'Pesachim',
+};
+
+/** Build the Sefaria "Jerusalem Talmud <Tractate> <perek>:<halachah>" ref from a
+ *  dafyomi yerushalmi DafyomiRef, defaulting the tractate to the daf's masechet. */
+export function yerushalmiRefToSefaria(ref: DafyomiRef, dafMasechet: string): string | undefined {
+  const detail = ref.detail ?? '';
+  if (!/^\d+:\d+$/.test(detail)) return undefined; // need perek:halachah
+  const raw = ref.tractate ?? dafMasechet;
+  const tractate = YERU_TRACTATE_ALIAS[raw] ?? raw;
+  return `Jerusalem Talmud ${tractate} ${detail}`;
+}
+
+function firstYerushalmiRef(refs?: DafyomiRef[]): DafyomiRef | undefined {
+  return (refs ?? []).find((r) => r.kind === 'yerushalmi');
+}
+
+/**
+ * Flatten the parsed yerushalmi block into leaf outline points, carrying each
+ * point's nearest ancestor topic + Yerushalmi ref. A "leaf" is any entry with
+ * Hebrew body text (the granular Yerushalmi unit).
+ */
+export function flattenYerushalmiOutline(entries: DafyomiEntry[], dafMasechet: string): YerushalmiOutlinePoint[] {
+  const out: YerushalmiOutlinePoint[] = [];
+  const walk = (e: DafyomiEntry, topic: string, ref: DafyomiRef | undefined) => {
+    // A top-level subject sets the topic + ref for everything beneath it.
+    const ownRef = firstYerushalmiRef(e.refs);
+    const curRef = ownRef ?? ref;
+    const curTopic = e.title?.en || topic;
+    const he = e.body?.he?.trim();
+    const en = e.body?.en?.trim();
+    if (he) {
+      out.push({
+        topic: curTopic,
+        refRaw: curRef?.raw,
+        yerushalmiRef: curRef ? yerushalmiRefToSefaria(curRef, dafMasechet) : undefined,
+        marker: e.marker,
+        label: e.label,
+        he,
+        en: en ?? '',
+      });
+    }
+    for (const c of e.children ?? []) walk(c, curTopic, curRef);
+  };
+  for (const e of entries) walk(e, '', undefined);
+  return out;
+}
+
+/** Longest common contiguous run of equal tokens between a and b.
+ *  Returns its length and the start index in b (the Bavli segment). */
+function longestCommonRun(a: string[], b: string[]): { len: number; bStart: number } {
+  let best = 0;
+  let bStart = -1;
+  // rolling DP over b for each position in a: prev[j] = run ending at a[i-1], b[j-1]
+  let prev = new Array<number>(b.length + 1).fill(0);
+  for (let i = 1; i <= a.length; i++) {
+    const cur = new Array<number>(b.length + 1).fill(0);
+    for (let j = 1; j <= b.length; j++) {
+      if (a[i - 1] === b[j - 1]) {
+        cur[j] = prev[j - 1] + 1;
+        if (cur[j] > best) { best = cur[j]; bStart = j - cur[j]; }
+      }
+    }
+    prev = cur;
+  }
+  return { len: best, bStart };
+}
+
+/**
+ * Anchor each outline point to the Bavli segment that shares the longest
+ * verbatim phrase with it (>= MIN_SHARED_RUN normalized words). Mutates +
+ * returns the points with segIdx / excerpt / score filled where a parallel is
+ * found; leaves the rest unanchored.
+ */
+export function alignOutlineToSegments(
+  points: YerushalmiOutlinePoint[],
+  segmentsHe: string[],
+): YerushalmiOutlinePoint[] {
+  const grid = buildVerbatimGrid(segmentsHe);
+  // Original (whitespace-split) words per segment, to recover a readable excerpt.
+  const segOrigWords = segmentsHe.map((s) => normalizeHebrew(s).length ? s.split(/\s+/).filter(Boolean) : []);
+  for (const p of points) {
+    const pWords = normalizeHebrew(p.he).split(' ').filter(Boolean);
+    if (pWords.length < MIN_SHARED_RUN) continue;
+    let bestSeg = -1, bestLen = 0, bestStart = -1;
+    for (let s = 0; s < grid.segWords.length; s++) {
+      const { len, bStart } = longestCommonRun(pWords, grid.segWords[s]);
+      if (len > bestLen) { bestLen = len; bestSeg = s; bestStart = bStart; }
+    }
+    if (bestLen >= MIN_SHARED_RUN && bestSeg >= 0) {
+      p.segIdx = bestSeg;
+      p.score = bestLen;
+      const orig = segOrigWords[bestSeg];
+      // normalized split ≈ original whitespace split; take the matched window.
+      p.excerpt = orig.slice(bestStart, bestStart + bestLen).join(' ') || undefined;
+    }
+  }
+  return points;
+}

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -11,6 +11,7 @@ import { getDafyomiMasechet } from '../lib/sefref/dafyomi/masechtos';
 import { collectContext } from './context-providers';
 import { fromDafyomi } from '../lib/context/fromDafyomi';
 import { curatedParallelsForDaf, type CuratedYerushalmiParallel } from '../lib/yerushalmiParallels';
+import { flattenYerushalmiOutline, alignOutlineToSegments } from '../lib/yerushalmiAlign';
 import { placeRevachWithAi } from './revach-ai-place';
 import { formatContextForPrompt, contextForAnchor, segsFromMarkInput } from '../lib/context/select';
 import { continuationLink, type FlowEdge } from '../lib/context/link';
@@ -6930,12 +6931,29 @@ app.post('/api/admin/translate-bio', async (c) => {
 // getYerushalmiCached). The reader's Yerushalmi card uses it to show the actual
 // parallel text under the differences. He/En are stripped of Sefaria's footnote
 // markup so the prose reads clean.
+/** The dafyomi "Yerushalmi to Match" outline for a daf, aligned to the Bavli
+ *  segments: each point tagged with the Bavli `segIdx` it parallels (the shared
+ *  Mishnah / baraita layer; divergent gemara points stay unanchored). Empty
+ *  until the daf's dafyomi content has been (re)warmed with the yerushalmi
+ *  parser (GET /api/dafyomi/:t/:p?refresh=1). */
+async function buildYerushalmiOutline(env: Bindings, tractate: string, page: string) {
+  const [daf, slice] = await Promise.all([
+    getDafyomiContentCached(env.CACHE, env.ASSETS, tractate, page, {}).catch(() => null),
+    getGemaraSlice(env, tractate, page, false),
+  ]);
+  const block = daf?.amudim?.a?.yerushalmi?.body ?? daf?.amudim?.b?.yerushalmi?.body;
+  if (!block || block.type !== 'yerushalmi') return [];
+  const points = flattenYerushalmiOutline(block.entries, tractate);
+  return alignOutlineToSegments(points, slice.segments_he);
+}
+
 app.get('/api/yerushalmi/:tractate/:page', async (c) => {
   const tractate = c.req.param('tractate');
   const page = c.req.param('page');
-  const [bundle, curated] = await Promise.all([
+  const [bundle, curated, outline] = await Promise.all([
     getYerushalmiCached(c.env.CACHE, tractate, page),
     fetchCuratedYerushalmi(curatedParallelsForDaf(tractate, page)),
+    buildYerushalmiOutline(c.env, tractate, page),
   ]);
   return c.json({
     parallels: bundle.map((y) => ({
@@ -6948,6 +6966,9 @@ app.get('/api/yerushalmi/:tractate/:page', async (c) => {
     // hand-made cross-references (Sefaria "Shared Stories"), with the real
     // Yerushalmi text + an editorial summary. Often cross-tractate.
     curated,
+    // dafyomi.co.il "Yerushalmi to Match" outline — the digestible parallel,
+    // each point aligned to the Bavli segment it parallels.
+    outline,
   });
 });
 

--- a/tests/yerushalmi-align.test.ts
+++ b/tests/yerushalmi-align.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { parseDafyomiContent } from '../src/lib/sefref/dafyomi/parse/index';
+import {
+  flattenYerushalmiOutline, alignOutlineToSegments, yerushalmiRefToSefaria,
+  type YerushalmiOutlinePoint,
+} from '../src/lib/yerushalmiAlign';
+
+const fixture = (name: string) =>
+  readFileSync(new URL(`./fixtures/dafyomi/${name}`, import.meta.url), 'utf-8');
+
+describe('yerushalmiRefToSefaria', () => {
+  it('builds a same-tractate Sefaria ref from perek:halachah', () => {
+    expect(yerushalmiRefToSefaria({ raw: 'Yerushalmi Perek 1 Halachah 1 Daf 1a', kind: 'yerushalmi', detail: '1:1' }, 'Berakhot'))
+      .toBe('Jerusalem Talmud Berakhot 1:1');
+  });
+  it('maps a cross-tractate ref to its Sefaria spelling', () => {
+    expect(yerushalmiRefToSefaria({ raw: 'Yerushalmi Terumos ...', kind: 'yerushalmi', tractate: 'Terumos', detail: '4:1' }, 'Chullin'))
+      .toBe('Jerusalem Talmud Terumot 4:1');
+  });
+  it('returns undefined without a perek:halachah', () => {
+    expect(yerushalmiRefToSefaria({ raw: 'x', kind: 'yerushalmi', detail: 'Halachah 7' }, 'Bava Metzia')).toBeUndefined();
+  });
+});
+
+describe('flatten + align Yerushalmi outline to Bavli segments', () => {
+  const body = parseDafyomiContent('yerushalmi', fixture('berachos-yerushalmi-002.htm')).blocks[0].body;
+  if (body.type !== 'yerushalmi') throw new Error('wrong body type');
+  const points = flattenYerushalmiOutline(body.entries, 'Berakhot');
+
+  it('flattens to leaf points carrying topic + Sefaria ref', () => {
+    expect(points.length).toBeGreaterThan(5);
+    expect(points.every((p) => p.he.length > 0)).toBe(true);
+    expect(points[0].yerushalmiRef).toBe('Jerusalem Talmud Berakhot 1:1');
+    expect(points[0].topic).toBe("THE TIME FOR KERI'AS SHMA AT NIGHT");
+  });
+
+  it('anchors a point whose Yerushalmi text is verbatim-shared with a Bavli segment', () => {
+    // seg 0 = the mishnah (shared), seg 1 = a divergent gemara line.
+    const segs = [
+      'מאימתי קורין את שמע בערבין משעה שהכהנים נכנסין לאכול בתרומתן עד סוף האשמורה הראשונה',
+      'תנא היכא קאי דקתני מאימתי וכו׳ והיכא קתני דאיירי בקריאת שמע',
+    ];
+    const copy: YerushalmiOutlinePoint[] = points.map((p) => ({ ...p }));
+    alignOutlineToSegments(copy, segs);
+    const mishnahPoint = copy.find((p) => /מאימתי קורין/.test(p.he));
+    expect(mishnahPoint?.segIdx).toBe(0);
+    expect((mishnahPoint?.score ?? 0)).toBeGreaterThanOrEqual(3);
+    expect(mishnahPoint?.excerpt).toContain('מאימתי');
+  });
+
+  it('leaves a point with no shared verbatim phrase unanchored (precision over recall)', () => {
+    const segs = ['טקסט בבלי שאין לו שום קשר מילולי לטקסט הירושלמי הזה כלל ועיקר'];
+    const copy: YerushalmiOutlinePoint[] = points.map((p) => ({ ...p }));
+    alignOutlineToSegments(copy, segs);
+    expect(copy.every((p) => p.segIdx === undefined)).toBe(true);
+  });
+});


### PR DESCRIPTION
Aligns the dafyomi 'Yerushalmi to Match' outline (#220) to the **actual Bavli segments** and surfaces it as the primary digestible parallel.

- **`src/lib/yerushalmiAlign.ts`**: flatten the parsed yerushalmi block into leaf points (topic + ref → Sefaria `Jerusalem Talmud P:H`), then anchor each point to the Bavli segment sharing the longest verbatim phrase (normalized longest-common-run ≥ 3 words). The shared **Mishnah/baraita** layer anchors; the **divergent Yerushalmi gemara stays unanchored** (precision > recall). On Berakhot 2: mishnah points → segs 0-4; R. Chiya/R. Yosi gemara → unanchored. Tested.
- **`/api/yerushalmi/:t/:p`** returns the aligned `outline` (points with `segIdx` + excerpt + Sefaria ref + he/en).
- **Card**: a 'Yerushalmi parallel' section renders the English outline grouped by topic, each point tagged with its aligned Bavli segment (**§N**, excerpt tooltip) + a Sefaria deep link — so the reader sees *which part* has a parallel.

**No global dafyomi cache bump** (would cold-miss all dafyomi Shas-wide + degrade halacha cards). The parsed yerushalmi blocks populate via a targeted **refresh** (`GET /api/dafyomi/:t/:p?refresh=1`), done for Berakhot in this PR. Follow-up: a refresh pass over the other Yerushalmi-bearing tractates; click-to-highlight the aligned Bavli segment in the daf text.