### PR TITLE
API: GET /api/run-tree — read-only build-provenance DAG for a piece

### DIFF
--- a/src/lib/registry/depGraph.ts
+++ b/src/lib/registry/depGraph.ts
@@ -50,6 +50,40 @@ export function producerNodesFrom(
   }));
 }
 
+/** The forward dependency subgraph reachable from a root producer: the set of
+ *  node ids (producers AND source-input leaves) and the consumer→dependency
+ *  edges between them. A node reached through several parents appears ONCE in
+ *  `nodes` with one edge per parent — so the DAG's sharing (e.g. `gemara`
+ *  depended on by many) is preserved as fan-in, not duplicated. Edges are emitted
+ *  parent→child in discovery order; cycle-safe via the visited set. Pure. */
+export interface ForwardGraph {
+  nodes: string[];
+  edges: Array<[string, string]>;
+}
+export function forwardSubgraph(
+  nodes: ReadonlyArray<ProducerNode>,
+  rootId: string,
+): ForwardGraph {
+  const byId = new Map(nodes.map((n) => [n.id, n]));
+  const seen = new Set<string>();
+  const edges: Array<[string, string]> = [];
+  // DFS; sources (ids absent from byId) are visited as childless leaves so they
+  // land in `nodes` but contribute no edges of their own.
+  const stack = [rootId];
+  while (stack.length) {
+    const id = stack.pop()!;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    const node = byId.get(id);
+    if (!node) continue;
+    for (const dep of node.dependsOn) {
+      edges.push([id, dep]);
+      if (!seen.has(dep)) stack.push(dep);
+    }
+  }
+  return { nodes: [...seen], edges };
+}
+
 /** Invert the forward graph: map each id (producer OR source input) to the SET
  *  of producer ids that depend on it DIRECTLY. */
 export function reverseDependencyIndex(nodes: ReadonlyArray<ProducerNode>): Map<string, Set<string>> {

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -18,7 +18,7 @@ import { continuationLink, type FlowEdge } from '../lib/context/link';
 import { formatGroundedRefsForPrompt, buildDerivation } from '../lib/halacha/codifiers';
 import { dafSpine } from '../lib/context/spine';
 import { dafLinks } from '../lib/context/dafLinks';
-import { producerNodesFrom, reverseDependencyIndex, transitiveDependents } from '../lib/registry/depGraph';
+import { producerNodesFrom, reverseDependencyIndex, transitiveDependents, forwardSubgraph } from '../lib/registry/depGraph';
 import { aiMatchToSegments } from './context-match';
 import type { MatchInput } from '../lib/context/anchor/ai-prompt';
 import {
@@ -942,6 +942,106 @@ app.get('/api/dependents/:id', (c) => {
   const direct = [...(rev.get(id) ?? [])].sort();
   const transitive = [...transitiveDependents(rev, id)].sort();
   return c.json({ id, direct, transitive, count: transitive.length });
+});
+
+// Source-input dependency keys (resolved in resolveDep, not producers) — used to
+// classify a dependency id as a SOURCE leaf (fetched/assembled, no LLM) vs a
+// producer (mark/enrichment). Mirrors validateEnrichmentDependencies' allowlist.
+const SOURCE_DEP_KEYS = new Set([
+  'gemara', 'commentaries', 'mishna', 'context', 'context-light', 'halacha-refs', 'yerushalmi-text',
+]);
+
+// GET /api/run-tree/:tractate/:page/:id — the build PROVENANCE of one piece on
+// one daf, read-only. Walks the producer's forward dependency DAG (the same
+// `dependencies` the resolver follows) and, for each node, reads its ALREADY
+// CACHED RunResult to report how it was made: source vs LLM, model, cold
+// generation time, cost, tokens, and whether it's cached now. Shared nodes (e.g.
+// `gemara`, depended on across the chain) appear once with fan-in edges, and
+// their cost counts a single time in the totals. NO LLM, NO writes — a node with
+// nothing cached reports cached:false and null telemetry. The reader-facing
+// prompt + full generation per node stay lazy (the dev inspector fetches them
+// per-node via /api/run + /api/run-sources on expand), so this response is small.
+// Scope: whole-daf instances ({fields:{}}); section/global-instance trees are a
+// later extension. Public + read-only, like /api/dependents and /api/stale.
+app.get('/api/run-tree/:tractate/:page/:id', async (c) => {
+  const tractate = c.req.param('tractate');
+  const page = c.req.param('page');
+  const id = c.req.param('id');
+  const lang: 'en' | 'he' = c.req.query('lang') === 'he' ? 'he' : 'en';
+
+  const defs = [...CODE_MARKS, ...CODE_ENRICHMENTS];
+  const byId = new Map(defs.map((d) => [d.id, d]));
+  if (!byId.has(id)) return c.json({ error: 'unknown producer (mark/enrichment id)' }, 404);
+  const markIds = new Set(CODE_MARKS.map((m) => m.id));
+
+  const { nodes: nodeIds, edges } = forwardSubgraph(producerNodesFrom(defs), id);
+
+  interface TreeNode {
+    id: string; label: string;
+    kind: 'source' | 'llm' | 'computed';
+    producer?: 'mark' | 'enrichment';
+    model?: string;
+    cached: boolean;
+    cold_ms: number | null;
+    cost: number | null;
+    tokens: number | null;
+  }
+  const out: Record<string, TreeNode> = {};
+  let totalColdMs = 0, totalCost = 0, llmCount = 0, sourceCount = 0, cachedCount = 0;
+
+  for (const nid of nodeIds) {
+    const def = byId.get(nid);
+    if (!def) {
+      // a dependency id with no producer def: a source-input leaf (gemara /
+      // context / …). SOURCE_DEP_KEYS confirms it's a known input vs a dangling
+      // ref (validateProducerGraph guards against the latter in CI).
+      out[nid] = {
+        id: nid, label: nid, kind: 'source',
+        cached: SOURCE_DEP_KEYS.has(nid), cold_ms: null, cost: null, tokens: null,
+      };
+      sourceCount++;
+      continue;
+    }
+    const isMark = markIds.has(nid);
+    const ext = (def as { extractor?: { kind?: string; model?: string } }).extractor;
+    const isLLM = ext?.kind === 'llm';
+    const job = (isMark
+      ? { mark_id: nid, tractate, page, lang }
+      : { enrichment_id: nid, tractate, page, mark_input: { fields: {} }, lang }) as unknown as JobMessage;
+    const { key } = await cacheKeyForRunBody(c.env, job);
+    const res = key ? await readCachedResult(c.env, key) : null;
+    const usage = res?.usage as { cost?: number; total_tokens?: number } | undefined;
+    const coldMs = typeof res?.elapsed_ms === 'number' ? res.elapsed_ms : null;
+    const cost = typeof usage?.cost === 'number' ? usage.cost : null;
+    if (res) cachedCount++;
+    if (isLLM && res) { totalColdMs += coldMs ?? 0; totalCost += cost ?? 0; llmCount++; }
+    else if (!isLLM) sourceCount++;
+    out[nid] = {
+      id: nid,
+      label: (def as { label?: string }).label ?? nid,
+      kind: isLLM ? 'llm' : 'computed',
+      producer: isMark ? 'mark' : 'enrichment',
+      model: isLLM ? ext?.model : undefined,
+      cached: !!res,
+      cold_ms: coldMs,
+      cost,
+      tokens: typeof usage?.total_tokens === 'number' ? usage.total_tokens : null,
+    };
+  }
+
+  return c.json({
+    root: id, tractate, page, lang,
+    nodes: out,
+    edges,
+    totals: {
+      count: nodeIds.length,
+      llm: llmCount,
+      source: sourceCount,
+      cached: cachedCount,
+      cold_ms: totalColdMs,
+      cost: Number(totalCost.toFixed(6)),
+    },
+  });
 });
 
 // Entity pieces (step 5): a first-class, addressable view of a "global" entity

--- a/tests/dep-graph.test.ts
+++ b/tests/dep-graph.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
-  dependencyId, producerNodesFrom, reverseDependencyIndex, transitiveDependents,
+  dependencyId, producerNodesFrom, reverseDependencyIndex, transitiveDependents, forwardSubgraph,
 } from '../src/lib/registry/depGraph';
 
 describe('dependencyId — normalise a raw dependency to the id it points at', () => {
@@ -55,5 +55,36 @@ describe('reverse-dependency index + transitive dependents (the re-warm cascade)
       { id: 'b', dependsOn: ['a'] },
     ]);
     expect([...transitiveDependents(cyc, 'a')].sort()).toEqual(['a', 'b']);
+  });
+});
+
+describe('forwardSubgraph — the build-provenance DAG reachable from a root', () => {
+  // tidbit-shaped: a root over two producers that SHARE a leaf (gemara) and a
+  // mid producer (argument), plus a source the root pulls directly.
+  const nodes = producerNodesFrom([
+    { id: 'tidbit', dependencies: ['gemara', { mark: 'argument' }, { enrichment: 'overview' }] },
+    { id: 'overview', dependencies: ['gemara', { mark: 'argument' }] },
+    { id: 'argument', dependencies: ['gemara'] },
+  ]);
+
+  it('collects every reachable node once, including source leaves', () => {
+    const { nodes: ids } = forwardSubgraph(nodes, 'tidbit');
+    expect([...ids].sort()).toEqual(['argument', 'gemara', 'overview', 'tidbit']);
+  });
+
+  it('keeps a shared node single with one edge PER parent (fan-in, not duplication)', () => {
+    const { edges } = forwardSubgraph(nodes, 'tidbit');
+    // gemara is depended on by tidbit, overview, and argument — three edges, one node.
+    const gemaraEdges = edges.filter(([, b]) => b === 'gemara').map(([a]) => a).sort();
+    expect(gemaraEdges).toEqual(['argument', 'overview', 'tidbit']);
+    // argument is shared by tidbit + overview.
+    const argEdges = edges.filter(([, b]) => b === 'argument').map(([a]) => a).sort();
+    expect(argEdges).toEqual(['overview', 'tidbit']);
+  });
+
+  it('is cycle-safe and returns just the root when it has no dependencies', () => {
+    const cyc = producerNodesFrom([{ id: 'a', dependencies: [{ mark: 'b' }] }, { id: 'b', dependencies: [{ mark: 'a' }] }]);
+    expect(forwardSubgraph(cyc, 'a').nodes.sort()).toEqual(['a', 'b']);
+    expect(forwardSubgraph([{ id: 'leaf', dependsOn: [] }], 'leaf')).toEqual({ nodes: ['leaf'], edges: [] });
   });
 });


### PR DESCRIPTION
Adds a read-only endpoint that returns the full **build provenance** of one piece on one daf: the dependency DAG plus per-node telemetry, for the dev inspector (and anything else that wants to see how a piece was made).

## What it does
`GET /api/run-tree/:tractate/:page/:id[?lang=he]` walks the producer's forward dependency graph — the same `dependencies` the resolver follows — and for each node reads its **already-cached** `RunResult` to report:

- **kind**: `source` (gemara/context/… — fetched, no LLM, no cost) vs `llm` (mark/enrichment) vs `computed`
- **model**, **cold_ms** (generation time), **cost**, **tokens**, **cached** (present in KV now)
- **edges**: consumer→dependency; a shared node (e.g. `gemara`, depended on across the chain) appears **once** with one edge per parent (fan-in, not duplication), and its cost counts a single time in `totals`

`tidbit.essay` is the deep example: gemara + context-light + 6 marks + 2 enrichments, those enrichments over more marks/sources — the whole chain resolved into one response.

## Properties
- **Read-only**: no LLM, no cache writes. A node with nothing cached reports `cached:false` and null telemetry.
- **Small response**: prompts + full generation stay lazy (the inspector fetches them per-node via the existing `/api/run` + `/api/run-sources` on expand).
- Public, like `/api/dependents` and `/api/stale`.
- Scope: whole-daf instances (`{fields:{}}`); section/global-instance trees are a later extension (documented inline).

## Implementation
- New pure `forwardSubgraph(nodes, rootId)` in `src/lib/registry/depGraph.ts` (reachable subgraph + fan-in edges, cycle-safe) with unit tests.
- The route reuses existing machinery: `producerNodesFrom`, `cacheKeyForRunBody`, `readCachedResult`.

`pnpm typecheck` + `pnpm test` green (1814 tests; +3 new for forwardSubgraph).