### PR TITLE
Cache stats: per-source alignment % + DafYomi coverage

### DIFF
--- a/src/worker/cache-stats.ts
+++ b/src/worker/cache-stats.ts
@@ -38,9 +38,10 @@ export interface CacheStats {
   generatedAt: string;
   total: number;
   source: {
-    hebrewbooks: CacheBucket;
-    gemara: CacheBucket;
-    commentaries: CacheBucket;
+    hebrewbooks: SourceBucket;
+    gemara: SourceBucket;
+    commentaries: SourceBucket;
+    dafyomi: SourceBucket;
   };
   marks: MarkCacheRow[];
   enrichments: EnrichmentCacheRow[];
@@ -76,6 +77,21 @@ export interface CacheStats {
 interface CacheBucket {
   count: number;
   percent: number;
+}
+
+/** A sampled "% of cached entries that actually aligned" figure. Reading every
+ *  value Shas-wide is the slow scan we avoid, so this samples up to N entries
+ *  per source and extrapolates. `pct` is aligned/sampled as a 0-100 number. */
+export interface AlignedSample {
+  sampled: number;
+  aligned: number;
+  pct: number;
+}
+/** A source-spine coverage row: how many dapim are cached + (sampled) how many
+ *  of those produced a usable alignment. `aligned` is null when nothing's
+ *  cached to sample. */
+export interface SourceBucket extends CacheBucket {
+  aligned: AlignedSample | null;
 }
 
 export interface MarkCacheRow {
@@ -138,6 +154,75 @@ interface HierarchyFile {
   }>;
 }
 const HIERARCHY = rabbiHierarchyData as unknown as HierarchyFile;
+
+// ---- Per-source alignment predicates -------------------------------------
+// "Aligned" = the cached source value actually carries usable, anchored content
+// (not an empty fetch or a `{__failed:true}` negative-cache marker). Each takes
+// the parsed cached value and returns whether that daf aligned for the source.
+type AlignPredicate = (v: unknown) => boolean;
+
+function failed(v: unknown): boolean {
+  return !!v && typeof v === 'object' && (v as { __failed?: boolean }).__failed === true;
+}
+const alignedHebrewBooks: AlignPredicate = (v) => {
+  if (!v || failed(v)) return false;
+  const d = v as { main?: string; rashi?: string; tosafot?: string };
+  return !!((d.main?.length ?? 0) || (d.rashi?.length ?? 0) || (d.tosafot?.length ?? 0));
+};
+const alignedGemara: AlignPredicate = (v) => {
+  if (!v || failed(v)) return false;
+  const d = v as { segments_he?: unknown[]; segments_en?: unknown[] };
+  return (Array.isArray(d.segments_he) && d.segments_he.length > 0) ||
+    (Array.isArray(d.segments_en) && d.segments_en.length > 0);
+};
+const alignedCommentaries: AlignPredicate = (v) => {
+  if (!v || failed(v)) return false;
+  const d = v as { by_commentator?: Record<string, unknown> };
+  return !!d.by_commentator && Object.keys(d.by_commentator).length > 0;
+};
+const alignedDafyomi: AlignPredicate = (v) => {
+  if (!v || failed(v)) return false;
+  const d = v as { amudim?: { a?: Record<string, unknown>; b?: Record<string, unknown> } };
+  const a = d.amudim?.a, b = d.amudim?.b;
+  return (!!a && Object.keys(a).length > 0) || (!!b && Object.keys(b).length > 0);
+};
+
+/**
+ * Sample up to `sampleSize` cached entries under `prefix`, read their values,
+ * and report how many satisfy `isAligned`. Bounded (not a Shas-wide scan) so it
+ * stays cheap enough to run inside the cron-warmed computeCacheStats. Returns
+ * null when nothing is cached to sample.
+ */
+export async function sampleAligned(
+  cache: KVNamespace,
+  prefix: string,
+  isAligned: AlignPredicate,
+  sampleSize = 300,
+): Promise<AlignedSample | null> {
+  const keys: string[] = [];
+  let cursor: string | undefined = undefined;
+  while (keys.length < sampleSize) {
+    const res = (await cache.list({ prefix, cursor, limit: Math.min(1000, sampleSize - keys.length) })) as {
+      keys: Array<{ name: string }>; list_complete: boolean; cursor?: string;
+    };
+    for (const k of res.keys) keys.push(k.name);
+    if (res.list_complete || !res.cursor) break;
+    cursor = res.cursor;
+  }
+  if (keys.length === 0) return null;
+  const raws = await Promise.all(keys.map((k) => cache.get(k)));
+  let sampled = 0;
+  let aligned = 0;
+  for (const raw of raws) {
+    if (raw == null) continue;
+    sampled++;
+    let v: unknown;
+    try { v = JSON.parse(raw); } catch { continue; }
+    if (isAligned(v)) aligned++;
+  }
+  if (sampled === 0) return null;
+  return { sampled, aligned, pct: Math.round((aligned / sampled) * 1000) / 10 };
+}
 
 async function countPrefix(cache: KVNamespace, prefix: string): Promise<number> {
   let cursor: string | undefined = undefined;
@@ -246,13 +331,22 @@ export async function cacheGcTargets(cache: KVNamespace): Promise<GcTarget[]> {
 export async function computeCacheStats(cache: KVNamespace): Promise<CacheStats> {
   const total = getWarmTotal();
 
-  const [hbCount, gemaraCount, commentariesCount, obsSlices, obsRabbis] = await Promise.all([
+  const [
+    hbCount, gemaraCount, commentariesCount, dafyomiCount, obsSlices, obsRabbis,
+    hbAligned, gemaraAligned, commentariesAligned, dafyomiAligned,
+  ] = await Promise.all([
     countPrefix(cache, 'hb:v2:'),
     countPrefix(cache, 'ctx:gemara:v1:'),
     countPrefix(cache, 'ctx:commentaries:v1:'),
+    countPrefix(cache, 'dafyomi:v5:'),
     // `rabbi-obs:v1:` matches slice keys only (dirty keys are `rabbi-obs-dirty:v1:`).
     countPrefix(cache, 'rabbi-obs:v1:'),
     countPrefix(cache, 'rabbi-obs-dirty:v1:'),
+    // Sampled "% aligned" per source — bounded value reads, not a full scan.
+    sampleAligned(cache, 'hb:v2:', alignedHebrewBooks),
+    sampleAligned(cache, 'ctx:gemara:v1:', alignedGemara),
+    sampleAligned(cache, 'ctx:commentaries:v1:', alignedCommentaries),
+    sampleAligned(cache, 'dafyomi:v5:', alignedDafyomi),
   ]);
 
   const markDefs = await mergedMarks(cache);
@@ -338,9 +432,10 @@ export async function computeCacheStats(cache: KVNamespace): Promise<CacheStats>
     generatedAt: new Date().toISOString(),
     total,
     source: {
-      hebrewbooks: { count: hbCount, percent: pct(hbCount, total) },
-      gemara: { count: gemaraCount, percent: pct(gemaraCount, total) },
-      commentaries: { count: commentariesCount, percent: pct(commentariesCount, total) },
+      hebrewbooks: { count: hbCount, percent: pct(hbCount, total), aligned: hbAligned },
+      gemara: { count: gemaraCount, percent: pct(gemaraCount, total), aligned: gemaraAligned },
+      commentaries: { count: commentariesCount, percent: pct(commentariesCount, total), aligned: commentariesAligned },
+      dafyomi: { count: dafyomiCount, percent: pct(dafyomiCount, total), aligned: dafyomiAligned },
     },
     marks,
     enrichments,

--- a/src/worker/cache-stats.ts
+++ b/src/worker/cache-stats.ts
@@ -31,7 +31,10 @@ import type { GcTarget } from './cache-gc';
 // `staleCount`) + the `observations` bucket (rabbi.observations reverse index).
 // v6: rows also carry `heCount` and `versions` buckets Hebrew entries under
 // `<version>:he`, so the dashboard can report EN vs HE cache coverage.
-export const CACHE_STATS_KEY = 'cache-stats:v6';
+// v7: source buckets carry sampled `aligned` + a `denom` (DafYomi is per-daf,
+// not per-amud), and a fourth `dafyomi` source. Bumped so a stale v6 payload
+// (missing those fields) isn't served.
+export const CACHE_STATS_KEY = 'cache-stats:v7';
 const FRESH_MS = 60_000;
 
 export interface CacheStats {
@@ -92,6 +95,9 @@ export interface AlignedSample {
  *  cached to sample. */
 export interface SourceBucket extends CacheBucket {
   aligned: AlignedSample | null;
+  /** Denominator `count`/`percent` are measured against. Most sources are
+   *  per-amud (= the daf total); DafYomi is per-daf, so it carries its own. */
+  denom: number;
 }
 
 export interface MarkCacheRow {
@@ -183,8 +189,12 @@ const alignedCommentaries: AlignPredicate = (v) => {
 const alignedDafyomi: AlignPredicate = (v) => {
   if (!v || failed(v)) return false;
   const d = v as { amudim?: { a?: Record<string, unknown>; b?: Record<string, unknown> } };
-  const a = d.amudim?.a, b = d.amudim?.b;
-  return (!!a && Object.keys(a).length > 0) || (!!b && Object.keys(b).length > 0);
+  // An amud counts only if at least one of its content-type blocks is itself a
+  // non-empty object — a parse can leave empty {} blocks, which shouldn't read
+  // as aligned.
+  const hasContent = (amud?: Record<string, unknown>): boolean =>
+    !!amud && Object.values(amud).some((c) => !!c && typeof c === 'object' && Object.keys(c as object).length > 0);
+  return hasContent(d.amudim?.a) || hasContent(d.amudim?.b);
 };
 
 /**
@@ -330,6 +340,8 @@ export async function cacheGcTargets(cache: KVNamespace): Promise<GcTarget[]> {
 
 export async function computeCacheStats(cache: KVNamespace): Promise<CacheStats> {
   const total = getWarmTotal();
+  // DafYomi is keyed per daf (both amudim in one entry); total is per amud.
+  const dafTotal = Math.max(1, Math.round(total / 2));
 
   const [
     hbCount, gemaraCount, commentariesCount, dafyomiCount, obsSlices, obsRabbis,
@@ -432,10 +444,12 @@ export async function computeCacheStats(cache: KVNamespace): Promise<CacheStats>
     generatedAt: new Date().toISOString(),
     total,
     source: {
-      hebrewbooks: { count: hbCount, percent: pct(hbCount, total), aligned: hbAligned },
-      gemara: { count: gemaraCount, percent: pct(gemaraCount, total), aligned: gemaraAligned },
-      commentaries: { count: commentariesCount, percent: pct(commentariesCount, total), aligned: commentariesAligned },
-      dafyomi: { count: dafyomiCount, percent: pct(dafyomiCount, total), aligned: dafyomiAligned },
+      hebrewbooks: { count: hbCount, percent: pct(hbCount, total), aligned: hbAligned, denom: total },
+      gemara: { count: gemaraCount, percent: pct(gemaraCount, total), aligned: gemaraAligned, denom: total },
+      commentaries: { count: commentariesCount, percent: pct(commentariesCount, total), aligned: commentariesAligned, denom: total },
+      // DafYomi keys are per-DAF (one entry covers both amudim), so its
+      // denominator is the daf count, not the per-amud total.
+      dafyomi: { count: dafyomiCount, percent: pct(dafyomiCount, dafTotal), aligned: dafyomiAligned, denom: dafTotal },
     },
     marks,
     enrichments,

--- a/tests/cache-stats-alignment.test.ts
+++ b/tests/cache-stats-alignment.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { sampleAligned } from '../src/worker/cache-stats';
+
+// Prefix-aware in-memory KV with cursor paging, so the sampleSize bound is
+// actually exercised (list returns up to `limit` per page).
+function makeKV(entries: Record<string, unknown>) {
+  const store = new Map<string, string | null>(
+    Object.entries(entries).map(([k, v]) => [k, v === null ? null : JSON.stringify(v)]),
+  );
+  return {
+    get: async (k: string) => store.get(k) ?? null,
+    put: async (k: string, v: string) => { store.set(k, v); },
+    delete: async (k: string) => { store.delete(k); },
+    list: async ({ prefix = '', cursor, limit = 1000 }: { prefix?: string; cursor?: string; limit?: number } = {}) => {
+      const all = [...store.keys()].filter((k) => k.startsWith(prefix)).sort();
+      const start = cursor ? Number(cursor) : 0;
+      const page = all.slice(start, start + limit);
+      const next = start + limit;
+      const complete = next >= all.length;
+      return { keys: page.map((name) => ({ name })), list_complete: complete, cursor: complete ? undefined : String(next) };
+    },
+    getWithMetadata: async () => ({ value: null, metadata: null }),
+  } as unknown as KVNamespace;
+}
+
+// Stand-in for the gemara predicate: aligned iff segments_he is non-empty.
+const isAligned = (v: unknown): boolean => {
+  const d = v as { segments_he?: unknown[]; __failed?: boolean } | null;
+  if (!d || d.__failed) return false;
+  return Array.isArray(d.segments_he) && d.segments_he.length > 0;
+};
+
+describe('sampleAligned', () => {
+  it('counts aligned vs not, skipping __failed and empty values', async () => {
+    const kv = makeKV({
+      'ctx:gemara:v1:a': { segments_he: ['x', 'y'] },     // aligned
+      'ctx:gemara:v1:b': { segments_he: ['z'] },           // aligned
+      'ctx:gemara:v1:c': { segments_he: [] },              // cached but not aligned
+      'ctx:gemara:v1:d': { __failed: true },               // negative-cache marker -> not aligned
+      'other:e': { segments_he: ['nope'] },                // different prefix -> ignored
+    });
+    const r = await sampleAligned(kv, 'ctx:gemara:v1:', isAligned);
+    expect(r).not.toBeNull();
+    expect(r!.sampled).toBe(4);   // 4 under the prefix
+    expect(r!.aligned).toBe(2);
+    expect(r!.pct).toBe(50);
+  });
+
+  it('returns null when nothing is cached under the prefix', async () => {
+    const kv = makeKV({ 'other:x': { segments_he: ['a'] } });
+    expect(await sampleAligned(kv, 'ctx:gemara:v1:', isAligned)).toBeNull();
+  });
+
+  it('respects the sample-size bound (does not read the whole prefix)', async () => {
+    const entries: Record<string, unknown> = {};
+    for (let i = 0; i < 50; i++) entries[`p:${String(i).padStart(3, '0')}`] = { segments_he: ['x'] };
+    const kv = makeKV(entries);
+    const r = await sampleAligned(kv, 'p:', isAligned, 10);
+    expect(r!.sampled).toBe(10);
+    expect(r!.aligned).toBe(10);
+    expect(r!.pct).toBe(100);
+  });
+
+  it('rounds pct to one decimal', async () => {
+    const kv = makeKV({
+      'p:a': { segments_he: ['x'] },
+      'p:b': { segments_he: [] },
+      'p:c': { segments_he: [] },
+    });
+    const r = await sampleAligned(kv, 'p:', isAligned);
+    expect(r!.pct).toBeCloseTo(33.3, 5); // 1/3
+  });
+});


### PR DESCRIPTION
Backend half of the usage-dashboard rethink (PR 1 of 2). Feeds the new **Content-In** view.

`computeCacheStats` only counted source-cache keys. This adds, per source spine, a **sampled "% aligned"** — what fraction of cached dapim actually produced usable, anchored content (vs an empty fetch or a `{__failed:true}` marker). Reading every value Shas-wide is the slow scan we avoid, so it samples up to 300/source and extrapolates. It also surfaces **DafYomi** as a fourth source bucket.

Predicates: HebrewBooks (any of main/rashi/tosafot non-empty), Sefaria gemara (non-empty segments), commentaries (≥1 commentator), DafYomi (≥1 amud with content). Runs inside the cron-warmed + SWR-cached `computeCacheStats`, so the extra reads are backgrounded. `CacheStats.source` entries gain `aligned: {sampled, aligned, pct} | null` and a new `dafyomi` entry (additive; UI guards for stale payloads).

The UI (PR 2) relabels these into friendly names (Daf Source 1/2, Rashi + Tosafot, DafYomi).

Tests: `cache-stats-alignment.test.ts` — sampling mechanics, __failed/empty skipping, sample-size bound, pct rounding. `pnpm typecheck` + `pnpm test` (1801) clean.