### PR TITLE
Context: place dafyomi Yerushalmi items onto Bavli segments (fix 'not located')

### DIFF
--- a/src/lib/context/anchor/yerushalmi.ts
+++ b/src/lib/context/anchor/yerushalmi.ts
@@ -1,0 +1,59 @@
+/**
+ * @fileoverview Yerushalmi-parallel matcher (deterministic, verbatim).
+ *
+ * dafyomi.co.il "Yerushalmi to Match <Bavli daf>" items carry the parallel
+ * YERUSHALMI text, not the Bavli text — but the genuinely-parallel layer (the
+ * shared Mishnah, quoted baraitot, biblical citations) is verbatim in both
+ * Talmuds. So we locate a yerushalmi item by the Bavli segment(s) whose Hebrew
+ * shares the longest contiguous verbatim phrase with it. The divergent
+ * Yerushalmi gemara shares no long phrase and stays unplaced — correct, and left
+ * for the AI matcher to place by meaning (precision over recall).
+ *
+ * Mirrors the bg-term / Tosfos-DH deterministic placers: free, instant, and it
+ * funnels its writes through the same `item.segs` / `item.via` contract.
+ */
+import type { ContextItem } from '../types.ts';
+import { normalizeHebrew } from '../../place/verbatim.ts';
+import { longestCommonRun } from '../../yerushalmiAlign.ts';
+
+/** Minimum shared contiguous normalized-word run to assert a Yerushalmi anchor.
+ *  Higher than the per-point threshold (these items are whole-subject, longer
+ *  text, so a short incidental match is more likely — be stricter). */
+const MIN_PLACE_RUN = 4;
+/** Don't smear an item across more than this many segments (ambiguous). */
+const MAX_HIT_SEGS = 4;
+
+/**
+ * Place each dafyomi-yerushalmi context item on the Bavli segment(s) it shares
+ * a long verbatim phrase with. Returns the number placed.
+ */
+export function matchYerushalmiToSegments(items: ContextItem[], segmentsHe: string[] | undefined): number {
+  if (!segmentsHe || segmentsHe.length === 0) return 0;
+  const segWords = segmentsHe.map((h) => normalizeHebrew(h).split(' ').filter(Boolean));
+
+  let placed = 0;
+  for (const item of items) {
+    if (item.source !== 'dafyomi:yerushalmi') continue;
+    if (item.segs.length > 0) continue;
+    const pWords = normalizeHebrew(item.body?.he ?? '').split(' ').filter(Boolean);
+    if (pWords.length < MIN_PLACE_RUN) continue;
+
+    const runs = segWords.map((sw) => longestCommonRun(pWords, sw).len);
+    const best = Math.max(0, ...runs);
+    if (best < MIN_PLACE_RUN) continue; // no strong verbatim overlap — leave for AI
+
+    // Place on every segment within one word of the best run (a Mishnah quoted
+    // across the item can land on 1-3 adjacent segments), capped to avoid smear.
+    const hits = runs
+      .map((len, i) => ({ len, i }))
+      .filter((s) => s.len >= Math.max(MIN_PLACE_RUN, best - 1))
+      .map((s) => s.i);
+    if (hits.length === 0 || hits.length > MAX_HIT_SEGS) continue;
+
+    item.segs = hits.sort((a, b) => a - b);
+    item.via = 'yerushalmi-phrase';
+    item.confidence = best >= 6 ? 0.85 : 0.7;
+    placed++;
+  }
+  return placed;
+}

--- a/src/lib/yerushalmiAlign.ts
+++ b/src/lib/yerushalmiAlign.ts
@@ -95,7 +95,7 @@ export function flattenYerushalmiOutline(entries: DafyomiEntry[], dafMasechet: s
 
 /** Longest common contiguous run of equal tokens between a and b.
  *  Returns its length and the start index in b (the Bavli segment). */
-function longestCommonRun(a: string[], b: string[]): { len: number; bStart: number } {
+export function longestCommonRun(a: string[], b: string[]): { len: number; bStart: number } {
   let best = 0;
   let bStart = -1;
   // rolling DP over b for each position in a: prev[j] = run ending at a[i-1], b[j-1]

--- a/src/worker/context-providers.ts
+++ b/src/worker/context-providers.ts
@@ -32,6 +32,7 @@ import {
 } from '../lib/context/fromSefaria';
 import { matchTosfos } from '../lib/context/anchor/tosfos';
 import { matchBackgroundTerms } from '../lib/context/anchor/bg-term';
+import { matchYerushalmiToSegments } from '../lib/context/anchor/yerushalmi';
 import { matchRevach, type SectionForMatch } from '../lib/context/anchor/revach';
 import { applyMatches } from '../lib/context/match';
 import type { ContextItem } from '../lib/context/types';
@@ -90,6 +91,10 @@ export async function collectContext(
     matchTosfos(dy, sefariaPage?.tosafot);
     // Place Background glossary/girsa terms onto the segment(s) that quote them.
     matchBackgroundTerms(dy, segments?.he);
+    // Place dafyomi "Yerushalmi to Match" items onto the Bavli segment(s) they
+    // share a verbatim phrase with (the shared Mishnah/baraita layer). Divergent
+    // Yerushalmi gemara shares no long phrase and stays unplaced (left for AI).
+    matchYerushalmiToSegments(dy, segments?.he);
     // Place whole-daf Revach summaries onto the argument section each describes
     // (conservative; unmatched entries are left whole-daf). LLM-free.
     if (opts.sections?.length) applyMatches(dy, matchRevach(dy, opts.sections));

--- a/tests/yerushalmi-place.test.ts
+++ b/tests/yerushalmi-place.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { matchYerushalmiToSegments } from '../src/lib/context/anchor/yerushalmi';
+import type { ContextItem } from '../src/lib/context/types';
+
+function yeruItem(he: string): ContextItem {
+  return { source: 'dafyomi:yerushalmi', sourceLabel: 'Yerushalmi', kind: 'yerushalmi', key: 'y:0', body: { he }, segs: [] };
+}
+
+describe('matchYerushalmiToSegments', () => {
+  // seg 0 = the mishnah (shared verbatim with the Yerushalmi); seg 1 = unrelated.
+  const segs = [
+    'מאימתי קורין את שמע בערבין משעה שהכהנים נכנסין לאכול בתרומתן עד סוף האשמורה הראשונה',
+    'תנא היכא קאי דקתני מאימתי וכו׳',
+  ];
+
+  it('places a yerushalmi item on the Bavli segment whose Hebrew it shares verbatim', () => {
+    const items = [yeruItem('מתני׳ מאימתי קורין את שמע בערבין משעה שהכהנים נכנסין לאכול')];
+    const placed = matchYerushalmiToSegments(items, segs);
+    expect(placed).toBe(1);
+    expect(items[0].segs).toEqual([0]);
+    expect(items[0].via).toBe('yerushalmi-phrase');
+    expect(items[0].confidence).toBeGreaterThan(0.5);
+  });
+
+  it('leaves a divergent item (no shared verbatim phrase) unplaced — precision over recall', () => {
+    const items = [yeruItem('כמה כוכבים יצאו ויהא ודאי לילה רבי פינחס בשם רבי אבא בר פפא')];
+    const placed = matchYerushalmiToSegments(items, segs);
+    expect(placed).toBe(0);
+    expect(items[0].segs).toEqual([]);
+    expect(items[0].via).toBeUndefined();
+  });
+
+  it('ignores non-yerushalmi items and already-placed items', () => {
+    const other: ContextItem = { source: 'dafyomi:background', sourceLabel: 'Background', kind: 'glossary', key: 'b:0', body: { he: 'מאימתי קורין את שמע בערבין' }, segs: [] };
+    const already = yeruItem('מאימתי קורין את שמע בערבין משעה שהכהנים');
+    already.segs = [2];
+    expect(matchYerushalmiToSegments([other, already], segs)).toBe(0);
+    expect(other.segs).toEqual([]);
+    expect(already.segs).toEqual([2]);
+  });
+});


### PR DESCRIPTION
In the alignment workbench, dafyomi 'Yerushalmi to Match' context items had **no placer**, so they rendered **'not located'** (`segs: []`).

Adds a deterministic matcher `matchYerushalmiToSegments` mirroring the existing `bg-term` / Tosfos-DH placers: a yerushalmi item is anchored to the Bavli segment(s) whose Hebrew shares the **longest verbatim phrase** with it (the shared Mishnah/baraita layer). Divergent Yerushalmi gemara shares no long run and stays unplaced — left for the AI matcher to place by meaning (**precision over recall**). Wired into `collectContext` after the other deterministic matchers; reuses the longest-common-run aligner from #224.