### PR TITLE
CI: typecheck+test workflow + Biome (lint/format) + drop dead eslint directives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm typecheck
+
+      - run: pnpm test

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "files": {
+    "includes": [
+      "**",
+      "!dist",
+      "!.wrangler",
+      "!node_modules",
+      "!static",
+      "!Sandbox",
+      "!scripts/out"
+    ]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "always",
+      "trailingCommas": "all"
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "suspicious": {
+        "noConsole": "off"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:int": "vitest run --config vitest.integration.config.ts",
+    "lint": "biome check .",
+    "format": "biome format --write .",
     "rebuild-rabbi-places": "python3 scripts/build-rabbi-places.py",
     "rebuild-geo-shapes": "python3 scripts/gen-geo-shapes.py --israel ~/Downloads/israel.svg --bavel ~/Downloads/mYxtJ7j01.svg --israel-mode union",
     "scrape-wikipedia-rabbis": "node scripts/scrape-wikipedia-rabbis.mjs",
@@ -37,6 +39,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.4.16",
     "@cloudflare/vite-plugin": "^1.36.4",
     "@cloudflare/workers-types": "^4.20260511.1",
     "@solidjs/testing-library": "^0.8.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@biomejs/biome':
+        specifier: ^2.4.16
+        version: 2.4.16
       '@cloudflare/vite-plugin':
         specifier: ^1.36.4
         version: 1.36.4(vite@6.4.2)(workerd@1.20260508.1)(wrangler@4.90.1(@cloudflare/workers-types@4.20260511.1))
@@ -171,6 +174,59 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@biomejs/biome@2.4.16':
+    resolution: {integrity: sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.4.16':
+    resolution: {integrity: sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.4.16':
+    resolution: {integrity: sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.4.16':
+    resolution: {integrity: sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-arm64@2.4.16':
+    resolution: {integrity: sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64-musl@2.4.16':
+    resolution: {integrity: sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64@2.4.16':
+    resolution: {integrity: sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-win32-arm64@2.4.16':
+    resolution: {integrity: sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.4.16':
+    resolution: {integrity: sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
@@ -2080,6 +2136,41 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@biomejs/biome@2.4.16':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.4.16
+      '@biomejs/cli-darwin-x64': 2.4.16
+      '@biomejs/cli-linux-arm64': 2.4.16
+      '@biomejs/cli-linux-arm64-musl': 2.4.16
+      '@biomejs/cli-linux-x64': 2.4.16
+      '@biomejs/cli-linux-x64-musl': 2.4.16
+      '@biomejs/cli-win32-arm64': 2.4.16
+      '@biomejs/cli-win32-x64': 2.4.16
+
+  '@biomejs/cli-darwin-arm64@2.4.16':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.4.16':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.4.16':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.4.16':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.4.16':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.4.16':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.4.16':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.4.16':
+    optional: true
 
   '@bramus/specificity@2.4.2':
     dependencies:

--- a/src/client/DafViewer.tsx
+++ b/src/client/DafViewer.tsx
@@ -1359,7 +1359,6 @@ export default function DafViewer(): JSX.Element {
         if (t !== tractate() || p !== page()) return;
         setCommentaryAnchorIndex(idx);
       } catch (err) {
-        // eslint-disable-next-line no-console
         console.warn('[commentary-anchor] failed to fetch index:', err);
       }
     })();

--- a/src/client/missLog.ts
+++ b/src/client/missLog.ts
@@ -84,7 +84,6 @@ export function logMiss(
     details,
   };
 
-  // eslint-disable-next-line no-console
   console.warn(`[daf-miss:${category}]`, { ...rec, ts: new Date(rec.ts).toISOString() });
 
   const all = load();

--- a/src/client/renderers/dispatch.ts
+++ b/src/client/renderers/dispatch.ts
@@ -224,7 +224,6 @@ export function applyMarkRenderers(
     try {
       out = r(out, instances, def);
     } catch (err) {
-      // eslint-disable-next-line no-console
       console.warn(`[renderer] ${def.id} (${key}) threw:`, err);
     }
   }

--- a/src/lib/daf-render/core/layout.ts
+++ b/src/lib/daf-render/core/layout.ts
@@ -167,7 +167,6 @@ export function computeLayout(
 
   if (typeof window !== 'undefined') {
     const r = Math.round;
-    // eslint-disable-next-line no-console
     console.log(
       `[daf-render] w=${options.contentWidth} case=${layoutCase} exception=${exception}`,
       `inner: narrow=${r(inner.narrowUsed)} end=${r(inner.endUsed)}`,

--- a/src/lib/daf-render/solid/DafRenderer.tsx
+++ b/src/lib/daf-render/solid/DafRenderer.tsx
@@ -143,7 +143,6 @@ export function DafRenderer(props: DafRendererProps): JSX.Element {
         'inner-end': h(q('.daf-inner .daf-end')),
         'outer-end': h(q('.daf-outer .daf-end')),
       };
-      // eslint-disable-next-line no-console
       console.log('[daf-render DOM] spans:', spans, 'spacers:', spacers);
     });
   });

--- a/src/lib/place/reanchor.ts
+++ b/src/lib/place/reanchor.ts
@@ -57,7 +57,6 @@ export function reanchorArgument(parsed: unknown, segmentsHe: string[]): unknown
     if (endSeg < 0) {
       cur.endSegIdx = upperBound;
       if (endEx) {
-        // eslint-disable-next-line no-console
         console.warn(`[argument] endExcerpt "${endEx}" not found in section starting at seg ${cur.startSegIdx} (search [${cur.startSegIdx},${upperBound}])`);
       }
     } else {
@@ -168,7 +167,6 @@ export function reanchorArgumentMove(parsed: unknown, segmentsHe: string[]): unk
         const wordsInLast = segWords[cur.endSegIdx]?.length ?? 0;
         cur.fields.tokenEnd = Math.max(0, wordsInLast - 1);
         if (endEx) {
-          // eslint-disable-next-line no-console
           console.warn(`[argument-move] endExcerpt "${endEx}" not found for last move in section ${sStart}-${sEnd}; defaulting to section end`);
         }
       }
@@ -222,7 +220,6 @@ export function reanchorPesukim(parsed: unknown, segmentsHe: string[]): unknown 
       inst.endSegIdx = startHit.seg;
       f.tokenEnd = startHit.tok + startHit.matchLen - 1;
       if (endExcerpt) {
-        // eslint-disable-next-line no-console
         console.warn(`[pesukim] endExcerpt "${endExcerpt}" not found in [${startHit.seg},${upperSeg}]`);
       }
     }
@@ -273,7 +270,6 @@ export function reanchorAggadata(parsed: unknown, segmentsHe: string[]): unknown
       inst.endSegIdx = startHit.seg;
       f.tokenEnd = startHit.tok + startHit.matchLen - 1;
       if (endExcerpt) {
-        // eslint-disable-next-line no-console
         console.warn(`[aggadata] endExcerpt "${endExcerpt}" not found in [${startHit.seg},${upperSeg}]`);
       }
     }

--- a/src/worker/budget.ts
+++ b/src/worker/budget.ts
@@ -177,7 +177,6 @@ async function sendBudgetAlert(env: BudgetEnv, subject: string, text: string): P
   try {
     await email.send({ from: ALERT_FROM, to: ALERT_TO, subject, text });
   } catch (err) {
-    // eslint-disable-next-line no-console
     console.error('[budget] alert email failed:', err);
   }
 }

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -2928,7 +2928,6 @@ async function recordRecentJobError(
     while (arr.length > RECENT_ERRORS_CAP) arr.shift();
     await cache.put(RECENT_ERRORS_KEY, JSON.stringify(arr), { expirationTtl: RECENT_ERRORS_TTL });
   } catch (err) {
-    // eslint-disable-next-line no-console
     console.warn('[recent-errors] KV write failed:', String(err));
   }
 }
@@ -3588,7 +3587,6 @@ app.get('/api/admin/cache-stats', async (c) => {
           const fresh = await computeCacheStats(cache);
           await writeCachedCacheStats(cache, fresh);
         } catch (err) {
-          // eslint-disable-next-line no-console
           console.warn('[cache-stats] background refresh failed:', err);
         }
       })());
@@ -3637,7 +3635,6 @@ app.post('/api/log', async (c) => {
     ...(body as Record<string, unknown>),
   };
   // Observability / wrangler tail pick this up.
-  // eslint-disable-next-line no-console
   console.warn('[client-log]', JSON.stringify(rec));
 
   const cache = c.env.CACHE;
@@ -3650,7 +3647,6 @@ app.post('/api/log', async (c) => {
       while (arr.length > 500) arr.shift();
       await cache.put(key, JSON.stringify(arr), { expirationTtl: 60 * 60 * 24 * 30 });
     } catch (err) {
-      // eslint-disable-next-line no-console
       console.warn('[client-log] KV write failed:', String(err));
     }
   }
@@ -3913,7 +3909,6 @@ app.post('/api/qa/ask', async (c) => {
     try {
       await c.env.ENRICHMENT_QUEUE.send(job);
     } catch (err) {
-      // eslint-disable-next-line no-console
       console.warn('[qa/ask] queue send failed:', String((err as Error)?.message ?? err));
     }
   }
@@ -4024,7 +4019,6 @@ async function logTelemetry(cache: KVNamespace | undefined, rec: TelemetryRecord
     while (arr.length > 500) arr.shift();
     await cache.put(key, JSON.stringify(arr), { expirationTtl: 60 * 60 * 24 * 30 });
   } catch (err) {
-    // eslint-disable-next-line no-console
     console.warn('[telemetry] KV write failed:', String(err));
   }
 }
@@ -4155,11 +4149,9 @@ app.post('/api/report', async (c) => {
       while (arr.length > 200) arr.shift();
       await cache.put(key, JSON.stringify(arr), { expirationTtl: 60 * 60 * 24 * 365 });
     } catch (err) {
-      // eslint-disable-next-line no-console
       console.warn('[report] KV write failed:', String(err));
     }
   }
-  // eslint-disable-next-line no-console
   console.warn('[bug-report]', JSON.stringify(rec));
   return c.json({ ok: true });
 });
@@ -4330,7 +4322,6 @@ async function serveUsageSection<T>(
                 const next = { ...(await build()), generatedAt: new Date().toISOString() };
                 await cache.put(key, JSON.stringify(next), { expirationTtl: 600 });
               } catch (err) {
-                // eslint-disable-next-line no-console
                 console.warn(`[usage] ${key} background refresh failed:`, err);
               } finally {
                 await cache.delete(lockKey).catch(() => {});
@@ -5205,7 +5196,6 @@ app.post('/api/translate', async (c) => {
     try {
       fallbackEnglish = await getSefariaEnglishContext(tractate, page, cache);
     } catch (err) {
-      // eslint-disable-next-line no-console
       console.warn('[translate] fallback Sefaria context fetch failed:', err);
     }
   }
@@ -5213,7 +5203,6 @@ app.post('/api/translate', async (c) => {
   // Sefaria Lexicon — authoritative BDB/Jastrow definitions for the word.
   // Cached per-word for a year (lexicons change rarely).
   const lexiconContext = await getSefariaLexicon(word, cache).catch((err) => {
-    // eslint-disable-next-line no-console
     console.warn('[translate] lexicon fetch failed:', err);
     return '';
   });
@@ -5291,7 +5280,6 @@ app.post('/api/translate', async (c) => {
       return c.json({ translation, cached: false, _model: m.label });
     } catch (err) {
       attempts.push(`${m.label}: ${String(err).slice(0, 200)}`);
-      // eslint-disable-next-line no-console
       console.warn(`[translate] ${m.label} failed:`, err);
     }
   }
@@ -7915,12 +7903,10 @@ async function deepWarmDaf(
  * failure (max_retries=1 in wrangler.toml is the safety net).
  */
 async function processEnrichmentJob(env: Bindings, job: JobMessage, ctx: ExecutionContext): Promise<void> {
-  // eslint-disable-next-line no-console
   console.log('[queue] picked up job', job.runId, '·', job.mark_id ?? job.enrichment_id ?? 'adhoc', job.tractate, job.page);
   const wrapped = wrapEnv(env);
   const cache = wrapped.CACHE;
   if (!cache) {
-    // eslint-disable-next-line no-console
     console.error('[queue] CACHE binding missing — cannot write job result');
     return;
   }
@@ -7949,7 +7935,6 @@ async function processEnrichmentJob(env: Bindings, job: JobMessage, ctx: Executi
       if (only && job.rewarm_only) await evictCascadeEntries(rc.env, job.rewarm_only, job.tractate, job.page);
       const stats = await deepWarmDaf(rc, job.tractate, job.page, rc.lang, only);
       await writeResult({ status: 'ok', result: { kind: 'warm', ...stats, total_ms: Date.now() - t0 } });
-      // eslint-disable-next-line no-console
       console.log(`[queue] deep-warm ${job.tractate}/${job.page} lang=${rc.lang} marks=${stats.marks} enqueued=${stats.enqueued} skipped=${stats.skipped} bridges=${stats.bridges}`);
       return;
     }
@@ -8009,7 +7994,6 @@ async function processEnrichmentJob(env: Bindings, job: JobMessage, ctx: Executi
       return;
     }
     const errorMsg = String((err as Error)?.message ?? err);
-    // eslint-disable-next-line no-console
     console.error('[queue] job failed', job.runId, '·', job.mark_id ?? job.enrichment_id ?? 'adhoc', job.tractate, job.page, '·', errorMsg.slice(0, 500));
     await writeResult({
       status: 'error',
@@ -8053,7 +8037,6 @@ export default {
   // simultaneous LLM workloads; max_batch_size=1 means one job per
   // invocation (no batching), which keeps memory bounded per worker.
   queue: async (batch: MessageBatch<JobMessage>, env: Bindings, ctx: ExecutionContext): Promise<void> => {
-    // eslint-disable-next-line no-console
     console.log('[queue] batch arrived:', batch.messages.length, 'message(s)');
     for (const msg of batch.messages) {
       try {
@@ -8061,7 +8044,6 @@ export default {
         msg.ack();
       } catch (err) {
         // Network / KV blip — let the runtime retry once (max_retries=1).
-        // eslint-disable-next-line no-console
         console.error('[queue] processEnrichmentJob threw:', err);
         const body = msg.body;
         const errorMsg = String((err as Error)?.message ?? err);

--- a/src/worker/lint-failures.ts
+++ b/src/worker/lint-failures.ts
@@ -80,7 +80,6 @@ export async function noteLintAttempt(env: Cache, ctx: Ctx, cacheKey: string, me
     count = (cur ? parseInt(cur, 10) || 0 : 0) + 1;
     await env.CACHE.put(key, String(count), { expirationTtl: ATTEMPT_TTL_S });
   } catch (err) {
-    // eslint-disable-next-line no-console
     console.warn('[lint-failures] attempt counter write failed:', String(err));
   }
   if (count < MAX_LINT_ATTEMPTS) return false;
@@ -115,7 +114,6 @@ export function recordLintFailure(env: Cache, ctx: Ctx, f: Omit<LintFailure, 'at
       counts[f.enrichmentId] = (counts[f.enrichmentId] ?? 0) + 1;
       await cache.put(COUNTS_KEY, JSON.stringify(counts));
     } catch (err) {
-      // eslint-disable-next-line no-console
       console.warn('[lint-failures] ring-buffer write failed:', String(err));
     }
   })());

--- a/src/worker/llm.ts
+++ b/src/worker/llm.ts
@@ -256,7 +256,6 @@ export async function runLLM(env: LLMEnv, opts: LLMCallOptions): Promise<LLMResu
       // fallback hides upstream errors and a final fallback failure
       // reports only the LAST model's error, not what actually started
       // the cascade.
-      // eslint-disable-next-line no-console
       console.warn(`[runLLM] ${model} attempt ${i + 1}/${chain.length} failed: ${detail.slice(0, 300)}`);
       if (!isFallbackWorthy(err) || i === chain.length - 1) throw err;
     }

--- a/src/worker/source-cache.ts
+++ b/src/worker/source-cache.ts
@@ -80,7 +80,6 @@ async function writeCache(
     const opts = ttl === null ? undefined : { expirationTtl: ttl };
     await cache.put(key, JSON.stringify(value), opts);
   } catch (err) {
-    // eslint-disable-next-line no-console
     console.warn(`[source-cache] KV put failed for ${key}:`, err);
   }
 }
@@ -108,7 +107,6 @@ export async function getHebrewBooksDafCached(
     await writeCache(cache, key, data, null);
     return data;
   } catch (err) {
-    // eslint-disable-next-line no-console
     console.warn(`[source-cache] hebrewbooks fetch failed for ${tractate} ${page}:`, err);
     await writeCache(cache, key, { __failed: true } satisfies FailedMarker, TTL_NEGATIVE);
     return null;
@@ -366,7 +364,6 @@ export async function getDafyomiContentCached(
     await writeCache(cache, key, { __failed: true } satisfies FailedMarker, TTL_NEGATIVE);
     return null;
   } catch (err) {
-    // eslint-disable-next-line no-console
     console.warn(`[source-cache] dafyomi read failed for ${tractate} ${daf}:`, err);
     await writeCache(cache, key, { __failed: true } satisfies FailedMarker, TTL_NEGATIVE);
     return null;

--- a/src/worker/unknown-registry.ts
+++ b/src/worker/unknown-registry.ts
@@ -127,7 +127,6 @@ async function bump<T extends { firstSeen: number; lastSeen: number; count: numb
     if (daf && !rec.dafs.includes(daf) && rec.dafs.length < MAX_DAFS) rec.dafs.push(daf);
     await cache.put(key, JSON.stringify(rec), { expirationTtl: TTL_S });
   } catch (err) {
-    // eslint-disable-next-line no-console
     console.warn('[unknown-registry] KV write failed:', String(err));
   }
 }
@@ -214,7 +213,6 @@ async function bumpBatch<T extends { firstSeen: number; lastSeen: number; count:
       for (const d of g.dafs) if (!rec.dafs.includes(d) && rec.dafs.length < MAX_DAFS) rec.dafs.push(d);
       await cache.put(key, JSON.stringify(rec), { expirationTtl: TTL_S });
     } catch (err) {
-      // eslint-disable-next-line no-console
       console.warn('[unknown-registry] batch write failed:', String(err));
     }
   }

--- a/src/worker/usage-rollup.ts
+++ b/src/worker/usage-rollup.ts
@@ -119,7 +119,6 @@ async function writeUsage(cache: KVNamespace, d: UsageDelta): Promise<void> {
     }
     await cache.put(key, JSON.stringify(r), { expirationTtl: TTL_S });
   } catch (err) {
-    // eslint-disable-next-line no-console
     console.warn('[usage-rollup] KV write failed:', String(err));
   }
 }

--- a/src/worker/warm-cron.ts
+++ b/src/worker/warm-cron.ts
@@ -100,7 +100,6 @@ async function sendCompletionEmail(env: WarmEnv): Promise<void> {
         `Dashboard: https://talmud.shaunregenbaum.com/usage\n`,
     });
   } catch (err) {
-    // eslint-disable-next-line no-console
     console.error('[warm-cron] send email failed:', err);
   }
 }
@@ -110,7 +109,6 @@ async function refreshStats(cache: KVNamespace): Promise<void> {
     const stats = await computeCacheStats(cache);
     await writeCachedCacheStats(cache, stats);
   } catch (err) {
-    // eslint-disable-next-line no-console
     console.warn('[warm-cron] refreshStats failed:', err);
   }
 }
@@ -147,7 +145,6 @@ async function runObservationsBackfill(env: WarmEnv): Promise<void> {
     }
     if (tractateIdx >= TRACTATES.length) {
       await cache.put(OBS_BACKFILL_CURSOR_KEY, JSON.stringify({ tractateIdx, amudIdx: 0, enqueued, done: true }));
-      // eslint-disable-next-line no-console
       console.log(`[warm-cron] rabbi.observations backfill COMPLETE — enqueued ${enqueued} amudim`);
       return;
     }
@@ -157,7 +154,6 @@ async function runObservationsBackfill(env: WarmEnv): Promise<void> {
       .replace(/[^a-zA-Z0-9._:-]+/g, '_').slice(0, 200);
     await env.ENRICHMENT_QUEUE.send({ runId, enrichment_id: 'rabbi.observations', mark_input: { id: 'daf' }, tractate, page: amud })
       .catch((e) => {
-        // eslint-disable-next-line no-console
         console.error(`[warm-cron] enqueue rabbi.observations ${tractate}/${amud} failed:`, e);
       });
     enqueued++;
@@ -165,7 +161,6 @@ async function runObservationsBackfill(env: WarmEnv): Promise<void> {
     processed++;
   }
   await cache.put(OBS_BACKFILL_CURSOR_KEY, JSON.stringify({ tractateIdx, amudIdx, enqueued }));
-  // eslint-disable-next-line no-console
   console.log(`[warm-cron] rabbi.observations backfill progress: enqueued=${enqueued} cursor=${tractateIdx}:${amudIdx}`);
 }
 
@@ -204,7 +199,6 @@ async function sendDafyomiCompletionEmail(env: WarmEnv, fetched: number): Promis
         `Content is cached in KV — study notes + poskim now feed the halacha cards Shas-wide.\n`,
     });
   } catch (err) {
-    // eslint-disable-next-line no-console
     console.error('[warm-cron] dafyomi email failed:', err);
   }
 }
@@ -227,7 +221,6 @@ async function runDafyomiBackfill(env: WarmEnv): Promise<void> {
     }
     if (tractateIdx >= masechtos.length) {
       await cache.put(DAFYOMI_CURSOR_KEY, JSON.stringify({ tractateIdx, daf: 2, fetched, done: true }));
-      // eslint-disable-next-line no-console
       console.log(`[warm-cron] dafyomi ingestion COMPLETE — fetched ${fetched} this pass`);
       await sendDafyomiCompletionEmail(env, fetched);
       return;
@@ -248,7 +241,6 @@ async function runDafyomiBackfill(env: WarmEnv): Promise<void> {
     processed++;
   }
   await cache.put(DAFYOMI_CURSOR_KEY, JSON.stringify({ tractateIdx, daf, fetched }));
-  // eslint-disable-next-line no-console
   console.log(`[warm-cron] dafyomi progress: fetched=${fetched} cursor=${tractateIdx}:${daf}`);
 }
 
@@ -295,7 +287,6 @@ async function runHbPhase(env: WarmEnv, cursor: WarmCursor): Promise<void> {
         CURSOR_KEY,
         JSON.stringify({ tractateIdx: TRACTATES.length, amudIdx: 0, done: true }),
       );
-      // eslint-disable-next-line no-console
       console.log(`[warm-cron] HB complete. total=${TOTAL_AMUDIM}`);
       await refreshStats(cache);
       await sendCompletionEmail(env);
@@ -319,7 +310,6 @@ async function runHbPhase(env: WarmEnv, cursor: WarmCursor): Promise<void> {
 
   await cache.put(CURSOR_KEY, JSON.stringify({ tractateIdx, amudIdx }));
   const elapsed = Date.now() - start;
-  // eslint-disable-next-line no-console
   console.log(
     `[warm-cron] HB processed=${processed} fetched=${fetched} elapsed=${elapsed}ms cursor=${tractateIdx}:${amudIdx}`,
   );
@@ -376,7 +366,6 @@ async function runSefariaPhase(env: WarmEnv): Promise<void> {
       wraps++;
       tractateIdx = 0;
       amudIdx = 0;
-      // eslint-disable-next-line no-console
       console.log(`[warm-cron] Sefaria pass ${wraps} complete — wrapping`);
     }
 
@@ -412,7 +401,6 @@ async function runSefariaPhase(env: WarmEnv): Promise<void> {
     JSON.stringify({ tractateIdx, amudIdx, wraps }),
   );
   const elapsed = Date.now() - start;
-  // eslint-disable-next-line no-console
   console.log(
     `[warm-cron] Sefaria processed=${processed} fetched=${fetched} elapsed=${elapsed}ms cursor=${tractateIdx}:${amudIdx} wraps=${wraps}`,
   );

--- a/src/worker/yomi-cron.ts
+++ b/src/worker/yomi-cron.ts
@@ -100,17 +100,14 @@ export async function runYomiWarmCron(env: YomiCronEnv): Promise<void> {
   const { year, month, day } = tomorrowUtc();
   const yomi = await fetchDafYomi(year, month, day);
   if (!yomi) {
-    // eslint-disable-next-line no-console
     console.warn(`[yomi-cron] no Daf Yomi entry for ${year}-${month}-${day}`);
     return;
   }
   const { tractate, daf } = yomi;
   if (!env.ENRICHMENT_QUEUE) {
-    // eslint-disable-next-line no-console
     console.error('[yomi-cron] ENRICHMENT_QUEUE binding not available; cannot warm');
     return;
   }
-  // eslint-disable-next-line no-console
   console.log(`[yomi-cron] warming ${tractate} ${daf} for ${year}-${month}-${day}`);
 
   const pages = [`${daf}a`, `${daf}b`];
@@ -121,10 +118,8 @@ export async function runYomiWarmCron(env: YomiCronEnv): Promise<void> {
     const job: JobMessage = { runId, mark_id: markId, tractate, page, ...(lang === 'he' ? { lang: 'he' } : {}) };
     try {
       await queue.send(job);
-      // eslint-disable-next-line no-console
       console.log(`[yomi-cron] enqueued mark=${markId} lang=${lang} ${tractate}/${page} runId=${runId}`);
     } catch (e) {
-      // eslint-disable-next-line no-console
       console.error(`[yomi-cron] enqueue mark=${markId} lang=${lang} ${tractate}/${page} failed:`, e);
     }
   };
@@ -141,11 +136,9 @@ export async function runYomiWarmCron(env: YomiCronEnv): Promise<void> {
     jobs.push(
       env.ENRICHMENT_QUEUE.send(obsJob)
         .then(() => {
-          // eslint-disable-next-line no-console
           console.log(`[yomi-cron] enqueued rabbi.observations ${tractate}/${page} runId=${obsRunId}`);
         })
         .catch((e) => {
-          // eslint-disable-next-line no-console
           console.error(`[yomi-cron] enqueue rabbi.observations ${tractate}/${page} failed:`, e);
         }),
     );
@@ -157,16 +150,13 @@ export async function runYomiWarmCron(env: YomiCronEnv): Promise<void> {
     jobs.push(
       env.ENRICHMENT_QUEUE.send({ runId: deepRunId, warm_deep: true, tractate, page })
         .then(() => {
-          // eslint-disable-next-line no-console
           console.log(`[yomi-cron] enqueued deep-warm ${tractate}/${page} runId=${deepRunId}`);
         })
         .catch((e) => {
-          // eslint-disable-next-line no-console
           console.error(`[yomi-cron] enqueue deep-warm ${tractate}/${page} failed:`, e);
         }),
     );
   }
   await Promise.allSettled(jobs);
-  // eslint-disable-next-line no-console
   console.log(`[yomi-cron] enqueued ${jobs.length} warm job(s) for ${tractate} ${daf}`);
 }


### PR DESCRIPTION
## Changes

- **GitHub Actions CI** (`.github/workflows/ci.yml`): single `check` job triggered on push to `master` and on all PRs. Steps: checkout → pnpm 9.12.1 → node 22 (with pnpm cache) → `pnpm install --frozen-lockfile` → `pnpm typecheck` → `pnpm test`.

- **Biome** (`biome.json` + `package.json`): replaces the never-installed ESLint with a single-binary lint+format tool. Config is low-friction — `recommended` rules with `noConsole` turned off (intentional worker logging), formatter set to match the existing style (2-space indent, single quotes, semicolons). New scripts: `pnpm lint` and `pnpm format`.

- **Dead ESLint directives removed**: 59 `// eslint-disable-next-line no-console` comment lines deleted across 15 files. ESLint was never in `package.json`; these comments were pure noise.

## Verification

`pnpm typecheck` and `pnpm test` (1797 tests) both pass on this branch.