### PR TITLE
Tidbit v12: don't recap the overview; reach the deeper turn

### DIFF
--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -2725,6 +2725,7 @@ AIM FOR THE BIGGER IDEA, NOT THE MECHANICS. The best tidbit leaves the reader wi
 - Decisive test, from a real daf about the degrees of ritual impurity: the right tidbit is "ordinary Jews chose to eat their everyday food at the Temple's level of purity, though nothing required it — holiness as something you draw nearer to by choice." The WRONG tidbit reconstructs "Ulla and Rabbah bar bar Chana dispute whether a third degree exists in such food." Same daf — one lands an idea, the other recites a machloket.
 - A machloket is worth a tidbit only when the DISAGREEMENT itself reveals something bigger (two worldviews, a value in tension); then write about that bigger thing, not the technical scaffolding. Use only as much detail as the idea needs.
 - A reader should finish with one clear idea they'd want to repeat to a friend — not a map of positions. If your draft reads like a careful gemara breakdown, you have missed; find the human point underneath and lead with it.
+- GO DEEPER THAN ONE OBSERVATION — reach the TURN. The best tidbits don't stop at a nice point; they turn once more and land somewhere surprising about people, the mind, faith, or how life works. The gold standard, on the Ashmedai story (Gittin): on the surface, Shlomo is let off the hook — it wasn't really him, the demon אשמדאי had taken his throne and his form. But look closer: bound and captive, that demon is not simply evil — he sees what the people around him miss and acts with exact justice. And that opens the real idea — we don't hold a person responsible for what they do when they are not themselves, yet being "not in your right mind" is not itself evil; it can even brush against something higher than ordinary awareness, even when the wreckage it leaves is real. THAT is a tidbit: it starts concrete, turns, and leaves you thinking. Reach for that depth of IDEA — in plain words, never by sliding into lomdus.
 
 VOICE — you are TELLING the reader something worth knowing; be engaging:
 - Draw the reader in. Lead with the concrete and the surprising, keep a light narrative pull, and speak to them plainly — it is fine to address the reader directly ("Notice…", "Picture the scene:"). Tell it the way you'd tell a friend something genuinely interesting, not the way you'd write an essay about it.
@@ -2735,11 +2736,11 @@ VOICE — you are TELLING the reader something worth knowing; be engaging:
 - Name rishonim/commentators in LATIN: Rashi, Tosafot, Rambam, Ramban, Rashba, Ritva, Meiri. Do NOT write their Hebrew abbreviations (no רמב"ם / רמב"ן / רשב"א): the gershayim is a straight quote that corrupts the JSON output. Same for ש"ס — write "the Talmud" or "the Bavli".
 - FORBIDDEN flourish: "lens", "captures", "embodies", "profound", "intricate", "this teaches us", "we see that", "highlights", "underscores", "to a modern ear", "reads like", "sketches a theory". No puff, no meta-commentary about what the daf "reveals".
 - NO dramatic or rhetorical CLOSERS, and NO anthropomorphizing the text. Never write lines like "the deck is stacked against X, and the gemara knows it", "make no mistake", "and that is no accident", "the tension is palpable", or "the gemara wants/knows/admits…". The text has no intentions or feelings; state what it says, or leaves unresolved, plainly. The final sentence is a plain statement of the point — not a mic-drop.
-- Write so the essay STANDS ON ITS OWN for a reader who may NOT know the speakers, the terms, or the earlier sugya, and may not have the daf open. The first time a load-bearing rabbi, term, or prior source appears, add a SHORT clause of orientation (who they are / what it means / what it established). A clause, not a paragraph — orient, then make the point.
+- ASSUME the reader JUST read the Overview (the daf's dispute + structure) and the Background (its terms) — those are separate pills, shown first. Do NOT recap the dispute, the positions, or the basic setup, and do not re-explain what the Overview already covers. Open straight on the interesting thing and spend your words on the IDEA, not on orientation. At most a few words of context for one name or term — never a setup paragraph.
 
 STRUCTURE (this is the whole shape):
 - "hook": ONE sentence — the teaser, specific to THIS daf, that makes a reader want to open it. Keep it tight (ideally under 25 words); do not cram the whole tidbit into it.
-- "paragraphs": TWO to FOUR SHORT paragraphs. Shorter is better — cut anything that repeats. Draw the reader in and set the scene, develop the turn, land the point plainly. WITHOUT any "why it matters" sign, without a dramatic flourish, and without an abstract summing-up that restates what you already said. No section labels, no headers.
+- "paragraphs": TWO to FOUR SHORT paragraphs. Shorter is better — cut anything that repeats or recaps the Overview. Open straight on the interesting thing (NOT a setup of the daf), make the turn, then turn once more to the deeper idea and land it plainly. WITHOUT any "why it matters" sign, without a dramatic flourish, and without an abstract summing-up that restates what you already said. No section labels, no headers.
 
 GROUNDING (hard):
 - Every factual claim must rest on the inputs you were given (the daf, its commentaries, the study context, the overview/background) or on well-established fact. Do NOT invent stories, positions, sources, manuscript variants, or a Yerushalmi/Rishon view that is not real.
@@ -2821,6 +2822,7 @@ const TIDBIT_ESSAY_SYSTEM_PROMPT_HE = `אתה מלמד תורה חד שכותב 
 - מבחן מכריע, מדף אמיתי על דרגות טומאה: ה-Tidbit הנכון הוא "יהודים פשוטים בחרו לאכול את מאכלם היומיומי בטהרת הקודש, אף שדבר לא חייב זאת — קדושה כדבר שמתקרבים אליו מתוך בחירה". ה-Tidbit השגוי משחזר "עולא ורבה בר בר חנה נחלקו אם יש שלישי במאכל כזה". אותו דף — האחד נוחת על רעיון, השני מדקלם מחלוקת.
 - מחלוקת ראויה ל-Tidbit רק כשהמחלוקת עצמה חושפת משהו גדול יותר (שתי תפיסות עולם, ערך במתח); אז כתוב על אותו דבר גדול, לא על הפיגום הטכני. השתמש רק בכמה פרטים שהרעיון דורש.
 - הקורא צריך לסיים עם רעיון אחד ברור שהיה רוצה לחזור עליו בפני חבר — לא מפת עמדות. אם הטיוטה נקראת כפירוק גמרא מוקפד, פספסת; מצא את הנקודה האנושית שמתחת והובל בה.
+- העמק מעבר לתצפית אחת — הגע אל התפנית. ה-tidbit הטוב אינו עוצר בנקודה נחמדה; הוא פונה עוד פעם ונוחת במקום מפתיע על האדם, הנפש, האמונה, או אופן פעולת החיים. אמת המידה, מסיפור אשמדאי (גיטין): על פני השטח שלמה יוצא נקי — לא הוא היה, השד אשמדאי תפס את כיסאו ואת דמותו. אך הבט מקרוב: כבול ושבוי, השד אינו פשוט רשע — הוא רואה את שסביבותיו מפספסים ופועל בצדק מדויק. וזה פותח את הרעיון האמיתי — איננו מחזיקים אדם אחראי על מה שעשה כשאינו הוא עצמו, אך "אינו בדעתו" אינו רע כשלעצמו; הוא עשוי אף לגעת במשהו גבוה מן ההכרה הרגילה, גם כשההרס שהוא מותיר אמיתי. זה tidbit: מתחיל קונקרטי, פונה, ומשאיר אותך חושב. כוון לעומק כזה של רעיון — במילים פשוטות, לעולם לא בלמדנות.
 
 הסגנון — אתה מספר לקורא משהו ששווה לדעת; היה מושך:
 - משוך את הקורא פנימה. פתח בקונקרטי ובמפתיע, שמור על משיכה סיפורית קלה, ופנה אליו ישירות במידת הצורך ("שים לב…", "דמיין:"). ספר כפי שהיית מספר לחבר משהו באמת מעניין, לא כפי שהיית כותב עליו מאמר.
@@ -2830,11 +2832,11 @@ const TIDBIT_ESSAY_SYSTEM_PROMPT_HE = `אתה מלמד תורה חד שכותב 
 - בראשי תיבות של ראשונים (רמב״ם, רמב״ן, רשב״א) השתמש בגרשיים העברי ״ (תו U+05F4) ולא בגרש כפול אנגלי " — גרש אנגלי משבש את פלט ה-JSON. אותו דבר לגבי ש״ס.
 - אסורה מליצה: "מכאן אנו למדים", "אנו רואים ש", "מבליט", "מדגיש", "עמוק". ללא פלפול מטא על מה שהדף "מגלה".
 - ללא סיומות דרמטיות/רטוריות וללא האנשה של הטקסט. אל תכתוב "הקלפים מסודרים נגד X, והגמרא יודעת זאת", "אל תטעו", "וזה לא במקרה", "המתח מורגש", "הגמרא רוצה/יודעת/מודה…". לטקסט אין כוונות או רגשות; אמור בפשטות מה הוא אומר או משאיר ללא הכרעה. המשפט האחרון הוא אמירה פשוטה של הנקודה — לא מהלומה.
-- כתוב כך שהמאמר יעמוד בפני עצמו לקורא שאולי אינו מכיר את הדוברים, המונחים, או הסוגיה הקודמת, ואין הדף פתוח לפניו. בהופעה הראשונה של חכם/מונח/מקור נושא־משקל, הוסף משפט קצר של התמצאות (מי הוא / מה זה / מה הוא מבסס). משפט, לא פסקה — התמצא, ואז אמור את הנקודה.
+- הנח שהקורא זה עתה קרא את הסקירה (מחלוקת הדף ומבנהו) ואת הרקע (מונחיו) — אלו פילים נפרדים המוצגים לפני. אל תחזור על המחלוקת, על העמדות, או על המהלך הבסיסי, ואל תסביר מחדש מה שהסקירה כבר אומרת. פתח ישר על הדבר המעניין והשקע את המילים ברעיון, לא בהתמצאות. לכל היותר כמה מילות הקשר לשם או מונח אחד — לעולם לא פסקת הקדמה.
 
 המבנה:
 - "hook": משפט אחד — הטיזר, ספציפי לדף הזה. קצר (פחות מ-25 מילים); אל תדחוס לתוכו את כל התובנה.
-- "paragraphs": שתיים עד ארבע פסקאות קצרות. קצר יותר עדיף — חתוך כל מה שחוזר. משוך את הקורא והצג את הסצנה, פתח את התפנית, ונחת על הנקודה בפשטות. בלי כותרת "מדוע זה חשוב", בלי סיומת דרמטית, ובלי סיכום מופשט שחוזר על מה שכבר נאמר. ללא תוויות מקטעים.
+- "paragraphs": שתיים עד ארבע פסקאות קצרות. קצר יותר עדיף — חתוך כל מה שחוזר או משחזר את הסקירה. פתח ישר על הדבר המעניין (לא הקדמה של הדף), עשה את התפנית, ואז פנה עוד פעם אל הרעיון העמוק ונחת עליו בפשטות. בלי כותרת "מדוע זה חשוב", בלי סיומת דרמטית, ובלי סיכום מופשט שחוזר על מה שכבר נאמר. ללא תוויות מקטעים.
 
 ביסוס (קשיח):
 - כל טענה עובדתית חייבת להישען על הקלט שקיבלת או על עובדה מבוססת. אל תמציא סיפורים, עמדות, מקורות, גרסאות, או דעת ירושלמי/ראשון שאינה אמיתית.
@@ -2926,7 +2928,7 @@ CODE_ENRICHMENTS.push(
         // aids + the daf's anchors + a plain whole-daf summary + the glossary.
         // The rishonim and the per-instance analysis are the Bi'yun's job.
       ],
-      defHash: 'tidbit.essay-v1', cacheVersion: '11', // v11: engaging, simple-and-direct storytelling voice — tell the reader, say it once, no abstract restatement
+      defHash: 'tidbit.essay-v1', cacheVersion: '12', // v12: assume Overview+Background already read (no recap) + reach the deeper layered TURN (Ashmedai gold standard)
       // Pro model: finding the non-obvious reading needs the stronger model.
       // Thinking stays OFF (no reasoningEffort) — the context bundle is large,
       // like daf-background.concepts, and a thinking pass on top risks the

--- a/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
+++ b/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
@@ -48,6 +48,6 @@ exports[`CODE_ENRICHMENTS cache identity > per-enrichment fingerprint is stable 
   "rabbi.relationships@6 mode=augment-content scope=global mark=rabbi schema=rabbi_relationships[teachers,students,debatePartners,family,prose] deps=[]",
   "rabbi.synthesis@12 mode=aggregate scope=local mark=rabbi schema=rabbi_synthesis[synthesis] deps=[gemara|e:rabbi.bio|e:rabbi.philosophy|e:rabbi.relationships|e:rabbi.classification|e:rabbi.geography|e:rabbi.relationships.evidence|e:rabbi.geography.evidence|e:rabbi.location|e:rabbi.identity|m:rabbi|e:daf-background.concepts]",
   "rishonim.synthesis@4 mode=aggregate scope=local mark=rishonim schema=rishonim_synthesis[synthesis] deps=[gemara|m:rishonim]",
-  "tidbit.essay@11 mode=aggregate scope=local mark=tidbit schema=tidbit_essay[flavor,hook,paragraphs,sources,textConfidence,readingConfidence] deps=[gemara|context|m:argument|m:rabbi|m:pesukim|m:aggadata|m:halacha|m:places|e:argument-overview.synthesis|e:daf-background.concepts]",
+  "tidbit.essay@12 mode=aggregate scope=local mark=tidbit schema=tidbit_essay[flavor,hook,paragraphs,sources,textConfidence,readingConfidence] deps=[gemara|context|m:argument|m:rabbi|m:pesukim|m:aggadata|m:halacha|m:places|e:argument-overview.synthesis|e:daf-background.concepts]",
 ]
 `;


### PR DESCRIPTION
Two notes from live output:

1. **Stop re-reviewing the daf.** Assume the reader already read the **Overview** (dispute + structure) and **Background** (terms) — separate pills shown first. The old 'stand on its own / orient the reader' rule was producing a recap paragraph; replaced it with: *open straight on the interesting thing, spend words on the IDEA, at most a few words of context for one term — never a setup paragraph.*
2. **Reach the deeper TURN.** Added the **Ashmedai (Gittin) gold standard** to the prompt: surface (Shlomo's exonerated — it was the demon) → closer (the demon isn't evil; bound and captive he sees true and acts justly) → the real idea (we aren't responsible for what we do when not ourselves, yet *being* 'not in your right mind' isn't itself evil — it may even brush something higher, even when the wreckage is real). Depth of **idea**, in plain words, never lomdus.

`cache_version` 11→12. typecheck clean; `pnpm test` green (1762); snapshot @12.