### PR TITLE
Mobile: restore gutter marks (Layers sheet), fix Hebrew off-screen, i18n mode labels + hint copy

### DIFF
--- a/src/client/DafViewer.tsx
+++ b/src/client/DafViewer.tsx
@@ -989,6 +989,12 @@ export default function DafViewer(): JSX.Element {
     onCleanup(() => window.removeEventListener('scroll', onScroll));
   });
 
+  // Mobile "Layers" sheet — the annotation-layer toggles (MarksRegistryPanel)
+  // live in the desktop dev shelf, which is hidden on mobile; without this
+  // sheet a phone user has no way to turn gutter marks on. Dev tooling stays
+  // desktop-only, but the layer switches are a normal reader feature.
+  const [layersOpen, setLayersOpen] = createSignal(false);
+
   // Geography-driven highlight: when the user clicks a city/region on the
   // GeographyMap, we highlight every rabbi in the set across the whole daf,
   // not scoped to a single argument section.
@@ -3016,6 +3022,19 @@ export default function DafViewer(): JSX.Element {
               {t('header.dev')}
             </button>
           </Show>
+          {/* Mobile-only "Layers" entry point. The mark toggles live in the
+              desktop dev shelf (hidden on phones), so this opens a dedicated
+              sheet with just the annotation layers. */}
+          <Show when={isMobile()}>
+            <button
+              class="tb-toggle"
+              classList={{ 'is-active': layersOpen() }}
+              onClick={() => setLayersOpen((v) => !v)}
+              title={t('mobile.layers.title')}
+            >
+              {t('mobile.layers')}
+            </button>
+          </Show>
           {/* EN/HE language toggle, folded inline here on the daf page; the
               floating TopBar overlay covers the other routes (see App.tsx). */}
           <div class="tb-seg" role="group" aria-label="Language">
@@ -3249,6 +3268,7 @@ export default function DafViewer(): JSX.Element {
             onClose={clearActive}
             mobile={isMobile()}
             getAnchorRect={() => unionRectOf(a().els)}
+            maxWords={MAX_PHRASE_WORDS}
           />
         )}
       </Show>
@@ -3427,6 +3447,64 @@ export default function DafViewer(): JSX.Element {
           onOpenArgument={openArgument}
         />
       </Show>
+
+      {/* Mobile "Layers" sheet. MarksRegistryPanel must stay MOUNTED for its
+          extraction effects to drive the gutter (same reason DevModeShelf keeps
+          it mounted on desktop), so visibility is a CSS `display` toggle here,
+          NOT a <Show> around the panel. The backdrop is the only part gated by
+          <Show>. */}
+      <Show when={isMobile()}>
+        <Show when={layersOpen()}>
+          <div
+            onClick={() => setLayersOpen(false)}
+            style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.25)', 'z-index': 200 }}
+          />
+        </Show>
+        <div
+          style={{
+            position: 'fixed', left: 0, right: 0, bottom: 0,
+            'z-index': 201, 'max-height': '75vh',
+            background: '#fff',
+            'border-top': '1px solid #d6d3d1',
+            'border-top-left-radius': '12px',
+            'border-top-right-radius': '12px',
+            'box-shadow': '0 -6px 20px rgba(0, 0, 0, 0.14)',
+            display: layersOpen() ? 'flex' : 'none',
+            'flex-direction': 'column',
+          }}
+        >
+          <div style={{
+            display: 'flex', 'align-items': 'center', 'justify-content': 'space-between',
+            padding: '0.6rem 0.85rem', 'border-bottom': '1px solid #eee', 'flex-shrink': 0,
+          }}>
+            <span style={{ 'font-size': '0.8rem', color: '#666', 'text-transform': 'uppercase', 'letter-spacing': '0.05em' }}>
+              {t('mobile.layers.title')}
+            </span>
+            <button
+              type="button"
+              onClick={() => setLayersOpen(false)}
+              aria-label={t('mobile.layers.close')}
+              style={{ border: 'none', background: 'transparent', cursor: 'pointer', 'font-size': '1.1rem', padding: '0.25rem 0.5rem', color: '#666' }}
+            >
+              ✕
+            </button>
+          </div>
+          <div style={{ flex: 1, 'min-height': 0, overflow: 'auto', padding: '0.5rem 0.75rem' }}>
+            <MarksRegistryPanel
+              tractate={tractate()}
+              page={page()}
+              seedMarks={buildSeedMarks({
+                showGenMarkers, setShowGenMarkers,
+                showArguments, setShowArguments,
+                showHalachot, setShowHalachot,
+                showAggadatot, setShowAggadatot,
+                showPesukim, setShowPesukim,
+              })}
+            />
+          </div>
+        </div>
+      </Show>
+
       <Show when={!isMobile()}>
       <DevModeShelf open={devOpen()} onClose={() => { setDevOpen(false); setDevModeActive(false); }}>
         <ChecksPanel tractate={tractate()} page={page()} />

--- a/src/client/MobileShelf.tsx
+++ b/src/client/MobileShelf.tsx
@@ -1,5 +1,6 @@
 import { Show, type JSX } from 'solid-js';
 import DafLoadProgress from './DafLoadProgress';
+import { t } from './i18n';
 import { ArgumentSidebar, type SidebarContent } from './ArgumentSidebar';
 import type { ConceptTerm } from './conceptLinks';
 import type { GenerationId } from './generations';
@@ -72,9 +73,10 @@ export function MobileShelf(props: MobileShelfProps): JSX.Element {
   );
 }
 
-const MODE_BUTTONS: Array<{ id: MobileInteractionMode; label: string; hint: string }> = [
-  { id: 'read', label: 'Read', hint: 'Pan & zoom; tap icons to open' },
-  { id: 'translate', label: 'Translate', hint: 'Tap words to translate' },
+// Labels/hints resolve through t() per-render so they follow the EN/HE switch.
+const MODE_BUTTONS: Array<{ id: MobileInteractionMode; labelKey: string; hintKey: string }> = [
+  { id: 'read', labelKey: 'mobile.mode.read', hintKey: 'mobile.mode.read.hint' },
+  { id: 'translate', labelKey: 'mobile.mode.translate', hintKey: 'mobile.mode.translate.hint' },
 ];
 
 // Pinned interaction-mode pills. Stays at the bottom of the shelf regardless
@@ -94,7 +96,7 @@ function ModeBar(props: { mode: MobileInteractionMode; onModeChange: (m: MobileI
           type="button"
           onClick={() => props.onModeChange(b.id)}
           aria-pressed={props.mode === b.id}
-          title={b.hint}
+          title={t(b.hintKey)}
           style={{
             flex: 1,
             padding: '0.55rem 0.4rem',
@@ -107,7 +109,7 @@ function ModeBar(props: { mode: MobileInteractionMode; onModeChange: (m: MobileI
             'font-weight': props.mode === b.id ? 600 : 400,
           }}
         >
-          {b.label}
+          {t(b.labelKey)}
         </button>
       ))}
     </div>

--- a/src/client/TranslationPopup.tsx
+++ b/src/client/TranslationPopup.tsx
@@ -26,6 +26,8 @@ export interface TranslationPopupProps {
    *  mobile to re-measure after an auto-scroll (the static `anchor` goes stale
    *  once we scroll). Falls back to `anchor` when absent. */
   getAnchorRect?: () => Rect | null;
+  /** Max words a tap-to-extend region can span (mobile hint copy). */
+  maxWords?: number;
 }
 
 // Module-level cache so reopening the popup for a word we already translated
@@ -231,7 +233,7 @@ export function TranslationPopup(props: TranslationPopupProps): JSX.Element {
             'line-height': 1.35,
           }}
         >
-          {t('translation.mobileHint')}
+          {t('translation.mobileHint', { max: props.maxWords ?? 20 })}
         </div>
       </Show>
     </div>

--- a/src/client/i18n.ts
+++ b/src/client/i18n.ts
@@ -758,13 +758,22 @@ const CATALOG = {
   // — Translation popup —
   'translation.loading': { en: 'Translating…', he: 'מתרגם…' },
   'translation.mobileHint': {
-    en: 'Tap another word to extend · tap again to close',
-    he: 'הקישו על מילה נוספת להרחבה · הקישו שוב לסגירה',
+    en: 'Tap another word within {max} words to translate a region · tap again to close',
+    he: 'הקישו על מילה נוספת בטווח {max} מילים לתרגום קטע · הקישו שוב לסגירה',
   },
 
   // — Mobile top drawer (daf picker / nav) —
   'header.drawer.expand': { en: 'Menu ▾', he: 'תפריט ▾' },
   'header.drawer.collapse': { en: 'Hide ▴', he: 'הסתר ▴' },
+
+  // — Mobile interaction modes + layers —
+  'mobile.mode.read': { en: 'Read', he: 'קריאה' },
+  'mobile.mode.read.hint': { en: 'Pan & zoom; tap icons to open', he: 'גלילה וזום; הקישו על סמלים לפתיחה' },
+  'mobile.mode.translate': { en: 'Translate', he: 'תרגום' },
+  'mobile.mode.translate.hint': { en: 'Tap words to translate', he: 'הקישו על מילים לתרגום' },
+  'mobile.layers': { en: 'Layers', he: 'שכבות' },
+  'mobile.layers.title': { en: 'Annotation layers', he: 'שכבות ביאור' },
+  'mobile.layers.close': { en: 'Close', he: 'סגירה' },
 
   // — User highlights / notes —
   'highlight.action': { en: 'Highlight:', he: 'הדגשה:' },

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -420,6 +420,16 @@ body.dev-shelf-open .daf-page {
   min-width: 0;
 }
 
+/* The daf reading surface lays out by physical position (the Tzurat HaDaf is
+   an absolute-positioned, fit-to-width box) and the daf text carries its own
+   `--daf-direction`. When the UI language is Hebrew the page goes dir=rtl,
+   which would flip the surface's flex/overflow anchoring and shove the scaled
+   daf off-screen on mobile. Pin the surface to LTR so it positions identically
+   in both languages (matching how English mode already renders correctly). */
+.daf-surface {
+  direction: ltr;
+}
+
 /* Strips are NOT sticky — they flow with the page like the timeline and
    daf body. Only the right-side on-demand sidebar (.daf-aside) sticks. */
 .daf-strip {


### PR DESCRIPTION
Fixes the mobile gutter-marks regression from the previous pass, plus three follow-ups.

## Gutter marks gone on mobile — root cause + fix
The previous pass hid the dev panel on mobile by wrapping `DevModeShelf` in `<Show when={!isMobile()}>`. But `DevModeShelf` is the only host of `MarksRegistryPanel`, and that panel's `createEffect`s are what actually run mark extraction and populate `enabledMarkDefs` (which drives the gutter `<Show>`s). Unmounting it on mobile stopped extraction entirely — so no gutter icons.

Fix: mobile now has a dedicated **Layers** bottom sheet (opened from a new "Layers" button in the mobile top drawer) that hosts `MarksRegistryPanel`. Following the same rule `DevModeShelf` uses, the panel is kept **mounted** and toggled with CSS `display` (not `<Show>`), so extraction keeps running while the sheet is closed. Genuine dev tooling (Checks, Type Profiles, AI activity, pipeline) stays desktop-only.

## Hebrew pushes the daf off-screen
Switching the UI to Hebrew sets `document.documentElement.dir = 'rtl'`, which flipped the daf surface's flex `justify-content`/overflow anchoring and shoved the scaled daf off-screen on mobile. The daf is an absolute-positioned fit-to-width box and its text carries its own `--daf-direction`, so the surface itself should never be RTL — pinned `.daf-surface { direction: ltr; }`. It now lays out identically in both languages (matching how English already rendered).

## Read/Translate + Layers under i18n
The mobile mode pills were hardcoded English; they (and their tooltips) now resolve through `t()` and follow the EN/HE switch. Added Layers strings.

## Translation hint copy
Now reads "Tap another word within N words to translate a region · tap again to close", with N = the max phrase length passed from DafViewer.

## Verification
- `pnpm typecheck` clean
- `pnpm test` — 1806 passing
- `pnpm build` clean