### PR TITLE
Whole-daf cards: convert tidbit, biyun, daf-background to recipes

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -27,8 +27,8 @@ import { InspectDot, registerMarkRenderer } from './MarkEnrichmentCards';
 // Recipes now live in the shared lib (carried on the worker mark def too).
 // Re-exported so existing importers (CARD_DEFS, tests) keep their `from
 // './ArgumentSidebar'` path.
-import { AGGADATA_RECIPE, PASUK_RECIPE, HALACHA_RECIPE, RISHONIM_RECIPE, RABBI_RECIPE, YERUSHALMI_RECIPE, ARGUMENT_RECIPE, ARGUMENT_OVERVIEW_RECIPE } from '../lib/sidebar/recipe';
-export { AGGADATA_RECIPE, PASUK_RECIPE, HALACHA_RECIPE, RISHONIM_RECIPE, RABBI_RECIPE, YERUSHALMI_RECIPE, ARGUMENT_RECIPE, ARGUMENT_OVERVIEW_RECIPE };
+import { AGGADATA_RECIPE, PASUK_RECIPE, HALACHA_RECIPE, RISHONIM_RECIPE, RABBI_RECIPE, YERUSHALMI_RECIPE, ARGUMENT_RECIPE, ARGUMENT_OVERVIEW_RECIPE, TIDBIT_RECIPE, BIYUN_RECIPE, DAF_BACKGROUND_RECIPE } from '../lib/sidebar/recipe';
+export { AGGADATA_RECIPE, PASUK_RECIPE, HALACHA_RECIPE, RISHONIM_RECIPE, RABBI_RECIPE, YERUSHALMI_RECIPE, ARGUMENT_RECIPE, ARGUMENT_OVERVIEW_RECIPE, TIDBIT_RECIPE, BIYUN_RECIPE, DAF_BACKGROUND_RECIPE };
 
 /** Localize an era date-range ("c. 290 – 320 CE") for Hebrew display. */
 function eraLabel(era: string): string {
@@ -1044,43 +1044,31 @@ function BackgroundGroups(props: { groups: BackgroundGroup[] }): JSX.Element {
   );
 }
 
-function DafBackgroundBody(props: { tractate: string; page: string }): JSX.Element {
-  const [groups, setGroups] = createSignal<BackgroundGroup[]>([]);
-  const [resolved, setResolved] = createSignal(false);
-
-  createEffect(() => {
-    void `${props.tractate}/${props.page}`;
-    setGroups([]);
-    setResolved(false);
+/** The grouped key-terms/concepts under the daf-background synthesis — read from
+ *  the daf-background.concepts leaf, ordered, with an empty state once the
+ *  synthesis settles with no groups. */
+function DafBackgroundGroups(props: SpecialBlockProps): JSX.Element {
+  const groups = createMemo<BackgroundGroup[]>(() => {
+    const concepts = props.deps['daf-background.concepts'] as { groups?: BackgroundGroup[] } | undefined;
+    return orderBackgroundGroups(concepts?.groups);
   });
-
-  const handleResolved = (r: { deps_resolved?: Record<string, unknown> }) => {
-    const concepts = r.deps_resolved?.['daf-background.concepts'] as { groups?: BackgroundGroup[] } | undefined;
-    setGroups(orderBackgroundGroups(concepts?.groups));
-    setResolved(true);
-  };
-
   return (
-    <Panel accent={ACCENTS['daf-background']} title={t('background.title')}>
-      <Synthesis
-        markId="daf-background"
-        instance={{ fields: {} }}
-        instanceKey={`${props.tractate}/${props.page}/background`}
-        tractate={props.tractate}
-        page={props.page}
-        onResolved={handleResolved}
-      />
+    <>
       <Show when={groups().length > 0}>
         <BackgroundGroups groups={groups()} />
       </Show>
-      <Show when={resolved() && groups().length === 0}>
+      <Show when={props.synthesisResolved && groups().length === 0}>
         <HebrewProse size="0.85rem" color="#999" margin="0.6rem 0 0">
           {t('background.empty')}
         </HebrewProse>
       </Show>
-    </Panel>
+    </>
   );
 }
+
+export const DAF_BACKGROUND_BLOCKS: Record<string, (p: SpecialBlockProps) => JSX.Element> = {
+  'daf-background-groups': DafBackgroundGroups,
+};
 
 // ===========================================================================
 // Tidbit body
@@ -1198,34 +1186,8 @@ registerMarkRenderer('tidbit', TidbitEssayView);
 // Bi'yun reuses the same essay renderer (its output has no `flavor`, so the
 // flavor tag simply doesn't render); only the panel accent + title differ.
 registerMarkRenderer('biyun', TidbitEssayView);
-
-function TidbitBody(props: { tractate: string; page: string }): JSX.Element {
-  return (
-    <Panel accent={ACCENTS.tidbit} title={t('tidbit.title')}>
-      <Synthesis
-        markId="tidbit"
-        instance={{ fields: {} }}
-        instanceKey={`${props.tractate}/${props.page}/tidbit`}
-        tractate={props.tractate}
-        page={props.page}
-      />
-    </Panel>
-  );
-}
-
-function BiyunBody(props: { tractate: string; page: string }): JSX.Element {
-  return (
-    <Panel accent={ACCENTS.biyun} title={t('biyun.title')}>
-      <Synthesis
-        markId="biyun"
-        instance={{ fields: {} }}
-        instanceKey={`${props.tractate}/${props.page}/biyun`}
-        tractate={props.tractate}
-        page={props.page}
-      />
-    </Panel>
-  );
-}
+// tidbit + biyun are recipe-driven (TIDBIT_RECIPE / BIYUN_RECIPE → CARD_DEFS):
+// header + synthesis, the essay rendering through the seam registered above.
 
 interface PasukDetail {
   ref: string;
@@ -1857,6 +1819,10 @@ export function instanceKeyForContent(content: SidebarContent, tractate: string,
     // run cache stays warm across this conversion.
     case 'argument': return `${content.section.startSegIdx}-${content.section.endSegIdx}-${content.section.title}`;
     case 'argument-overview': return `${tractate}/${page}/overview`;
+    // Whole-daf essay/background cards — match the old *Body instanceKeys.
+    case 'tidbit': return `${tractate}/${page}/tidbit`;
+    case 'biyun': return `${tractate}/${page}/biyun`;
+    case 'daf-background': return `${tractate}/${page}/background`;
     case 'aggadata': return `${tractate}:${page}:${content.index}:${content.story.title}`;
     case 'yerushalmi': return `${tractate}:${page}:${content.index}:${content.parallel.yerushalmiRef}`;
     case 'pesuk': return content.pasuk.verseRef;
@@ -2238,6 +2204,28 @@ export const CARD_DEFS: Partial<Record<SidebarContent['kind'], CardDef>> = {
     forwardHighlight: true,
     extras: (ctx) => ({ sections: ctx.dafSections, onPushRabbi: ctx.onPushRabbi, onOpenArgument: ctx.onOpenArgument }),
   },
+  // Whole-daf essay cards: header + synthesis only (the essay renders through
+  // the registerMarkRenderer seam). Display instance carries the localized
+  // heading; synthInstance keeps the old `{fields:{}}` mark_input so the warmed
+  // whole-daf caches still hit.
+  tidbit: {
+    recipe: TIDBIT_RECIPE,
+    blocks: {},
+    instance: () => ({ fields: { title: t('tidbit.title') } }),
+    synthInstance: () => ({ fields: {} }),
+  },
+  biyun: {
+    recipe: BIYUN_RECIPE,
+    blocks: {},
+    instance: () => ({ fields: { title: t('biyun.title') } }),
+    synthInstance: () => ({ fields: {} }),
+  },
+  'daf-background': {
+    recipe: DAF_BACKGROUND_RECIPE,
+    blocks: DAF_BACKGROUND_BLOCKS,
+    instance: () => ({ fields: { title: t('background.title') } }),
+    synthInstance: () => ({ fields: {} }),
+  },
   aggadata: {
     recipe: AGGADATA_RECIPE,
     blocks: AGGADATA_BLOCKS,
@@ -2425,18 +2413,6 @@ export function ArgumentSidebar(props: ArgumentSidebarProps): JSX.Element {
                 page={props.page}
                 chips={<PlaceChips place={(c() as Extract<SidebarContent, { kind: 'place' }>).place} />}
               />
-            </Show>
-
-            <Show when={c().kind === 'daf-background'}>
-              <DafBackgroundBody tractate={props.tractate} page={props.page} />
-            </Show>
-
-            <Show when={c().kind === 'tidbit'}>
-              <TidbitBody tractate={props.tractate} page={props.page} />
-            </Show>
-
-            <Show when={c().kind === 'biyun'}>
-              <BiyunBody tractate={props.tractate} page={props.page} />
             </Show>
 
         </aside>

--- a/src/lib/sidebar/recipe.ts
+++ b/src/lib/sidebar/recipe.ts
@@ -165,6 +165,43 @@ export const ARGUMENT_OVERVIEW_RECIPE: SidebarRecipe = {
   ],
 };
 
+// Whole-daf essay cards (the chip-in-header pieces). Each is just a header +
+// the synthesis — the essay body renders through the per-mark renderer seam
+// (registerMarkRenderer), not deps — so the recipe is a single synthesis
+// section. The display instance supplies the localized heading; the synthesis
+// mark_input stays the old empty `{fields:{}}` (an explicit synthInstance in
+// CARD_DEFS) so the warmed whole-daf caches still hit.
+export const TIDBIT_RECIPE: SidebarRecipe = {
+  kind: 'tidbit',
+  markId: 'tidbit',
+  titleField: 'title',
+  sections: [
+    { type: 'synthesis' },
+  ],
+};
+
+export const BIYUN_RECIPE: SidebarRecipe = {
+  kind: 'biyun',
+  markId: 'biyun',
+  titleField: 'title',
+  sections: [
+    { type: 'synthesis' },
+  ],
+};
+
+// Whole-daf background: the synthesis, then the grouped key-terms/concepts
+// (legal concepts / realia / persons / assumed-prior) from the
+// daf-background.concepts leaf — a single special block, plus an empty state.
+export const DAF_BACKGROUND_RECIPE: SidebarRecipe = {
+  kind: 'daf-background',
+  markId: 'daf-background',
+  titleField: 'title',
+  sections: [
+    { type: 'synthesis' },
+    { type: 'special', block: 'daf-background-groups', deps: ['daf-background.concepts'] },
+  ],
+};
+
 export const RABBI_RECIPE: SidebarRecipe = {
   kind: 'rabbi',
   markId: 'rabbi',

--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -82,7 +82,7 @@ import {
   BIYUN_ESSAY_OUTPUT_SCHEMA,
   proseSchema,
 } from './output-schemas';
-import { AGGADATA_RECIPE, PASUK_RECIPE, HALACHA_RECIPE, RISHONIM_RECIPE, RABBI_RECIPE, YERUSHALMI_RECIPE, ARGUMENT_RECIPE, ARGUMENT_OVERVIEW_RECIPE } from '../lib/sidebar/recipe';
+import { AGGADATA_RECIPE, PASUK_RECIPE, HALACHA_RECIPE, RISHONIM_RECIPE, RABBI_RECIPE, YERUSHALMI_RECIPE, ARGUMENT_RECIPE, ARGUMENT_OVERVIEW_RECIPE, TIDBIT_RECIPE, BIYUN_RECIPE, DAF_BACKGROUND_RECIPE } from '../lib/sidebar/recipe';
 
 // ---------------------------------------------------------------------------
 // Rabbi mark — phrase anchor + inline render
@@ -634,6 +634,7 @@ export const CODE_MARKS: MarkDefinition[] = [
   },
   {
     id: 'daf-background',
+    recipe: DAF_BACKGROUND_RECIPE,
     label: 'Background',
     description: 'Whole-daf background: the key terms/concepts a reader needs to follow the daf, grouped into legal concepts / realia / persons / assumed-prior sugyot, grounded on the dafyomi.co.il glossary.',
     category: 'canon',
@@ -658,6 +659,7 @@ export const CODE_MARKS: MarkDefinition[] = [
   },
   {
     id: 'tidbit',
+    recipe: TIDBIT_RECIPE,
     label: 'Tidbit',
     description: 'Whole-daf "did you notice…": ONE curated, genuinely interesting thing about this daf — an aggadah read against the grain, a legal concept with a twist, a sharp machloket, a textual point, or a hidden point inside a dry sugya. Grounded on the full daf + commentaries + study context + the overview & background it depends on.',
     category: 'canon',
@@ -684,6 +686,7 @@ export const CODE_MARKS: MarkDefinition[] = [
   },
   {
     id: 'biyun',
+    recipe: BIYUN_RECIPE,
     label: "Bi'yun",
     description: "Whole-daf עיון: a deep dive into ONE halachic/conceptual problem on the daf that the rishonim are wrestling with — the difficulty, the competing approaches, what's at stake. The lomdus counterpart to the Tidbit. Grounded on the full daf + commentaries + the rishonim/argument/halacha analysis it depends on.",
     category: 'canon',

--- a/tests/client/card-defs.test.ts
+++ b/tests/client/card-defs.test.ts
@@ -15,7 +15,7 @@ describe('CARD_DEFS registry', () => {
 
   it('covers exactly the recipe-driven kinds', () => {
     expect(Object.keys(CARD_DEFS).sort()).toEqual(
-      ['aggadata', 'argument', 'argument-overview', 'halacha', 'pesuk', 'rabbi', 'rishonim', 'yerushalmi'].sort(),
+      ['aggadata', 'argument', 'argument-overview', 'biyun', 'daf-background', 'halacha', 'pesuk', 'rabbi', 'rishonim', 'tidbit', 'yerushalmi'].sort(),
     );
   });
 });

--- a/tests/sidebar-recipe-on-marks.test.ts
+++ b/tests/sidebar-recipe-on-marks.test.ts
@@ -2,14 +2,14 @@ import { describe, it, expect } from 'vitest';
 import { CODE_MARKS } from '../src/worker/code-marks';
 import {
   AGGADATA_RECIPE, PASUK_RECIPE, HALACHA_RECIPE, RISHONIM_RECIPE, RABBI_RECIPE,
-  ARGUMENT_RECIPE, ARGUMENT_OVERVIEW_RECIPE,
+  ARGUMENT_RECIPE, ARGUMENT_OVERVIEW_RECIPE, TIDBIT_RECIPE, BIYUN_RECIPE, DAF_BACKGROUND_RECIPE,
   type SidebarRecipe,
 } from '../src/lib/sidebar/recipe';
 import { t, setLang } from '../src/client/i18n';
 
 const RECIPES: SidebarRecipe[] = [
   AGGADATA_RECIPE, PASUK_RECIPE, HALACHA_RECIPE, RISHONIM_RECIPE, RABBI_RECIPE,
-  ARGUMENT_RECIPE, ARGUMENT_OVERVIEW_RECIPE,
+  ARGUMENT_RECIPE, ARGUMENT_OVERVIEW_RECIPE, TIDBIT_RECIPE, BIYUN_RECIPE, DAF_BACKGROUND_RECIPE,
 ];
 
 describe('sidebar recipes carried on mark definitions', () => {


### PR DESCRIPTION
Converts the three remaining mark-backed whole-daf cards onto the RECIPE framework (roadmap step 4), retiring their bespoke `*Body` components.

## What changed
- **`tidbit` / `biyun`** — one-section recipes (`[{ type: 'synthesis' }]`). The essay body still renders through the `registerMarkRenderer('tidbit'/'biyun', TidbitEssayView)` seam, unchanged.
- **`daf-background`** — `synthesis` + a `daf-background-groups` special block that reads the `daf-background.concepts` leaf (ordered via `orderBackgroundGroups`), with the empty state gated on `synthesisResolved`.
- All three carry their recipe in `code-marks.ts`, light up in the dev-shelf Recipe panel, and route through the single generic `CARD_DEFS` dispatch arm. The three bespoke arms + bodies are gone.

## Faithfulness
- Synthesis `mark_input` kept **byte-for-byte**: explicit `synthInstance: () => ({ fields: {} })` (the localized heading is display-only, never leaks into the cache key).
- `instanceKeyForContent` returns the same `${tractate}/${page}/{tidbit|biyun|background}` keys as the old bodies — warmed whole-daf caches still hit.

## Checks
- `pnpm typecheck` clean; `pnpm test` 1762 passed.
- `codex exec --sandbox read-only` review: LGTM, no regressions.

## Result
Leaves only `place` (intentionally on the older hint adapter) and `voice-group` (no mark behind it — purely presentational) off the recipe model.