### PR TITLE
Prose: script-hygiene guard (English + Hebrew script only)

### DIFF
--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -905,7 +905,8 @@ ${alwaysHebraizeBlock()}
     GOOD: "the term 'אמר' indicates direct attribution"
   If you don't remember the Hebrew/Aramaic verbatim, paraphrase in English instead of writing the transliteration in quotes. NEVER fake a verbatim quote with transliteration.
 - Plain English is the BASE; Hebrew script is the technical anchor. Don't pile Hebrew script on every common word — only where the term is genuinely the technical concept.
-- THE DAF'S OWN GLOSSARY IS AUTHORITATIVE. If the prompt gives you this daf's background terms (each an English label + its Hebrew + a gloss), treat that list as the definitive set of terms to show in Hebrew here. Whenever your prose uses one of them, write it in Form A/B using EXACTLY that Hebrew spelling — e.g. given "Tevul Yom / טבול יום", write "טבול יום (one who immersed that day)" rather than "tevul yom" or English alone; given "Midnight / חצות", write "חצות (halakhic midnight)". This keeps the prose consistent with the glossary the reader sees on the daf and lets each term carry its own tooltip.`;
+- THE DAF'S OWN GLOSSARY IS AUTHORITATIVE. If the prompt gives you this daf's background terms (each an English label + its Hebrew + a gloss), treat that list as the definitive set of terms to show in Hebrew here. Whenever your prose uses one of them, write it in Form A/B using EXACTLY that Hebrew spelling — e.g. given "Tevul Yom / טבול יום", write "טבול יום (one who immersed that day)" rather than "tevul yom" or English alone; given "Midnight / חצות", write "חצות (halakhic midnight)". This keeps the prose consistent with the glossary the reader sees on the daf and lets each term carry its own tooltip.
+- SCRIPT HYGIENE: write ONLY in English, with Hebrew/Aramaic script for terms and quotes. Never emit any other language or writing system — no Korean, Cyrillic, Arabic, CJK, Devanagari, emoji, etc. Every character must be plain Latin or Hebrew script (plus ordinary punctuation). If you reach for a non-English word, use its plain English equivalent instead.`;
 
 /**
  * Hebrew-output style guide — the lang='he' counterpart of HEBREW_GLOSS_STYLE.
@@ -929,7 +930,8 @@ const HEBREW_NATIVE_STYLE = `סגנון — כתיבה בעברית (החל בא
 - ציטוטי excerpt מן הדף נשארים בעברית/ארמית מילה במילה כפי שהם בדף, ללא שינוי.
 - הימנע ממליצות ריקות ומשפה מנופחת. אל תכתוב: "תמצית", "מבעד לעדשה של", "מגלם", "עומק רוחני", "ביטוי מובהק", "רגישות עמוקה", "שואף בעקביות", "טבוע בו". כתוב משפטי נושא-נשוא-מושא ענייניים עם עובדות קונקרטיות (תקופה, אזור, שמות חכמים, שיטות).
 - עברית היא שפת הבסיס; אין צורך לפזר מילים לועזיות או תעתיקים.
-- מילון הדף הוא סמכותי. אם הקלט כולל את מונחי הרקע של הדף (תווית באנגלית + עברית + הסבר לכל אחד), התייחס לרשימה כקבוצת המונחים המוסמכת: בכל פעם שהפרוזה נוקטת באחד מהם, כתוב אותו בדיוק באותה צורה עברית שניתנה (למשל "טבול יום", "חצות", "תרומה"). כך הפרוזה עקבית עם מילון הרקע שהקורא רואה בדף.`;
+- מילון הדף הוא סמכותי. אם הקלט כולל את מונחי הרקע של הדף (תווית באנגלית + עברית + הסבר לכל אחד), התייחס לרשימה כקבוצת המונחים המוסמכת: בכל פעם שהפרוזה נוקטת באחד מהם, כתוב אותו בדיוק באותה צורה עברית שניתנה (למשל "טבול יום", "חצות", "תרומה"). כך הפרוזה עקבית עם מילון הרקע שהקורא רואה בדף.
+- ניקיון כתב: כתוב אך ורק בעברית (ובכתב עברי/ארמי למונחים וציטוטים). לעולם אל תפלוט שפה או מערכת כתב אחרת — לא קוריאנית, קירילית, ערבית, סינית/יפנית, אימוג'י וכו'. כל תו חייב להיות עברי או לטיני בסיסי (בתוספת פיסוק רגיל).`;
 
 
 // rabbi.bio — DAF-AGNOSTIC general biography. Same regardless of which daf
@@ -2953,7 +2955,7 @@ CODE_ENRICHMENTS.push(
         // aids + the daf's anchors + a plain whole-daf summary + the glossary.
         // The rishonim and the per-instance analysis are the Bi'yun's job.
       ],
-      defHash: 'tidbit.essay-v1', cacheVersion: '14', // v14: idea-first structure (idea -> how the gemara teaches it -> a step further) + context-light (drop the rashi/tosafot/rishonim/halacha that leaked via 'context')
+      defHash: 'tidbit.essay-v1', cacheVersion: '15', // v15: + shared script-hygiene guard (English + Hebrew script only; no stray foreign-script tokens)
       // Pro model + a reasoning pass. Thinking is ON now (reasoningEffort) —
       // the move to 'context-light' shrank the prompt enough that a thinking
       // pass no longer risks the OpenRouter cap, and the tidbit genuinely needs
@@ -3153,7 +3155,7 @@ CODE_ENRICHMENTS.push(
         { enrichment: 'pesukim.synthesis', fanOut: true },
         { enrichment: 'halacha.synthesis', fanOut: true },
       ],
-      defHash: 'biyun.essay-v1', cacheVersion: '3', // v3: engaging, simple-and-direct voice — walk the reader through the problem, say each move once
+      defHash: 'biyun.essay-v1', cacheVersion: '4', // v4: + shared script-hygiene guard (English + Hebrew script only)
       model: ARGUMENT_PRO_MODEL,
       systemPromptHe: BIYUN_ESSAY_SYSTEM_PROMPT_HE,
       userPromptTemplateHe: BIYUN_ESSAY_USER_TEMPLATE_HE,

--- a/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
+++ b/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
@@ -18,7 +18,7 @@ exports[`CODE_ENRICHMENTS cache identity > per-enrichment fingerprint is stable 
   "argument.narrative@3 mode=augment-content scope=local mark=argument schema=argument_narrative[summary,actors,beats] deps=[gemara|m:argument-move|m:rabbi]",
   "argument.synthesis@12 mode=aggregate scope=local mark=argument schema=argument_synthesis[synthesis] deps=[gemara|commentaries|mishna|e:argument.voices|e:argument.background|m:rabbi|m:argument-move|e:daf-background.concepts]",
   "argument.voices@6 mode=augment-content scope=local mark=argument schema=argument_voices[voices,edges] deps=[gemara|m:argument-move|m:rabbi]",
-  "biyun.essay@3 mode=aggregate scope=local mark=biyun schema=biyun_essay[hook,paragraphs,sources,textConfidence,readingConfidence] deps=[gemara|commentaries|context|m:argument|m:rishonim|m:pesukim|e:argument-overview.synthesis|e:daf-background.concepts|e*:rishonim.synthesis|e*:argument.synthesis|e*:pesukim.synthesis|e*:halacha.synthesis]",
+  "biyun.essay@4 mode=aggregate scope=local mark=biyun schema=biyun_essay[hook,paragraphs,sources,textConfidence,readingConfidence] deps=[gemara|commentaries|context|m:argument|m:rishonim|m:pesukim|e:argument-overview.synthesis|e:daf-background.concepts|e*:rishonim.synthesis|e*:argument.synthesis|e*:pesukim.synthesis|e*:halacha.synthesis]",
   "daf-background.concepts@5 mode=augment-content scope=local mark=daf-background schema=daf_background_concepts[groups] deps=[gemara|context|m:argument]",
   "daf-background.synthesis@6 mode=aggregate scope=local mark=daf-background schema=daf_background_synthesis[synthesis] deps=[gemara|context|e:daf-background.concepts]",
   "halacha.codification@4 mode=augment-content scope=local mark=halacha schema=halacha_codification[mishnehTorah,tur,shulchanAruch,rema,prose] deps=[gemara|halacha-refs]",
@@ -48,6 +48,6 @@ exports[`CODE_ENRICHMENTS cache identity > per-enrichment fingerprint is stable 
   "rabbi.relationships@6 mode=augment-content scope=global mark=rabbi schema=rabbi_relationships[teachers,students,debatePartners,family,prose] deps=[]",
   "rabbi.synthesis@12 mode=aggregate scope=local mark=rabbi schema=rabbi_synthesis[synthesis] deps=[gemara|e:rabbi.bio|e:rabbi.philosophy|e:rabbi.relationships|e:rabbi.classification|e:rabbi.geography|e:rabbi.relationships.evidence|e:rabbi.geography.evidence|e:rabbi.location|e:rabbi.identity|m:rabbi|e:daf-background.concepts]",
   "rishonim.synthesis@4 mode=aggregate scope=local mark=rishonim schema=rishonim_synthesis[synthesis] deps=[gemara|m:rishonim]",
-  "tidbit.essay@14 mode=aggregate scope=local mark=tidbit schema=tidbit_essay[flavor,hook,paragraphs,sources,textConfidence,readingConfidence] deps=[gemara|context-light|m:argument|m:rabbi|m:pesukim|m:aggadata|m:halacha|m:places|e:argument-overview.synthesis|e:daf-background.concepts]",
+  "tidbit.essay@15 mode=aggregate scope=local mark=tidbit schema=tidbit_essay[flavor,hook,paragraphs,sources,textConfidence,readingConfidence] deps=[gemara|context-light|m:argument|m:rabbi|m:pesukim|m:aggadata|m:halacha|m:places|e:argument-overview.synthesis|e:daf-background.concepts]",
 ]
 `;


### PR DESCRIPTION
A thinking-model run of the Chullin 34 tidbit spliced a **Korean word** (`바리케이드`) where it meant 'barricade' — a rare stray foreign-script token (verified: 5 Korean codepoints). Add a one-line guard to the **shared** `HEBREW_GLOSS_STYLE` / `HEBREW_NATIVE_STYLE` so every prose enrichment must emit only English + Hebrew/Aramaic script (no Korean/Cyrillic/Arabic/CJK/emoji). Bumped the two reader-facing pills to regenerate clean now (tidbit 14→15, biyun 3→4); others adopt it lazily (SWR). typecheck clean; pnpm test green (1765).