### PR TITLE
Chart mark (experimental): comparison tables for dense, multi-opinion regions

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -1,5 +1,6 @@
 import { For, Show, Switch, Match, createEffect, createMemo, createResource, createSignal, onCleanup, type JSX } from 'solid-js';
-import type { Section, Rabbi, HalachaTopic, AggadataStory, Pasuk, YerushalmiParallel } from './shapes';
+import type { Section, Rabbi, HalachaTopic, AggadataStory, Pasuk, YerushalmiParallel, ChartTable } from './shapes';
+import { ChartTableView } from './ChartTableView';
 import { GENERATION_BY_ID, generationLabelHe, type GenerationId } from './generations';
 import type { IdentifiedRabbi } from './dafContext';
 import { Hebraized } from './Hebraized';
@@ -27,7 +28,7 @@ import { InspectDot, registerMarkRenderer } from './MarkEnrichmentCards';
 // Recipes now live in the shared lib (carried on the worker mark def too).
 // Re-exported so existing importers (CARD_DEFS, tests) keep their `from
 // './ArgumentSidebar'` path.
-import { AGGADATA_RECIPE, PASUK_RECIPE, HALACHA_RECIPE, RISHONIM_RECIPE, RABBI_RECIPE, YERUSHALMI_RECIPE, ARGUMENT_RECIPE, ARGUMENT_OVERVIEW_RECIPE, TIDBIT_RECIPE, BIYUN_RECIPE, DAF_BACKGROUND_RECIPE } from '../lib/sidebar/recipe';
+import { AGGADATA_RECIPE, PASUK_RECIPE, HALACHA_RECIPE, RISHONIM_RECIPE, RABBI_RECIPE, YERUSHALMI_RECIPE, ARGUMENT_RECIPE, ARGUMENT_OVERVIEW_RECIPE, TIDBIT_RECIPE, BIYUN_RECIPE, DAF_BACKGROUND_RECIPE, CHART_RECIPE } from '../lib/sidebar/recipe';
 export { AGGADATA_RECIPE, PASUK_RECIPE, HALACHA_RECIPE, RISHONIM_RECIPE, RABBI_RECIPE, YERUSHALMI_RECIPE, ARGUMENT_RECIPE, ARGUMENT_OVERVIEW_RECIPE, TIDBIT_RECIPE, BIYUN_RECIPE, DAF_BACKGROUND_RECIPE };
 
 /** Localize an era date-range ("c. 290 – 320 CE") for Hebrew display. */
@@ -131,6 +132,7 @@ function useVoicesGate(tractate: () => string, page: () => string, section: () =
 export type SidebarContent =
   | { kind: 'argument'; section: Section; index: number }
   | { kind: 'halacha'; topic: HalachaTopic; index: number }
+  | { kind: 'chart'; chart: ChartTable; index: number }
   | { kind: 'aggadata'; story: AggadataStory; index: number }
   | { kind: 'yerushalmi'; parallel: YerushalmiParallel; index: number }
   | { kind: 'pesuk'; pasuk: Pasuk; index: number }
@@ -1672,6 +1674,39 @@ export const HALACHA_BLOCKS: Record<string, (p: SpecialBlockProps) => JSX.Elemen
   'halacha-dispute': HalachaDispute,
 };
 
+// ---------------------------------------------------------------------------
+// Chart (experimental) — the whole card IS the comparison table. The instance
+// fields carry {headers, rows, notes}; ChartTableView renders the RTL grid.
+// ---------------------------------------------------------------------------
+
+export function chartInstance(chart: ChartTable): { fields: Record<string, unknown>; startSegIdx: number; endSegIdx: number } {
+  return {
+    startSegIdx: chart.startSegIdx ?? 0,
+    endSegIdx: chart.endSegIdx ?? chart.startSegIdx ?? 0,
+    fields: {
+      caption: chart.caption ?? '',
+      captionHe: chart.captionHe ?? '',
+      headers: chart.headers,
+      rows: chart.rows,
+      notes: chart.notes ?? [],
+      grounded: chart.grounded ?? false,
+    },
+  };
+}
+
+function ChartTableBlock(props: SpecialBlockProps): JSX.Element {
+  const f = () => props.instance.fields as { headers?: string[]; rows?: string[][]; notes?: { marker: string; text: string }[] };
+  return (
+    <Show when={(f().headers?.length ?? 0) > 0 && (f().rows?.length ?? 0) > 0}>
+      <ChartTableView table={{ headers: f().headers ?? [], rows: f().rows ?? [], notes: f().notes }} />
+    </Show>
+  );
+}
+
+export const CHART_BLOCKS: Record<string, (p: SpecialBlockProps) => JSX.Element> = {
+  'chart-table': ChartTableBlock,
+};
+
 /** Sidebar panel for a cited pasuk: shows the full Hebrew Tanakh verse and,
  *  on expand, the surrounding verses inlined as one continuous Hebrew block
  *  (prev + cited + next) with the cited verse rendered dark and the others
@@ -1827,6 +1862,7 @@ export function instanceKeyForContent(content: SidebarContent, tractate: string,
     case 'yerushalmi': return `${tractate}:${page}:${content.index}:${content.parallel.yerushalmiRef}`;
     case 'pesuk': return content.pasuk.verseRef;
     case 'halacha': return `${tractate}:${page}:${content.index}:${content.topic.topic}`;
+    case 'chart': return `${tractate}:${page}:${content.index}:${content.chart.caption ?? content.chart.excerpt ?? ''}`;
     case 'rabbi': return content.rabbi.name;
     case 'rishonim': return `rishonim:${tractate}:${page}:${content.instance.segIdx}`;
     default: return null;
@@ -2196,6 +2232,11 @@ export const CARD_DEFS: Partial<Record<SidebarContent['kind'], CardDef>> = {
     recipe: HALACHA_RECIPE,
     blocks: HALACHA_BLOCKS,
     instance: (c) => halachaInstance((c as Extract<SidebarContent, { kind: 'halacha' }>).topic),
+  },
+  chart: {
+    recipe: CHART_RECIPE,
+    blocks: CHART_BLOCKS,
+    instance: (c) => chartInstance((c as Extract<SidebarContent, { kind: 'chart' }>).chart),
   },
   rishonim: {
     recipe: RISHONIM_RECIPE,

--- a/src/client/ChartTableView.tsx
+++ b/src/client/ChartTableView.tsx
@@ -1,0 +1,62 @@
+/**
+ * Shared renderer for a Hebrew comparison chart — a bordered RTL table whose
+ * first column holds the (blue, bold) row labels, with footnotes below. Used by
+ * the dafyomi context workbench (ContextSourcePanel) and the experimental
+ * `chart` mark's sidebar card, so both render identically.
+ */
+import { For, Show, type JSX } from 'solid-js';
+
+export interface ChartTableShape {
+  headers: string[];
+  rows: string[][];
+  notes?: { marker: string; text: string }[];
+}
+
+/** Strip any residual HTML tags from scraped/generated cell text. */
+function stripTags(s: string | undefined): string {
+  return (s ?? '').replace(/<[^>]*>/g, '').trim();
+}
+
+export function ChartTableView(props: { table: ChartTableShape }): JSX.Element {
+  const cell = { border: '1px solid #4b5563', padding: '0.25rem 0.45rem', 'text-align': 'center', 'vertical-align': 'middle' } as const;
+  const hasHeaders = () => props.table.headers.some((h) => stripTags(h));
+  return (
+    <div style={{ 'overflow-x': 'auto', 'margin-top': '0.35rem' }}>
+      <table dir="rtl" lang="he" style={{ 'border-collapse': 'collapse', 'font-family': '"Mekorot Vilna", serif', 'font-size': '0.85rem', width: '100%' }}>
+        <Show when={hasHeaders()}>
+          <thead>
+            <tr>
+              <For each={props.table.headers}>
+                {(h) => <th style={{ ...cell, background: '#fef9c3', color: '#1e3a8a', 'font-weight': 700 }}>{stripTags(h)}</th>}
+              </For>
+            </tr>
+          </thead>
+        </Show>
+        <tbody>
+          <For each={props.table.rows}>
+            {(row) => (
+              <tr>
+                <For each={row}>
+                  {(c, ci) => (
+                    <td style={{ ...cell, color: ci() === 0 ? '#1e3a8a' : '#333', 'font-weight': ci() === 0 ? 700 : 400 }}>{stripTags(c)}</td>
+                  )}
+                </For>
+              </tr>
+            )}
+          </For>
+        </tbody>
+      </table>
+      <Show when={props.table.notes?.length}>
+        <div style={{ 'margin-top': '0.35rem', 'font-size': '0.72rem', color: '#666' }}>
+          <For each={props.table.notes}>
+            {(n) => (
+              <div dir="rtl" lang="he" style={{ 'font-family': '"Mekorot Vilna", serif' }}>
+                <span style={{ color: '#0369a1', 'font-family': 'monospace' }}>{n.marker}</span> {stripTags(n.text)}
+              </div>
+            )}
+          </For>
+        </div>
+      </Show>
+    </div>
+  );
+}

--- a/src/client/ContextSourcePanel.tsx
+++ b/src/client/ContextSourcePanel.tsx
@@ -1,6 +1,7 @@
 import { createSignal, createMemo, createEffect, For, Show, type JSX } from 'solid-js';
 import { type ContextItem, rangeLabel } from '../lib/context/types';
 import { isLocated, placementOf, isReferenceSource } from '../lib/context/placement';
+import { ChartTableView } from './ChartTableView';
 
 /** Highlight payload: precise HB word indices + the segments they sit in, or a
  *  whole-daf wash (`daf`). */
@@ -205,57 +206,11 @@ function ContextCard(props: { item: ContextItem; onEnter: () => void; onLeave: (
         </Show>
       </Show>
       <Show when={it.table}>
-        {(tbl) => <ChartTable table={tbl()} />}
+        {(tbl) => <ChartTableView table={tbl()} />}
       </Show>
       <Show when={!it.table && !bodyEn() && it.body?.he}>
         <div dir="rtl" lang="he" style={{ 'font-family': '"Mekorot Vilna", serif', 'font-size': '0.9rem', 'line-height': 1.55 }}>{stripTags(it.body!.he)}</div>
       </Show>
     </article>
-  );
-}
-
-/** Render a dafyomi Hebrew comparison chart as a bordered RTL table: the first
- *  cell of each row is the (blue, bold) row label; footnotes follow below. */
-function ChartTable(props: { table: NonNullable<ContextItem['table']> }): JSX.Element {
-  const cell = { border: '1px solid #4b5563', padding: '0.25rem 0.45rem', 'text-align': 'center', 'vertical-align': 'middle' } as const;
-  const hasHeaders = () => props.table.headers.some((h) => stripTags(h));
-  return (
-    <div style={{ 'overflow-x': 'auto', 'margin-top': '0.35rem' }}>
-      <table dir="rtl" lang="he" style={{ 'border-collapse': 'collapse', 'font-family': '"Mekorot Vilna", serif', 'font-size': '0.85rem', width: '100%' }}>
-        <Show when={hasHeaders()}>
-          <thead>
-            <tr>
-              <For each={props.table.headers}>
-                {(h) => <th style={{ ...cell, background: '#fef9c3', color: '#1e3a8a', 'font-weight': 700 }}>{stripTags(h)}</th>}
-              </For>
-            </tr>
-          </thead>
-        </Show>
-        <tbody>
-          <For each={props.table.rows}>
-            {(row) => (
-              <tr>
-                <For each={row}>
-                  {(c, ci) => (
-                    <td style={{ ...cell, color: ci() === 0 ? '#1e3a8a' : '#333', 'font-weight': ci() === 0 ? 700 : 400 }}>{stripTags(c)}</td>
-                  )}
-                </For>
-              </tr>
-            )}
-          </For>
-        </tbody>
-      </table>
-      <Show when={props.table.notes?.length}>
-        <div style={{ 'margin-top': '0.35rem', 'font-size': '0.72rem', color: '#666' }}>
-          <For each={props.table.notes}>
-            {(n) => (
-              <div dir="rtl" lang="he" style={{ 'font-family': '"Mekorot Vilna", serif' }}>
-                <span style={{ color: '#0369a1', 'font-family': 'monospace' }}>{n.marker}</span> {stripTags(n.text)}
-              </div>
-            )}
-          </For>
-        </div>
-      </Show>
-    </div>
   );
 }

--- a/src/client/DafViewer.tsx
+++ b/src/client/DafViewer.tsx
@@ -8,6 +8,7 @@ import { HighlightNotePopover, NotesPanel } from './UserHighlightUI';
 import type {
   DafAnalysis, Section,
   HalachaResult, HalachaTopic,
+  ChartResult, ChartTable,
   AggadataResult,
   PesukimResult,
   YerushalmiResult,
@@ -126,7 +127,7 @@ function paintRangeOverlay(
   overlay: HTMLElement,
   origin: HTMLElement,
   ranges: Range[],
-  kind: 'section' | 'halacha' | 'aggadata' | 'yerushalmi' | 'pesuk' | 'rishonim' | 'move' | 'commentary' | 'commentary-active' | 'comm-anchor' | 'user',
+  kind: 'section' | 'halacha' | 'chart' | 'aggadata' | 'yerushalmi' | 'pesuk' | 'rishonim' | 'move' | 'commentary' | 'commentary-active' | 'comm-anchor' | 'user',
   /** Optional per-range inline background color. */
   bgFor?: (rangeIdx: number) => string | undefined,
 ): void {
@@ -269,6 +270,7 @@ import { LruMap } from '../lib/lruMap';
 const SESSION_CACHE_MAX = 32;
 const analysisSessionCache = new LruMap<string, DafAnalysis>(SESSION_CACHE_MAX);
 const halachaSessionCache = new LruMap<string, HalachaResult>(SESSION_CACHE_MAX);
+const chartSessionCache = new LruMap<string, ChartResult>(SESSION_CACHE_MAX);
 const aggadataSessionCache = new LruMap<string, AggadataResult>(SESSION_CACHE_MAX);
 const yerushalmiSessionCache = new LruMap<string, YerushalmiResult>(SESSION_CACHE_MAX);
 const pesukimSessionCache = new LruMap<string, PesukimResult>(SESSION_CACHE_MAX);
@@ -277,6 +279,7 @@ const GEN_KEY = 'daf.showGenMarkers';
 const COMMENTARIES_KEY = 'daf.toggle.commentaries';
 const ARGUMENTS_KEY = 'daf.toggle.arguments';
 const HALACHOT_KEY = 'daf.toggle.halachot';
+const CHART_KEY = 'daf.toggle.chart';
 const AGGADATOT_KEY = 'daf.toggle.aggadatot';
 const YERUSHALMI_KEY = 'daf.toggle.yerushalmi';
 const PESUKIM_KEY = 'daf.toggle.pesukim';
@@ -382,6 +385,7 @@ export default function DafViewer(): JSX.Element {
   const [showCommentaries, setShowCommentaries] = createSignal(loadToggle(COMMENTARIES_KEY, false));
   const [showArguments, setShowArguments] = createSignal(loadToggle(ARGUMENTS_KEY, false));
   const [showHalachot, setShowHalachot] = createSignal(loadToggle(HALACHOT_KEY, false));
+  const [showChart, setShowChart] = createSignal(loadToggle(CHART_KEY, false));
   const [showAggadatot, setShowAggadatot] = createSignal(loadToggle(AGGADATOT_KEY, false));
   const [showYerushalmi, setShowYerushalmi] = createSignal(loadToggle(YERUSHALMI_KEY, false));
   const [showPesukim, setShowPesukim] = createSignal(loadToggle(PESUKIM_KEY, false));
@@ -467,6 +471,45 @@ export default function DafViewer(): JSX.Element {
     };
     setHalacha(adapted);
     halachaSessionCache.set(`${tractate()}:${page()}:${lang()}`, adapted);
+  });
+
+  // Adapter: chart mark instances → ChartResult (experimental). Each instance's
+  // fields ARE the comparison table.
+  createEffect(() => {
+    const runs = markRunsByMarkId();
+    const r = runs['chart'];
+    if (!r?.parsed) return;
+    const p = r.parsed as {
+      instances?: Array<{
+        startSegIdx: number;
+        endSegIdx: number;
+        fields: {
+          caption?: string; captionHe?: string;
+          headers?: string[]; rows?: string[][];
+          notes?: { marker: string; text: string }[];
+          excerpt?: string; grounded?: boolean; confidence?: string;
+        };
+      }>;
+    };
+    if (!Array.isArray(p.instances)) return;
+    const adapted: ChartResult = {
+      charts: p.instances
+        .filter((inst) => Array.isArray(inst.fields.headers) && Array.isArray(inst.fields.rows) && inst.fields.rows.length > 0)
+        .map((inst) => ({
+          caption: inst.fields.caption,
+          captionHe: inst.fields.captionHe,
+          headers: inst.fields.headers ?? [],
+          rows: inst.fields.rows ?? [],
+          notes: inst.fields.notes,
+          excerpt: inst.fields.excerpt,
+          grounded: inst.fields.grounded,
+          confidence: inst.fields.confidence,
+          startSegIdx: inst.startSegIdx,
+          endSegIdx: inst.endSegIdx,
+        })),
+    };
+    setChart(adapted);
+    chartSessionCache.set(`${tractate()}:${page()}:${lang()}`, adapted);
   });
 
   // Adapter: aggadata mark instances → AggadataResult.
@@ -612,6 +655,7 @@ export default function DafViewer(): JSX.Element {
     if (showGenMarkers() !== want('rabbi')) setShowGenMarkers(want('rabbi'));
     if (showArguments() !== want('argument')) setShowArguments(want('argument'));
     if (showHalachot() !== want('halacha')) setShowHalachot(want('halacha'));
+    if (showChart() !== want('chart')) setShowChart(want('chart'));
     if (showAggadatot() !== want('aggadata')) setShowAggadatot(want('aggadata'));
     if (showYerushalmi() !== want('yerushalmi')) setShowYerushalmi(want('yerushalmi'));
     if (showPesukim() !== want('pesukim')) setShowPesukim(want('pesukim'));
@@ -770,6 +814,7 @@ export default function DafViewer(): JSX.Element {
   // error states are surfaced via `markStatuses()` from the registry.
   const [analysis, setAnalysis] = createSignal<DafAnalysis | null>(null);
   const [halacha, setHalacha] = createSignal<HalachaResult | null>(null);
+  const [chart, setChart] = createSignal<ChartResult | null>(null);
   const [aggadata, setAggadata] = createSignal<AggadataResult | null>(null);
   const [yerushalmi, setYerushalmi] = createSignal<YerushalmiResult | null>(null);
   const [pesukim, setPesukim] = createSignal<PesukimResult | null>(null);
@@ -815,6 +860,7 @@ export default function DafViewer(): JSX.Element {
   const sidebarLabel = (c: SidebarContent): string => {
     if (c.kind === 'argument') return c.section.title || 'Argument';
     if (c.kind === 'halacha') return c.topic.topic || 'Halacha';
+    if (c.kind === 'chart') return c.chart.caption || 'Chart';
     if (c.kind === 'aggadata') return c.story.title || 'Aggada';
     if (c.kind === 'yerushalmi') return c.parallel.yerushalmiRef || 'Yerushalmi';
     if (c.kind === 'pesuk') return c.pasuk.verseRef || 'Pasuk';
@@ -831,6 +877,7 @@ export default function DafViewer(): JSX.Element {
   const sidebarKey = (c: SidebarContent): string => {
     if (c.kind === 'argument') return `argument:${c.section.startSegIdx}-${c.section.endSegIdx}`;
     if (c.kind === 'halacha') return `halacha:${c.topic.topic}`;
+    if (c.kind === 'chart') return `chart:${c.index}:${c.chart.caption ?? c.chart.excerpt ?? ''}`;
     if (c.kind === 'aggadata') return `aggadata:${c.story.title}`;
     if (c.kind === 'yerushalmi') return `yerushalmi:${c.parallel.yerushalmiRef}`;
     if (c.kind === 'pesuk') return `pesuk:${c.pasuk.verseRef}`;
@@ -1074,6 +1121,10 @@ export default function DafViewer(): JSX.Element {
   });
   createEffect(() => {
     if (typeof localStorage === 'undefined') return;
+    localStorage.setItem(CHART_KEY, String(showChart()));
+  });
+  createEffect(() => {
+    if (typeof localStorage === 'undefined') return;
     localStorage.setItem(AGGADATOT_KEY, String(showAggadatot()));
   });
   createEffect(() => {
@@ -1095,6 +1146,12 @@ export default function DafViewer(): JSX.Element {
   });
   createEffect(() => {
     if (!showHalachot() && sidebar()?.kind === 'halacha') {
+      setSidebar(null);
+      setActiveRabbi(null);
+    }
+  });
+  createEffect(() => {
+    if (!showChart() && sidebar()?.kind === 'chart') {
       setSidebar(null);
       setActiveRabbi(null);
     }
@@ -1182,6 +1239,7 @@ export default function DafViewer(): JSX.Element {
     const key = `${t}:${p}:${l}`;
     setAnalysis(analysisSessionCache.get(key) ?? null);
     setHalacha(halachaSessionCache.get(key) ?? null);
+    setChart(chartSessionCache.get(key) ?? null);
     setAggadata(aggadataSessionCache.get(key) ?? null);
     setYerushalmi(yerushalmiSessionCache.get(key) ?? null);
     setPesukim(pesukimSessionCache.get(key) ?? null);
@@ -1337,6 +1395,7 @@ export default function DafViewer(): JSX.Element {
 
     const sectionRanges: Range[] = [];
     const halachaRanges: Range[] = [];
+    const chartRanges: Range[] = [];
     const aggadataRanges: Range[] = [];
     const yerushalmiRanges: Range[] = [];
     const pesukRanges: Range[] = [];
@@ -1349,10 +1408,11 @@ export default function DafViewer(): JSX.Element {
      *  commAnchorActive.direction === 'from-piece'. */
     const commAnchorRanges: Range[] = [];
 
-    const collectRange = (range: Range, bucket: 'section' | 'halacha' | 'aggadata' | 'yerushalmi' | 'pesuk' | 'rishonim') => {
+    const collectRange = (range: Range, bucket: 'section' | 'halacha' | 'chart' | 'aggadata' | 'yerushalmi' | 'pesuk' | 'rishonim') => {
       if (range.collapsed) return;
       if (bucket === 'section') sectionRanges.push(range);
       else if (bucket === 'halacha') halachaRanges.push(range);
+      else if (bucket === 'chart') chartRanges.push(range);
       else if (bucket === 'aggadata') aggadataRanges.push(range);
       else if (bucket === 'yerushalmi') yerushalmiRanges.push(range);
       else if (bucket === 'pesuk') pesukRanges.push(range);
@@ -1464,6 +1524,28 @@ export default function DafViewer(): JSX.Element {
           range.setStartBefore(target[0]);
           range.setEndAfter(target[target.length - 1]);
           collectRange(range, 'halacha');
+        }
+      }
+    }
+
+    // Chart (experimental): the excerpt anchored by the injected marker.
+    if (s?.kind === 'chart') {
+      const anchor = dafRootDiv.querySelector<HTMLElement>(
+        `.daf-chart-anchor[data-idx="${s.index}"]`,
+      );
+      const len = Number(anchor?.getAttribute('data-excerpt-len') ?? 0);
+      const mainText = dafRootDiv.querySelector<HTMLElement>('.daf-main .daf-text');
+      if (anchor && len > 0 && mainText) {
+        const words = Array.from(mainText.querySelectorAll<HTMLElement>('.daf-word'));
+        const after = words.filter(
+          (w) => !!(anchor.compareDocumentPosition(w) & Node.DOCUMENT_POSITION_FOLLOWING),
+        );
+        const target = after.slice(0, len);
+        if (target.length > 0) {
+          const range = document.createRange();
+          range.setStartBefore(target[0]);
+          range.setEndAfter(target[target.length - 1]);
+          collectRange(range, 'chart');
         }
       }
     }
@@ -1711,6 +1793,7 @@ export default function DafViewer(): JSX.Element {
     paintRangeOverlay(overlay, dafRootDiv, commentaryActiveRanges, 'commentary-active');
     paintRangeOverlay(overlay, dafRootDiv, sectionRanges, 'section');
     paintRangeOverlay(overlay, dafRootDiv, halachaRanges, 'halacha');
+    paintRangeOverlay(overlay, dafRootDiv, chartRanges, 'chart');
     paintRangeOverlay(overlay, dafRootDiv, aggadataRanges, 'aggadata');
     paintRangeOverlay(overlay, dafRootDiv, yerushalmiRanges, 'yerushalmi');
     paintRangeOverlay(overlay, dafRootDiv, pesukRanges, 'pesuk');
@@ -1786,7 +1869,7 @@ export default function DafViewer(): JSX.Element {
       // Scroll to the topmost *selection* band only (ignore the ambient
       // commentary tint, which can sit higher up the daf).
       const bands = overlay.querySelectorAll<HTMLElement>(
-        '.daf-range-highlight-section, .daf-range-highlight-halacha, .daf-range-highlight-aggadata, .daf-range-highlight-yerushalmi, .daf-range-highlight-pesuk, .daf-range-highlight-move',
+        '.daf-range-highlight-section, .daf-range-highlight-halacha, .daf-range-highlight-chart, .daf-range-highlight-aggadata, .daf-range-highlight-yerushalmi, .daf-range-highlight-pesuk, .daf-range-highlight-move',
       );
       let topY = Infinity;
       bands.forEach((el) => {
@@ -1972,6 +2055,15 @@ export default function DafViewer(): JSX.Element {
       if (anchors.length > 0) main = injectAnchorMarkers(main, anchors, 'daf-halacha-anchor', ctx);
     }
 
+    // Chart anchors (experimental): one per chart at its region's start.
+    const ch = chart();
+    if (ch && showChart()) {
+      const anchors = ch.charts
+        .map((c, i) => ({ excerpt: c.excerpt ?? '', index: i, startSegIdx: c.startSegIdx }))
+        .filter((x) => x.excerpt.length > 0 || x.startSegIdx != null);
+      if (anchors.length > 0) main = injectAnchorMarkers(main, anchors, 'daf-chart-anchor', ctx);
+    }
+
     // Aggadata anchors: one start + one end per story so the highlight spans
     // from the opening phrase to the closing phrase, rather than bleeding
     // into the next topic.
@@ -2018,7 +2110,7 @@ export default function DafViewer(): JSX.Element {
   const gutterKey = createMemo(() => {
     const t = tokenized();
     if (!t) return '';
-    return `${tractate()}:${page()}:${t.main.length}:${analysis()?.sections.length ?? 0}:${halacha()?.topics.length ?? 0}:${aggadata()?.stories.length ?? 0}:${yerushalmi()?.parallels.length ?? 0}:${pesukim()?.pesukim.length ?? 0}`;
+    return `${tractate()}:${page()}:${t.main.length}:${analysis()?.sections.length ?? 0}:${halacha()?.topics.length ?? 0}:${chart()?.charts.length ?? 0}:${aggadata()?.stories.length ?? 0}:${yerushalmi()?.parallels.length ?? 0}:${pesukim()?.pesukim.length ?? 0}`;
   });
 
   // Mutual exclusion: opening anything in the argument/rabbi/aggadata sidebar
@@ -2049,6 +2141,15 @@ export default function DafViewer(): JSX.Element {
     clearCommentarySelection();
     setActiveRabbi(null);
     setSidebar({ kind: 'halacha', topic: h.topics[index], index });
+    setLastInteractedCard('argument');
+  };
+
+  const openChart = (index: number) => {
+    const ch = chart();
+    if (!ch || !ch.charts[index]) return;
+    clearCommentarySelection();
+    setActiveRabbi(null);
+    setSidebar({ kind: 'chart', chart: ch.charts[index], index });
     setLastInteractedCard('argument');
   };
 
@@ -2097,6 +2198,7 @@ export default function DafViewer(): JSX.Element {
     }
     if (kind === 'argument') openArgument(index);
     else if (kind === 'halacha') openHalacha(index);
+    else if (kind === 'chart') openChart(index);
     else if (kind === 'aggadata') openStory(index);
     else if (kind === 'yerushalmi') openYerushalmi(index);
     else if (kind === 'pesuk') openPasuk(index);
@@ -3026,6 +3128,15 @@ export default function DafViewer(): JSX.Element {
                   triggerKey={gutterKey()}
                   onClick={onGutterClick}
                   kind="halacha"
+                  activeKey={sidebarActiveKey()}
+                />
+              </Show>
+              <Show when={showChart()}>
+                <GutterIcons
+                  containerRef={dafRootEl}
+                  triggerKey={gutterKey()}
+                  onClick={onGutterClick}
+                  kind="chart"
                   activeKey={sidebarActiveKey()}
                 />
               </Show>

--- a/src/client/GutterIcons.tsx
+++ b/src/client/GutterIcons.tsx
@@ -17,7 +17,7 @@ import { createEffect, onMount, onCleanup, type JSX } from 'solid-js';
 import { publishGutterEntry, clearGutterEntry, type GutterSide } from './gutterStack';
 import { t } from './i18n';
 
-export type GutterKind = 'argument' | 'halacha' | 'aggadata' | 'yerushalmi' | 'pesuk' | 'rishonim';
+export type GutterKind = 'argument' | 'halacha' | 'chart' | 'aggadata' | 'yerushalmi' | 'pesuk' | 'rishonim';
 
 export interface GutterItem {
   kind: GutterKind;
@@ -104,6 +104,7 @@ export function GutterIcons(props: GutterIconsProps): JSX.Element {
 
     const klass = props.kind === 'argument' ? '.daf-argument-anchor'
       : props.kind === 'halacha' ? '.daf-halacha-anchor'
+      : props.kind === 'chart' ? '.daf-chart-anchor'
       : props.kind === 'aggadata' ? '.daf-aggadata-anchor'
       : props.kind === 'yerushalmi' ? '.daf-yerushalmi-anchor'
       : props.kind === 'rishonim' ? '.daf-rishonim-anchor'
@@ -178,6 +179,7 @@ export function GutterIcons(props: GutterIconsProps): JSX.Element {
 export function colorForKind(kind: GutterKind): string {
   return kind === 'argument' ? '#8a2a2b'
     : kind === 'halacha' ? '#1e40af'
+    : kind === 'chart' ? '#0e7490'
     : kind === 'aggadata' ? '#7c3aed'
     : kind === 'yerushalmi' ? '#0f766e'
     : kind === 'rishonim' ? '#475569'
@@ -187,6 +189,7 @@ export function colorForKind(kind: GutterKind): string {
 export function titleForKind(kind: GutterKind): string {
   return kind === 'argument' ? t('gutter.argument')
     : kind === 'halacha' ? t('gutter.halacha')
+    : kind === 'chart' ? t('gutter.chart')
     : kind === 'aggadata' ? t('gutter.aggadata')
     : kind === 'yerushalmi' ? t('gutter.yerushalmi')
     : kind === 'rishonim' ? t('gutter.rishonim')
@@ -257,6 +260,23 @@ export function GutterGlyph(props: { kind: GutterKind }): JSX.Element {
     >
       י
     </span>
+  ) : props.kind === 'chart' ? (
+    <svg
+      viewBox="0 0 24 24"
+      width="9"
+      height="9"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="3"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="3" y="3" width="18" height="18" rx="2" />
+      <path d="M3 9h18" />
+      <path d="M3 15h18" />
+      <path d="M9 3v18" />
+    </svg>
   ) : props.kind === 'rishonim' ? (
     <span
       aria-hidden="true"

--- a/src/client/GutterOverlay.tsx
+++ b/src/client/GutterOverlay.tsx
@@ -90,7 +90,7 @@ function clustersFromEntries(entries: Partial<Record<GutterKind, GutterStackEntr
   // Within a cluster, give the icons a stable order so collisions don't
   // shuffle visually on every measurement. Sort by kind priority — argument
   // first on left, halacha first on right (matches user mental model).
-  const KIND_ORDER: GutterKind[] = ['argument', 'pesuk', 'halacha', 'aggadata', 'yerushalmi', 'rishonim'];
+  const KIND_ORDER: GutterKind[] = ['argument', 'pesuk', 'halacha', 'chart', 'aggadata', 'yerushalmi', 'rishonim'];
   for (const c of out) {
     c.items.sort((a, b) => KIND_ORDER.indexOf(a.kind) - KIND_ORDER.indexOf(b.kind));
   }

--- a/src/client/MobileShelf.tsx
+++ b/src/client/MobileShelf.tsx
@@ -167,6 +167,7 @@ function labelForSidebar(s: SidebarContent | null): string {
   switch (s.kind) {
     case 'argument': return 'Argument';
     case 'halacha': return 'Halacha';
+    case 'chart': return 'Chart';
     case 'aggadata': return 'Aggadata';
     case 'yerushalmi': return 'Yerushalmi';
     case 'pesuk': return 'Pasuk';

--- a/src/client/i18n.ts
+++ b/src/client/i18n.ts
@@ -165,6 +165,7 @@ const CATALOG = {
   // — Sidebar kind titles —
   'sidebar.kind.argument': { en: 'Argument', he: 'סוגיה' },
   'sidebar.kind.halacha': { en: 'Practical Halacha', he: 'הלכה למעשה' },
+  'sidebar.kind.chart': { en: 'Chart', he: 'טבלה' },
   'sidebar.kind.aggadata': { en: 'Aggada', he: 'אגדה' },
   'sidebar.kind.yerushalmi': { en: 'Yerushalmi', he: 'ירושלמי' },
   'sidebar.kind.pesuk': { en: 'Pasuk', he: 'פסוק' },
@@ -717,6 +718,7 @@ const CATALOG = {
   // — Gutter icon tooltips —
   'gutter.argument': { en: 'Argument structure & rabbis', he: 'מבנה הסוגיה וחכמים' },
   'gutter.halacha': { en: 'Practical halacha', he: 'הלכה למעשה' },
+  'gutter.chart': { en: 'Comparison chart for this region', he: 'טבלת השוואה לקטע זה' },
   'gutter.aggadata': { en: 'Aggada — narrative on this line', he: 'אגדה — סיפור בשורה זו' },
   'gutter.yerushalmi': { en: 'Yerushalmi — parallel in the Jerusalem Talmud', he: 'ירושלמי — מקבילה בתלמוד הירושלמי' },
   'gutter.rishonim': { en: 'Rishonim on this line', he: 'ראשונים על שורה זו' },

--- a/src/client/shapes.ts
+++ b/src/client/shapes.ts
@@ -67,6 +67,32 @@ export interface HalachaResult {
 }
 
 // ===========================================================================
+// Charts (mark id: 'chart') — EXPERIMENTAL. Comparison tables for dense,
+// multi-opinion regions; cells are Hebrew (like the dafyomi.co.il source
+// charts). The first cell of each row is its row-label.
+// ===========================================================================
+
+export interface ChartTable {
+  caption?: string;
+  captionHe?: string;
+  headers: string[];
+  rows: string[][];
+  notes?: { marker: string; text: string }[];
+  excerpt?: string;
+  grounded?: boolean;
+  confidence?: string;
+  startSegIdx?: number;
+  endSegIdx?: number;
+}
+
+export interface ChartResult {
+  charts: ChartTable[];
+  _cached?: boolean;
+  _model?: string;
+  error?: string;
+}
+
+// ===========================================================================
 // Aggadata stories (mark id: 'aggadata')
 // ===========================================================================
 

--- a/src/client/sidebar/primitives.tsx
+++ b/src/client/sidebar/primitives.tsx
@@ -34,6 +34,7 @@ export const ACCENTS = {
   tidbit: '#2f6b66',
   biyun: '#3f4ea0',
   halacha: '#1e40af',
+  chart: '#0e7490',
   aggadata: '#7c3aed',
   yerushalmi: '#0f766e',
   pesuk: '#9a3412',
@@ -55,6 +56,7 @@ export function kindLabelKey(kind: SidebarKind): CatalogKey {
     case 'tidbit': return 'sidebar.kind.tidbit';
     case 'biyun': return 'sidebar.kind.biyun';
     case 'halacha': return 'sidebar.kind.halacha';
+    case 'chart': return 'sidebar.kind.chart';
     case 'aggadata': return 'sidebar.kind.aggadata';
     case 'yerushalmi': return 'sidebar.kind.yerushalmi';
     case 'pesuk': return 'sidebar.kind.pesuk';

--- a/src/lib/daf-render/styles.css
+++ b/src/lib/daf-render/styles.css
@@ -273,6 +273,11 @@
 .daf-root .daf-range-highlight-halacha {
   background-color: rgba(30, 64, 175, 0.25);
 }
+/* Chart highlight (experimental) — cyan tint matching the chart gutter/sidebar
+   accent (#0e7490), painted over the dense region a comparison table covers. */
+.daf-root .daf-range-highlight-chart {
+  background-color: rgba(14, 116, 144, 0.2);
+}
 .daf-root .daf-range-highlight-aggadata {
   background-color: rgba(124, 58, 237, 0.22);
 }

--- a/src/lib/sidebar/recipe.ts
+++ b/src/lib/sidebar/recipe.ts
@@ -122,6 +122,19 @@ export const HALACHA_RECIPE: SidebarRecipe = {
   ],
 };
 
+export const CHART_RECIPE: SidebarRecipe = {
+  kind: 'chart',
+  markId: 'chart',
+  titleField: 'caption',
+  titleHeField: 'captionHe',
+  sections: [
+    // The whole card IS the table — a custom block that renders the instance's
+    // own {headers, rows, notes} as an RTL Hebrew comparison grid (reusing the
+    // dafyomi ChartTable renderer). No enrichment deps.
+    { type: 'special', block: 'chart-table' },
+  ],
+};
+
 export const RISHONIM_RECIPE: SidebarRecipe = {
   kind: 'rishonim',
   markId: 'rishonim',

--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -47,6 +47,7 @@ import {
   ARGUMENT_VOICES_OUTPUT_SCHEMA,
   ARGUMENT_NARRATIVE_OUTPUT_SCHEMA,
   ARGUMENT_OVERVIEW_FLOW_OUTPUT_SCHEMA,
+  CHART_OUTPUT_SCHEMA,
   DAF_BACKGROUND_CONCEPTS_OUTPUT_SCHEMA,
   HALACHA_CODIFICATION_OUTPUT_SCHEMA,
   HALACHA_DISPUTE_OUTPUT_SCHEMA,
@@ -82,7 +83,7 @@ import {
   BIYUN_ESSAY_OUTPUT_SCHEMA,
   proseSchema,
 } from './output-schemas';
-import { AGGADATA_RECIPE, PASUK_RECIPE, HALACHA_RECIPE, RISHONIM_RECIPE, RABBI_RECIPE, YERUSHALMI_RECIPE, ARGUMENT_RECIPE, ARGUMENT_OVERVIEW_RECIPE, TIDBIT_RECIPE, BIYUN_RECIPE, DAF_BACKGROUND_RECIPE } from '../lib/sidebar/recipe';
+import { AGGADATA_RECIPE, PASUK_RECIPE, HALACHA_RECIPE, RISHONIM_RECIPE, RABBI_RECIPE, YERUSHALMI_RECIPE, ARGUMENT_RECIPE, ARGUMENT_OVERVIEW_RECIPE, TIDBIT_RECIPE, BIYUN_RECIPE, DAF_BACKGROUND_RECIPE, CHART_RECIPE } from '../lib/sidebar/recipe';
 
 // ---------------------------------------------------------------------------
 // Rabbi mark — phrase anchor + inline render
@@ -289,6 +290,75 @@ const HALACHA_USER_TEMPLATE_HE = `מסכת: {{tractate}}, דף {{page}}.
 {{segments_he}}
 
 זהה נושאים הלכתיים. החזר JSON לפי הסכמה.`;
+
+
+// ---------------------------------------------------------------------------
+// Chart mark (experimental) — comparison tables for dense, multi-opinion
+// regions. Grounded on the dafyomi.co.il "## Charts" exemplars when present,
+// generated from gemara + commentaries otherwise. Cells are Hebrew (the
+// content language, like the source charts), regardless of UI language — so
+// it stays single-prompt (no _he variant).
+// ---------------------------------------------------------------------------
+
+const CHART_SYSTEM_PROMPT = `You are a Talmud scholar who builds COMPARISON TABLES that let a learner grasp a dense, tangled region of the daf at a single glance.
+
+Output STRICT JSON only — no markdown, no prose:
+
+{
+  "instances": [
+    {
+      "startSegIdx": 0,
+      "endSegIdx": 4,
+      "fields": {
+        "caption": "Short English title of what the table compares (e.g. 'When the evening Shema may be read, by opinion').",
+        "captionHe": "Short Hebrew title (3-8 words).",
+        "headers": ["", "מפלג המנחה", "משעה שקדש היום"],
+        "rows": [
+          ["פרשה ראשונה על מטתו לרש\\"י", "לא יצא", "לא יצא"],
+          ["לרבינו תם", "יצא", "יצא"]
+        ],
+        "notes": [{ "marker": "[1]", "text": "Short Hebrew clarification referenced from a cell." }],
+        "excerpt": "3-5 Hebrew/Aramaic words copied VERBATIM where the region begins.",
+        "grounded": true,
+        "confidence": "high"
+      }
+    }
+  ]
+}
+
+WHEN to make a table — be STRICT:
+- ONLY for a region that is genuinely hard to follow because MULTIPLE opinions interact across MULTIPLE cases/scenarios/conditions: a machloket where each view rules differently across several situations, a multi-way dispute over times/amounts/measures, a grid of "according to X it is A, according to Y it is B".
+- A good table has at least 2 rows AND at least 2 comparison columns (a true grid). A two-column list is usually better as prose — skip it.
+- DO NOT tabulate: a single linear argument, a single opinion, narrative/aggadah, a definition, or anything one sentence captures.
+- If nothing on the daf qualifies, return {"instances": []}. MOST dapim yield 0-1 tables; many yield 0. PRECISION OVER RECALL — a forced or wrong table is worse than none.
+
+HOW to build it:
+- rows = the things being compared down the side (usually the opinions/views, sometimes the cases); columns = the dimension across the top (usually the cases/scenarios, sometimes the opinions). Pick whichever orientation reads most clearly.
+- The FIRST cell of every row is its row-label. headers[0] labels the row-label column and is often "". Every row MUST have exactly headers.length cells.
+- CELLS ARE HEBREW and TERSE — the ruling/value at that intersection in a few words (e.g. "יצא" / "לא יצא" / "עד חצות"), NOT full sentences. Mirror the source's wording.
+- attribute opinions in Hebrew the way the gemara/commentators do (לרש"י, לרבינו תם, לר"י, לחכמים, לרבן גמליאל).
+- notes: optional footnotes ([1], [2]) referenced inside cells for a caveat that doesn't fit a cell.
+
+GROUNDING:
+- The context below may include a "## Charts" section — real comparison charts from Kollel Iyun HaDaf for THIS daf. If one covers your region, ADOPT its structure and values (it is authoritative); set "grounded": true.
+- Where no such chart exists but the region still qualifies, build the table yourself from the gemara + commentaries; set "grounded": false and be conservative.
+
+ANCHORING:
+- "startSegIdx"/"endSegIdx" are valid 0-based indices from the [N] markers spanning the region the table summarizes. "excerpt" is Hebrew/Aramaic verbatim from where that region begins.
+- "confidence": "high" | "medium" | "low" — how faithfully the table represents the actual dispute.`;
+
+const CHART_USER_TEMPLATE = `Tractate: {{tractate}}, page {{page}}.
+
+Hebrew/Aramaic source — each line begins with [N], the 0-based segment index. USE these indices for startSegIdx / endSegIdx:
+{{segments_he}}
+
+Commentaries (Rashi, Tosafot, Rishonim) on this daf:
+{{commentaries}}
+
+External study context — note any "## Charts" entries are authoritative Kollel Iyun HaDaf comparison charts to ground on:
+{{context}}
+
+Build comparison tables ONLY for regions that genuinely warrant a grid. Return JSON per the schema (empty instances if none qualify).`;
 
 
 // ---------------------------------------------------------------------------
@@ -734,6 +804,37 @@ export const CODE_MARKS: MarkDefinition[] = [
     status: 'promoted',
     def_hash: 'halacha-llm-v2',
     cache_version: '3',
+    source: 'code',
+    updated_at: NOW,
+  },
+  {
+    id: 'chart',
+    recipe: CHART_RECIPE,
+    label: 'Charts',
+    description: 'Experimental: comparison-table gutter icons + sidebar for dense, multi-opinion regions. Grounded on dafyomi.co.il charts where present, generated from gemara + commentaries otherwise.',
+    category: 'experimental',
+    experimental: true,
+    anchor: 'segment-range',
+    render: {
+      kind: 'gutter+sidebar',
+      icon: 'T',
+      sidebar_title: 'Chart',
+    },
+    extractor: {
+      kind: 'llm',
+      // Heavier reasoning than the section/topic marks: laying out a faithful
+      // grid (orientation, cell values, attribution) benefits from a thinking
+      // pass. Flash keeps it within the streaming window on dense dapim.
+      model: 'openrouter/deepseek/deepseek-v4-flash' as LLMModelId,
+      system_prompt: CHART_SYSTEM_PROMPT,
+      user_prompt_template: CHART_USER_TEMPLATE,
+      output_schema: CHART_OUTPUT_SCHEMA,
+      reasoning_effort: 'medium',
+    },
+    dependencies: ['gemara', 'commentaries', 'context'],
+    status: 'draft',
+    def_hash: 'chart-v1',
+    cache_version: '1',
     source: 'code',
     updated_at: NOW,
   },

--- a/src/worker/output-schemas.ts
+++ b/src/worker/output-schemas.ts
@@ -59,6 +59,21 @@ export const PLACES_OUTPUT_SCHEMA = responseFormat('places_marks',
 export const HALACHA_OUTPUT_SCHEMA = responseFormat('halacha_topics',
   segInstances({ topic: z.string(), topicHe: z.string(), summary: z.string(), excerpt: z.string() }));
 
+// Chart (experimental): comparison tables for dense multi-opinion regions.
+// Cells are Hebrew (like the dafyomi.co.il charts this grounds on); the first
+// cell of every row is its row-label. `grounded` = a dafyomi chart anchored it.
+export const CHART_OUTPUT_SCHEMA = responseFormat('chart_tables',
+  segInstances({
+    caption: z.string(),
+    captionHe: z.string(),
+    headers: z.array(z.string()),
+    rows: z.array(z.array(z.string())),
+    notes: z.array(z.object({ marker: z.string(), text: z.string() })),
+    excerpt: z.string(),
+    grounded: z.boolean(),
+    confidence: z.enum(['high', 'medium', 'low']),
+  }));
+
 export const AGGADATA_OUTPUT_SCHEMA = responseFormat('aggadata_stories',
   segInstances({
     title: z.string(), titleHe: z.string(), summary: z.string(),

--- a/src/worker/studio-schema.ts
+++ b/src/worker/studio-schema.ts
@@ -340,11 +340,12 @@ export type Extractor = LLMExtractor | SefariaExtractor | ComputedExtractor | Ma
 //   { enrichment: id }   → {{depends.<id>}}    (recursively resolved)
 //   { mark: id }         → {{anchors.<id>}}    (mark extractor for same daf)
 //
-// Marks may depend on input slices and other marks (secondary anchors),
-// but not on enrichments. Enrichments may depend on anything.
+// Marks may depend on input slices, aggregated context (for grounding), and
+// other marks (secondary anchors), but not on enrichments. Enrichments may
+// depend on anything.
 // ===========================================================================
 
-export type MarkDependency = 'gemara' | 'commentaries' | 'yerushalmi-text' | { mark: string };
+export type MarkDependency = 'gemara' | 'commentaries' | 'context' | 'yerushalmi-text' | { mark: string };
 
 export type EnrichmentDependency =
   | 'gemara'

--- a/tests/client/card-defs.test.ts
+++ b/tests/client/card-defs.test.ts
@@ -15,7 +15,7 @@ describe('CARD_DEFS registry', () => {
 
   it('covers exactly the recipe-driven kinds', () => {
     expect(Object.keys(CARD_DEFS).sort()).toEqual(
-      ['aggadata', 'argument', 'argument-overview', 'biyun', 'daf-background', 'halacha', 'pesuk', 'rabbi', 'rishonim', 'tidbit', 'yerushalmi'].sort(),
+      ['aggadata', 'argument', 'argument-overview', 'biyun', 'chart', 'daf-background', 'halacha', 'pesuk', 'rabbi', 'rishonim', 'tidbit', 'yerushalmi'].sort(),
     );
   });
 });


### PR DESCRIPTION
Experimental gutter+sidebar mark that attaches **comparison tables** to dense, multi-opinion regions of a daf — the kind of grid that makes a tangled machloket scannable at a glance (in the spirit of the dafyomi.co.il / Kollel Iyun HaDaf charts).

Stays **experimental** (`status: draft`, `experimental: true`): visible only in the dev marks panel, not a reader toggle, not warmed.

## Phase 1 — producer
- New `chart` mark: `segment-range` anchor, `gutter+sidebar` render, deps `gemara + commentaries + context`, deepseek-v4-flash + medium reasoning.
- Builds Hebrew comparison tables **only** for genuinely dense, multi-opinion regions (strict gate, place-or-omit). **Grounds** on the dafyomi.co.il `## Charts` exemplars already in the context pool when present; generates from gemara+commentaries otherwise.
- `CHART_OUTPUT_SCHEMA` (caption/captionHe/headers/rows/notes/excerpt/grounded/confidence), `CHART_RECIPE`.
- Widen `MarkDependency` to allow `'context'` (the runtime already handled it).

## Phase 2 — UI
- Cyan grid gutter icon at each chart's region; click opens a sidebar card rendering the RTL Hebrew table + a tint highlight over the region.
- Shared `ChartTableView` RTL renderer — **dedupes** the copy previously inline in `ContextSourcePanel`.
- Mirrors the `halacha` gutter+sidebar plumbing across the client (types, sidebar card/recipe/special-block, gutter kind/color/glyph/anchor, DafViewer signal/cache/adapter/toggle/anchor-injection/click/range-paint, highlight CSS).

## Verification
- `pnpm typecheck` + `pnpm test` (1765) green.
- Verified live in the reader (dev mode) on Berakhot 3a: gutter icon -> sidebar table render -> region highlight; confirmed it disappears when dev mode is off.
- Producer fires on Berakhot 2b/3a/4a/7a (1-2 grounded tables each), including aggadic regions.

## Known follow-ups (not in this PR)
- Firing is somewhat **nondeterministic** under the strict gate on deepseek-flash (Berakhot 2a rolled 0 tables on one prod run while local reliably gave 2). Stabilizing this (stronger model / softer gate / eval-gate) is a producer-refinement follow-up.
- Server-side warm-path wiring (`index.ts` per-daf preload, `profile.ts` overlays, warm cron) intentionally omitted while experimental.