### PR TITLE
Tidbit v14: idea-first structure + context-light + thinking on

### DIFF
--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -2746,9 +2746,13 @@ VOICE — you are TELLING the reader something worth knowing; be engaging:
 - NO dramatic or rhetorical CLOSERS, and NO anthropomorphizing the text. Never write lines like "the deck is stacked against X, and the gemara knows it", "make no mistake", "and that is no accident", "the tension is palpable", or "the gemara wants/knows/admits…". The text has no intentions or feelings; state what it says, or leaves unresolved, plainly. The final sentence is a plain statement of the point — not a mic-drop.
 - ASSUME the reader JUST read the Overview (the daf's dispute + structure) and the Background (its terms) — those are separate pills, shown first. Do NOT recap the dispute, the positions, or the basic setup, and do not re-explain what the Overview already covers. Open straight on the interesting thing and spend your words on the IDEA, not on orientation. At most a few words of context for one name or term — never a setup paragraph.
 
-STRUCTURE (this is the whole shape):
-- "hook": ONE sentence — the teaser, specific to THIS daf, that makes a reader want to open it. Keep it tight (ideally under 25 words); do not cram the whole tidbit into it.
-- "paragraphs": TWO to FOUR SHORT paragraphs. Shorter is better — cut anything that repeats or recaps the Overview. Open straight on the interesting thing (NOT a setup of the daf), make the turn, then turn once more to the deeper idea and land it plainly. WITHOUT any "why it matters" sign, without a dramatic flourish, and without an abstract summing-up that restates what you already said. No section labels, no headers.
+STRUCTURE — lead with the IDEA, show it, then go a step further:
+- "hook": ONE sentence — the teaser/promise of the idea, specific to THIS daf. Tight (under ~25 words); don't cram the whole tidbit into it.
+- "paragraphs": THREE short paragraphs, in this order:
+  1) THE IDEA — state the interesting thing up front, in plain words. Don't make the reader wait through a setup; open on the insight itself.
+  2) HOW THE GEMARA TEACHES IT — the concrete scene or text that shows it, just enough to ground the idea (do NOT recap the Overview).
+  3) A STEP FURTHER — turn once more: the deeper implication or surprise that leaves the reader thinking. Land it plainly; no abstract summing-up.
+  TWO paragraphs are fine if the daf is simple; never more than four. No "why it matters" sign, no dramatic flourish, no section labels or headers.
 
 GROUNDING (hard):
 - Every factual claim must rest on the inputs you were given (the daf, its commentaries, the study context, the overview/background) or on well-established fact. Do NOT invent stories, positions, sources, manuscript variants, or a Yerushalmi/Rishon view that is not real.
@@ -2801,7 +2805,7 @@ Halachic topics on this daf:
 Places on this daf:
 {{anchors.places}}
 
-Study-aid context (dafyomi.co.il Insights / Points / Halacha / Yerushalmi / Tosfos notes + Sefaria cross-references):
+Study aids (dafyomi.co.il Insights / Points / Background / Yerushalmi / Revach — the accessible material; not the commentaries):
 {{context}}
 
 You now have the full picture of this daf — its text, commentaries, structure and flow, sages, verses, stories, halachic topics, places, and study aids. Use ALL of it to choose well. Write ONE Tidbit per the schema: the single most interesting, non-obvious thing on the page, as a hook plus three or four flowing paragraphs. Ground every claim in the materials above, and rate both confidences honestly.`;
@@ -2847,9 +2851,13 @@ const TIDBIT_ESSAY_SYSTEM_PROMPT_HE = `אתה מלמד תורה חד שכותב 
 - ללא סיומות דרמטיות/רטוריות וללא האנשה של הטקסט. אל תכתוב "הקלפים מסודרים נגד X, והגמרא יודעת זאת", "אל תטעו", "וזה לא במקרה", "המתח מורגש", "הגמרא רוצה/יודעת/מודה…". לטקסט אין כוונות או רגשות; אמור בפשטות מה הוא אומר או משאיר ללא הכרעה. המשפט האחרון הוא אמירה פשוטה של הנקודה — לא מהלומה.
 - הנח שהקורא זה עתה קרא את הסקירה (מחלוקת הדף ומבנהו) ואת הרקע (מונחיו) — אלו פילים נפרדים המוצגים לפני. אל תחזור על המחלוקת, על העמדות, או על המהלך הבסיסי, ואל תסביר מחדש מה שהסקירה כבר אומרת. פתח ישר על הדבר המעניין והשקע את המילים ברעיון, לא בהתמצאות. לכל היותר כמה מילות הקשר לשם או מונח אחד — לעולם לא פסקת הקדמה.
 
-המבנה:
-- "hook": משפט אחד — הטיזר, ספציפי לדף הזה. קצר (פחות מ-25 מילים); אל תדחוס לתוכו את כל התובנה.
-- "paragraphs": שתיים עד ארבע פסקאות קצרות. קצר יותר עדיף — חתוך כל מה שחוזר או משחזר את הסקירה. פתח ישר על הדבר המעניין (לא הקדמה של הדף), עשה את התפנית, ואז פנה עוד פעם אל הרעיון העמוק ונחת עליו בפשטות. בלי כותרת "מדוע זה חשוב", בלי סיומת דרמטית, ובלי סיכום מופשט שחוזר על מה שכבר נאמר. ללא תוויות מקטעים.
+המבנה — פתח ברעיון, הראה אותו, ואז לך צעד אחד הלאה:
+- "hook": משפט אחד — הטיזר/הבטחת הרעיון, ספציפי לדף הזה. קצר (פחות מ-25 מילים).
+- "paragraphs": שלוש פסקאות קצרות, בסדר הזה:
+  1) הרעיון — אמור את הדבר המעניין מיד, במילים פשוטות. אל תשאיר את הקורא ממתין דרך הקדמה; פתח על התובנה עצמה.
+  2) כיצד הגמרא מלמדת זאת — הסצנה או הטקסט הקונקרטי שמראה אותה, רק כדי לבסס את הרעיון (אל תחזור על הסקירה).
+  3) צעד אחד הלאה — פנה עוד פעם: ההשלכה העמוקה או ההפתעה שמשאירה את הקורא חושב. נחת בפשטות; בלי סיכום מופשט.
+  שתי פסקאות מספיקות אם הדף פשוט; לעולם לא יותר מארבע. בלי כותרת "מדוע זה חשוב", בלי סיומת דרמטית, ללא תוויות מקטעים.
 
 ביסוס (קשיח):
 - כל טענה עובדתית חייבת להישען על הקלט שקיבלת או על עובדה מבוססת. אל תמציא סיפורים, עמדות, מקורות, גרסאות, או דעת ירושלמי/ראשון שאינה אמיתית.
@@ -2902,7 +2910,7 @@ const TIDBIT_ESSAY_USER_TEMPLATE_HE = `מסכת: {{tractate}}, דף {{page}}.
 מקומות בדף זה:
 {{anchors.places}}
 
-תוכן לימוד נלווה (dafyomi.co.il — תובנות / נקודות / הלכה / ירושלמי / תוספות + הפניות ספריא):
+תוכן לימוד נלווה (dafyomi.co.il — תובנות / נקודות / רקע / ירושלמי / רווח — החומר הנגיש; לא המפרשים):
 {{context}}
 
 כעת יש לך תמונה מלאה של הדף — הטקסט, המפרשים, המבנה והזרימה, החכמים, הפסוקים, האגדות, נושאי ההלכה, המקומות, ותוכן הלימוד. השתמש בכל זה כדי לבחור היטב. כתוב Tidbit אחד לפי הסכימה: הדבר האחד הכי מעניין ולא־מובן־מאליו בדף, כטיזר ושלוש או ארבע פסקאות זורמות. בסס כל טענה בחומר שלמעלה, ודרג את שני מדדי הביטחון בכנות.`;
@@ -2925,7 +2933,7 @@ CODE_ENRICHMENTS.push(
       // halacha topics, places).
       dependencies: [
         'gemara',
-        'context',
+        'context-light', // accessible study aids only — no Rashi/Tosafot/rishonim/halacha apparatus (that fueled lomdus)
         { mark: 'argument' },
         { mark: 'rabbi' },
         { mark: 'pesukim' },
@@ -2941,12 +2949,14 @@ CODE_ENRICHMENTS.push(
         // aids + the daf's anchors + a plain whole-daf summary + the glossary.
         // The rishonim and the per-instance analysis are the Bi'yun's job.
       ],
-      defHash: 'tidbit.essay-v1', cacheVersion: '13', // v13: survey-the-whole-daf-and-pick-the-MOST-engaging selection step (don't default to the structural skeleton; hunt the vivid/buried thing; find the turn under the famous beat)
-      // Pro model: finding the non-obvious reading needs the stronger model.
-      // Thinking stays OFF (no reasoningEffort) — the context bundle is large,
-      // like daf-background.concepts, and a thinking pass on top risks the
-      // OpenRouter cap. Revisit reasoningEffort if quality calls for it.
+      defHash: 'tidbit.essay-v1', cacheVersion: '14', // v14: idea-first structure (idea -> how the gemara teaches it -> a step further) + context-light (drop the rashi/tosafot/rishonim/halacha that leaked via 'context')
+      // Pro model + a reasoning pass. Thinking is ON now (reasoningEffort) —
+      // the move to 'context-light' shrank the prompt enough that a thinking
+      // pass no longer risks the OpenRouter cap, and the tidbit genuinely needs
+      // it: surveying the whole daf to pick the MOST engaging thing, building
+      // the layered turn, and knowing what to cut so it doesn't lose itself.
       model: ARGUMENT_PRO_MODEL,
+      reasoningEffort: 'high',
       systemPromptHe: TIDBIT_ESSAY_SYSTEM_PROMPT_HE,
       userPromptTemplateHe: TIDBIT_ESSAY_USER_TEMPLATE_HE,
     },

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1481,6 +1481,19 @@ function recordSource(out: ResolvedInputs, name: string, content: unknown): void
   };
 }
 
+// 'context-light' keep-list: the accessible, idea-rich study aids only. Drops
+// the commentary + halachic-apparatus layers (sefaria-rashi/tosafot/rishonim/
+// halacha/topic, dafyomi halacha/tosfos/hebcharts/review-of-mechanics) that
+// pull a reader-facing piece toward lomdus.
+const LIGHT_CONTEXT_SOURCES = new Set<string>([
+  'sefaria-mishnah',
+  'dafyomi:insights',
+  'dafyomi:points',
+  'dafyomi:background',
+  'dafyomi:yerushalmi',
+  'dafyomi:revach',
+]);
+
 async function resolveDependencies(
   rc: RunCtx,
   dependencies: ReadonlyArray<EnrichmentDependency> | ReadonlyArray<MarkDependency> | undefined,
@@ -1559,12 +1572,16 @@ async function resolveDependencies(
       recordSource(out, 'yerushalmi-text', out.vars.yerushalmi);
       return;
     }
-    if (dep === 'context') {
+    if (dep === 'context' || dep === 'context-light') {
       // Aggregated external context (dafyomi Points/Halacha/Charts + Sefaria
       // Rishonim/halacha/topics), SCOPED to the instance's segments: a section
       // enrichment gets the context grounded to its own lines; a whole-daf one
       // (no segment location) gets the full pool. Each source that fails
       // contributes nothing rather than throwing.
+      // 'context-light' drops the commentary/halachic-apparatus layers (Rashi,
+      // Tosafot, rishonim, sefaria-halacha/topic, dafyomi halacha/tosfos/charts)
+      // and keeps only the accessible, idea-rich aids — so the Tidbit isn't fed
+      // the lomdus that kept pulling it scholarly. The Bi'yun uses full 'context'.
       // This amud's argument sections let Revach summaries be placed per-section
       // (English↔English alignment, conservative); a cheap cached read.
       const sections = (await readMarkInstances(rc.env, 'argument', tractate, page))
@@ -1575,7 +1592,10 @@ async function resolveDependencies(
           title: typeof i.fields?.title === 'string' ? i.fields.title : undefined,
           summary: typeof i.fields?.summary === 'string' ? i.fields.summary : undefined,
         }));
-      const items = await collectContext(rc.env, tractate, page, { sections });
+      const allItems = await collectContext(rc.env, tractate, page, { sections });
+      const items = dep === 'context-light'
+        ? allItems.filter((it) => LIGHT_CONTEXT_SOURCES.has(it.source))
+        : allItems;
       // Back up the deterministic Revach placer with the cached AI matcher for
       // any entries it left whole-daf (once per daf; LLM-free on cache hit). In
       // the source-only inspector pass, run it cache-only so the preview still

--- a/src/worker/studio-registry.ts
+++ b/src/worker/studio-registry.ts
@@ -214,7 +214,7 @@ function validateEnrichmentDependencies(input: unknown): { ok: true; deps: Enric
   if (!Array.isArray(input)) return { ok: false, error: 'dependencies must be an array' };
   const out: EnrichmentDependency[] = [];
   for (const e of input) {
-    if (e === 'gemara' || e === 'commentaries' || e === 'mishna' || e === 'context' || e === 'halacha-refs' || e === 'yerushalmi-text') { out.push(e); continue; }
+    if (e === 'gemara' || e === 'commentaries' || e === 'mishna' || e === 'context' || e === 'context-light' || e === 'halacha-refs' || e === 'yerushalmi-text') { out.push(e); continue; }
     if (e && typeof e === 'object') {
       const o = e as { mark?: unknown; enrichment?: unknown };
       if (typeof o.mark === 'string') { out.push({ mark: o.mark }); continue; }

--- a/src/worker/studio-schema.ts
+++ b/src/worker/studio-schema.ts
@@ -351,6 +351,11 @@ export type EnrichmentDependency =
   | 'commentaries'
   | 'mishna'
   | 'context'
+  // Like 'context' but only the accessible, idea-rich study aids (Insights /
+  // Points / Background / Yerushalmi / Revach / Mishnah) — drops the commentary
+  // + halachic-apparatus layers. For reader-facing pieces that should not be
+  // pulled toward lomdus (the Tidbit). See LIGHT_CONTEXT_SOURCES in index.ts.
+  | 'context-light'
   | 'halacha-refs'
   | 'yerushalmi-text'
   // `{ enrichment: id }` resolves the dep for the CONSUMER's own instance.

--- a/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
+++ b/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
@@ -48,6 +48,6 @@ exports[`CODE_ENRICHMENTS cache identity > per-enrichment fingerprint is stable 
   "rabbi.relationships@6 mode=augment-content scope=global mark=rabbi schema=rabbi_relationships[teachers,students,debatePartners,family,prose] deps=[]",
   "rabbi.synthesis@12 mode=aggregate scope=local mark=rabbi schema=rabbi_synthesis[synthesis] deps=[gemara|e:rabbi.bio|e:rabbi.philosophy|e:rabbi.relationships|e:rabbi.classification|e:rabbi.geography|e:rabbi.relationships.evidence|e:rabbi.geography.evidence|e:rabbi.location|e:rabbi.identity|m:rabbi|e:daf-background.concepts]",
   "rishonim.synthesis@4 mode=aggregate scope=local mark=rishonim schema=rishonim_synthesis[synthesis] deps=[gemara|m:rishonim]",
-  "tidbit.essay@13 mode=aggregate scope=local mark=tidbit schema=tidbit_essay[flavor,hook,paragraphs,sources,textConfidence,readingConfidence] deps=[gemara|context|m:argument|m:rabbi|m:pesukim|m:aggadata|m:halacha|m:places|e:argument-overview.synthesis|e:daf-background.concepts]",
+  "tidbit.essay@14 mode=aggregate scope=local mark=tidbit schema=tidbit_essay[flavor,hook,paragraphs,sources,textConfidence,readingConfidence] deps=[gemara|context-light|m:argument|m:rabbi|m:pesukim|m:aggadata|m:halacha|m:places|e:argument-overview.synthesis|e:daf-background.concepts]",
 ]
 `;

--- a/tests/dep-graph-validate.test.ts
+++ b/tests/dep-graph-validate.test.ts
@@ -7,7 +7,7 @@ import { CODE_MARKS, CODE_ENRICHMENTS } from '../src/worker/code-marks';
 // 'yerushalmi-text' feeds the real parallel Jerusalem Talmud text into the
 // yerushalmi mark (named distinctly from the `yerushalmi` mark id so it reads
 // as a slice input, not a `{ mark: 'yerushalmi' }` producer reference).
-const SOURCES = new Set(['gemara', 'commentaries', 'context', 'mishna', 'halacha-refs', 'yerushalmi-text']);
+const SOURCES = new Set(['gemara', 'commentaries', 'context', 'context-light', 'mishna', 'halacha-refs', 'yerushalmi-text']);
 
 describe('validateProducerGraph — unit', () => {
   it('flags a dependency on a nonexistent producer/source as dangling', () => {


### PR DESCRIPTION
Three changes from live feedback:

1. **Idea-first structure** — hook → state the idea up front → how the gemara teaches it → a step further (replaces scene-first).
2. **`context-light`** — the 'too many sources' fix. `context` was still feeding the tidbit Rashi/Tosafot/rishonim/halacha/topic (the lomdus fuel). New `context-light` source dep keeps only the accessible aids (insights/points/background/yerushalmi/revach/mishnah). Tidbit uses it; **Bi'yun keeps full `context`**. Registered in the dep type, studio validator, and dep-graph SOURCES. The engaging gemara framing (e.g. Chullin bird-carcass) is unaffected.
3. **Thinking ON** (`reasoningEffort:'high'`) — was pro-with-thinking-off to dodge the cap on the old bundle; context-light shrank the prompt enough to enable a reasoning pass, aimed at 'loses itself at the end'.

Codex reviewed — clean (its one finding, the studio validator, is fixed). typecheck clean; pnpm test green (1765). cache_version 13→14.