### PR TITLE
Dev inspector: break aggregated context into its constituent study-aids

### DIFF
--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1584,7 +1584,24 @@ async function resolveDependencies(
       await placeRevachWithAi(rc.env, tractate, page, items, sourcesOnly);
       const scoped = contextForAnchor(items, segsFromMarkInput(markInput));
       out.vars.context = formatContextForPrompt(scoped);
-      recordSource(out, 'context', out.vars.context);
+      // Break the aggregated context into its constituent study-aids for the
+      // inspector instead of one opaque blob: group the scoped items by their
+      // `source` (sefaria-rashi / sefaria-rishonim / sefaria-topic / dafyomi:* /
+      // …) and record each part, rendered with the same formatter the prompt
+      // uses so every part is faithful to that source's contribution. Key as
+      // `context-<kind>` (provider prefix stripped) so chips read cleanly
+      // ("Context rashi", "Context points", "Context revach"). `out.vars.context`
+      // (above) stays the combined string the prompt actually consumes.
+      const byContextSource = new Map<string, typeof scoped>();
+      for (const it of scoped) {
+        const group = byContextSource.get(it.source) ?? [];
+        group.push(it);
+        byContextSource.set(it.source, group);
+      }
+      for (const [src, group] of byContextSource) {
+        const kind = src.replace(/^sefaria-/, '').replace(/^dafyomi:/, '');
+        recordSource(out, `context-${kind}`, formatContextForPrompt(group));
+      }
       return;
     }
     if (typeof dep === 'object' && dep !== null) {


### PR DESCRIPTION
Follow-up: the inspector's \`context\` chip was one opaque ~60KB blob that mixed every study-aid the context aggregator pulls. Now each constituent is its own chip.

## What

Group the scoped context items by their \`source\` (sefaria-rashi/tosafot/rishonim/halacha/mishnah/topic + dafyomi insights/background/points/charts/tosfos/review/yerushalmi/revach) and record each part separately, keyed \`context-<kind>\` so chips read cleanly: "Context rashi", "Context points", "Context revach", etc.

Each part is rendered with the **same** \`formatContextForPrompt\` the real prompt uses, so it's faithful to that source's contribution. The combined \`{{context}}\` string the prompt actually consumes is unchanged.

## Result

The inspector now comprehensively shows every text that fed a generation, broken down — not a single lump.

\`pnpm typecheck\`, \`pnpm test\` (1762 passing), \`pnpm build\` all green.