### PR TITLE
Mobile translation: drop note creator, tap-to-extend multi-select, bigger anchor taps

### DIFF
--- a/src/client/DafViewer.tsx
+++ b/src/client/DafViewer.tsx
@@ -25,7 +25,6 @@ import {
   loadUserHighlights,
   saveUserHighlights,
   highlightCoversWord,
-  buildHighlight,
   wordCoordFromTarget,
 } from './userHighlights';
 import { GutterIcons, type GutterKind } from './GutterIcons';
@@ -1011,7 +1010,6 @@ export default function DafViewer(): JSX.Element {
     setUserHighlights(next);
     saveUserHighlights(tractate(), page(), next);
   };
-  const addHighlight = (h: UserHighlight) => persistHighlights([...userHighlights(), h]);
   const deleteHighlight = (id: string) =>
     persistHighlights(userHighlights().filter((h) => h.id !== id));
   const updateHighlightNote = (id: string, note: string) =>
@@ -1023,25 +1021,6 @@ export default function DafViewer(): JSX.Element {
     if (!root) return null;
     const dafRootDiv = root.querySelector<HTMLElement>('.daf-root') ?? root;
     return dafRootDiv.querySelector<HTMLElement>('.daf-main .daf-text');
-  };
-
-  // Resolve the currently-active selection (from `active().els`) to a user-
-  // highlight word-range. Returns null when the selection isn't inside the
-  // main text column (e.g. a Rashi/Tosafot word) — those aren't highlightable.
-  const highlightCoordsForActive = ():
-    | { startSeg: number; startTok: number; endSeg: number; endTok: number; text: string }
-    | null => {
-    const a = active();
-    if (!a || a.els.length === 0) return null;
-    const mainCol = mainTextCol();
-    if (!mainCol) return null;
-    const first = a.els[0];
-    const last = a.els[a.els.length - 1];
-    const s = wordCoordFromTarget(first, mainCol);
-    const e = wordCoordFromTarget(last, mainCol);
-    if (!s || !e) return null;
-    const text = a.els.map((el) => el.textContent ?? '').join(' ').replace(/\s+/g, ' ').trim();
-    return { startSeg: s.seg, startTok: s.tok, endSeg: e.seg, endTok: e.tok, text };
   };
 
   // A plain click on a word already covered by a personal highlight opens that
@@ -2786,11 +2765,14 @@ export default function DafViewer(): JSX.Element {
   // main paint effect above — same continuous-band treatment as everything
   // else — rather than via a CSS outline on the wrapping .daf-comm-piece span.
 
-  // On mouseup: prefer a text selection snapped to word boundaries over a plain
-  // word click. Any .daf-word element intersecting the selection range counts
-  // as "selected", so starting a drag mid-word includes the whole word. Mobile
-  // multi-word selection uses native iOS/Android long-press-and-extend handles,
-  // which produce the same selection range this code reads.
+  // On mouseup (desktop): prefer a text selection snapped to word boundaries
+  // over a plain word click. Any .daf-word element intersecting the selection
+  // range counts as "selected", so starting a drag mid-word includes the whole
+  // word. On mobile we DON'T read native selection — Android's long-press
+  // handles are unreliable inside the CSS-scaled daf (the transform breaks the
+  // native selection UI), so multi-word translate there uses explicit
+  // tap-to-extend instead (see the mobile branch below). Native long-press
+  // still works for plain copy/paste at the browser level.
   const onMouseUpRoot = (e: MouseEvent) => {
     // Commentary anchor highlight fires alongside any other click behaviour
     // (translate popup, commentary-on-tap, etc). Runs first so it lights
@@ -2800,12 +2782,9 @@ export default function DafViewer(): JSX.Element {
 
     const sel = window.getSelection();
 
-    if (sel && !sel.isCollapsed && sel.rangeCount > 0) {
+    if (!isMobile() && sel && !sel.isCollapsed && sel.rangeCount > 0) {
       const snapped = collectSnappedWords(sel.getRangeAt(0));
       if (snapped.length >= 2 && snapped.length <= MAX_PHRASE_WORDS) {
-        // Mobile read mode opts out of translation entirely — the user is
-        // selecting for native copy/paste, not asking to translate.
-        if (isMobile() && mobileMode() === 'read') return;
         setActiveFromWordEls(snapped, e);
         return;
       }
@@ -2852,13 +2831,37 @@ export default function DafViewer(): JSX.Element {
         if (wordEl && tryOpenUserHighlight(wordEl, e)) return;
         return;
       }
-      // Translate mode: tap-to-translate, bypassing rabbi/city handlers so
-      // the drawer doesn't hijack the popup on rabbi-underlined words.
+      // Translate mode: tap a word to translate it; tap a second word to
+      // extend the selection from the first to the second and translate the
+      // whole phrase (tap-to-extend). This replaces native long-press
+      // selection, which is unreliable on Android inside the scaled daf.
+      // Bypasses rabbi/city handlers so the drawer doesn't hijack the popup
+      // on rabbi-underlined words.
       if (!wordEl) return;
       if (tryOpenUserHighlight(wordEl, e)) return;
-      if (active()?.els.includes(wordEl)) {
-        clearActive();
-        return;
+      const cur = active();
+      if (cur) {
+        if (cur.els.includes(wordEl)) {
+          // Tapped a word already inside the selection → dismiss.
+          clearActive();
+          return;
+        }
+        // Extend from the first selected word to the tapped word. The range
+        // spans either direction depending on which was tapped first.
+        const anchorEl = cur.els[0];
+        if (anchorEl && anchorEl.isConnected) {
+          const range = document.createRange();
+          const following = anchorEl.compareDocumentPosition(wordEl) & Node.DOCUMENT_POSITION_FOLLOWING;
+          range.setStartBefore(following ? anchorEl : wordEl);
+          range.setEndAfter(following ? wordEl : anchorEl);
+          const phrase = collectSnappedWords(range);
+          if (phrase.length >= 2 && phrase.length <= MAX_PHRASE_WORDS) {
+            setActiveFromWordEls(phrase, e);
+            return;
+          }
+          // Out of range (too far apart, or different text columns) → fall
+          // through and re-anchor on the freshly tapped word.
+        }
       }
       setActiveFromWordEls([wordEl], e);
       return;
@@ -3177,7 +3180,7 @@ export default function DafViewer(): JSX.Element {
                   activeKey={sidebarActiveKey()}
                 />
               </Show>
-              <GutterOverlay />
+              <GutterOverlay scale={dafScale()} />
             </div>
             </div>
           )}
@@ -3195,15 +3198,6 @@ export default function DafViewer(): JSX.Element {
             hebrewAfter={a().hebrewAfter}
             segIdx={a().segIdx}
             onClose={clearActive}
-            onHighlight={
-              highlightCoordsForActive()
-                ? (color, note) => {
-                    const c = highlightCoordsForActive();
-                    if (c) addHighlight(buildHighlight(c, { color, note }));
-                    clearActive();
-                  }
-                : undefined
-            }
           />
         )}
       </Show>

--- a/src/client/GutterOverlay.tsx
+++ b/src/client/GutterOverlay.tsx
@@ -99,8 +99,23 @@ function clustersFromEntries(entries: Partial<Record<GutterKind, GutterStackEntr
   return out;
 }
 
-export function GutterOverlay(): JSX.Element {
+export interface GutterOverlayProps {
+  /** Visual scale of the daf-root the overlay lives inside (mobile
+   *  fit-to-width applies `transform: scale()` < 1). The overlay's `top`
+   *  values are already in pre-scale layout coordinates, but the icons would
+   *  also shrink with the frame — at 0.5 a 14px icon renders at ~7px, too
+   *  small to tap. Counter-scaling each cluster by 1/scale keeps icons a
+   *  constant on-screen size regardless of zoom. Defaults to 1 (desktop). */
+  scale?: number;
+}
+
+export function GutterOverlay(props: GutterOverlayProps): JSX.Element {
   const clusters = createMemo(() => clustersFromEntries(gutterEntries()));
+  // Clamp so a transient 0/NaN measurement never blows the icons up.
+  const inv = () => {
+    const s = props.scale ?? 1;
+    return s > 0 && s < 1 ? 1 / s : 1;
+  };
 
   const renderItem = (item: ClusterItem, idx: number, total: number): JSX.Element => {
     const key = `${item.kind}:${item.index}`;
@@ -160,7 +175,9 @@ export function GutterOverlay(): JSX.Element {
               position: 'absolute',
               top: `${c.top}px`,
               left: x,
-              transform: 'translate(-50%, -50%)',
+              // Counter-scale by 1/dafScale so icons keep a constant on-screen
+              // size (and tappable hit area) even when the daf is zoomed out.
+              transform: `translate(-50%, -50%) scale(${inv()})`,
               'pointer-events': 'auto',
             }}
           >

--- a/src/client/TranslationPopup.tsx
+++ b/src/client/TranslationPopup.tsx
@@ -1,6 +1,5 @@
-import { createSignal, createEffect, onCleanup, Show, For, type JSX } from 'solid-js';
+import { createSignal, createEffect, onCleanup, Show, type JSX } from 'solid-js';
 import { t, lang } from './i18n';
-import { HIGHLIGHT_COLORS } from './userHighlights';
 
 export interface TranslationPopupProps {
   word: string;
@@ -16,10 +15,6 @@ export interface TranslationPopupProps {
   /** Sefaria segment index resolved client-side from `data-seg` on the
    *  clicked .daf-word. The server uses it directly when provided. */
   segIdx?: number;
-  /** When set, the popup offers personal-highlight controls (a color-swatch
-   *  row + optional note) over the selected words. Called with the chosen
-   *  color key + note text; the host persists + closes. */
-  onHighlight?: (color: string, note: string) => void;
 }
 
 // Module-level cache so reopening the popup for a word we already translated
@@ -30,7 +25,6 @@ export function TranslationPopup(props: TranslationPopupProps): JSX.Element {
   const [translation, setTranslation] = createSignal<string | null>(null);
   const [loading, setLoading] = createSignal(true);
   const [error, setError] = createSignal<string | null>(null);
-  const [noteText, setNoteText] = createSignal('');
   let popupRef: HTMLDivElement | undefined;
 
   // Cache key includes a cheap hash of the surrounding text so the same word
@@ -93,7 +87,13 @@ export function TranslationPopup(props: TranslationPopupProps): JSX.Element {
     if (e.key === 'Escape') props.onClose();
   };
   const onDocClick = (e: MouseEvent) => {
-    if (popupRef && !popupRef.contains(e.target as Node)) props.onClose();
+    const target = e.target as HTMLElement | null;
+    if (popupRef && popupRef.contains(target)) return;
+    // A tap on another daf word should retarget/extend the selection (handled
+    // by the viewer's mouseup), not dismiss the popup — otherwise mobile
+    // tap-to-extend would clear the anchor before the second tap registers.
+    if (target?.closest('.daf-word')) return;
+    props.onClose();
   };
   window.addEventListener('keydown', onKey);
   // Use capture so we beat the viewer's own click handler on `.daf-word`
@@ -159,56 +159,6 @@ export function TranslationPopup(props: TranslationPopupProps): JSX.Element {
           {translation()}
         </Show>
       </div>
-      <Show when={props.onHighlight}>
-        <div
-          style={{
-            'margin-top': '0.55rem',
-            'padding-top': '0.5rem',
-            'border-top': '1px solid #eee',
-          }}
-        >
-          <input
-            type="text"
-            value={noteText()}
-            onInput={(e) => setNoteText(e.currentTarget.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') props.onHighlight?.(HIGHLIGHT_COLORS[0].key, noteText().trim());
-            }}
-            placeholder={t('highlight.notePlaceholder')}
-            style={{
-              width: '100%',
-              'box-sizing': 'border-box',
-              'font-size': '0.82rem',
-              padding: '0.3rem 0.4rem',
-              border: '1px solid #ddd',
-              'border-radius': '4px',
-              'margin-bottom': '0.45rem',
-              'font-family': 'system-ui, -apple-system, sans-serif',
-            }}
-          />
-          <div style={{ display: 'flex', 'align-items': 'center', gap: '0.4rem' }}>
-            <span style={{ 'font-size': '0.72rem', color: '#888' }}>{t('highlight.action')}</span>
-            <For each={HIGHLIGHT_COLORS}>
-              {(c) => (
-                <button
-                  type="button"
-                  title={c.label}
-                  onClick={() => props.onHighlight?.(c.key, noteText().trim())}
-                  style={{
-                    width: '20px',
-                    height: '20px',
-                    'border-radius': '50%',
-                    border: '1px solid rgba(0,0,0,0.2)',
-                    background: c.swatch,
-                    cursor: 'pointer',
-                    padding: '0',
-                  }}
-                />
-              )}
-            </For>
-          </div>
-        </div>
-      </Show>
     </div>
   );
 }

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -686,3 +686,15 @@ body.dev-shelf-open .daf-page {
 .gutter-cluster[data-count="1"] .gutter-icon {
   margin: 0 !important;
 }
+/* Touch devices: there's no hover to fan a stack out, and the icons are only
+   14px, so extend each icon's tap target with an invisible ~36px halo. The
+   glyph stays the same size; only the clickable area grows. Later-painted
+   icons sit on top, so on a stacked cluster the topmost wins the tap. */
+@media (pointer: coarse) {
+  .gutter-cluster .gutter-icon::before {
+    content: "";
+    position: absolute;
+    inset: -11px;
+    border-radius: 50%;
+  }
+}


### PR DESCRIPTION
Three mobile-focused fixes to the daf word-translation UX.

## 1. Translation popup is translation-only
The translate popup was doubling as the personal-highlight creator (note input + color-swatch row). That's removed — the popup now shows just the word and its gloss. Existing highlights still open/edit via their note popover and the notes panel; only the create-from-translate path is gone. Dropped the now-dead `addHighlight` / `highlightCoordsForActive` / `buildHighlight` wiring.

## 2. Mobile multi-select → tap-to-extend
The old path relied entirely on native long-press text selection read on `mouseup`, which is unreliable on Android (the daf sits inside a `transform: scale()` wrapper that breaks native selection handles). On mobile in **Translate** mode now:
- Tap a word → translate it
- Tap a second word → translate the phrase between the two (either direction)
- Tap a selected word → dismiss

Native selection is read on desktop only; long-press copy/paste still works on mobile. The popup's outside-click dismiss now ignores `.daf-word` taps so the first-tap anchor survives until the second tap.

## 3. Constant-size, larger anchor taps when zoomed out
The 14px gutter icons lived inside the scaled daf, so at ~0.5 zoom they rendered at ~7px. They're now counter-scaled by `1/dafScale` to keep a constant on-screen size at any zoom, plus a ~36px invisible tap halo on coarse-pointer (touch) devices.

## Verification
- `pnpm typecheck` clean
- `pnpm test` — 1797 passing