### PR TITLE
Top bar: tidy mobile layout into intentional rows

### DIFF
--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -431,6 +431,19 @@ body.dev-shelf-open .daf-page {
        content is never occluded. 55vh matches the shelf's max-height. */
     padding-bottom: calc(0.75rem + 55vh);
   }
+  /* Header: the flat flex-wrap goes ragged on phones. Organize it into tidy
+     rows via explicit order — wordmark + utilities share the top row, the
+     tractate picker spans its own row, nav + Today's Daf share the next, and
+     the hint stays centered below. Each row reads as one intentional unit. */
+  .daf-header {
+    gap: 0.4rem 0.5rem;
+  }
+  .tb-wordmark { order: 0; font-size: 1.05rem; }
+  .tb-utils    { order: 1; }            /* auto margin keeps it top-right */
+  .tb-select   { order: 2; flex-basis: 100%; width: 100%; }
+  .tb-nav      { order: 3; }
+  .tb-primary  { order: 4; flex: 1; }   /* fills the rest of the nav row */
+  .tb-hint     { order: 5; }
   .daf-layout {
     flex-direction: column;
     gap: 0.75rem;


### PR DESCRIPTION
On phones the header relied on bare `flex-wrap`, so the wordmark, the wide tractate dropdown, the nav pill, Today's Daf and the utilities (Help/dev/lang) wrapped into ragged rows.

This adds explicit `order`/`flex` rules to `.daf-header` children inside the existing `max-width: 767px` breakpoint so the bar reads as four deliberate rows:

1. `Talmud` wordmark (left) + utilities Help / dev / EN·עב (right)
2. full-width tractate picker
3. nav pill `‹ 2 a ›` + `Today's Daf` (stretches to fill the row)
4. centered navigation hint

Desktop (>767px) is untouched. CSS-only change; `pnpm typecheck` and `pnpm test` (1765) pass. Verified the layout at 320 / 375 / 1280px.