### PR TITLE
Chart mark: bilingual cells + app styling + halacha gutter to left

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -1694,11 +1694,27 @@ export function chartInstance(chart: ChartTable): { fields: Record<string, unkno
   };
 }
 
+type BiCell = { en?: string; he?: string };
 function ChartTableBlock(props: SpecialBlockProps): JSX.Element {
-  const f = () => props.instance.fields as { headers?: string[]; rows?: string[][]; notes?: { marker: string; text: string }[] };
+  const f = () => props.instance.fields as {
+    headers?: BiCell[]; rows?: BiCell[][];
+    notes?: { marker: string; en?: string; he?: string }[];
+  };
+  const he = () => lang() === 'he';
+  // Resolve each bilingual cell to the reader's language (fall back to the
+  // other language if one side is missing).
+  const pick = (c: BiCell | undefined): string => (he() ? (c?.he || c?.en) : (c?.en || c?.he)) ?? '';
+  const headers = () => (f().headers ?? []).map(pick);
+  const rows = () => (f().rows ?? []).map((r) => r.map(pick));
+  const notes = () => (f().notes ?? []).map((n) => ({ marker: n.marker, text: (he() ? (n.he || n.en) : (n.en || n.he)) ?? '' }));
   return (
     <Show when={(f().headers?.length ?? 0) > 0 && (f().rows?.length ?? 0) > 0}>
-      <ChartTableView table={{ headers: f().headers ?? [], rows: f().rows ?? [], notes: f().notes }} />
+      <ChartTableView
+        table={{ headers: headers(), rows: rows(), notes: notes() }}
+        dir={he() ? 'rtl' : 'ltr'}
+        lang={he() ? 'he' : 'en'}
+        accent="#0e7490"
+      />
     </Show>
   );
 }

--- a/src/client/ChartTableView.tsx
+++ b/src/client/ChartTableView.tsx
@@ -1,8 +1,11 @@
 /**
- * Shared renderer for a Hebrew comparison chart — a bordered RTL table whose
- * first column holds the (blue, bold) row labels, with footnotes below. Used by
- * the dafyomi context workbench (ContextSourcePanel) and the experimental
- * `chart` mark's sidebar card, so both render identically.
+ * Shared renderer for a comparison chart — a clean bordered table in the app's
+ * own palette (muted earth borders + a per-card accent for headers/row-labels),
+ * NOT the source-site yellow/blue look. Cells are language-resolved strings; the
+ * caller passes `dir`/`lang` so the same component renders Hebrew (RTL, Vilna
+ * serif) or English (LTR, system sans). Used by the dafyomi context workbench
+ * (ContextSourcePanel, HE) and the experimental `chart` mark's sidebar card
+ * (follows the reader's language).
  */
 import { For, Show, type JSX } from 'solid-js';
 
@@ -17,17 +20,51 @@ function stripTags(s: string | undefined): string {
   return (s ?? '').replace(/<[^>]*>/g, '').trim();
 }
 
-export function ChartTableView(props: { table: ChartTableShape }): JSX.Element {
-  const cell = { border: '1px solid #4b5563', padding: '0.25rem 0.45rem', 'text-align': 'center', 'vertical-align': 'middle' } as const;
+export function ChartTableView(props: {
+  table: ChartTableShape;
+  /** Reading direction of the cell text. Default 'rtl' (Hebrew). */
+  dir?: 'rtl' | 'ltr';
+  /** BCP-47 lang for the cells. Default 'he'. */
+  lang?: string;
+  /** Card accent for headers + row labels. Default the chart cyan. */
+  accent?: string;
+}): JSX.Element {
+  const dir = () => props.dir ?? 'rtl';
+  const lang = () => props.lang ?? 'he';
+  const accent = () => props.accent ?? '#0e7490';
+  const font = () => (lang() === 'he' ? '"Mekorot Vilna", serif' : 'system-ui, -apple-system, sans-serif');
+  const start = () => (dir() === 'rtl' ? 'right' : 'left');
+  const cell = (): JSX.CSSProperties => ({
+    border: '1px solid #e4e0d4',
+    padding: '0.32rem 0.5rem',
+    'vertical-align': 'top',
+    'line-height': 1.4,
+  });
   const hasHeaders = () => props.table.headers.some((h) => stripTags(h));
   return (
-    <div style={{ 'overflow-x': 'auto', 'margin-top': '0.35rem' }}>
-      <table dir="rtl" lang="he" style={{ 'border-collapse': 'collapse', 'font-family': '"Mekorot Vilna", serif', 'font-size': '0.85rem', width: '100%' }}>
+    <div style={{ 'overflow-x': 'auto', 'margin-top': '0.4rem' }}>
+      <table
+        dir={dir()}
+        lang={lang()}
+        style={{ 'border-collapse': 'collapse', 'font-family': font(), 'font-size': '0.82rem', width: '100%', 'border': '1px solid #e4e0d4' }}
+      >
         <Show when={hasHeaders()}>
           <thead>
             <tr>
               <For each={props.table.headers}>
-                {(h) => <th style={{ ...cell, background: '#fef9c3', color: '#1e3a8a', 'font-weight': 700 }}>{stripTags(h)}</th>}
+                {(h, ci) => (
+                  <th
+                    style={{
+                      ...cell(),
+                      background: '#faf9f6',
+                      color: accent(),
+                      'font-weight': 600,
+                      'text-align': ci() === 0 ? start() : 'center',
+                    }}
+                  >
+                    {stripTags(h)}
+                  </th>
+                )}
               </For>
             </tr>
           </thead>
@@ -38,7 +75,17 @@ export function ChartTableView(props: { table: ChartTableShape }): JSX.Element {
               <tr>
                 <For each={row}>
                   {(c, ci) => (
-                    <td style={{ ...cell, color: ci() === 0 ? '#1e3a8a' : '#333', 'font-weight': ci() === 0 ? 700 : 400 }}>{stripTags(c)}</td>
+                    <td
+                      style={{
+                        ...cell(),
+                        color: ci() === 0 ? accent() : '#2a2723',
+                        'font-weight': ci() === 0 ? 600 : 400,
+                        'text-align': ci() === 0 ? start() : 'center',
+                        background: ci() === 0 ? '#fcfbf8' : '#fff',
+                      }}
+                    >
+                      {stripTags(c)}
+                    </td>
                   )}
                 </For>
               </tr>
@@ -47,11 +94,12 @@ export function ChartTableView(props: { table: ChartTableShape }): JSX.Element {
         </tbody>
       </table>
       <Show when={props.table.notes?.length}>
-        <div style={{ 'margin-top': '0.35rem', 'font-size': '0.72rem', color: '#666' }}>
+        <div style={{ 'margin-top': '0.4rem', 'font-size': '0.72rem', color: '#777', display: 'flex', 'flex-direction': 'column', gap: '0.15rem' }}>
           <For each={props.table.notes}>
             {(n) => (
-              <div dir="rtl" lang="he" style={{ 'font-family': '"Mekorot Vilna", serif' }}>
-                <span style={{ color: '#0369a1', 'font-family': 'monospace' }}>{n.marker}</span> {stripTags(n.text)}
+              <div dir={dir()} lang={lang()} style={{ 'font-family': font() }}>
+                <span style={{ color: accent(), 'font-family': 'ui-monospace, monospace', 'margin-inline-end': '0.25rem' }}>{n.marker}</span>
+                {stripTags(n.text)}
               </div>
             )}
           </For>

--- a/src/client/DafViewer.tsx
+++ b/src/client/DafViewer.tsx
@@ -479,14 +479,15 @@ export default function DafViewer(): JSX.Element {
     const runs = markRunsByMarkId();
     const r = runs['chart'];
     if (!r?.parsed) return;
+    type BiCell = { en: string; he: string };
     const p = r.parsed as {
       instances?: Array<{
         startSegIdx: number;
         endSegIdx: number;
         fields: {
           caption?: string; captionHe?: string;
-          headers?: string[]; rows?: string[][];
-          notes?: { marker: string; text: string }[];
+          headers?: BiCell[]; rows?: BiCell[][];
+          notes?: { marker: string; en: string; he: string }[];
           excerpt?: string; grounded?: boolean; confidence?: string;
         };
       }>;

--- a/src/client/GutterIcons.tsx
+++ b/src/client/GutterIcons.tsx
@@ -30,10 +30,11 @@ export interface GutterItem {
   atEdge: boolean;
 }
 
-/** Per-kind side. Right gutter is busier (halacha + aggadata + rishonim);
- *  left handles argument + pesuk. The overlay uses this to bucket items. */
+/** Per-kind side. Left holds argument + pesuk + halacha; the right gutter
+ *  handles chart + aggadata + yerushalmi + rishonim. The overlay buckets items
+ *  by this. */
 export function gutterSideFor(kind: GutterKind): GutterSide {
-  return kind === 'argument' || kind === 'pesuk' ? 'left' : 'right';
+  return kind === 'argument' || kind === 'pesuk' || kind === 'halacha' ? 'left' : 'right';
 }
 
 export interface GutterIconsProps {

--- a/src/client/shapes.ts
+++ b/src/client/shapes.ts
@@ -68,16 +68,21 @@ export interface HalachaResult {
 
 // ===========================================================================
 // Charts (mark id: 'chart') — EXPERIMENTAL. Comparison tables for dense,
-// multi-opinion regions; cells are Hebrew (like the dafyomi.co.il source
-// charts). The first cell of each row is its row-label.
+// multi-opinion regions. Every cell is BILINGUAL ({en, he}) so the table
+// renders in the reader's language. The first cell of each row is its row-label.
 // ===========================================================================
+
+export interface ChartCell {
+  en: string;
+  he: string;
+}
 
 export interface ChartTable {
   caption?: string;
   captionHe?: string;
-  headers: string[];
-  rows: string[][];
-  notes?: { marker: string; text: string }[];
+  headers: ChartCell[];
+  rows: ChartCell[][];
+  notes?: { marker: string; en: string; he: string }[];
   excerpt?: string;
   grounded?: boolean;
   confidence?: string;

--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -302,7 +302,9 @@ const HALACHA_USER_TEMPLATE_HE = `מסכת: {{tractate}}, דף {{page}}.
 
 const CHART_SYSTEM_PROMPT = `You are a Talmud scholar who builds COMPARISON TABLES that let a learner grasp a dense, tangled region of the daf at a single glance.
 
-Output STRICT JSON only — no markdown, no prose:
+Output STRICT JSON only — no markdown, no prose. EVERY table cell, header, and
+note is BILINGUAL — an object {"en": "...", "he": "..."} — so the reader sees it
+in their own language:
 
 {
   "instances": [
@@ -312,12 +314,24 @@ Output STRICT JSON only — no markdown, no prose:
       "fields": {
         "caption": "Short English title of what the table compares (e.g. 'When the evening Shema may be read, by opinion').",
         "captionHe": "Short Hebrew title (3-8 words).",
-        "headers": ["", "מפלג המנחה", "משעה שקדש היום"],
-        "rows": [
-          ["פרשה ראשונה על מטתו לרש\\"י", "לא יצא", "לא יצא"],
-          ["לרבינו תם", "יצא", "יצא"]
+        "headers": [
+          { "en": "", "he": "" },
+          { "en": "From plag haMincha", "he": "מפלג המנחה" },
+          { "en": "From when the day is sanctified", "he": "משעה שקדש היום" }
         ],
-        "notes": [{ "marker": "[1]", "text": "Short Hebrew clarification referenced from a cell." }],
+        "rows": [
+          [
+            { "en": "First paragraph at bedtime — per Rashi", "he": "פרשה ראשונה על מטתו לרש\\"י" },
+            { "en": "Not fulfilled", "he": "לא יצא" },
+            { "en": "Not fulfilled", "he": "לא יצא" }
+          ],
+          [
+            { "en": "Per Rabbeinu Tam", "he": "לרבינו תם" },
+            { "en": "Fulfilled", "he": "יצא" },
+            { "en": "Fulfilled", "he": "יצא" }
+          ]
+        ],
+        "notes": [{ "marker": "[1]", "en": "Short English clarification referenced from a cell.", "he": "Short Hebrew clarification referenced from a cell." }],
         "excerpt": "3-5 Hebrew/Aramaic words copied VERBATIM where the region begins.",
         "grounded": true,
         "confidence": "high"
@@ -334,10 +348,12 @@ WHEN to make a table — be STRICT:
 
 HOW to build it:
 - rows = the things being compared down the side (usually the opinions/views, sometimes the cases); columns = the dimension across the top (usually the cases/scenarios, sometimes the opinions). Pick whichever orientation reads most clearly.
-- The FIRST cell of every row is its row-label. headers[0] labels the row-label column and is often "". Every row MUST have exactly headers.length cells.
-- CELLS ARE HEBREW and TERSE — the ruling/value at that intersection in a few words (e.g. "יצא" / "לא יצא" / "עד חצות"), NOT full sentences. Mirror the source's wording.
-- attribute opinions in Hebrew the way the gemara/commentators do (לרש"י, לרבינו תם, לר"י, לחכמים, לרבן גמליאל).
-- notes: optional footnotes ([1], [2]) referenced inside cells for a caveat that doesn't fit a cell.
+- The FIRST cell of every row is its row-label. headers[0] labels the row-label column and is usually { "en": "", "he": "" }. Every row MUST have exactly headers.length cells.
+- EVERY cell is the object {"en","he"} and TERSE — the ruling/value at that intersection in a few words, NOT full sentences.
+  - "he" mirrors the source's own wording (e.g. "יצא" / "לא יצא" / "עד חצות"), and attributes opinions the way the gemara/commentators do (לרש"י, לרבינו תם, לר"י, לחכמים, לרבן גמליאל).
+  - "en" is a faithful, CONCISE translation using conventional English terms — NEVER a word-for-word calque of a fixed Hebrew phrase. Attribute opinions in readable English ("per Rashi", "Rabbeinu Tam", "the Sages", "Rabban Gamliel"). Keep a genuinely-technical term in transliteration where there is no clean English ("plag haMincha", "tzeit hakochavim").
+  - Both languages must say the SAME thing; the grid must read coherently top-to-bottom and side-to-side in EITHER language.
+- notes: optional footnotes ([1], [2]) referenced inside cells for a caveat that doesn't fit a cell — also bilingual.
 
 GROUNDING:
 - The context below may include a "## Charts" section — real comparison charts from Kollel Iyun HaDaf for THIS daf. If one covers your region, ADOPT its structure and values (it is authoritative); set "grounded": true.
@@ -835,8 +851,8 @@ export const CODE_MARKS: MarkDefinition[] = [
     },
     dependencies: ['gemara', 'commentaries', 'context'],
     status: 'draft',
-    def_hash: 'chart-v1',
-    cache_version: '1',
+    def_hash: 'chart-v2',
+    cache_version: '2',
     source: 'code',
     updated_at: NOW,
   },

--- a/src/worker/output-schemas.ts
+++ b/src/worker/output-schemas.ts
@@ -60,15 +60,17 @@ export const HALACHA_OUTPUT_SCHEMA = responseFormat('halacha_topics',
   segInstances({ topic: z.string(), topicHe: z.string(), summary: z.string(), excerpt: z.string() }));
 
 // Chart (experimental): comparison tables for dense multi-opinion regions.
-// Cells are Hebrew (like the dafyomi.co.il charts this grounds on); the first
-// cell of every row is its row-label. `grounded` = a dafyomi chart anchored it.
+// Every cell is BILINGUAL ({en, he}) so the table renders in the reader's
+// language; the first cell of every row is its row-label. `grounded` = a
+// dafyomi chart anchored it.
+const CHART_CELL = z.object({ en: z.string(), he: z.string() });
 export const CHART_OUTPUT_SCHEMA = responseFormat('chart_tables',
   segInstances({
     caption: z.string(),
     captionHe: z.string(),
-    headers: z.array(z.string()),
-    rows: z.array(z.array(z.string())),
-    notes: z.array(z.object({ marker: z.string(), text: z.string() })),
+    headers: z.array(CHART_CELL),
+    rows: z.array(z.array(CHART_CELL)),
+    notes: z.array(z.object({ marker: z.string(), en: z.string(), he: z.string() })),
     excerpt: z.string(),
     grounded: z.boolean(),
     confidence: z.enum(['high', 'medium', 'low']),


### PR DESCRIPTION
Follow-up fixes to the experimental chart mark (#240):

## Bilingual cells (English on English, Hebrew on Hebrew)
Previously the tables were always Hebrew (copied from the source charts). Now every header / cell / note is `{en, he}`, and the sidebar card renders in the reader's language — English cells LTR in system-sans, Hebrew cells RTL in Vilna serif. Same chart, language-switched. Schema + prompt reworked; `cache_version 1 -> 2`, `def_hash chart-v2`. Verified on Berakhot 3a: EN ("First watch", "Donkey brays") and HE (משמרה ראשונה, חמור נוער) render from one generation.

## Our styling (not a dafyomi copy)
`ChartTableView` restyled to the app's own palette — muted earth borders + the card accent (`#0e7490`) for headers and row-labels — dropping the source-site yellow-header/blue-label look. Added `dir`/`lang`/`accent` props; the dafyomi context workbench (`ContextSourcePanel`, Hebrew) keeps its defaults.

## Halacha gutter to the left
`gutterSideFor` now routes halacha to the LEFT gutter (with argument + pesuk).

Verified live in the reader (EN + HE views); `pnpm typecheck` + `pnpm test` (1765) green. Mark stays experimental (dev-only).