### PR TITLE
Dev inspector sources: label chips like the built-from badges

### DIFF
--- a/src/client/InstanceInspectorShelf.tsx
+++ b/src/client/InstanceInspectorShelf.tsx
@@ -230,7 +230,7 @@ export default function InstanceInspectorShelf(props: Props) {
                     'font-family': 'inherit',
                   }}
                 >
-                  {name}
+                  {props.prettyDepLabel(name)}
                 </button>
               )}</For>
             </div>


### PR DESCRIPTION
The source chips now run their names through `prettyDepLabel` (same as the "built from" badges), so `halacha-refs` -> "Halacha refs", `gemara` -> "Gemara", etc. — uniform badge language across the inspector. One-line label change; styling was already shared.