### PR TITLE
Context source registry (foundation for alignment rebuild)

### DIFF
--- a/src/lib/context/fromDafyomi.ts
+++ b/src/lib/context/fromDafyomi.ts
@@ -12,14 +12,7 @@ import type {
 } from '../sefref/dafyomi/schema.ts';
 import type { ContextItem } from './types.ts';
 import { dafCoord, type AnchorCoord } from './coord.ts';
-
-const SOURCE_LABEL: Record<DafyomiContentType, string> = {
-  // dafyomi "Tosfos" is the Kollel's explanation OF Tosafot, not Tosafot itself —
-  // label it so it reads as a companion to the Sefaria "Tosafot" source.
-  insights: 'Insights', background: 'Background', halacha: 'Halacha', tosfos: 'Tosafot explanation',
-  review: 'Review', points: 'Points', hebcharts: 'Charts', yerushalmi: 'Yerushalmi',
-  revach: 'Revach l\'Daf',
-};
+import { sourceLabel } from './sources.ts';
 
 export function fromDafyomi(daf: DafyomiDaf): ContextItem[] {
   const items: ContextItem[] = [];
@@ -40,7 +33,7 @@ function collectBlock(
   const type = block.type;
   const url = daf.source.urls[type];
   const base = (kind: string, key: string): ContextItem => ({
-    source: `dafyomi:${type}`, sourceLabel: SOURCE_LABEL[type], kind, key, url,
+    source: `dafyomi:${type}`, sourceLabel: sourceLabel(`dafyomi:${type}`), kind, key, url,
     segs: [], ...(block.wholeDaf ? {} : { amud }),
   });
 

--- a/src/lib/context/fromSefaria.ts
+++ b/src/lib/context/fromSefaria.ts
@@ -10,6 +10,7 @@ import type {
   TalmudPageData, RishonimBundle, HalachicRefBundle, MishnaBundle, SefariaTopicBundle,
 } from '../sefref/sefaria/client.ts';
 import type { ContextItem, ContextSource } from './types.ts';
+import { sourceLabel } from './sources.ts';
 
 function item(source: ContextSource, label: string, kind: string, key: string, fields: Partial<ContextItem>): ContextItem {
   return { source, sourceLabel: label, kind, key, segs: [], ...fields };
@@ -35,7 +36,7 @@ export function fromCommentaryPieces(
   const keys = data?.pieceKeys ?? [];
   if (pieces.length === 0) return [];
   const source: ContextSource = which === 'rashi' ? 'sefaria-rashi' : 'sefaria-tosafot';
-  const label = which === 'rashi' ? 'Rashi' : 'Tosafot';
+  const label = sourceLabel(source);
   return pieces.map((piece, i) => {
     const seg = segOf(keys[i]);
     return item(source, label, which, `${which}:${keys[i] ?? i}`, {
@@ -74,7 +75,7 @@ export function fromHalachaRefs(bundle: HalachicRefBundle | undefined): ContextI
   for (const [book, snips] of Object.entries(bundle)) {
     snips.forEach((s, i) => {
       const segs = s.segStart != null && s.segEnd != null ? segArr(s.segStart, s.segEnd) : [];
-      out.push(item('sefaria-halacha', 'Halacha', 'halachaRef', `halacha:${s.ref || `${book}:${i}`}`, {
+      out.push(item('sefaria-halacha', sourceLabel('sefaria-halacha'), 'halachaRef', `halacha:${s.ref || `${book}:${i}`}`, {
         title: { en: s.ref || book }, body: { he: s.hebrew, en: s.english }, url: refUrl(s.ref),
         segs, via: segs.length ? 'sefaria-link' : undefined,
       }));
@@ -89,7 +90,7 @@ export function fromMishna(bundle: MishnaBundle | undefined): ContextItem[] {
   return bundle.map((m, i) => {
     const segs: number[] = [];
     for (let s = m.anchorStartSeg; s <= m.anchorEndSeg; s++) segs.push(s);
-    return item('sefaria-mishnah', 'Mishnah', 'mishnah', `mishnah:${m.ref ?? i}`, {
+    return item('sefaria-mishnah', sourceLabel('sefaria-mishnah'), 'mishnah', `mishnah:${m.ref ?? i}`, {
       title: { en: m.ref }, body: { he: m.hebrew, en: m.english }, url: refUrl(m.ref),
       segs, via: 'mishnah',
     });
@@ -102,7 +103,7 @@ export function fromTopics(bundle: SefariaTopicBundle | undefined): ContextItem[
   return bundle.map((t) => {
     const sources = t.sources?.slice(0, 8).map((s) => s.ref).join(', ');
     const en = [t.description, sources && `Sources: ${sources}`].filter(Boolean).join('\n');
-    return item('sefaria-topic', 'Topic', 'topic', `topic:${t.slug}`, {
+    return item('sefaria-topic', sourceLabel('sefaria-topic'), 'topic', `topic:${t.slug}`, {
       title: { en: t.titleEn ?? t.slug, he: t.titleHe },
       body: en ? { en } : undefined,
       url: `https://www.sefaria.org/topics/${encodeURIComponent(t.slug)}`,

--- a/src/lib/context/sources.ts
+++ b/src/lib/context/sources.ts
@@ -1,0 +1,126 @@
+/**
+ * @fileoverview The source registry — the single declarative list of every
+ * external source the context pool can contain.
+ *
+ * Adding a source to the app means adding ONE entry here (plus its cached
+ * fetcher + `from*` mapper). Because `SOURCE_META` is typed as an exhaustive
+ * `Record<ContextSource, SourceMeta>`, TypeScript refuses to compile if a
+ * `ContextSource` is missing an entry or an entry names a source that isn't in
+ * the union — so the registry can never silently drift from what the system
+ * actually serves. That is the foundation for:
+ *   - the alignment workbench rendering one row per *declared* source (an
+ *     unwired/empty source shows up as "0 items", never silently absent), and
+ *   - the coverage tests in `tests/context-sources.test.ts`.
+ *
+ * `label` is the canonical display name (the `sourceLabel` on emitted items —
+ * except `sefaria-rishonim`, whose per-item label is the specific rishon's
+ * name; here it's the group name). `anchor` / `defaultLevel` document how the
+ * source is placed; they mirror the `via` strings written by the matchers in
+ * `anchor/` and the grounding levels in `placement.ts`.
+ */
+
+import type { ContextSource } from './types.ts';
+
+/** How a source is anchored onto the text. Mirrors the `via` values the
+ *  deterministic + AI matchers write. `none` = placed only by the AI placer. */
+export type AnchorStrategy =
+  | 'pieceKeys'        // parallel Sefaria "S:P" piece segmentation (Rashi/Tosafot)
+  | 'sefaria-link'     // Sefaria's own link to the daf segment(s)
+  | 'mishnah'          // Mishnah anchor range
+  | 'tosfos-dh'        // dibur-hamaschil matched to a Sefaria tosafot pieceKey
+  | 'bg-term'          // background girsa/glossary term quoted in a segment
+  | 'yerushalmi-text'  // verbatim phrase shared with a Bavli segment
+  | 'section'          // conservative English↔English section alignment (Revach)
+  | 'reference'        // daf-level by nature (cross-refs, topic tags)
+  | 'ai'               // placed by the AI semantic placer
+  | 'none';            // unplaced until the AI placer runs
+
+/** The coarsest grounding a source reaches before per-item matchers refine it. */
+export type DefaultLevel = 'segment' | 'amud' | 'daf';
+
+export interface SourceMeta {
+  /** Canonical display label (the `sourceLabel` on emitted items). */
+  label: string;
+  /** Where the bytes come from. */
+  origin: 'sefaria' | 'dafyomi';
+  /** How items from this source get anchored. */
+  anchor: AnchorStrategy;
+  /** Grounding level when no finer matcher fires. */
+  defaultLevel: DefaultLevel;
+  /** Emits cross-text citations (`refs`/`coord`) rather than only in-daf segs. */
+  cites?: boolean;
+  /** One line: what it is. Shown in docs + the alignment source rail. */
+  notes: string;
+}
+
+/** EXHAUSTIVE over `ContextSource`. TypeScript enforces one entry per source. */
+export const SOURCE_META: Record<ContextSource, SourceMeta> = {
+  'sefaria-rashi': {
+    label: 'Rashi', origin: 'sefaria', anchor: 'pieceKeys', defaultLevel: 'segment',
+    notes: "Rashi commentary text, one item per piece, placed on its segment via Sefaria's pieceKeys.",
+  },
+  'sefaria-tosafot': {
+    label: 'Tosafot', origin: 'sefaria', anchor: 'pieceKeys', defaultLevel: 'segment',
+    notes: 'Tosafot commentary text, one item per piece, placed on its segment via pieceKeys.',
+  },
+  'sefaria-rishonim': {
+    label: 'Rishonim', origin: 'sefaria', anchor: 'sefaria-link', defaultLevel: 'segment',
+    notes: "Other rishonim (Rashba, Ritva, Rosh, …); per-item label is the rishon's name.",
+  },
+  'sefaria-halacha': {
+    label: 'Halacha', origin: 'sefaria', anchor: 'reference', defaultLevel: 'daf', cites: true,
+    notes: 'Halachic codifications (Mishneh Torah, Shulchan Aruch, …) linked to this daf.',
+  },
+  'sefaria-mishnah': {
+    label: 'Mishnah', origin: 'sefaria', anchor: 'mishnah', defaultLevel: 'segment',
+    notes: 'Mishnayot anchored to the daf on a segment range.',
+  },
+  'sefaria-topic': {
+    label: 'Topic', origin: 'sefaria', anchor: 'reference', defaultLevel: 'daf', cites: true,
+    notes: 'Sefaria topic tags + their cross-Shas sources — whole-daf reference.',
+  },
+  'dafyomi:insights': {
+    label: 'Insights', origin: 'dafyomi', anchor: 'ai', defaultLevel: 'daf',
+    notes: 'Kollel Iyun HaDaf insights — placed by the AI placer.',
+  },
+  'dafyomi:background': {
+    label: 'Background', origin: 'dafyomi', anchor: 'bg-term', defaultLevel: 'daf',
+    notes: 'Girsa variants + glossary terms; placed onto the segment that quotes the term.',
+  },
+  'dafyomi:halacha': {
+    label: 'Halacha', origin: 'dafyomi', anchor: 'ai', defaultLevel: 'daf', cites: true,
+    notes: 'Practical halachic rules (Gemara/Rishonim/Poskim).',
+  },
+  'dafyomi:tosfos': {
+    label: 'Tosafot explanation', origin: 'dafyomi', anchor: 'tosfos-dh', defaultLevel: 'amud',
+    notes: "The Kollel's explanation OF Tosafot; placed via the dibur-hamaschil → Sefaria pieceKey.",
+  },
+  'dafyomi:review': {
+    label: 'Review', origin: 'dafyomi', anchor: 'ai', defaultLevel: 'amud',
+    notes: 'Review questions for the amud.',
+  },
+  'dafyomi:points': {
+    label: 'Points', origin: 'dafyomi', anchor: 'ai', defaultLevel: 'amud',
+    notes: 'Key conceptual points for the amud.',
+  },
+  'dafyomi:hebcharts': {
+    label: 'Charts', origin: 'dafyomi', anchor: 'ai', defaultLevel: 'amud',
+    notes: 'Hebrew comparison tables; kept structured so the card renders a real table.',
+  },
+  'dafyomi:yerushalmi': {
+    label: 'Yerushalmi', origin: 'dafyomi', anchor: 'yerushalmi-text', defaultLevel: 'daf',
+    notes: 'Yerushalmi parallels; placed onto the Bavli segment sharing a verbatim phrase.',
+  },
+  'dafyomi:revach': {
+    label: "Revach l'Daf", origin: 'dafyomi', anchor: 'section', defaultLevel: 'daf', cites: true,
+    notes: "Revach l'Daf brief per-daf highlights; conservatively aligned to argument sections.",
+  },
+};
+
+/** Every declared source id, in registry order. */
+export const SOURCES = Object.keys(SOURCE_META) as ContextSource[];
+
+/** Canonical label for a source (the registry is the single source of truth). */
+export function sourceLabel(source: ContextSource): string {
+  return SOURCE_META[source].label;
+}

--- a/tests/context-sources.test.ts
+++ b/tests/context-sources.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import type { DafyomiDaf } from '../src/lib/sefref/dafyomi/schema';
+import { SOURCE_META, SOURCES, sourceLabel } from '../src/lib/context/sources';
+import { fromDafyomi } from '../src/lib/context/fromDafyomi';
+import {
+  fromCommentaryPieces, fromRishonim, fromHalachaRefs, fromMishna, fromTopics,
+} from '../src/lib/context/fromSefaria';
+
+/**
+ * The registry is the single source of truth for what sources exist. Exhaustive
+ * coverage over `ContextSource` is already enforced at compile time (SOURCE_META
+ * is a `Record<ContextSource, …>`); these tests guard the runtime side:
+ *   - the declared set doesn't silently drift, and
+ *   - every mapper emits sources/labels the registry knows about (so a source
+ *     can never reach the pool — and thus the alignment workbench — unregistered).
+ */
+describe('source registry', () => {
+  it('declares exactly the 15 known sources', () => {
+    expect([...SOURCES].sort()).toEqual([
+      'dafyomi:background', 'dafyomi:halacha', 'dafyomi:hebcharts', 'dafyomi:insights',
+      'dafyomi:points', 'dafyomi:revach', 'dafyomi:review', 'dafyomi:tosfos', 'dafyomi:yerushalmi',
+      'sefaria-halacha', 'sefaria-mishnah', 'sefaria-rashi', 'sefaria-rishonim', 'sefaria-topic', 'sefaria-tosafot',
+    ]);
+  });
+
+  it('every entry has a non-empty label + notes', () => {
+    for (const id of SOURCES) {
+      expect(SOURCE_META[id].label.length, id).toBeGreaterThan(0);
+      expect(SOURCE_META[id].notes.length, id).toBeGreaterThan(0);
+    }
+  });
+
+  it('labels are unique per origin group (Sefaria/dafyomi Halacha intentionally share)', () => {
+    // "Halacha" appears for both sefaria-halacha and dafyomi:halacha by design.
+    expect(sourceLabel('sefaria-halacha')).toBe('Halacha');
+    expect(sourceLabel('dafyomi:halacha')).toBe('Halacha');
+    expect(sourceLabel('dafyomi:tosfos')).toBe('Tosafot explanation');
+    expect(sourceLabel('sefaria-tosafot')).toBe('Tosafot');
+  });
+});
+
+describe('mappers stay inside the registry', () => {
+  const corpus = (): DafyomiDaf =>
+    JSON.parse(readFileSync(new URL('../static/dafyomi/Chullin/76.json', import.meta.url), 'utf-8'));
+
+  it('fromDafyomi: every item is a registered source with the registry label', () => {
+    for (const it of fromDafyomi(corpus())) {
+      expect(SOURCES, it.source).toContain(it.source);
+      expect(it.sourceLabel, it.source).toBe(sourceLabel(it.source));
+    }
+  });
+
+  it('fromSefaria mappers: every item is a registered source', () => {
+    const items = [
+      ...fromCommentaryPieces('rashi', { hebrew: '', english: '', pieces: ['a'], pieceKeys: ['1:1'] }),
+      ...fromCommentaryPieces('tosafot', { hebrew: '', english: '', pieces: ['b'], pieceKeys: ['1:1'] }),
+      ...fromRishonim([{ label: 'Rashba', ref: 'Rashba on Berakhot 2a', hebrew: 'x', english: 'y', segStart: 0, segEnd: 0 }]),
+      ...fromHalachaRefs({ 'Shulchan Arukh': [{ ref: 'SA OC 1:1', hebrew: 'h', english: 'e', segStart: 0, segEnd: 0 }] }),
+      ...fromMishna([{ ref: 'Mishnah Berakhot 1:1', hebrew: 'h', english: 'e', anchorStartSeg: 0, anchorEndSeg: 1 }]),
+      ...fromTopics([{ slug: 'shema', titleEn: 'Shema', titleHe: 'שמע', description: 'd', sources: [] }]),
+    ];
+    for (const it of items) expect(SOURCES, it.source).toContain(it.source);
+    // constant-label sources draw their label from the registry…
+    expect(items.find((i) => i.source === 'sefaria-mishnah')?.sourceLabel).toBe(sourceLabel('sefaria-mishnah'));
+    expect(items.find((i) => i.source === 'sefaria-topic')?.sourceLabel).toBe(sourceLabel('sefaria-topic'));
+    // …rishonim keeps the specific rishon's name as its per-item label (documented exception).
+    expect(items.find((i) => i.source === 'sefaria-rishonim')?.sourceLabel).toBe('Rashba');
+  });
+});


### PR DESCRIPTION
First step of the alignment-page redesign: a **source registry** so adding a context source is one declarative entry, and so nothing can reach the pool (and thus the alignment workbench) unregistered.

## What
- `src/lib/context/sources.ts` — `SOURCE_META: Record<ContextSource, SourceMeta>`, exhaustive over the `ContextSource` union (TypeScript refuses to compile if a source is missing or extra). Each entry declares `label`, `origin`, `anchor` strategy, `defaultLevel`, optional `cites`, and a one-line `notes`.
- Single source of truth for labels: `fromDafyomi` drops its local `SOURCE_LABEL` map; `fromSefaria`'s constant labels derive from the registry. `sefaria-rishonim` keeps its per-item rishon name (documented exception). No behaviour change — identical label strings.
- `tests/context-sources.test.ts` — guards the runtime side: the declared set of 15 doesn't drift, and every mapper (`fromDafyomi` over the `Chullin/76` fixture; `fromSefaria` mappers) emits only registered sources with the registry label.

## Why
The roadmap's DX/coverage goal: adding a source should be trivial and **impossible to forget to surface**. The exhaustive `Record` is the compile-time coverage guarantee; the test is the runtime belt-and-suspenders. This unblocks the alignment rebuild (render one row per *declared* source — an unwired source shows as "0 items", never silently absent) and the live coverage readout.

Pure refactor + additive test. `pnpm typecheck` clean; full suite 1802 passing.