### PR TITLE
Alignment: segment-first debug view + prune dead placement helpers

### DIFF
--- a/src/client/AlignPage.tsx
+++ b/src/client/AlignPage.tsx
@@ -273,10 +273,12 @@ export function AlignPage(): JSX.Element {
                   ${Array.from({ length: segmentCount() }).map((_, i) =>
                     `.daf-word[data-seg="${i}"] { background-color: ${segColor(i)}; border-radius: 2px; }`
                   ).join('\n')}
-                  ${(effective().words.length
-                    ? effective().words.map((w) => `.daf-word[data-word-index="${w}"] { outline: 2px solid #8a2a2b; background-color: #fde68a; }`)
-                    : effective().segs.map((s) => `.daf-word[data-seg="${s}"] { outline: 2px solid #8a2a2b; }`)
-                  ).join('\n')}
+                  ${/* Segment-first: the bordered + washed segment span is what
+                       downstream actually consumes, so it's always the headline
+                       highlight. A precise word landing (when known) is a fill
+                       INSIDE that span — visible, but subordinate to the segment. */ ''}
+                  ${effective().segs.map((s) => `.daf-word[data-seg="${s}"] { outline: 2px solid #8a2a2b; background-color: rgba(138,42,43,0.09); }`).join('\n')}
+                  ${effective().words.map((w) => `.daf-word[data-word-index="${w}"] { background-color: #fde68a; }`).join('\n')}
                 `}</style>
               </section>
 

--- a/src/client/ContextSourcePanel.tsx
+++ b/src/client/ContextSourcePanel.tsx
@@ -141,19 +141,29 @@ function ContextCard(props: { item: ContextItem; onEnter: () => void; onLeave: (
   const level = () => place()?.level;
   const via = () => place()?.via ?? it.hbVia ?? it.via;
   const conf = () => place()?.confidence;
+  // Segment is the unit the rest of the app consumes, so the headline is the
+  // segment range for BOTH `words` and `segment` — a word landing is the same
+  // segment grounding, just tightened. The word count rides along as a muted
+  // sub-detail (see `wordDetail`) rather than the headline.
+  const located = () => level() === 'words' || level() === 'segment';
   const placeLabel = () => {
     switch (level()) {
       case 'daf': return 'whole daf';
-      case 'words': return `${it.hbWords!.length} word${it.hbWords!.length === 1 ? '' : 's'}`;
-      case 'amud': return `amud ${it.amud}`;
+      case 'words':
       case 'segment': return rangeLabel(it.segs, it.amud);
+      case 'amud': return `amud ${it.amud}`;
       // unplaced: distinguish daf-level reference context from a placement miss.
       default: return isReferenceSource(it) ? 'reference' : 'not located';
     }
   };
-  // Word-precise → green, whole-daf → violet, segment → amber, else neutral.
-  const accent = () => (level() === 'words' ? '#059669' : level() === 'daf' ? '#a78bfa' : level() === 'segment' ? '#f59e0b' : '#d1d5db');
-  const labelColor = () => (level() === 'words' ? '#059669' : level() === 'daf' ? '#7c3aed' : '#999');
+  // The precise landing, shown small and muted — visible for debugging, but it
+  // doesn't change what downstream sees (which is the segment span above).
+  const wordDetail = () =>
+    level() === 'words' && it.hbWords?.length ? `${it.hbWords.length} word${it.hbWords.length === 1 ? '' : 's'}` : '';
+  // Located on the text (words OR segment, indistinguishable downstream) → green;
+  // whole-daf → violet; else neutral.
+  const accent = () => (located() ? '#059669' : level() === 'daf' ? '#a78bfa' : '#d1d5db');
+  const labelColor = () => (located() ? '#059669' : level() === 'daf' ? '#7c3aed' : '#999');
   const bodyEn = () => stripTags(it.body?.en ?? '');
   const long = () => bodyEn().length > 280;
   const shown = () => (open() || !long() ? bodyEn() : bodyEn().slice(0, 280) + '…');
@@ -174,6 +184,11 @@ function ContextCard(props: { item: ContextItem; onEnter: () => void; onLeave: (
         <span style={{ 'font-size': '0.68rem', 'font-family': 'monospace', color: labelColor() }}>
           {placeLabel()}
         </span>
+        <Show when={wordDetail()}>
+          <span style={{ 'font-size': '0.62rem', 'font-family': 'monospace', color: '#aaa' }}>
+            {wordDetail()}
+          </span>
+        </Show>
         <Show when={via()}>
           <span style={{ 'font-size': '0.62rem', 'font-family': 'monospace', color: '#0369a1', background: '#e0f2fe', padding: '0 0.3rem', 'border-radius': '3px' }}>
             {via()}{conf() != null ? ` ${conf()!.toFixed(2)}` : ''}

--- a/src/lib/context/placement.ts
+++ b/src/lib/context/placement.ts
@@ -14,10 +14,14 @@
  * (`segs`/`via`/`confidence` from the server pool + the client-resolved
  * `hbWords`/`hbVia`/`hbConfidence`) into a normalized `Placement`. Granularity
  * is DERIVED, not stored, so it can never drift from the underlying anchors.
- * Producers (the deterministic matchers, the AI placer) write the fields;
- * everyone else — the workbench panel, and downstream anchors/enrichments —
- * reads through here so "what context applies here, at what level, how sure"
- * has one answer.
+ * Producers (the deterministic matchers, the AI placer) write the fields; the
+ * alignment workbench (the source panel + the auto-grounding loop) reads through
+ * here so "what landed where, at what level, how sure" has one answer.
+ *
+ * Scope note: this is a CLIENT-side workbench helper. Downstream enrichments do
+ * NOT read placements — they consume the segment grounding (`segs`) directly via
+ * `contextForAnchor` in select.ts. So the `words` level is a debugging nicety,
+ * not a precision the rest of the app can act on; the panel renders accordingly.
  */
 
 import type { ContextItem } from './types.ts';
@@ -28,10 +32,6 @@ import { type AnchorCoord, type DafRef, isCrossDaf } from './coord.ts';
  *  "here" — hence it ranks below `daf`. Only derived when `placementOf` is
  *  given the current daf AND the item carries an off-daf `coord`. */
 export type PlacementLevel = 'cross-daf' | 'words' | 'segment' | 'amud' | 'daf';
-
-/** Coarsest→finest, for ranking "most specific grounding wins". `cross-daf`
- *  sits below everything on-daf (it isn't on this page at all). */
-export const LEVEL_RANK: Record<PlacementLevel, number> = { 'cross-daf': -1, daf: 0, amud: 1, segment: 2, words: 3 };
 
 export interface Placement {
   /** The finest granularity this grounding reached. */
@@ -104,16 +104,6 @@ export function isLocated(it: ContextItem): boolean {
   return l === 'words' || l === 'segment';
 }
 
-/** Word-precise: a real phrase/AI-quote landing, not a whole-segment fallback. */
-export function isPrecise(it: ContextItem): boolean {
-  return placementLevel(it) === 'words';
-}
-
-/** Placed at any level at all (words / segment / amud / whole-daf). */
-export function isGrounded(it: ContextItem): boolean {
-  return placementOf(it) != null;
-}
-
 /** Grounded by the AI semantic placer (so an AI pass shouldn't re-offer it). */
 export function isAiGrounded(it: ContextItem): boolean {
   return it.via === 'ai' || it.hbVia === 'ai-phrase' || it.hbVia === 'ai-segment' || it.hbVia === 'ai-daf';
@@ -127,29 +117,3 @@ export function isReferenceSource(it: ContextItem): boolean {
   return REFERENCE_SOURCES.has(it.source);
 }
 
-/** What an enrichment/anchor asks for: a specific segment, or the whole daf. */
-export type GroundingTarget = { seg: number } | { daf: true };
-
-/**
- * The context items whose grounding applies to `target`, most-specific and
- * most-confident first. For a segment target: items grounded ON that segment
- * (words/segment whose `segs` include it) plus whole-daf items (they apply
- * everywhere). For a daf target: everything that's grounded at all. Unplaced
- * items are excluded. (Amud-level items match a daf target but not a bare
- * segment target, since the seg→amud map isn't known here.)
- */
-export function contextForTarget(items: ContextItem[], target: GroundingTarget): ContextItem[] {
-  const seg = 'seg' in target ? target.seg : null;
-  const hits: { it: ContextItem; p: Placement }[] = [];
-  for (const it of items) {
-    const p = placementOf(it);
-    if (!p) continue;
-    const applies =
-      'daf' in target
-        ? true
-        : p.level === 'daf' || ((p.level === 'words' || p.level === 'segment') && seg != null && p.segs.includes(seg));
-    if (applies) hits.push({ it, p });
-  }
-  hits.sort((a, b) => LEVEL_RANK[b.p.level] - LEVEL_RANK[a.p.level] || (b.p.confidence ?? 0) - (a.p.confidence ?? 0));
-  return hits.map((h) => h.it);
-}

--- a/tests/placement.test.ts
+++ b/tests/placement.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
-  placementOf, placementLevel, isLocated, isPrecise, isGrounded, isAiGrounded, isReferenceSource, contextForTarget,
+  placementOf, placementLevel, isLocated, isAiGrounded, isReferenceSource,
 } from '../src/lib/context/placement';
 import type { ContextItem } from '../src/lib/context/types';
 
@@ -63,10 +63,8 @@ describe('grounding predicates', () => {
   const daf = item({ key: 'd', segs: [], via: 'ai', hbVia: 'ai-daf' });
   const none = item({ key: 'n' });
 
-  it('isLocated = words|segment; isPrecise = words; isGrounded = any level', () => {
+  it('isLocated = words|segment (the segment grounding downstream consumes)', () => {
     expect([words, seg, daf, none].map(isLocated)).toEqual([true, true, false, false]);
-    expect([words, seg, daf, none].map(isPrecise)).toEqual([true, false, false, false]);
-    expect([words, seg, daf, none].map(isGrounded)).toEqual([true, true, true, false]);
   });
 
   it('isAiGrounded flags anything the AI placer set', () => {
@@ -80,25 +78,5 @@ describe('grounding predicates', () => {
     expect(isReferenceSource(item({ key: 't', source: 'sefaria-topic' }))).toBe(true);
     expect(isReferenceSource(item({ key: 'r', source: 'sefaria-rishonim' }))).toBe(false);
     expect(isReferenceSource(item({ key: 'i', source: 'dafyomi:insights' }))).toBe(false);
-  });
-});
-
-describe('contextForTarget — the enrichment-facing query', () => {
-  const onSeg4 = item({ key: 'words4', segs: [4], hbWords: [1], hbVia: 'ai-phrase', hbConfidence: 0.9 });
-  const segOnly4 = item({ key: 'seg4', segs: [4], via: 'tosfos-dh', confidence: 0.6 });
-  const elsewhere = item({ key: 'seg9', segs: [9], via: 'mishnah' });
-  const wholeDaf = item({ key: 'daf', segs: [], via: 'ai', hbVia: 'ai-daf', hbConfidence: 0.5 });
-  const unplaced = item({ key: 'none' });
-  const all = [segOnly4, onSeg4, elsewhere, wholeDaf, unplaced];
-
-  it('segment target: items on that seg + whole-daf, finest & most-confident first', () => {
-    const got = contextForTarget(all, { seg: 4 }).map((i) => i.key);
-    // words (0.9) > segment (0.6) > daf (0.5); seg9 excluded; unplaced excluded
-    expect(got).toEqual(['words4', 'seg4', 'daf']);
-  });
-
-  it('daf target: everything grounded, unplaced excluded', () => {
-    const got = contextForTarget(all, { daf: true }).map((i) => i.key).sort();
-    expect(got).toEqual(['daf', 'seg4', 'seg9', 'words4']);
   });
 });


### PR DESCRIPTION
## Why

The alignment workbench was visually biased toward **word precision** (green "N words" headline, word-only highlight), but that precision reaches **nothing downstream**: enrichments consume the segment grounding (`segs`) directly via `contextForAnchor` (select.ts) and never read placements. So the debug view implied a precision the rest of the app cannot act on.

`placement.ts` also advertised itself in its docblock as the downstream seam ("downstream anchors/enrichments read through here") — but no server/enrichment code imports it, and its intended enrichment-facing selector (`contextForTarget`) had zero production callers.

## What

**Make the debug view honest (segment-first):**
- Card headline is the **segment range** for both `words` and `segment` levels — a word landing is the same segment grounding, just tightened. Word count becomes a muted sub-detail; "located" items (words|segment) share one colour since they're indistinguishable downstream.
- Daf highlight: the bordered + washed **segment span** (what's consumed) is the headline; a precise word landing is a fill *inside* it, not the whole story.

**Prune the unused abstraction surface in `placement.ts`:**
- Remove `contextForTarget` + `GroundingTarget` + `LEVEL_RANK` (the intended enrichment-facing selector; never called in production).
- Remove `isPrecise` / `isGrounded` (zero callers).
- Docblock now states the real scope: a client-side workbench helper; downstream reads `segs`, so `words` is a debugging nicety.

Net: `placement.ts` shrinks to what's true, and the workbench's headline matches what enrichments actually receive.

## Tests
- `pnpm typecheck` clean.
- `pnpm test` green (1776 passed). Removed the `contextForTarget`/`isPrecise`/`isGrounded` test cases along with the dead code.