### PR TITLE
Usage endpoints: per-section split + per-daf cost drill-down

### DIFF
--- a/src/worker/context-match.ts
+++ b/src/worker/context-match.ts
@@ -31,6 +31,10 @@ export async function aiMatchToSegments(
   segmentsHe: string[],
   segmentsEn: string[],
   items: MatchInput[],
+  /** Daf this alignment is for — attributes the matcher's spend to a page in
+   *  the cost ledger ('source alignment' on daf X). Omitted by callers that
+   *  don't have it (spend then lands under kind='match', no daf). */
+  daf?: { tractate: string; page: string },
 ): Promise<SegMatch[]> {
   if (segmentsHe.length === 0 || items.length === 0) return [];
 
@@ -48,7 +52,7 @@ export async function aiMatchToSegments(
     for (;;) {
       const idx = next++;
       if (idx >= chunks.length) return;
-      results[idx] = await matchChunk(env, segmentsHe, segmentsEn, chunks[idx]);
+      results[idx] = await matchChunk(env, segmentsHe, segmentsEn, chunks[idx], daf);
     }
   };
   await Promise.all(
@@ -63,6 +67,7 @@ async function matchChunk(
   segmentsHe: string[],
   segmentsEn: string[],
   batch: MatchInput[],
+  daf?: { tractate: string; page: string },
 ): Promise<SegMatch[]> {
   const { system, user } = buildMatchPrompt(segmentsHe, segmentsEn, batch);
   const result = await runLLM(env, {
@@ -74,6 +79,7 @@ async function matchChunk(
     temperature: 0,
     response_format: { type: 'json_object' },
     tag: 'context-match',
+    attribution: { kind: 'match', ...(daf ? { tractate: daf.tractate, page: daf.page } : {}) },
   });
   const validKeys = new Set(batch.map((b) => b.key));
   return parseMatchResponse(result.content, validKeys, segmentsHe.length);

--- a/src/worker/daf-cost.ts
+++ b/src/worker/daf-cost.ts
@@ -1,0 +1,155 @@
+/**
+ * Per-daf cost trace from the permanent cache-entry stamps. Each mark cache
+ * entry carries a `cost` stamp (see RunResult.cost in index.ts) recording what
+ * that entry cost to generate. The cache is permanent, so summing the stamps
+ * for ONE daf across a mark's cached versions answers, without re-running
+ * anything: "what did the current version of this daf cost, and what did its
+ * superseded versions cost". Reads are bounded — one KV get per (mark, version)
+ * for the single daf — so this is cheap enough to serve on a drill-down click,
+ * unlike a whole-Shas value scan.
+ *
+ * Enrichments are NOT covered here: local enrichments are keyed by a derived
+ * instance id (rabbi name, section title) that can't be reconstructed from the
+ * daf alone, and global ones aren't daf-bound. Recent enrichment + source-
+ * alignment spend for a daf is available from the per-call ledger
+ * (GET /api/admin/llm-cost -> byDaf); this endpoint is the durable MARK record.
+ */
+
+import { keyForMark } from './cache-keys';
+
+/** The cost stamp shape written onto each cache entry (subset we read here). */
+export interface CostStampLite {
+  billedUsd: number | null;
+  estimatedUsd: number | null;
+  costInUsd: number | null;
+  costOutUsd: number | null;
+  tokensIn: number;
+  tokensOut: number;
+  lang?: 'en' | 'he';
+  cacheVersion?: string;
+}
+
+/** A mark row as produced by computeCacheStats — id/label/current version plus
+ *  the count-by-version map (its keys are the version segments, e.g. `5`,
+ *  `5:he`, `4`). */
+export interface MarkRowLite {
+  id: string;
+  label: string;
+  cache_version: string;
+  versions: Record<string, number>;
+}
+
+export interface DafVersionCost {
+  /** Version segment as it appears in the cache key, e.g. `5` or `5:he`. */
+  version: string;
+  lang: 'en' | 'he';
+  billedUsd: number | null;
+  estimatedUsd: number | null;
+  costInUsd: number | null;
+  costOutUsd: number | null;
+  tokensIn: number;
+  tokensOut: number;
+}
+
+export interface DafMarkCost {
+  id: string;
+  label: string;
+  /** Entries on the mark's CURRENT cache_version (en and/or he). */
+  current: DafVersionCost[];
+  /** Entries left on a superseded cache_version (still in KV, money already spent). */
+  superseded: DafVersionCost[];
+  /** billed-or-estimated USD summed across every version of this mark for the daf. */
+  totalUsd: number;
+}
+
+/** billed cost wins (authoritative, net of prompt-cache); else the list-price
+ *  estimate; else 0. Mirrors computeSpendUsd in budget.ts. */
+export function bestStampUsd(s: Pick<CostStampLite, 'billedUsd' | 'estimatedUsd'> | null | undefined): number {
+  if (!s) return 0;
+  if (typeof s.billedUsd === 'number') return s.billedUsd;
+  if (typeof s.estimatedUsd === 'number') return s.estimatedUsd;
+  return 0;
+}
+
+function toVersionCost(version: string, s: CostStampLite): DafVersionCost {
+  const lang: 'en' | 'he' = version.endsWith(':he') ? 'he' : 'en';
+  return {
+    version, lang,
+    billedUsd: s.billedUsd ?? null,
+    estimatedUsd: s.estimatedUsd ?? null,
+    costInUsd: s.costInUsd ?? null,
+    costOutUsd: s.costOutUsd ?? null,
+    tokensIn: s.tokensIn ?? 0,
+    tokensOut: s.tokensOut ?? 0,
+  };
+}
+
+/**
+ * Read one mark's cost stamps for a single daf across every cached version.
+ * `mark.versions` enumerates which version segments exist; we reconstruct each
+ * one's key for this daf and read its stamp. Entries with no stamp (computed
+ * marks, pre-stamp legacy entries) contribute nothing.
+ */
+export async function dafMarkCost(
+  cache: KVNamespace,
+  mark: MarkRowLite,
+  tractate: string,
+  page: string,
+): Promise<DafMarkCost> {
+  const current: DafVersionCost[] = [];
+  const superseded: DafVersionCost[] = [];
+  let totalUsd = 0;
+
+  await Promise.all(
+    Object.keys(mark.versions).map(async (verKey) => {
+      const he = verKey.endsWith(':he');
+      const baseVer = he ? verKey.slice(0, -3) : verKey;
+      const key = keyForMark(
+        { id: mark.id, cache_version: baseVer } as unknown as Parameters<typeof keyForMark>[0],
+        tractate, page, he ? 'he' : 'en',
+      );
+      const raw = await cache.get(key);
+      if (!raw) return;
+      let entry: { cost?: CostStampLite };
+      try { entry = JSON.parse(raw) as { cost?: CostStampLite }; } catch { return; }
+      if (!entry.cost) return;
+      const vc = toVersionCost(verKey, entry.cost);
+      totalUsd += bestStampUsd(entry.cost);
+      if (baseVer === mark.cache_version) current.push(vc);
+      else superseded.push(vc);
+    }),
+  );
+
+  current.sort((a, b) => a.lang.localeCompare(b.lang));
+  superseded.sort((a, b) => b.version.localeCompare(a.version));
+  return { id: mark.id, label: mark.label, current, superseded, totalUsd };
+}
+
+export interface DafCostReport {
+  tractate: string;
+  page: string;
+  marks: DafMarkCost[];
+  totals: { currentUsd: number; supersededUsd: number; totalUsd: number };
+}
+
+/** Assemble the per-daf cost report from the cache-stats mark rows. */
+export async function dafCostReport(
+  cache: KVNamespace,
+  marks: MarkRowLite[],
+  tractate: string,
+  page: string,
+): Promise<DafCostReport> {
+  const rows = await Promise.all(marks.map((m) => dafMarkCost(cache, m, tractate, page)));
+  const withCost = rows.filter((m) => m.current.length > 0 || m.superseded.length > 0);
+  let currentUsd = 0;
+  let supersededUsd = 0;
+  for (const m of withCost) {
+    for (const v of m.current) currentUsd += bestStampUsd(v);
+    for (const v of m.superseded) supersededUsd += bestStampUsd(v);
+  }
+  withCost.sort((a, b) => b.totalUsd - a.totalUsd);
+  return {
+    tractate, page, marks: withCost,
+    totals: { currentUsd, supersededUsd, totalUsd: currentUsd + supersededUsd },
+  };
+}

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -52,6 +52,7 @@ import {
   isFresh,
   cacheGcTargets,
 } from './cache-stats';
+import { dafCostReport } from './daf-cost';
 import { gcStaleCache } from './cache-gc';
 import { runYomiWarmCron } from './yomi-cron';
 import { GENERATION_IDS, GENERATION_BY_ID, GENERATIONS_PROMPT_REFERENCE, type GenerationId } from '../client/generations';
@@ -4132,180 +4133,170 @@ function percentile(sorted: number[], p: number): number {
   return sorted[idx];
 }
 
-app.get('/api/usage', async (c) => {
-  const cache = c.env.CACHE;
-  // Assembling this payload reads several full KV prefixes — the usage rollups
-  // and the three observed-entity backlogs each fetch EVERY key's value across
-  // the warmed Shas — so a cold build runs ~10s. The dashboard polls every 30s
-  // and a few seconds of staleness is harmless, so serve a cached payload and
-  // refresh it in the background (stale-while-revalidate): every load after the
-  // first is instant. A best-effort refresh lock (below) collapses the common
-  // case of one viewer polling — or several at once — into a single rebuild per
-  // window instead of one rebuild per stale request.
-  const PAYLOAD_KEY = 'usage-payload:v1';
-  const REFRESH_LOCK_KEY = 'usage-payload:refreshing';
-  const PAYLOAD_FRESH_MS = 30_000;
+// ===========================================================================
+// Usage dashboard — section builders + endpoints
+//
+// The dashboard is built from independent sections (cost / activity / telemetry
+// / backlog / health). Each has a pure builder below, so the full `/api/usage`
+// payload and the per-section endpoints (`/api/usage/<section>`) share one
+// implementation. Splitting them lets the client load and render each card on
+// its own — a slow section (or the slow cache-stats scan) no longer blocks the
+// headline cost numbers. Every endpoint is stale-while-revalidate cached.
+// ===========================================================================
 
-  const computeUsagePayload = async () => {
+type UsageCtx = { env: Bindings; executionCtx: ExecutionContext };
 
-  // External analytics, cached 5 min so the 30s dashboard refresh doesn't
-  // hammer the CF analytics API. Closures so they participate in the single
-  // parallel fetch below.
-  const loadAigw = async (): Promise<Awaited<ReturnType<typeof fetchGatewayCost>>> => {
-    if (!cache) return fetchGatewayCost(c.env);
-    const raw = await cache.get('aigw-cost:v1');
-    if (raw) { try { return JSON.parse(raw) as Awaited<ReturnType<typeof fetchGatewayCost>>; } catch { /* recompute */ } }
-    const fresh = await fetchGatewayCost(c.env);
-    c.executionCtx.waitUntil(cache.put('aigw-cost:v1', JSON.stringify(fresh), { expirationTtl: 300 }));
-    return fresh;
+// External analytics, sub-cached 5 min so the dashboard refresh doesn't hammer
+// the CF analytics API.
+async function loadAigwCached(c: UsageCtx, cache?: KVNamespace): Promise<Awaited<ReturnType<typeof fetchGatewayCost>>> {
+  if (!cache) return fetchGatewayCost(c.env);
+  const raw = await cache.get('aigw-cost:v1');
+  if (raw) { try { return JSON.parse(raw) as Awaited<ReturnType<typeof fetchGatewayCost>>; } catch { /* recompute */ } }
+  const fresh = await fetchGatewayCost(c.env);
+  c.executionCtx.waitUntil(cache.put('aigw-cost:v1', JSON.stringify(fresh), { expirationTtl: 300 }));
+  return fresh;
+}
+async function loadActivityCached(c: UsageCtx, cache?: KVNamespace): Promise<Awaited<ReturnType<typeof fetchZoneActivity>>> {
+  if (!cache) return fetchZoneActivity(c.env);
+  const raw = await cache.get('zone-activity:v1');
+  if (raw) { try { return JSON.parse(raw) as Awaited<ReturnType<typeof fetchZoneActivity>>; } catch { /* recompute */ } }
+  const fresh = await fetchZoneActivity(c.env);
+  c.executionCtx.waitUntil(cache.put('zone-activity:v1', JSON.stringify(fresh), { expirationTtl: 300 }));
+  return fresh;
+}
+
+interface TelemetryRollup {
+  count: number; cacheHits: number; cacheHitRate: number;
+  p50Ms: number; p95Ms: number; errorCount: number; errorsByKind: Record<string, number>;
+}
+function rollupTelemetry(rows: TelemetryRecord[]): TelemetryRollup {
+  const sorted = rows.map((r) => r.ms).sort((a, b) => a - b);
+  const hits = rows.filter((r) => r.cache_hit).length;
+  const errors = rows.filter((r) => !r.ok);
+  const errorsByKind: Record<string, number> = {};
+  for (const e of errors) errorsByKind[e.error_kind ?? 'other'] = (errorsByKind[e.error_kind ?? 'other'] ?? 0) + 1;
+  return {
+    count: rows.length, cacheHits: hits, cacheHitRate: rows.length ? hits / rows.length : 0,
+    p50Ms: percentile(sorted, 50), p95Ms: percentile(sorted, 95),
+    errorCount: errors.length, errorsByKind,
   };
-  const loadActivity = async (): Promise<Awaited<ReturnType<typeof fetchZoneActivity>>> => {
-    if (!cache) return fetchZoneActivity(c.env);
-    const raw = await cache.get('zone-activity:v1');
-    if (raw) { try { return JSON.parse(raw) as Awaited<ReturnType<typeof fetchZoneActivity>>; } catch { /* recompute */ } }
-    const fresh = await fetchZoneActivity(c.env);
-    c.executionCtx.waitUntil(cache.put('zone-activity:v1', JSON.stringify(fresh), { expirationTtl: 300 }));
-    return fresh;
-  };
+}
 
-  // Every source below is independent, and several are full KV-prefix scans
-  // (telemetry, usage rollups, the three observed-entity backlogs). Fetching
-  // them serially made the page wait on the SUM of those scans; fetch them all
-  // concurrently so it waits only on the slowest.
-  const emptyUnknown = { total: 0, sightings: 0, sample: [] as never[] };
-  const [
-    telRaw, repRaw, selfTracked, aiGateway, activity,
-    unknownRabbis, observedPlaces, observedConcepts, jeRaw, lintFailures,
-  ] = await Promise.all([
-    cache ? cache.get('telemetry:v1:recent') : null,
-    cache ? cache.get('reports:v1:recent') : null,
+async function buildTelemetrySection(cache?: KVNamespace) {
+  const telRaw = cache ? await cache.get('telemetry:v1:recent') : null;
+  const telemetry = telRaw ? (JSON.parse(telRaw) as TelemetryRecord[]) : [];
+  // Group dynamically over whatever endpoint/mark/enrichment values appear, so
+  // the dashboard stays correct without code changes as new producers record.
+  const group = (key: (r: TelemetryRecord) => string | undefined): Record<string, TelemetryRollup> => {
+    const buckets = new Map<string, TelemetryRecord[]>();
+    for (const r of telemetry) {
+      const k = key(r);
+      if (k == null) continue;
+      const arr = buckets.get(k) ?? [];
+      arr.push(r); buckets.set(k, arr);
+    }
+    const out: Record<string, TelemetryRollup> = {};
+    for (const [k, rows] of buckets) out[k] = rollupTelemetry(rows);
+    return out;
+  };
+  const recentErrors = telemetry
+    .filter((r) => !r.ok).slice(-30).reverse()
+    .map((r) => ({
+      ts: r.ts, endpoint: r.endpoint, tractate: r.tractate, page: r.page,
+      error_kind: r.error_kind, model: r.model, mark_id: r.mark_id, enrichment_id: r.enrichment_id,
+    }));
+  return {
+    perEndpoint: group((r) => r.endpoint),
+    perMark: group((r) => r.mark_id),
+    perEnrichment: group((r) => r.enrichment_id),
+    recentErrors,
+    totalCount: telemetry.length,
+  };
+}
+
+async function buildCostSection(c: UsageCtx, cache?: KVNamespace) {
+  const [selfTracked, aiGateway, telRaw] = await Promise.all([
     cache ? readUsageSummary(cache) : null,
-    loadAigw(),
-    loadActivity(),
-    cache ? listUnknownRabbis(cache) : emptyUnknown,
-    cache ? listObservedPlaces(cache) : emptyUnknown,
-    cache ? listObservedConcepts(cache) : emptyUnknown,
+    loadAigwCached(c, cache),
+    cache ? cache.get('telemetry:v1:recent') : null,
+  ]);
+  // Cost avoided by serving cache hits, over the recent telemetry window. Each
+  // hit's telemetry record recomputes what the call WOULD have cost from the
+  // stamped usage, so this is "money the cache saved us" without re-charging.
+  const telemetry = telRaw ? (JSON.parse(telRaw) as TelemetryRecord[]) : [];
+  let avoidedUsd = 0;
+  let avoidedCalls = 0;
+  for (const r of telemetry) {
+    if (r.cache_hit && typeof r.cost_usd === 'number') { avoidedUsd += r.cost_usd; avoidedCalls += 1; }
+  }
+  return {
+    selfTracked,
+    aiGateway,
+    costAvoided: { recentUsd: Math.round(avoidedUsd * 1e6) / 1e6, recentCalls: avoidedCalls },
+  };
+}
+
+async function buildActivitySection(c: UsageCtx, cache?: KVNamespace) {
+  return loadActivityCached(c, cache);
+}
+
+async function buildBacklogSection(cache?: KVNamespace) {
+  const empty = { total: 0, sightings: 0, sample: [] as never[] };
+  const [rabbis, places, concepts] = await Promise.all([
+    cache ? listUnknownRabbis(cache) : empty,
+    cache ? listObservedPlaces(cache) : empty,
+    cache ? listObservedConcepts(cache) : empty,
+  ]);
+  return { rabbis, places, concepts };
+}
+
+async function buildHealthSection(cache?: KVNamespace) {
+  const [jeRaw, lintFailures, repRaw] = await Promise.all([
     cache ? cache.get(RECENT_ERRORS_KEY) : null,
     readLintFailures(cache),
+    cache ? cache.get('reports:v1:recent') : null,
   ]);
-
-  const telemetry = telRaw ? (JSON.parse(telRaw) as TelemetryRecord[]) : [];
-  const reports = repRaw ? (JSON.parse(repRaw) as BugReport[]) : [];
-
-  interface Rollup {
-    count: number;
-    cacheHits: number;
-    cacheHitRate: number;
-    p50Ms: number;
-    p95Ms: number;
-    errorCount: number;
-    errorsByKind: Record<string, number>;
-  }
-
-  function rollup(rows: TelemetryRecord[]): Rollup {
-    const sorted = rows.map((r) => r.ms).sort((a, b) => a - b);
-    const hits = rows.filter((r) => r.cache_hit).length;
-    const errors = rows.filter((r) => !r.ok);
-    const errorsByKind: Record<string, number> = {};
-    for (const e of errors) errorsByKind[e.error_kind ?? 'other'] = (errorsByKind[e.error_kind ?? 'other'] ?? 0) + 1;
-    return {
-      count: rows.length,
-      cacheHits: hits,
-      cacheHitRate: rows.length ? hits / rows.length : 0,
-      p50Ms: percentile(sorted, 50),
-      p95Ms: percentile(sorted, 95),
-      errorCount: errors.length,
-      errorsByKind,
-    };
-  }
-
-  // Group dynamically over whatever endpoint values appear in the ring buffer
-  // — keeps the dashboard correct without code changes when new endpoints
-  // start recording.
-  const byEndpoint = new Map<string, TelemetryRecord[]>();
-  for (const r of telemetry) {
-    const arr = byEndpoint.get(r.endpoint) ?? [];
-    arr.push(r);
-    byEndpoint.set(r.endpoint, arr);
-  }
-  const perEndpoint: Record<string, Rollup> = {};
-  for (const [ep, rows] of byEndpoint) perEndpoint[ep] = rollup(rows);
-
-  // Per-mark / per-enrichment splits for the studio-run endpoint. The UI
-  // shows these in addition to the high-level studio-mark / studio-enrichment
-  // rollup so a slow mark doesn't hide behind the aggregate.
-  const byMark = new Map<string, TelemetryRecord[]>();
-  const byEnrichment = new Map<string, TelemetryRecord[]>();
-  for (const r of telemetry) {
-    if (r.mark_id) {
-      const arr = byMark.get(r.mark_id) ?? [];
-      arr.push(r);
-      byMark.set(r.mark_id, arr);
-    }
-    if (r.enrichment_id) {
-      const arr = byEnrichment.get(r.enrichment_id) ?? [];
-      arr.push(r);
-      byEnrichment.set(r.enrichment_id, arr);
-    }
-  }
-  const perMark: Record<string, Rollup> = {};
-  for (const [id, rows] of byMark) perMark[id] = rollup(rows);
-  const perEnrichment: Record<string, Rollup> = {};
-  for (const [id, rows] of byEnrichment) perEnrichment[id] = rollup(rows);
-
-  const recentErrors = telemetry
-    .filter((r) => !r.ok)
-    .slice(-30)
-    .reverse()
-    .map((r) => ({
-      ts: r.ts, endpoint: r.endpoint, tractate: r.tractate,
-      page: r.page, error_kind: r.error_kind, model: r.model,
-      mark_id: r.mark_id, enrichment_id: r.enrichment_id,
-    }));
-
-  // --- Hard queue-job failures (separate ring buffer from telemetry) -------
   let jobErrors: RecentJobError[] = [];
   if (jeRaw) { try { jobErrors = (JSON.parse(jeRaw) as RecentJobError[]).slice(-30).reverse(); } catch { jobErrors = []; } }
+  const reports = repRaw ? [...(JSON.parse(repRaw) as BugReport[])].reverse() : [];
+  return { jobErrors, lintFailures, reports };
+}
 
-  return {
-    telemetry: { perEndpoint, perMark, perEnrichment, recentErrors, totalCount: telemetry.length },
-    cost: { selfTracked, aiGateway },
-    activity,
-    unknowns: { rabbis: unknownRabbis, places: observedPlaces, concepts: observedConcepts },
-    jobErrors,
-    lintFailures,
-    reports: [...reports].reverse(),
-    generatedAt: new Date().toISOString(),
-  };
-  };
-
-  // --- Stale-while-revalidate dispatch ------------------------------------
+/**
+ * Generic stale-while-revalidate dispatcher for a usage section. Serves the
+ * cached value instantly; once past `freshMs` it refreshes in the background
+ * (a best-effort lock collapses concurrent rebuilds). A true cold miss builds
+ * synchronously. `build` returns the section data; this stamps `generatedAt`.
+ */
+async function serveUsageSection<T>(
+  c: { env: Bindings; executionCtx: ExecutionContext; json: (v: unknown) => Response },
+  cache: KVNamespace | undefined,
+  key: string,
+  freshMs: number,
+  build: () => Promise<T>,
+): Promise<Response> {
   if (cache) {
-    const cachedRaw = await cache.get(PAYLOAD_KEY);
+    const cachedRaw = await cache.get(key);
     if (cachedRaw) {
       let parsed: (Record<string, unknown> & { generatedAt?: string }) | null = null;
       try { parsed = JSON.parse(cachedRaw); } catch { parsed = null; }
       if (parsed) {
         const age = Date.now() - Date.parse(parsed.generatedAt ?? '');
-        const fresh = Number.isFinite(age) && age >= 0 && age < PAYLOAD_FRESH_MS;
+        const fresh = Number.isFinite(age) && age >= 0 && age < freshMs;
         if (!fresh) {
-          // Best-effort singleflight: skip the rebuild if another request is
-          // already refreshing. The lock self-expires (60s) so a crashed build
-          // can't wedge it, and it's cleared on completion. KV is eventually
-          // consistent, so this isn't a hard mutex — it just keeps a burst of
-          // stale hits from each kicking off their own ~10s rebuild.
-          const refreshing = await cache.get(REFRESH_LOCK_KEY);
+          const lockKey = `${key}:refreshing`;
+          const refreshing = await cache.get(lockKey);
           if (!refreshing) {
             c.executionCtx.waitUntil((async () => {
               try {
-                await cache.put(REFRESH_LOCK_KEY, '1', { expirationTtl: 60 });
-                const next = await computeUsagePayload();
-                await cache.put(PAYLOAD_KEY, JSON.stringify(next), { expirationTtl: 600 });
+                await cache.put(lockKey, '1', { expirationTtl: 60 });
+                const next = { ...(await build()), generatedAt: new Date().toISOString() };
+                await cache.put(key, JSON.stringify(next), { expirationTtl: 600 });
               } catch (err) {
                 // eslint-disable-next-line no-console
-                console.warn('[usage] background refresh failed:', err);
+                console.warn(`[usage] ${key} background refresh failed:`, err);
               } finally {
-                await cache.delete(REFRESH_LOCK_KEY).catch(() => {});
+                await cache.delete(lockKey).catch(() => {});
               }
             })());
           }
@@ -4314,10 +4305,58 @@ app.get('/api/usage', async (c) => {
       }
     }
   }
-  // Cold miss (no cached payload): build synchronously, then cache it.
-  const payload = await computeUsagePayload();
-  if (cache) c.executionCtx.waitUntil(cache.put(PAYLOAD_KEY, JSON.stringify(payload), { expirationTtl: 600 }));
-  return c.json(payload);
+  const data = { ...(await build()), generatedAt: new Date().toISOString() };
+  if (cache) c.executionCtx.waitUntil(cache.put(key, JSON.stringify(data), { expirationTtl: 600 }));
+  return c.json(data);
+}
+
+// Full payload — back-compatible shape. Composed from the same builders; keeps
+// its own SWR so existing clients keep working unchanged.
+app.get('/api/usage', async (c) => {
+  const cache = c.env.CACHE;
+  const build = async () => {
+    const [telemetry, cost, activity, backlog, health] = await Promise.all([
+      buildTelemetrySection(cache),
+      buildCostSection(c, cache),
+      buildActivitySection(c, cache),
+      buildBacklogSection(cache),
+      buildHealthSection(cache),
+    ]);
+    return {
+      telemetry,
+      cost,
+      activity,
+      unknowns: backlog,
+      jobErrors: health.jobErrors,
+      lintFailures: health.lintFailures,
+      reports: health.reports,
+    };
+  };
+  return serveUsageSection(c, cache, 'usage-payload:v1', 30_000, build);
+});
+
+// Per-section endpoints — the client loads these independently so each card
+// renders as soon as its own data arrives.
+app.get('/api/usage/cost', (c) => serveUsageSection(c, c.env.CACHE, 'usage-cost:v1', 30_000, () => buildCostSection(c, c.env.CACHE)));
+app.get('/api/usage/telemetry', (c) => serveUsageSection(c, c.env.CACHE, 'usage-telemetry:v1', 30_000, () => buildTelemetrySection(c.env.CACHE)));
+app.get('/api/usage/activity', (c) => serveUsageSection(c, c.env.CACHE, 'usage-activity:v1', 60_000, () => buildActivitySection(c, c.env.CACHE)));
+app.get('/api/usage/backlog', (c) => serveUsageSection(c, c.env.CACHE, 'usage-backlog:v1', 60_000, () => buildBacklogSection(c.env.CACHE)));
+app.get('/api/usage/health', (c) => serveUsageSection(c, c.env.CACHE, 'usage-health:v1', 30_000, () => buildHealthSection(c.env.CACHE)));
+
+// Per-daf cost drill-down — "trace this daf". Reads the permanent per-entry
+// cost stamps for one daf across each mark's cached versions (bounded reads):
+// current-version cost vs superseded-version cost. Recent enrichment + source-
+// alignment spend for the daf lives in the per-call ledger (GET
+// /api/admin/llm-cost -> byDaf), which the UI overlays.
+app.get('/api/usage/daf/:tractate/:page', (c) => {
+  const cache = c.env.CACHE;
+  if (!cache) return c.json({ error: 'no cache binding' }, 503);
+  const tractate = c.req.param('tractate');
+  const page = c.req.param('page');
+  return serveUsageSection(c, cache, `usage-daf:v1:${tractate}:${page}`, 60_000, async () => {
+    const stats = (await readCachedCacheStats(cache)) ?? (await computeCacheStats(cache));
+    return dafCostReport(cache, stats.marks, tractate, page);
+  });
 });
 
 // --- Commentaries list --------------------------------------------------

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -73,7 +73,7 @@ import {
   type LLMRabbiOutput,
 } from '../lib/rabbi/types';
 import { wrapEnv, gatewayStatus, gatewayActive } from './ai-gateway';
-import { runLLM, type LLMModelId, type LLMResult, type LLMUsage } from './llm';
+import { runLLM, type LLMModelId, type LLMResult, type LLMUsage, type CostAttribution } from './llm';
 import { checkBudget, isBudgetPaused, budgetStatus, clearPauses, type BudgetScope } from './budget';
 import { lookupRelationships } from './rabbi-graph';
 import { runPasses } from '../lib/check/passes';
@@ -82,7 +82,7 @@ import { findMarkers } from '../lib/typing/markers';
 import { noteLintAttempt, readLintFailures, type LintFailuresSummary } from './lint-failures';
 import { partitionSections, dedupeByRange, dedupeBy, selectSectionMoves, type MoveLike } from '../lib/argumentMoves';
 import { DEFAULT_MODEL, DEFAULT_FALLBACK_CHAIN, isLLMModelId, MODEL_PRESETS } from './settings';
-import { costUsd as priceCostUsd, normalizeUsage } from './pricing';
+import { costUsd as priceCostUsd, costSplitUsd, normalizeUsage } from './pricing';
 import { recordUsage, readUsageSummary } from './usage-rollup';
 import { recordUnknownRabbi, recordObservedPlace, recordObservedConcept, listUnknownRabbis, listObservedPlaces, listObservedConcepts } from './unknown-registry';
 import { fetchGatewayCost } from './aigw-analytics';
@@ -409,7 +409,7 @@ async function runKimiStreaming(
   modelId: string,
   messages: KimiMessage[],
   maxTokens: number,
-  opts?: { temperature?: number; chatTemplateKwargs?: { enable_thinking?: boolean }; responseFormat?: unknown },
+  opts?: { temperature?: number; chatTemplateKwargs?: { enable_thinking?: boolean }; responseFormat?: unknown; tag?: string; attribution?: CostAttribution },
 ): Promise<StreamedResult> {
   const t0 = Date.now();
   const promptChars = messages.reduce((s, m) => s + m.content.length, 0);
@@ -422,6 +422,8 @@ async function runKimiStreaming(
     thinking: typeof enableThinking === 'boolean' ? enableThinking : undefined,
     response_format: opts?.responseFormat as { type: 'json_schema'; json_schema: unknown } | undefined,
     stream: true,
+    tag: opts?.tag,
+    attribution: opts?.attribution,
   });
   return {
     content: r.content,
@@ -564,6 +566,8 @@ app.get('/api/admin/ai-gateway-test', async (c) => {
       ],
       max_tokens: 16,
       temperature: 0,
+      tag: 'gateway-test',
+      attribution: { kind: 'other', producerId: 'gateway-test' },
     });
     return c.json({
       status,
@@ -801,6 +805,7 @@ async function computeDafBridge(env: Bindings, tractate: string, page: string): 
           max_tokens: 1500, temperature: 0.2,
           response_format: { type: 'json_schema', json_schema: ARGUMENT_BRIDGE_OUTPUT_SCHEMA },
           thinking: false, tag: 'argument-overview.bridge',
+          attribution: { kind: 'bridge', producerId: 'argument-overview.bridge', tractate, page },
         });
         let verdict: { continues?: unknown; note?: unknown } = {};
         try { verdict = JSON.parse(res.content); } catch { /* fall through */ }
@@ -1757,6 +1762,53 @@ interface RunResult {
   // that the cached value predates a prompt/schema edit even when cache_version
   // wasn't bumped (GET /api/stale/...). Absent on entries written before this.
   recipe_hash?: string;
+  // What this entry cost to GENERATE, stamped at write time. The cache is
+  // permanent, so this makes it the durable per-daf / per-version cost record:
+  // "what did the current version of daf X cost" = sum over its entries' cost;
+  // "earlier versions" = sum over the superseded-version keys. Absent on
+  // computed (no-LLM) marks and on entries written before this field existed.
+  cost?: CostStamp;
+}
+
+/** Generation cost stamped onto a cache entry — the permanent per-entry ledger. */
+interface CostStamp {
+  /** OpenRouter billed USD (net of prompt-cache); null on Workers AI / unpriced. */
+  billedUsd: number | null;
+  /** List-price estimate total; null when the model has no known rate. */
+  estimatedUsd: number | null;
+  /** Estimate split so input-vs-output dollars are answerable per entry. */
+  costInUsd: number | null;
+  costOutUsd: number | null;
+  tokensIn: number;
+  tokensOut: number;
+  lang: 'en' | 'he';
+  cacheVersion: string;
+  computedAt: number;
+}
+
+/** Build the per-entry cost stamp from a completed LLM result. Reuses the same
+ *  pricing helpers as the budget guard and daily rollup so every cost figure in
+ *  the system is computed one way. */
+function costStampOf(
+  model: string | undefined,
+  usage: LLMUsage | null | undefined,
+  lang: 'en' | 'he',
+  cacheVersion: string,
+): CostStamp {
+  const { input, output } = normalizeUsage(usage as Parameters<typeof normalizeUsage>[0]);
+  const { costInUsd, costOutUsd } = costSplitUsd(model, usage as Parameters<typeof costSplitUsd>[1]);
+  const billed = usage && typeof usage.cost === 'number' ? usage.cost : null;
+  return {
+    billedUsd: billed,
+    estimatedUsd: priceCostUsd(model, usage as Parameters<typeof priceCostUsd>[1]),
+    costInUsd,
+    costOutUsd,
+    tokensIn: input,
+    tokensOut: output,
+    lang,
+    cacheVersion,
+    computedAt: Date.now(),
+  };
 }
 
 interface RunResultEnrichment extends RunResult {
@@ -1975,6 +2027,12 @@ async function runExtractorFannedOut(
         usage.prompt_tokens = (usage.prompt_tokens ?? 0) + (r.usage.prompt_tokens ?? 0);
         usage.completion_tokens = (usage.completion_tokens ?? 0) + (r.usage.completion_tokens ?? 0);
         usage.total_tokens = (usage.total_tokens ?? 0) + (r.usage.total_tokens ?? 0);
+        // Sum the billed cost too, so the synthesized result (and the cache
+        // entry's cost stamp built from it) reflects what the fanned-out
+        // subcalls actually cost — not null, which would force a list-price
+        // fallback and drop the prompt-cache discount. (Budget + per-call ledger
+        // already saw each subcall's cost inside runLLM; this is for the stamp.)
+        if (typeof r.usage.cost === 'number') usage.cost = (usage.cost ?? 0) + r.usage.cost;
       }
     }
   }
@@ -2102,6 +2160,14 @@ async function runMarkOnce(
     // Cost-ledger attribution; the fan-out path spreads llmOptsBase, so this
     // tags every argument-move sub-call too.
     tag: `mark:${def.id}`,
+    attribution: {
+      kind: 'mark' as const,
+      producerId: def.id,
+      tractate,
+      page,
+      lang: useHe ? 'he' as const : 'en' as const,
+      cache_version: def.cache_version,
+    },
   };
 
   let result: LLMResult;
@@ -2191,6 +2257,7 @@ async function runMarkOnce(
       user_prompt: userPrompt.length > 2000 ? userPrompt.slice(0, 2000) + '… [+' + (userPrompt.length - 2000) + ' chars]' : userPrompt,
     },
     cache_hit: false,
+    cost: costStampOf(result.model, result.usage, useHe ? 'he' : 'en', def.cache_version),
     ...(markCheckIssues ? { check_issues: markCheckIssues } : {}),
     ...(markHardIssues ? { lint_issues: markHardIssues } : {}),
   };
@@ -2462,6 +2529,14 @@ async function runEnrichmentOnce(
     reasoning_effort: def.reasoning_effort,
     bypass_cache: bypassCache,
     tag: `enrich:${def.id}`,
+    attribution: {
+      kind: def.id.endsWith('.qa') ? 'qa' as const : 'enrichment' as const,
+      producerId: def.id,
+      tractate,
+      page,
+      lang: useHe ? 'he' as const : 'en' as const,
+      cache_version: def.cache_version,
+    },
     // Custom Q&A enrichments (<mark>.qa) count against the hourly custom-question
     // budget; everything else only against the daily total. See ./budget.
     cost_class: def.id.endsWith('.qa') ? 'custom-question' : undefined,
@@ -2537,6 +2612,7 @@ async function runEnrichmentOnce(
     },
     cache_hit: false,
     recipe_hash,
+    cost: costStampOf(result.model, result.usage, useHe ? 'he' : 'en', def.cache_version),
     deps_resolved: Object.keys(inputs.depends).length > 0 ? inputs.depends : undefined,
     anchors_resolved: Object.keys(inputs.anchors).length > 0 ? inputs.anchors : undefined,
     ...(lint_issues ? { lint_issues } : {}),
@@ -3182,6 +3258,11 @@ interface LlmCostRec {
   ts: number; model: string; transport: string; tag: string;
   attempts: number; ms: number;
   cost: number | null; prompt_tokens: number | null; completion_tokens: number | null; total_tokens: number | null;
+  // Attribution (additive; null on entries written before it existed).
+  cost_in_est?: number | null; cost_out_est?: number | null;
+  kind?: string | null; producer_id?: string | null;
+  tractate?: string | null; page?: string | null; lang?: string | null;
+  cache_version?: string | null; cost_class?: string | null;
 }
 app.get('/api/admin/llm-cost', async (c) => {
   const cache = c.env.CACHE;
@@ -3210,6 +3291,8 @@ app.get('/api/admin/llm-cost', async (c) => {
   } while (cursor && keys.length < 10000);
 
   let totalCost = 0;
+  let totalCostInEst = 0;
+  let totalCostOutEst = 0;
   let calls = 0;
   let callsWithCost = 0;
   let promptTokens = 0;
@@ -3218,6 +3301,10 @@ app.get('/api/admin/llm-cost', async (c) => {
   let maxTs = 0;
   const byModel: Record<string, { calls: number; cost: number; promptTokens: number; completionTokens: number }> = {};
   const byTag: Record<string, { calls: number; cost: number }> = {};
+  const byKind: Record<string, { calls: number; cost: number }> = {};
+  // Per-daf recent spend (7-day ledger window). The permanent per-daf record is
+  // the cache-entry cost stamp; this is the live drill-down for what just ran.
+  const byDaf: Record<string, { calls: number; cost: number; costInEst: number; costOutEst: number }> = {};
 
   for (const key of keys) {
     const raw = await cache.get(key);
@@ -3227,6 +3314,8 @@ app.get('/api/admin/llm-cost', async (c) => {
     if (since && r.ts < since) continue;
     calls++;
     if (typeof r.cost === 'number') { totalCost += r.cost; callsWithCost++; }
+    if (typeof r.cost_in_est === 'number') totalCostInEst += r.cost_in_est;
+    if (typeof r.cost_out_est === 'number') totalCostOutEst += r.cost_out_est;
     if (typeof r.prompt_tokens === 'number') promptTokens += r.prompt_tokens;
     if (typeof r.completion_tokens === 'number') completionTokens += r.completion_tokens;
     if (r.ts < minTs) minTs = r.ts;
@@ -3235,14 +3324,26 @@ app.get('/api/admin/llm-cost', async (c) => {
     m.calls++; m.cost += r.cost ?? 0; m.promptTokens += r.prompt_tokens ?? 0; m.completionTokens += r.completion_tokens ?? 0;
     const t = (byTag[r.tag] ??= { calls: 0, cost: 0 });
     t.calls++; t.cost += r.cost ?? 0;
+    const k = (byKind[r.kind ?? 'untagged'] ??= { calls: 0, cost: 0 });
+    k.calls++; k.cost += r.cost ?? 0;
+    if (r.tractate && r.page) {
+      const d = (byDaf[`${r.tractate}:${r.page}`] ??= { calls: 0, cost: 0, costInEst: 0, costOutEst: 0 });
+      d.calls++; d.cost += r.cost ?? 0; d.costInEst += r.cost_in_est ?? 0; d.costOutEst += r.cost_out_est ?? 0;
+    }
   }
 
   const round = (n: number) => Math.round(n * 1e6) / 1e6;
   for (const m of Object.values(byModel)) m.cost = round(m.cost);
   for (const t of Object.values(byTag)) t.cost = round(t.cost);
+  for (const k of Object.values(byKind)) k.cost = round(k.cost);
+  for (const d of Object.values(byDaf)) { d.cost = round(d.cost); d.costInEst = round(d.costInEst); d.costOutEst = round(d.costOutEst); }
 
   return c.json({
     totalCostUsd: round(totalCost),
+    // List-price input/output split (est) — OpenRouter bills one number, so the
+    // in/out ratio is estimated; totalCostUsd stays billed-authoritative.
+    estInputCostUsd: round(totalCostInEst),
+    estOutputCostUsd: round(totalCostOutEst),
     calls,
     callsWithCost,
     promptTokens,
@@ -3250,6 +3351,8 @@ app.get('/api/admin/llm-cost', async (c) => {
     window: { from: calls ? minTs : null, to: calls ? maxTs : null },
     byModel,
     byTag,
+    byKind,
+    byDaf,
     truncated: keys.length >= 10000,
   });
 });
@@ -3902,6 +4005,7 @@ function captureLlmUsage(
 ): void {
   const { input, output } = normalizeUsage(args.result.usage as Parameters<typeof normalizeUsage>[0]);
   const cost = priceCostUsd(args.result.model, args.result.usage as Parameters<typeof priceCostUsd>[1]);
+  const { costInUsd, costOutUsd } = costSplitUsd(args.result.model, args.result.usage as Parameters<typeof costSplitUsd>[1]);
   recordUsage(rc.env, rc.ctx, {
     ok: !args.result.parse_error,
     cacheHit: false,
@@ -3909,6 +4013,8 @@ function captureLlmUsage(
     tokensIn: input,
     tokensOut: output,
     costUsd: cost,
+    costInUsd,
+    costOutUsd,
     markId: args.kind === 'mark' ? args.id : undefined,
     enrichmentId: args.kind === 'enrichment' ? args.id : undefined,
   });
@@ -4417,6 +4523,8 @@ app.post('/api/commentary-translate', async (c) => {
         max_tokens: 800,
         temperature: 0.2,
         thinking: false,
+        tag: 'commentary-translate',
+        attribution: { kind: 'translate', ...(body.tractate && body.page ? { tractate: body.tractate, page: body.page } : {}) },
       });
       const translation = r.content.trim().replace(/^["\']|["\']$/g, '');
       if (!translation) { attempts.push(`${m.label}: empty`); continue; }
@@ -4697,7 +4805,7 @@ app.post('/api/context/match', async (c) => {
   try {
     const segments = await getSefariaSegmentsCached(cache, t, p);
     if (!segments) return c.json({ matches: [], warning: 'no segments for daf' });
-    const matches = await aiMatchToSegments(c.env, segments.he, segments.en, items);
+    const matches = await aiMatchToSegments(c.env, segments.he, segments.en, items, { tractate: t, page: p });
     if (cache) { try { await cache.put(cacheKey, JSON.stringify(matches)); } catch { /* ignore */ } }
     return c.json({ matches });
   } catch (err) {
@@ -5091,6 +5199,8 @@ app.post('/api/translate', async (c) => {
         max_tokens: m.kimi ? 400 : isPhrase ? 120 : 30,
         temperature: 0.1,
         thinking: false,
+        tag: 'translate',
+        attribution: { kind: 'translate', tractate, page },
       });
       const translation = r.content.trim().replace(/^["']|["']$/g, '');
       if (!translation) {
@@ -5486,6 +5596,8 @@ app.get('/api/admin/enrich-rabbi/:slug', async (c) => {
       temperature: 0.1,
       thinking: false,
       response_format: { type: 'json_schema', json_schema: ENRICH_JSON_SCHEMA },
+      tag: 'rabbi-enrich',
+      attribution: { kind: 'rabbi', producerId: 'rabbi-enrich' },
     });
     const payload = r.content.trim() || extractJsonPayload({ response: r.content });
     if (!payload) return c.json({ error: 'empty payload', slug }, 502);
@@ -5608,6 +5720,7 @@ app.get('/api/admin/rabbi-relationships/:slug', async (c) => {
         { role: 'user', content: userContent },
       ],
       8192,
+      { tag: 'rabbi-relationships', attribution: { kind: 'rabbi', producerId: 'rabbi-relationships' } },
     );
   } catch (err) {
     return c.json({ error: String(err).slice(0, 300), slug }, 502);
@@ -5734,6 +5847,7 @@ app.get('/api/admin/rabbi-family/:slug', async (c) => {
         { role: 'user', content: userContent },
       ],
       8192,
+      { tag: 'rabbi-family', attribution: { kind: 'rabbi', producerId: 'rabbi-family' } },
     );
   } catch (err) {
     return c.json({ error: String(err).slice(0, 300), slug }, 502);
@@ -5864,6 +5978,7 @@ app.get('/api/admin/rabbi-orientation/:slug', async (c) => {
         { role: 'user', content: userContent },
       ],
       4096,
+      { tag: 'rabbi-orientation', attribution: { kind: 'rabbi', producerId: 'rabbi-orientation' } },
     );
   } catch (err) {
     return c.json({ error: String(err).slice(0, 300), slug }, 502);
@@ -6135,7 +6250,7 @@ export async function enrichRabbiUnified(
         { role: 'user', content: userContent },
       ],
       12288,
-      { chatTemplateKwargs: { enable_thinking: false } },
+      { chatTemplateKwargs: { enable_thinking: false }, tag: 'rabbi-enrich-sefaria', attribution: { kind: 'rabbi', producerId: 'rabbi-enrich-sefaria' } },
     );
   } catch (err) {
     return { ok: false, error: `llm: ${String(err).slice(0, 200)}`, ms: Date.now() - t0 };
@@ -7065,6 +7180,8 @@ app.post('/api/admin/translate-bio', async (c) => {
       temperature: 0.1,
       thinking: false,
       response_format: { type: 'json_schema', json_schema: TRANSLATE_BIO_JSON_SCHEMA },
+      tag: 'translate-bio',
+      attribution: { kind: 'rabbi', producerId: 'translate-bio' },
     });
     const payload = r.content.trim() || extractJsonPayload({ response: r.content });
     if (!payload) return c.json({ error: 'empty payload' }, 502);
@@ -7274,6 +7391,8 @@ app.post('/api/hebraize', async (c) => {
       ],
       max_tokens: Math.min(4096, Math.ceil(core.length * 1.5) + 256),
       temperature: 0,
+      tag: 'hebraize',
+      attribution: { kind: 'hebraize' },
     });
     // Guard the model output: collapse any `X (X)` echo the model emitted so a
     // mistranslated gloss can never reach the cache or the UI (see
@@ -7485,7 +7604,7 @@ app.post('/api/enrich-rabbi-bio/:tractate/:page/:slug', async (c) => {
         { role: 'user', content: userContent },
       ],
       4000,
-      { chatTemplateKwargs: { enable_thinking: false } },
+      { chatTemplateKwargs: { enable_thinking: false }, tag: 'rabbi-bio-daf', attribution: { kind: 'rabbi', producerId: 'rabbi-bio-daf', tractate, page } },
     );
     let payload = s.content.trim();
     const fenced = payload.match(/```(?:json)?\s*([\s\S]*?)```/);

--- a/src/worker/llm.ts
+++ b/src/worker/llm.ts
@@ -26,6 +26,7 @@ import { runWithRetry } from './ai-gateway';
 import { LLMError, isFallbackWorthy, NEITHER, TIMEOUT } from './llm-error';
 import { DEFAULT_MODEL, DEFAULT_FALLBACK_CHAIN } from './settings';
 import { checkBudget, recordSpend, BudgetPausedError, type EmailBinding } from './budget';
+import { costSplitUsd, normalizeUsage } from './pricing';
 
 export type LLMModelId = `@cf/${string}` | `openrouter/${string}`;
 
@@ -94,10 +95,45 @@ export interface LLMCallOptions {
    *  'mark:rabbi', 'enrich:rabbi.synthesis'). Lets /api/admin/llm-cost break
    *  spend down by mark/enrichment. Untagged calls still count toward totals. */
   tag?: string;
+  /** Structured cost-ledger provenance: which daf / language / producer / kind
+   *  of paid work this call was. Lets spend be traced to a daf and a producer,
+   *  not just a free-text tag. See CostAttribution. */
+  attribution?: CostAttribution;
   /** Spend classification for the budget guard (./budget). 'custom-question'
    *  counts against the hourly custom-Q&A cap AND the daily total; everything
    *  else counts only against the daily total. */
   cost_class?: 'custom-question';
+}
+
+/** Coarse category of paid work, so spend can be grouped by what it was for
+ *  even when there's no producer id (translate, hebraize, diagnostics, …). */
+export type CostKind =
+  | 'mark'
+  | 'enrichment'
+  | 'translate'
+  | 'hebraize'
+  | 'match'
+  | 'bridge'
+  | 'analyze'
+  | 'rabbi'
+  | 'adhoc'
+  | 'qa'
+  | 'other';
+
+/** Structured provenance attached to a paid LLM call. Every field is optional —
+ *  daf-bound work fills tractate/page/lang/cache_version; global work (rabbi
+ *  enrichment, diagnostics) just sets `kind`. Written verbatim into the cost
+ *  ledger so a dollar can be traced to a daf, a language, a producer version. */
+export interface CostAttribution {
+  tractate?: string;
+  page?: string;
+  lang?: 'en' | 'he';
+  /** The producer's cache_version at generation time — lets spend on a
+   *  superseded version be told apart from spend on the current one. */
+  cache_version?: string;
+  kind?: CostKind;
+  /** Mark or enrichment id (e.g. 'rabbi', 'argument.synthesis'). */
+  producerId?: string;
 }
 
 export type LLMTransport = 'workers-ai' | 'openrouter-gateway';
@@ -208,7 +244,7 @@ export async function runLLM(env: LLMEnv, opts: LLMCallOptions): Promise<LLMResu
     const model = chain[i];
     try {
       const result = await withHardTimeout(callOnce(env, model, opts), MODEL_CALL_HARD_TIMEOUT_MS, model);
-      await recordLLMCost(env, model, opts.tag, i + 1, result);
+      await recordLLMCost(env, model, i + 1, result, opts);
       // Feed the spend budget (./budget) so the next checkBudget sees this call.
       await recordSpend(env, { model: result.model, usage: result.usage, custom });
       return { ...result, attempts: i + 1 };
@@ -232,32 +268,51 @@ export async function runLLM(env: LLMEnv, opts: LLMCallOptions): Promise<LLMResu
 // concurrent queue workers never clobber each other (a single ring buffer's
 // read-modify-write would lose entries and undercount). /api/admin/llm-cost
 // sums the prefix. Best-effort + short TTL; failures never block the call.
+// Schema is additive over the original (model/tag/cost/tokens stay put), so the
+// 7-day window of pre-attribution entries still aggregates — new fields just
+// read as null on them.
 const LLM_COST_PREFIX = 'llmcost:v1:';
 const LLM_COST_TTL_S = 7 * 24 * 3600;
 
 async function recordLLMCost(
   env: LLMEnv,
   model: LLMModelId,
-  tag: string | undefined,
   attempts: number,
   result: Omit<LLMResult, 'attempts'>,
+  opts: LLMCallOptions,
 ): Promise<void> {
   const cache = env.CACHE;
   if (!cache) return;
   try {
     const u = result.usage;
-    const key = `${LLM_COST_PREFIX}${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+    const a = opts.attribution;
+    const { input, output } = normalizeUsage(u);
+    // OpenRouter returns one billed `cost`; the in/out split is a list-price
+    // estimate so the dashboard can show where tokens (and dollars) went.
+    const { costInUsd, costOutUsd } = costSplitUsd(model, u);
+    const now = Date.now();
+    const key = `${LLM_COST_PREFIX}${now.toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
     const rec = {
-      ts: Date.now(),
+      ts: now,
       model,
       transport: result.transport,
-      tag: tag ?? 'untagged',
+      tag: opts.tag ?? 'untagged',
       attempts,
       ms: result.elapsed_ms,
       cost: typeof u?.cost === 'number' ? u.cost : null,
-      prompt_tokens: u?.prompt_tokens ?? null,
-      completion_tokens: u?.completion_tokens ?? null,
+      cost_in_est: costInUsd,
+      cost_out_est: costOutUsd,
+      prompt_tokens: u?.prompt_tokens ?? input ?? null,
+      completion_tokens: u?.completion_tokens ?? output ?? null,
       total_tokens: u?.total_tokens ?? null,
+      // Structured attribution — null when the caller didn't supply it.
+      kind: a?.kind ?? null,
+      producer_id: a?.producerId ?? null,
+      tractate: a?.tractate ?? null,
+      page: a?.page ?? null,
+      lang: a?.lang ?? null,
+      cache_version: a?.cache_version ?? null,
+      cost_class: opts.cost_class ?? null,
     };
     await cache.put(key, JSON.stringify(rec), { expirationTtl: LLM_COST_TTL_S });
   } catch {

--- a/src/worker/mcp-openapi.ts
+++ b/src/worker/mcp-openapi.ts
@@ -335,8 +335,36 @@ export const TALMUD_OPENAPI: Record<string, unknown> = {
 
     '/api/usage': {
       get: {
-        summary: 'Usage + performance rollups per endpoint / mark / enrichment, plus recent errors.',
-        responses: { '200': { description: '{ perEndpoint, perMark, perEnrichment, recentErrors }' } },
+        summary: 'Full usage dashboard payload (telemetry + cost + activity + backlog + health). Section endpoints below load the same data piecemeal.',
+        responses: { '200': { description: '{ telemetry, cost, activity, unknowns, jobErrors, lintFailures, reports }' } },
+      },
+    },
+    '/api/usage/cost': {
+      get: {
+        summary: 'Cost section: self-tracked spend (per model/mark/enrichment, input-vs-output split), AI Gateway billed cost, and recent cost-avoided-by-cache.',
+        responses: { '200': { description: '{ selfTracked, aiGateway, costAvoided }' } },
+      },
+    },
+    '/api/usage/telemetry': {
+      get: { summary: 'Latency + cache-hit + error rollups per endpoint / mark / enrichment.', responses: { '200': { description: '{ perEndpoint, perMark, perEnrichment, recentErrors }' } } },
+    },
+    '/api/usage/activity': {
+      get: { summary: 'Cloudflare zone traffic (requests/visits by day + country).', responses: { '200': { description: 'zone activity' } } },
+    },
+    '/api/usage/backlog': {
+      get: { summary: 'Needs-enrichment backlog: unknown rabbis / observed places / observed concepts.', responses: { '200': { description: '{ rabbis, places, concepts }' } } },
+    },
+    '/api/usage/health': {
+      get: { summary: 'Operational health: queue-job errors, enrichment lint failures, bug reports.', responses: { '200': { description: '{ jobErrors, lintFailures, reports }' } } },
+    },
+    '/api/usage/daf/{tractate}/{page}': {
+      get: {
+        summary: 'Per-daf cost trace: each mark\'s current-version vs superseded-version generation cost, from the permanent cache-entry cost stamps.',
+        parameters: [
+          { name: 'tractate', in: 'path', required: true, schema: { type: 'string' } },
+          { name: 'page', in: 'path', required: true, schema: { type: 'string' }, description: 'e.g. "5a".' },
+        ],
+        responses: { '200': { description: '{ tractate, page, marks: [...], totals: { currentUsd, supersededUsd, totalUsd } }' } },
       },
     },
     '/api/admin/recent-errors': {

--- a/src/worker/pricing.ts
+++ b/src/worker/pricing.ts
@@ -63,3 +63,23 @@ export function costUsd(model: string | null | undefined, usage: TokenUsage | nu
   const { input, output } = normalizeUsage(usage);
   return (input / 1e6) * price.inputPer1M + (output / 1e6) * price.outputPer1M;
 }
+
+/**
+ * The list-price estimate split into its input-side and output-side dollars.
+ * OpenRouter only returns ONE billed `cost` number (net of prompt-cache), so an
+ * exact input-vs-output dollar decomposition isn't available — this estimate
+ * (tokens x list rate) is how the dashboard shows the in/out ratio. Both fields
+ * are null for unpriced models (Workers AI etc.).
+ */
+export function costSplitUsd(
+  model: string | null | undefined,
+  usage: TokenUsage | null | undefined,
+): { costInUsd: number | null; costOutUsd: number | null } {
+  const price = priceFor(model);
+  if (!price) return { costInUsd: null, costOutUsd: null };
+  const { input, output } = normalizeUsage(usage);
+  return {
+    costInUsd: (input / 1e6) * price.inputPer1M,
+    costOutUsd: (output / 1e6) * price.outputPer1M,
+  };
+}

--- a/src/worker/revach-ai-place.ts
+++ b/src/worker/revach-ai-place.ts
@@ -81,7 +81,7 @@ async function getOrCompute(
     if (!segs?.he?.length) return null;
     let matches: SegMatch[];
     try {
-      matches = await aiMatchToSegments(env, segs.he, segs.en ?? [], all.map(toMatchInput));
+      matches = await aiMatchToSegments(env, segs.he, segs.en ?? [], all.map(toMatchInput), { tractate, page });
     } catch {
       return null; // budget paused / LLM error → deterministic stands
     }

--- a/src/worker/usage-rollup.ts
+++ b/src/worker/usage-rollup.ts
@@ -13,7 +13,13 @@
  */
 
 const PREFIX = 'usage:daily:v1:';
-const TTL_S = 60 * 60 * 24 * 120; // keep ~4 months of daily history
+// Keep ~2 years of daily history. These per-day rollups are the durable
+// time-series record (the per-call llmcost ledger is only 7 days), so they
+// outlive a realistic full-shas warming campaign instead of rotting at 4 months.
+// Per-DAF cost is NOT kept here (it would make this doc grow unboundedly with
+// warming volume and worsen the read-modify-write raciness) — that lives on the
+// permanent cache entries' cost stamp, which is exact and non-racy.
+const TTL_S = 60 * 60 * 24 * 730;
 
 export interface UsageDelta {
   ok: boolean;
@@ -23,6 +29,11 @@ export interface UsageDelta {
   tokensOut: number;
   /** null when the model has no known list price (Workers AI etc.). */
   costUsd: number | null;
+  /** List-price estimate split (input-side / output-side dollars) so the
+   *  dashboard can show where spend went even though OpenRouter bills one
+   *  number. Null/absent for unpriced models. */
+  costInUsd?: number | null;
+  costOutUsd?: number | null;
   markId?: string;
   enrichmentId?: string;
 }
@@ -31,7 +42,9 @@ export interface UsageBucket {
   calls: number;
   tokensIn: number;
   tokensOut: number;
-  costUsd: number;       // sum of priced calls only
+  costUsd: number;       // sum of priced calls only (billed-or-est total)
+  costInUsd: number;     // est input-side dollars
+  costOutUsd: number;    // est output-side dollars
   pricedCalls: number;   // calls we could attach a $ figure to
   unpricedCalls: number; // calls whose model has no list price
 }
@@ -46,7 +59,7 @@ export interface DailyRollup extends UsageBucket {
 }
 
 function emptyBucket(): UsageBucket {
-  return { calls: 0, tokensIn: 0, tokensOut: 0, costUsd: 0, pricedCalls: 0, unpricedCalls: 0 };
+  return { calls: 0, tokensIn: 0, tokensOut: 0, costUsd: 0, costInUsd: 0, costOutUsd: 0, pricedCalls: 0, unpricedCalls: 0 };
 }
 
 function applyToBucket(b: UsageBucket, d: UsageDelta): void {
@@ -55,6 +68,8 @@ function applyToBucket(b: UsageBucket, d: UsageDelta): void {
   b.tokensOut += d.tokensOut;
   if (d.costUsd != null) {
     b.costUsd += d.costUsd;
+    b.costInUsd += d.costInUsd ?? 0;
+    b.costOutUsd += d.costOutUsd ?? 0;
     b.pricedCalls += 1;
   } else {
     b.unpricedCalls += 1;
@@ -128,6 +143,8 @@ function mergeBucketInto(into: Record<string, UsageBucket>, from: Record<string,
     t.tokensIn += b.tokensIn;
     t.tokensOut += b.tokensOut;
     t.costUsd += b.costUsd;
+    t.costInUsd += b.costInUsd ?? 0;
+    t.costOutUsd += b.costOutUsd ?? 0;
     t.pricedCalls += b.pricedCalls;
     t.unpricedCalls += b.unpricedCalls;
   }
@@ -164,6 +181,8 @@ export async function readUsageSummary(cache: KVNamespace, days = 120): Promise<
     totals.tokensIn += r.tokensIn;
     totals.tokensOut += r.tokensOut;
     totals.costUsd += r.costUsd;
+    totals.costInUsd += r.costInUsd ?? 0;
+    totals.costOutUsd += r.costOutUsd ?? 0;
     totals.pricedCalls += r.pricedCalls;
     totals.unpricedCalls += r.unpricedCalls;
     totals.errors += r.errors;

--- a/tests/cost-attribution.test.ts
+++ b/tests/cost-attribution.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { costUsd, costSplitUsd, normalizeUsage } from '../src/worker/pricing';
+
+// deepseek-v4-flash is list-priced in MODEL_PRESETS (input 0.14, output 0.28
+// per 1M tokens). These tests pin the input-vs-output dollar split that the
+// cost ledger + per-entry cost stamp rely on to answer "where did the money go".
+const FLASH = 'openrouter/deepseek/deepseek-v4-flash';
+
+describe('costSplitUsd', () => {
+  it('splits a priced call into input-side and output-side dollars', () => {
+    const { costInUsd, costOutUsd } = costSplitUsd(FLASH, { prompt_tokens: 1_000_000, completion_tokens: 1_000_000 });
+    expect(costInUsd).toBeCloseTo(0.14, 6);
+    expect(costOutUsd).toBeCloseTo(0.28, 6);
+  });
+
+  it('the split sums to the total list-price estimate', () => {
+    const usage = { prompt_tokens: 250_000, completion_tokens: 80_000 };
+    const { costInUsd, costOutUsd } = costSplitUsd(FLASH, usage);
+    const total = costUsd(FLASH, usage);
+    expect(total).not.toBeNull();
+    expect((costInUsd ?? 0) + (costOutUsd ?? 0)).toBeCloseTo(total as number, 9);
+  });
+
+  it('returns null for both sides on an unpriced model (Workers AI)', () => {
+    expect(costSplitUsd('@cf/moonshotai/kimi-k2.5', { prompt_tokens: 1000, completion_tokens: 1000 }))
+      .toEqual({ costInUsd: null, costOutUsd: null });
+  });
+
+  it('handles the input_tokens/output_tokens shape too (deterministic short-circuits)', () => {
+    const { costInUsd, costOutUsd } = costSplitUsd(FLASH, { input_tokens: 1_000_000, output_tokens: 0 });
+    expect(costInUsd).toBeCloseTo(0.14, 6);
+    expect(costOutUsd).toBe(0);
+  });
+
+  it('zero usage costs zero on a priced model (not null)', () => {
+    expect(costSplitUsd(FLASH, { prompt_tokens: 0, completion_tokens: 0 })).toEqual({ costInUsd: 0, costOutUsd: 0 });
+  });
+});
+
+describe('normalizeUsage (shape tolerance)', () => {
+  it('reads OpenAI-shaped usage', () => {
+    expect(normalizeUsage({ prompt_tokens: 5, completion_tokens: 7 })).toEqual({ input: 5, output: 7 });
+  });
+  it('reads input_tokens/output_tokens-shaped usage', () => {
+    expect(normalizeUsage({ input_tokens: 5, output_tokens: 7 })).toEqual({ input: 5, output: 7 });
+  });
+  it('treats absent usage as zero', () => {
+    expect(normalizeUsage(null)).toEqual({ input: 0, output: 0 });
+  });
+});

--- a/tests/daf-cost.test.ts
+++ b/tests/daf-cost.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { dafMarkCost, dafCostReport, bestStampUsd, type MarkRowLite } from '../src/worker/daf-cost';
+import { keyForMark } from '../src/worker/cache-keys';
+
+// Build a mark cache key the same way the worker does, so the fake KV is seeded
+// at the exact keys dafMarkCost reconstructs.
+function markKey(id: string, version: string, tractate: string, page: string, lang: 'en' | 'he' = 'en'): string {
+  return keyForMark({ id, cache_version: version } as never, tractate, page, lang);
+}
+
+function makeKV(entries: Record<string, unknown>) {
+  const store = new Map<string, string>(Object.entries(entries).map(([k, v]) => [k, JSON.stringify(v)]));
+  return {
+    get: async (k: string) => store.get(k) ?? null,
+    put: async (k: string, v: string) => { store.set(k, v); },
+    delete: async (k: string) => { store.delete(k); },
+    list: async () => ({ keys: [], list_complete: true, cursor: '' }),
+    getWithMetadata: async () => ({ value: null, metadata: null }),
+  } as unknown as KVNamespace;
+}
+
+const stamp = (over: Record<string, unknown> = {}) => ({
+  cost: {
+    billedUsd: 0.01, estimatedUsd: 0.012, costInUsd: 0.004, costOutUsd: 0.006,
+    tokensIn: 1000, tokensOut: 500, lang: 'en', cacheVersion: '5', computedAt: 1,
+    ...over,
+  },
+});
+
+describe('bestStampUsd', () => {
+  it('prefers billed, falls back to estimate, then zero', () => {
+    expect(bestStampUsd({ billedUsd: 0.01, estimatedUsd: 0.99 })).toBe(0.01);
+    expect(bestStampUsd({ billedUsd: null, estimatedUsd: 0.02 })).toBe(0.02);
+    expect(bestStampUsd({ billedUsd: null, estimatedUsd: null })).toBe(0);
+    expect(bestStampUsd(null)).toBe(0);
+  });
+});
+
+describe('dafMarkCost', () => {
+  it('splits current-version from superseded-version entries for one daf', async () => {
+    const T = 'Berakhot', P = '5a';
+    const kv = makeKV({
+      [markKey('rabbi', '5', T, P)]: stamp({ billedUsd: 0.02 }),           // current EN
+      [markKey('rabbi', '5', T, P, 'he')]: stamp({ billedUsd: 0.03 }),     // current HE
+      [markKey('rabbi', '4', T, P)]: stamp({ billedUsd: 0.01 }),           // superseded
+      // a different daf must NOT leak in
+      [markKey('rabbi', '5', T, '7b')]: stamp({ billedUsd: 0.99 }),
+    });
+    const mark: MarkRowLite = { id: 'rabbi', label: 'Rabbi', cache_version: '5', versions: { '5': 1, '5:he': 1, '4': 1 } };
+    const r = await dafMarkCost(kv, mark, T, P);
+    expect(r.current.map((c) => c.version).sort()).toEqual(['5', '5:he']);
+    expect(r.superseded.map((c) => c.version)).toEqual(['4']);
+    expect(r.totalUsd).toBeCloseTo(0.06, 9); // 0.02 + 0.03 + 0.01, not the other daf
+  });
+
+  it('ignores versions with no cached entry and entries with no stamp', async () => {
+    const T = 'Berakhot', P = '5a';
+    const kv = makeKV({
+      [markKey('argument', '3', T, P)]: { content: '{}' }, // entry exists but no cost stamp (legacy)
+    });
+    const mark: MarkRowLite = { id: 'argument', label: 'Argument', cache_version: '3', versions: { '3': 1, '2': 1 } };
+    const r = await dafMarkCost(kv, mark, T, P);
+    expect(r.current).toEqual([]);
+    expect(r.superseded).toEqual([]);
+    expect(r.totalUsd).toBe(0);
+  });
+});
+
+describe('dafCostReport', () => {
+  it('aggregates current vs superseded totals across marks, sorted by spend', async () => {
+    const T = 'Berakhot', P = '5a';
+    const kv = makeKV({
+      [markKey('rabbi', '5', T, P)]: stamp({ billedUsd: 0.02 }),
+      [markKey('rabbi', '4', T, P)]: stamp({ billedUsd: 0.01 }),
+      [markKey('argument', '2', T, P)]: stamp({ billedUsd: 0.10 }),
+    });
+    const marks: MarkRowLite[] = [
+      { id: 'rabbi', label: 'Rabbi', cache_version: '5', versions: { '5': 1, '4': 1 } },
+      { id: 'argument', label: 'Argument', cache_version: '2', versions: { '2': 1 } },
+      { id: 'places', label: 'Places', cache_version: '1', versions: { '1': 1 } }, // no daf entry -> dropped
+    ];
+    const rep = await dafCostReport(kv, marks, T, P);
+    expect(rep.marks.map((m) => m.id)).toEqual(['argument', 'rabbi']); // sorted by totalUsd desc
+    expect(rep.totals.currentUsd).toBeCloseTo(0.12, 9); // 0.02 (rabbi v5) + 0.10 (argument v2)
+    expect(rep.totals.supersededUsd).toBeCloseTo(0.01, 9); // rabbi v4
+    expect(rep.totals.totalUsd).toBeCloseTo(0.13, 9);
+  });
+});

--- a/tests/usage-rollup.test.ts
+++ b/tests/usage-rollup.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { recordUsage, readUsageSummary, type UsageDelta } from '../src/worker/usage-rollup';
+
+// Prefix-aware in-memory KV — usage-rollup lists `usage:daily:v1:*` and does a
+// read-modify-write per record, so the fake must support get/put + prefix list.
+function makeFakeKV() {
+  const store = new Map<string, string>();
+  const kv = {
+    get: async (k: string) => store.get(k) ?? null,
+    put: async (k: string, v: string) => { store.set(k, v); },
+    delete: async (k: string) => { store.delete(k); },
+    list: async ({ prefix = '' }: { prefix?: string; cursor?: string; limit?: number } = {}) => ({
+      keys: [...store.keys()].filter((k) => k.startsWith(prefix)).map((name) => ({ name })),
+      list_complete: true,
+      cursor: '',
+    }),
+    getWithMetadata: async () => ({ value: null, metadata: null }),
+  };
+  return { kv: kv as unknown as KVNamespace, store };
+}
+
+// recordUsage is fire-and-forget via ctx.waitUntil. Each write is a
+// read-modify-write of the same daily key, and KV has no atomic increment — so
+// in production concurrent writes can lose increments (the rollup accepts that
+// raciness deliberately). The test settles each write before the next so the
+// aggregation under test is exercised deterministically.
+async function record(env: { CACHE: KVNamespace }, deltas: UsageDelta[]) {
+  for (const d of deltas) {
+    let captured: Promise<unknown> = Promise.resolve();
+    recordUsage(env, { waitUntil: (p: Promise<unknown>) => { captured = p; } }, d);
+    await captured;
+  }
+}
+
+const priced = (over: Partial<UsageDelta> = {}): UsageDelta => ({
+  ok: true, cacheHit: false, model: 'openrouter/deepseek/deepseek-v4-flash',
+  tokensIn: 1000, tokensOut: 500, costUsd: 0.001, costInUsd: 0.0007, costOutUsd: 0.0003,
+  ...over,
+});
+
+describe('usage-rollup with cost split', () => {
+  it('accumulates totals and the input/output cost split', async () => {
+    const { kv } = makeFakeKV();
+    const env = { CACHE: kv };
+    await record(env, [
+      priced({ markId: 'rabbi' }),
+      priced({ markId: 'rabbi', tokensIn: 2000, tokensOut: 1000, costUsd: 0.002, costInUsd: 0.0014, costOutUsd: 0.0006 }),
+    ]);
+    const s = await readUsageSummary(kv);
+    expect(s.totals.calls).toBe(2);
+    expect(s.totals.costUsd).toBeCloseTo(0.003, 9);
+    expect(s.totals.costInUsd).toBeCloseTo(0.0021, 9);
+    expect(s.totals.costOutUsd).toBeCloseTo(0.0009, 9);
+    // in + out split sums back to the total
+    expect(s.totals.costInUsd + s.totals.costOutUsd).toBeCloseTo(s.totals.costUsd, 9);
+    // attributed to the mark bucket
+    expect(s.byMark.rabbi.calls).toBe(2);
+    expect(s.byMark.rabbi.costInUsd).toBeCloseTo(0.0021, 9);
+  });
+
+  it('splits across model / mark / enrichment buckets', async () => {
+    const { kv } = makeFakeKV();
+    const env = { CACHE: kv };
+    await record(env, [
+      priced({ markId: 'rabbi' }),
+      priced({ enrichmentId: 'rabbi.synthesis' }),
+    ]);
+    const s = await readUsageSummary(kv);
+    expect(s.byModel['openrouter/deepseek/deepseek-v4-flash'].calls).toBe(2);
+    expect(s.byMark.rabbi.calls).toBe(1);
+    expect(s.byEnrichment['rabbi.synthesis'].calls).toBe(1);
+  });
+
+  it('counts unpriced calls without inflating cost, and tracks errors/cache hits', async () => {
+    const { kv } = makeFakeKV();
+    const env = { CACHE: kv };
+    await record(env, [
+      priced(),
+      { ok: false, cacheHit: false, model: '@cf/moonshotai/kimi-k2.5', tokensIn: 10, tokensOut: 5, costUsd: null },
+      { ok: true, cacheHit: true, model: 'openrouter/deepseek/deepseek-v4-flash', tokensIn: 0, tokensOut: 0, costUsd: 0 },
+    ]);
+    const s = await readUsageSummary(kv);
+    expect(s.totals.calls).toBe(3);
+    expect(s.totals.pricedCalls).toBe(2); // the priced() and the zero-cost hit
+    expect(s.totals.unpricedCalls).toBe(1);
+    expect(s.totals.errors).toBe(1);
+    expect(s.totals.cacheHits).toBe(1);
+    // unpriced call contributed tokens but no dollars
+    expect(s.totals.costUsd).toBeCloseTo(0.001, 9);
+  });
+});


### PR DESCRIPTION
Second of three staged PRs. **Stacked on #245** (base = `usage-cost-granular`); review/merge #245 first.

Builds the aggregation + endpoint surface so PR3's UI can load section-by-section and offer a per-daf cost trace.

## What
- **`/api/usage` split into reusable section builders** (cost / telemetry / activity / backlog / health) behind one generic stale-while-revalidate dispatcher. `/api/usage` keeps its **exact** back-compatible shape (now composed from the builders), and new per-section endpoints — `/api/usage/cost`, `/telemetry`, `/activity`, `/backlog`, `/health` — let the client load each card independently. The slow cache-stats scan no longer blocks the headline cost numbers.
- **Cost section** gains "cost avoided by cache" (recent window) and surfaces the input-vs-output split from the rollup.
- **`/api/usage/daf/:tractate/:page`** — the "trace this daf" drill-down. Reads the permanent per-entry cost stamps for one daf across each mark's cached versions (**bounded** reads — one KV get per mark/version, not a Shas-wide value scan) → current-version vs superseded-version cost. Logic lives in `src/worker/daf-cost.ts` (unit-tested). Recent enrichment + source-alignment per-daf spend comes from the ledger's `byDaf` (`/api/admin/llm-cost`), which the UI overlays.
- `mcp-openapi.ts` kept in sync.

## Notes
- Per-producer aggregate cost is sourced from the daily rollup (no value scan); per-version cost is exact per-daf in the drill-down. Surfacing per-version cost Shas-wide would require reading every entry's value (~the 10s scan) — deliberately avoided for the "load faster" goal.

## Tests
`pnpm typecheck` + `pnpm test` clean (1793). New: `daf-cost.test.ts`.