### PR TITLE
Worker: extract readJsonBody + getRabbiEntryOr404 helpers

### DIFF
--- a/src/worker/http-helpers.ts
+++ b/src/worker/http-helpers.ts
@@ -1,0 +1,54 @@
+// Small HTTP-handler helpers shared across the worker's route bodies.
+//
+// These exist to kill copy-paste, not to build an abstraction layer. Two
+// patterns recurred verbatim across ~18 handlers in index.ts:
+//   1. parse the JSON body, return 400 on failure
+//   2. resolve a `:slug` param to a rabbi entry, return 404 when unknown
+// Both are now single-sourced here so the error shape is consistent and a new
+// handler can't accidentally diverge.
+//
+// NOTE on caching: the get-or-compute cache pattern is deliberately NOT here.
+// It already lives in source-cache.ts (getMishnaBundleCached etc.); the few
+// remaining inline CACHE.get/put sites in index.ts are bespoke (append-to-array
+// recent-errors, section-range-guarded hot path) and don't share one shape.
+
+import type { Context } from 'hono';
+
+/** Result of reading a JSON body: either the parsed value or a ready-to-return
+ *  error Response. Callers do `if (!r.ok) return r.response;` then use r.value. */
+export type JsonBodyResult<T> = { ok: true; value: T } | { ok: false; response: Response };
+
+/**
+ * Parse the request JSON body. On parse failure, returns a 400 Response built
+ * from `errorBody` (default `{ error: 'invalid JSON' }`) so each call site can
+ * preserve its exact error contract while dropping the try/catch boilerplate.
+ */
+export async function readJsonBody<T = unknown>(
+  c: Context,
+  errorBody: Record<string, unknown> = { error: 'invalid JSON' },
+): Promise<JsonBodyResult<T>> {
+  try {
+    return { ok: true, value: (await c.req.json()) as T };
+  } catch {
+    return { ok: false, response: c.json(errorBody, 400) };
+  }
+}
+
+/** Result of resolving a rabbi `:slug`: the slug + entry, or a 404 Response. */
+export type RabbiEntryResult<E> =
+  | { ok: true; slug: string; entry: E }
+  | { ok: false; response: Response };
+
+/**
+ * Resolve the route's `:slug` param against a rabbi map, returning a 404
+ * Response (`{ error: 'unknown slug: <slug>' }`) when the slug is absent.
+ */
+export function getRabbiEntryOr404<E>(
+  c: Context,
+  rabbis: Record<string, E>,
+): RabbiEntryResult<E> {
+  const slug = c.req.param('slug') ?? '';
+  const entry = rabbis[slug];
+  if (!entry) return { ok: false, response: c.json({ error: `unknown slug: ${slug}` }, 404) };
+  return { ok: true, slug, entry };
+}

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -9,6 +9,7 @@ import {
 } from '../lib/sefref';
 import { getDafyomiMasechet } from '../lib/sefref/dafyomi/masechtos';
 import { collectContext } from './context-providers';
+import { readJsonBody, getRabbiEntryOr404 } from './http-helpers';
 import { curatedParallelsForDaf, type CuratedYerushalmiParallel } from '../lib/yerushalmiParallels';
 import { flattenYerushalmiOutline, alignOutlineToSegments, yerushalmiFloorGroups, type YerushalmiFloorGroup } from '../lib/yerushalmiAlign';
 import { placeRevachWithAi } from './revach-ai-place';
@@ -644,8 +645,9 @@ app.get('/api/marks/:id', async (c) => {
   return c.json({ error: 'not found' }, 404);
 });
 app.put('/api/marks/:id', async (c) => {
-  let body: unknown;
-  try { body = await c.req.json(); } catch { return c.json({ error: 'invalid JSON' }, 400); }
+  const parsed = await readJsonBody(c);
+  if (!parsed.ok) return parsed.response;
+  const body = parsed.value;
   const v = validateMark({ ...(body as object), id: c.req.param('id') });
   if (!v.ok) return c.json({ error: v.error }, 400);
   const saved = await writeMark(c.env, v.spec);
@@ -1098,8 +1100,9 @@ app.get('/api/enrichments/:id', async (c) => {
   return c.json({ error: 'not found' }, 404);
 });
 app.put('/api/enrichments/:id', async (c) => {
-  let body: unknown;
-  try { body = await c.req.json(); } catch { return c.json({ error: 'invalid JSON' }, 400); }
+  const parsed = await readJsonBody(c);
+  if (!parsed.ok) return parsed.response;
+  const body = parsed.value;
   const v = validateEnrichment({ ...(body as object), id: c.req.param('id') });
   if (!v.ok) return c.json({ error: v.error }, 400);
   const saved = await writeEnrichment(c.env, v.spec);
@@ -2949,9 +2952,9 @@ async function recordRecentJobError(
  * result to KV under `job:{runId}` AND the canonical cache key.
  */
 app.post('/api/run', async (c) => {
-  let raw: unknown;
-  try { raw = await c.req.json(); }
-  catch { return c.json({ error: 'invalid JSON' }, 400); }
+  const parsed = await readJsonBody(c);
+  if (!parsed.ok) return parsed.response;
+  const raw = parsed.value;
   const body = raw as Partial<JobMessage>;
   if (!body.tractate || !body.page) return c.json({ error: 'tractate and page required' }, 400);
 
@@ -3098,9 +3101,9 @@ app.post('/api/run', async (c) => {
  * that endpoint's surface (no model, no studio knobs), so it needs no extra auth.
  */
 app.post('/api/run-sources', async (c) => {
-  let raw: unknown;
-  try { raw = await c.req.json(); }
-  catch { return c.json({ error: 'invalid JSON' }, 400); }
+  const parsed = await readJsonBody(c);
+  if (!parsed.ok) return parsed.response;
+  const raw = parsed.value;
   const body = raw as { mark_id?: string; enrichment_id?: string; tractate?: string; page?: string; mark_input?: unknown; lang?: string };
   if (!body.tractate || !body.page) return c.json({ error: 'tractate and page required' }, 400);
   if (!body.mark_id && !body.enrichment_id) return c.json({ error: 'mark_id or enrichment_id required' }, 400);
@@ -3133,9 +3136,9 @@ app.post('/api/run-sources', async (c) => {
  * on idle so forward/back navigation lands on a fully-cached page.
  */
 app.post('/api/warm-daf', async (c) => {
-  let raw: unknown;
-  try { raw = await c.req.json(); }
-  catch { return c.json({ error: 'invalid JSON' }, 400); }
+  const parsed = await readJsonBody(c);
+  if (!parsed.ok) return parsed.response;
+  const raw = parsed.value;
   const body = raw as { tractate?: string; page?: string; lang?: string };
   if (!body.tractate || !body.page) return c.json({ error: 'tractate and page required' }, 400);
   if (!c.env.ENRICHMENT_QUEUE) return c.json({ error: 'ENRICHMENT_QUEUE binding not available' }, 503);
@@ -3624,12 +3627,9 @@ app.post('/api/admin/cache-gc', async (c) => {
  * unauthenticated + cheap to call.
  */
 app.post('/api/log', async (c) => {
-  let body: unknown;
-  try {
-    body = await c.req.json();
-  } catch {
-    return c.json({ ok: false, error: 'bad-json' }, 400);
-  }
+  const parsed = await readJsonBody(c, { ok: false, error: 'bad-json' });
+  if (!parsed.ok) return parsed.response;
+  const body = parsed.value;
   const rec = {
     ts: new Date().toISOString(),
     ua: c.req.header('user-agent') ?? null,
@@ -3831,9 +3831,9 @@ app.get('/api/qa/registry', async (c) => {
  * Returns: { qHash, alreadyAsked, rateLimited?, remaining }
  */
 app.post('/api/qa/ask', async (c) => {
-  let body: unknown;
-  try { body = await c.req.json(); }
-  catch { return c.json({ error: 'invalid JSON' }, 400); }
+  const parsed = await readJsonBody(c);
+  if (!parsed.ok) return parsed.response;
+  const body = parsed.value;
   const b = body as Partial<{
     tractate: string; page: string;
     mark: string; move_id: string; instance_id: string;
@@ -3931,9 +3931,9 @@ app.post('/api/qa/ask', async (c) => {
  * 2 questions" ranking on the panel.
  */
 app.post('/api/qa/click', async (c) => {
-  let body: unknown;
-  try { body = await c.req.json(); }
-  catch { return c.json({ error: 'invalid JSON' }, 400); }
+  const parsed = await readJsonBody(c);
+  if (!parsed.ok) return parsed.response;
+  const body = parsed.value;
   const b = body as Partial<{
     tractate: string; page: string;
     mark: string; move_id: string; instance_id: string;
@@ -4125,12 +4125,9 @@ interface BugReport {
 }
 
 app.post('/api/report', async (c) => {
-  let body: { tractate?: string; page?: string; description?: string };
-  try {
-    body = (await c.req.json()) as typeof body;
-  } catch {
-    return c.json({ ok: false, error: 'bad-json' }, 400);
-  }
+  const parsed = await readJsonBody<{ tractate?: string; page?: string; description?: string }>(c, { ok: false, error: 'bad-json' });
+  if (!parsed.ok) return parsed.response;
+  const body = parsed.value;
   const tractate = (body.tractate ?? '').slice(0, 60).trim();
   const page = (body.page ?? '').slice(0, 20).trim();
   const description = (body.description ?? '').slice(0, 4000).trim();
@@ -4728,9 +4725,9 @@ function resolveRabbiName(raw: string): RabbiPlacesEntry | null {
 // can swap to the target rabbi's bio without a second enrichment hop. 404 if
 // the slug isn't in our rabbi dataset (biblical figures, holidays, etc.).
 app.get('/api/rabbi/:slug', (c) => {
-  const slug = c.req.param('slug');
-  const entry = RABBI_PLACES.rabbis[slug];
-  if (!entry) return c.json({ error: `unknown slug: ${slug}` }, 404);
+  const rr = getRabbiEntryOr404(c, RABBI_PLACES.rabbis);
+  if (!rr.ok) return rr.response;
+  const { slug, entry } = rr;
   const rawGen = entry.generation ?? 'unknown';
   const generation: GenerationId =
     (GENERATION_IDS as string[]).includes(rawGen) ? (rawGen as GenerationId) : 'unknown';
@@ -4860,8 +4857,9 @@ function hashMatchKeys(keys: string[]): string {
 }
 
 app.post('/api/context/match', async (c) => {
-  let body: { tractate?: string; page?: string; items?: MatchInput[] };
-  try { body = await c.req.json(); } catch { return c.json({ error: 'bad JSON body' }, 400); }
+  const parsed = await readJsonBody<{ tractate?: string; page?: string; items?: MatchInput[] }>(c, { error: 'bad JSON body' });
+  if (!parsed.ok) return parsed.response;
+  const body = parsed.value;
   const t = body.tractate;
   const p = body.page;
   const items = Array.isArray(body.items) ? body.items.filter((i) => i && typeof i.key === 'string') : [];
@@ -5630,9 +5628,9 @@ app.get('/api/sages-index', (c) => {
 });
 
 app.get('/api/admin/enrich-rabbi/:slug', async (c) => {
-  const slug = c.req.param('slug');
-  const entry = RABBI_PLACES.rabbis[slug];
-  if (!entry) return c.json({ error: `unknown slug: ${slug}` }, 404);
+  const rr = getRabbiEntryOr404(c, RABBI_PLACES.rabbis);
+  if (!rr.ok) return rr.response;
+  const { slug, entry } = rr;
   if (!entry.bio) return c.json({ error: `no bio available for ${slug}` }, 422);
 
   // Cache per-slug — this Kimi-thinking call is ~30-60s and the upstream
@@ -5766,9 +5764,9 @@ function resolveRefs(names: string[], selfSlug: string): ResolvedRef[] {
 
 app.get('/api/admin/rabbi-relationships/:slug', async (c) => {
   if (!c.env.AI) return c.json({ error: 'AI binding not available' }, 503);
-  const slug = c.req.param('slug');
-  const entry = RABBI_PLACES.rabbis[slug];
-  if (!entry) return c.json({ error: `unknown slug: ${slug}` }, 404);
+  const rr = getRabbiEntryOr404(c, RABBI_PLACES.rabbis);
+  if (!rr.ok) return rr.response;
+  const { slug, entry } = rr;
   if (!entry.bio) return c.json({ error: `no bio available for ${slug}` }, 422);
 
   const userContent = [
@@ -5896,9 +5894,9 @@ function validateFamily(x: unknown): x is FamilyResult {
 
 app.get('/api/admin/rabbi-family/:slug', async (c) => {
   if (!c.env.AI) return c.json({ error: 'AI binding not available' }, 503);
-  const slug = c.req.param('slug');
-  const entry = RABBI_PLACES.rabbis[slug];
-  if (!entry) return c.json({ error: `unknown slug: ${slug}` }, 404);
+  const rr = getRabbiEntryOr404(c, RABBI_PLACES.rabbis);
+  if (!rr.ok) return rr.response;
+  const { slug, entry } = rr;
   if (!entry.bio) return c.json({ error: `no bio available for ${slug}` }, 422);
 
   const userContent = [
@@ -6027,9 +6025,9 @@ function validateOrientation(x: unknown): x is OrientationResult {
 
 app.get('/api/admin/rabbi-orientation/:slug', async (c) => {
   if (!c.env.AI) return c.json({ error: 'AI binding not available' }, 503);
-  const slug = c.req.param('slug');
-  const entry = RABBI_PLACES.rabbis[slug];
-  if (!entry) return c.json({ error: `unknown slug: ${slug}` }, 404);
+  const rr = getRabbiEntryOr404(c, RABBI_PLACES.rabbis);
+  if (!rr.ok) return rr.response;
+  const { slug, entry } = rr;
   if (!entry.bio) return c.json({ error: `no bio available for ${slug}` }, 422);
 
   const userContent = [
@@ -6412,9 +6410,9 @@ export async function enrichRabbiUnified(
 
 app.get('/api/admin/rabbi-enrich-unified/:slug', async (c) => {
   if (!c.env.AI) return c.json({ error: 'AI binding not available' }, 503);
-  const slug = c.req.param('slug');
-  const entry = RABBI_PLACES.rabbis[slug];
-  if (!entry) return c.json({ error: `unknown slug: ${slug}` }, 404);
+  const rr = getRabbiEntryOr404(c, RABBI_PLACES.rabbis);
+  if (!rr.ok) return rr.response;
+  const { slug, entry } = rr;
 
   const refresh = c.req.query('refresh') === '1';
   const cache = c.env.CACHE;
@@ -7228,9 +7226,9 @@ function validateTranslatedBio(x: unknown): x is TranslatedBio {
 
 app.post('/api/admin/translate-bio', async (c) => {
   if (!c.env.AI) return c.json({ error: 'AI binding not available' }, 503);
-  let body: { hebrewBio?: string; nameHe?: string; nameEn?: string };
-  try { body = await c.req.json(); }
-  catch { return c.json({ error: 'invalid JSON body' }, 400); }
+  const parsed = await readJsonBody<{ hebrewBio?: string; nameHe?: string; nameEn?: string }>(c, { error: 'invalid JSON body' });
+  if (!parsed.ok) return parsed.response;
+  const body = parsed.value;
   const hebrewBio = (body.hebrewBio ?? '').trim();
   const nameHe = (body.nameHe ?? '').trim();
   if (!hebrewBio) return c.json({ error: 'hebrewBio is required' }, 400);
@@ -7427,9 +7425,9 @@ export function splitOuterWhitespace(text: string): { leading: string; core: str
 
 app.post('/api/hebraize', async (c) => {
   if (!c.env.AI) return c.json({ error: 'AI binding not available' }, 503);
-  let body: { text?: string };
-  try { body = await c.req.json() as { text?: string }; }
-  catch { return c.json({ error: 'bad json' }, 400); }
+  const parsed = await readJsonBody<{ text?: string }>(c, { error: 'bad json' });
+  if (!parsed.ok) return parsed.response;
+  const body = parsed.value;
   const text = body.text ?? '';
   if (!text) return c.json({ hebraized: '', _empty: true });
   if (text.length > 8000) return c.json({ error: 'text too long (max 8000 chars)' }, 413);

--- a/tests/http-helpers.test.ts
+++ b/tests/http-helpers.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { Hono } from 'hono';
+import { readJsonBody, getRabbiEntryOr404 } from '../src/worker/http-helpers';
+
+// These helpers replace boilerplate that appeared verbatim across ~18 route
+// bodies in index.ts. The tests pin the contract those call sites relied on:
+// the success value passes through untouched, and the failure path returns the
+// exact status + body each handler used to emit by hand.
+
+const app = new Hono();
+
+app.post('/echo', async (c) => {
+  const r = await readJsonBody<{ x: number }>(c);
+  if (!r.ok) return r.response;
+  return c.json({ got: r.value.x });
+});
+
+app.post('/echo-custom', async (c) => {
+  const r = await readJsonBody(c, { ok: false, error: 'bad-json' });
+  if (!r.ok) return r.response;
+  return c.json({ ok: true });
+});
+
+const RABBIS: Record<string, { name: string }> = { hillel: { name: 'Hillel' } };
+app.get('/rabbi/:slug', (c) => {
+  const r = getRabbiEntryOr404(c, RABBIS);
+  if (!r.ok) return r.response;
+  return c.json({ slug: r.slug, name: r.entry.name });
+});
+
+describe('readJsonBody', () => {
+  it('returns the parsed value on valid JSON', async () => {
+    const res = await app.request('/echo', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ x: 42 }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ got: 42 });
+  });
+
+  it('returns 400 with the default error body on invalid JSON', async () => {
+    const res = await app.request('/echo', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: 'not json{',
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid JSON' });
+  });
+
+  it('honors a custom error body shape', async () => {
+    const res = await app.request('/echo-custom', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{{',
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ ok: false, error: 'bad-json' });
+  });
+});
+
+describe('getRabbiEntryOr404', () => {
+  it('resolves a known slug to its entry', async () => {
+    const res = await app.request('/rabbi/hillel');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ slug: 'hillel', name: 'Hillel' });
+  });
+
+  it('returns 404 with the unknown-slug message for a missing slug', async () => {
+    const res = await app.request('/rabbi/nobody');
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'unknown slug: nobody' });
+  });
+});


### PR DESCRIPTION
Extracts two verbatim-repeated patterns from the ~7,900-line `src/worker/index.ts` into `src/worker/http-helpers.ts`:

- **`readJsonBody<T>(c, errorBody?)`** — replaces the JSON `try { … } catch { return 400 }` boilerplate at **12** sites. Each site keeps its exact original error body (`invalid JSON` / `bad JSON body` / `invalid JSON body` / `bad json` / `{ok:false,error:'bad-json'}`) via the optional `errorBody` arg.
- **`getRabbiEntryOr404<E>(c, rabbis)`** — replaces the `:slug` → entry → 404 pattern at **6** sites (the one site returning `{error:'not found'}` was deliberately left).

Adds `tests/http-helpers.test.ts` (5 tests pinning the success + failure contracts).

Deliberately **not** included: a generic cache get-or-compute helper. The caching layer is already abstracted in `source-cache.ts`; the remaining inline `CACHE` sites in index.ts are bespoke (append-to-array, section-range-guarded hot path) and don't share one shape — wrapping them would be a speculative engine.

Verification: `pnpm typecheck` clean, `pnpm test` 1802 passed, Codex read-only review confirmed every call site is behavior-preserving.