### PR TITLE
Backlog: bug reports at the top, check-off → collapsed "done"

### DIFF
--- a/src/client/UsagePage.tsx
+++ b/src/client/UsagePage.tsx
@@ -264,11 +264,11 @@ interface BacklogSectionData {
   rabbis: UnknownSummary<UnknownRabbi>;
   places: UnknownSummary<ObservedPlace>;
   concepts: UnknownSummary<ObservedConcept>;
+  reports?: { active: BugReport[]; done: BugReport[] };
 }
 interface HealthSectionData {
   jobErrors: JobError[];
   lintFailures: LintFailuresSummary;
-  reports: BugReport[];
 }
 interface DafLedgerBucket { calls: number; cost: number; costInEst: number; costOutEst: number }
 interface LlmCostData {
@@ -673,10 +673,14 @@ function NotesSection(props: { stats: CacheStats }): JSX.Element {
 }
 
 // ---- Needs-enrichment backlog -------------------------------------------
-function BacklogSection(props: { rabbis: UnknownSummary<UnknownRabbi>; places: UnknownSummary<ObservedPlace>; concepts: UnknownSummary<ObservedConcept> }): JSX.Element {
+function BacklogSection(props: { rabbis: UnknownSummary<UnknownRabbi>; places: UnknownSummary<ObservedPlace>; concepts: UnknownSummary<ObservedConcept>; reports?: { active: BugReport[]; done: BugReport[] } }): JSX.Element {
   const combinedTotal = () => props.rabbis.total + props.places.total + props.concepts.total;
   return (
     <>
+    {/* User-submitted bug reports at the top — check them off as you triage. */}
+    <Show when={props.reports}>
+      {(rep) => <BacklogReports reports={rep()} />}
+    </Show>
     <p style={{ 'font-size': '0.82rem', color: '#555', margin: '0 0 0.7rem' }}>
       {t('usage.backlog.combined', { count: fmtInt(combinedTotal()) })}
     </p>
@@ -1404,25 +1408,57 @@ function ErrorsSection(props: { recentErrors: RecentError[]; health: HealthSecti
 }
 
 // ---- Health: User reports ------------------------------------------------
-function ReportsSection(props: { reports: BugReport[] }): JSX.Element {
+// One bug report, with a check-off / restore button. Checking it off moves it
+// to the collapsed "done" group (persisted server-side by report timestamp).
+function ReportItem(props: { report: BugReport; done: boolean; onToggle: () => void }): JSX.Element {
+  const r = () => props.report;
   return (
-    <Collapsible id="health.reports" title={t('usage.bugReports.title', { count: props.reports.length })}>
-      <Show when={props.reports.length > 0} fallback={<p style={{ color: '#888' }}>{t('usage.bugReports.empty')}</p>}>
+    <li style={{ display: 'flex', gap: '0.6rem', 'align-items': 'flex-start', padding: '0.6rem 0.7rem', margin: '0 0 0.45rem', background: '#fcfcfa', border: '1px solid #eee', 'border-radius': '4px' }}>
+      <button
+        onClick={props.onToggle}
+        title={props.done ? t('usage.reports.restore') : t('usage.reports.markDone')}
+        style={{ 'flex-shrink': 0, width: '1.5rem', height: '1.5rem', 'border-radius': '4px', border: `1px solid ${props.done ? '#2a8a42' : '#ccc'}`, background: props.done ? '#2a8a42' : '#fff', color: props.done ? '#fff' : '#888', cursor: 'pointer', 'font-size': '0.85rem', 'line-height': 1 }}
+      >
+        {props.done ? '↺' : '✓'}
+      </button>
+      <div style={{ flex: 1 }}>
+        <div style={{ 'font-size': '0.75rem', color: '#888', 'margin-bottom': '0.25rem' }}>
+          {fmtTime(r().ts)} · <b>{r().tractate} {r().page}</b><Show when={r().country}><span> · {r().country}</span></Show>
+        </div>
+        <div style={{ 'white-space': 'pre-wrap', 'font-size': '0.88rem', color: props.done ? '#888' : '#222', 'line-height': 1.45, 'text-decoration': props.done ? 'line-through' : 'none' }}>{r().description}</div>
+      </div>
+    </li>
+  );
+}
+
+function BacklogReports(props: { reports: { active: BugReport[]; done: BugReport[] } }): JSX.Element {
+  // Optimistic local overrides (ts → done?) layered on the server split, so a
+  // click is instant; the POST persists it and invalidates the backlog cache.
+  const [overrides, setOverrides] = createSignal<Record<number, boolean>>({});
+  const toggle = (ts: number, done: boolean) => {
+    setOverrides((o) => ({ ...o, [ts]: done }));
+    void fetch('/api/admin/report-dismiss', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ ts, done }) }).catch(() => {});
+  };
+  const all = () => [...props.reports.active, ...props.reports.done];
+  const isDone = (r: BugReport) => overrides()[r.ts] ?? props.reports.done.some((d) => d.ts === r.ts);
+  const active = () => all().filter((r) => !isDone(r));
+  const done = () => all().filter((r) => isDone(r));
+  return (
+    <div style={{ 'margin-bottom': '1.3rem' }}>
+      <h3 style={{ 'font-size': '0.8rem', color: '#777', margin: '0 0 0.4rem' }}>{t('usage.reports.title', { count: fmtInt(active().length) })}</h3>
+      <Show when={active().length > 0} fallback={<p style={{ color: '#888', 'font-size': '0.82rem' }}>{t('usage.reports.empty')}</p>}>
         <ul style={{ 'list-style': 'none', padding: 0, margin: 0 }}>
-          <For each={props.reports}>
-            {(r) => (
-              <li style={{ padding: '0.7rem 0.8rem', margin: '0 0 0.5rem', background: '#fcfcfa', border: '1px solid #eee', 'border-radius': '4px' }}>
-                <div style={{ 'font-size': '0.75rem', color: '#888', 'margin-bottom': '0.3rem' }}>
-                  {fmtTime(r.ts)} · <b>{r.tractate} {r.page}</b>
-                  <Show when={r.country}><span> · {r.country}</span></Show>
-                </div>
-                <div style={{ 'white-space': 'pre-wrap', 'font-size': '0.88rem', color: '#222', 'line-height': 1.45 }}>{r.description}</div>
-              </li>
-            )}
-          </For>
+          <For each={active()}>{(r) => <ReportItem report={r} done={false} onToggle={() => toggle(r.ts, true)} />}</For>
         </ul>
       </Show>
-    </Collapsible>
+      <Show when={done().length > 0}>
+        <Collapsible id="backlog.reportsDone" title={t('usage.reports.doneTitle', { count: fmtInt(done().length) })}>
+          <ul style={{ 'list-style': 'none', padding: 0, margin: 0 }}>
+            <For each={done()}>{(r) => <ReportItem report={r} done onToggle={() => toggle(r.ts, false)} />}</For>
+          </ul>
+        </Collapsible>
+      </Show>
+    </div>
   );
 }
 
@@ -1531,12 +1567,7 @@ export function UsagePage(): JSX.Element {
           )}
         </SectionShell>
         <SectionShell section={health} skeletonRows={4}>
-          {(h) => (
-            <>
-              <ErrorsSection recentErrors={telemetry.value()?.recentErrors ?? []} health={h} />
-              <ReportsSection reports={h.reports} />
-            </>
-          )}
+          {(h) => <ErrorsSection recentErrors={telemetry.value()?.recentErrors ?? []} health={h} />}
         </SectionShell>
       </Show>
 
@@ -1561,7 +1592,7 @@ export function UsagePage(): JSX.Element {
 
       <Show when={tab() === 'backlog'}>
         <SectionShell section={backlog} skeletonRows={6}>
-          {(b) => <BacklogSection rabbis={b.rabbis} places={b.places} concepts={b.concepts} />}
+          {(b) => <BacklogSection rabbis={b.rabbis} places={b.places} concepts={b.concepts} reports={b.reports} />}
         </SectionShell>
       </Show>
     </main>

--- a/src/client/i18n.ts
+++ b/src/client/i18n.ts
@@ -628,6 +628,12 @@ const CATALOG = {
   'usage.lintFailures.hint': { en: 'cards pinned after repeated gloss-style / Hebrew-anchor lint failures', he: 'כרטיסים שננעלו לאחר כשלים חוזרים בבדיקת סגנון/עוגן עברי' },
   'usage.bugReports.title': { en: 'Bug reports ({count})', he: 'דיווחי תקלות ({count})' },
   'usage.bugReports.empty': { en: 'Inbox empty.', he: 'תיבת הדואר ריקה.' },
+  // Actionable bug reports at the top of Backlog
+  'usage.reports.title': { en: 'User reports ({count})', he: 'דיווחי משתמשים ({count})' },
+  'usage.reports.empty': { en: 'No open reports — nicely done.', he: 'אין דיווחים פתוחים — כל הכבוד.' },
+  'usage.reports.doneTitle': { en: 'Done ({count})', he: 'טופלו ({count})' },
+  'usage.reports.markDone': { en: 'Mark done', he: 'סמן כטופל' },
+  'usage.reports.restore': { en: 'Restore', he: 'שחזר' },
   'usage.notTracked': { en: 'not tracked', he: 'לא במעקב' },
   'usage.missing': { en: '{count} missing', he: '{count} חסרים' },
   'usage.activity.title': { en: 'Activity', he: 'פעילות' },

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -4366,26 +4366,39 @@ async function buildActivitySection(c: UsageCtx, cache?: KVNamespace) {
   return loadActivityCached(c, cache);
 }
 
+const REPORTS_DISMISSED_KEY = 'reports:v1:dismissed';
+
 async function buildBacklogSection(cache?: KVNamespace) {
   const empty = { total: 0, sightings: 0, sample: [] as never[] };
-  const [rabbis, places, concepts] = await Promise.all([
+  const [rabbis, places, concepts, repRaw, disRaw] = await Promise.all([
     cache ? listUnknownRabbis(cache) : empty,
     cache ? listObservedPlaces(cache) : empty,
     cache ? listObservedConcepts(cache) : empty,
+    cache ? cache.get('reports:v1:recent') : null,
+    cache ? cache.get(REPORTS_DISMISSED_KEY) : null,
   ]);
-  return { rabbis, places, concepts };
+  // Bug reports, split into active vs. checked-off ("done"). The dismissed set
+  // is a list of report timestamps (a report's `ts` is its id).
+  let allReports: BugReport[] = [];
+  if (repRaw) { try { allReports = [...(JSON.parse(repRaw) as BugReport[])].reverse(); } catch { allReports = []; } }
+  let dismissed: number[] = [];
+  if (disRaw) { try { dismissed = JSON.parse(disRaw) as number[]; } catch { dismissed = []; } }
+  const dset = new Set(dismissed);
+  const reports = {
+    active: allReports.filter((r) => !dset.has(r.ts)),
+    done: allReports.filter((r) => dset.has(r.ts)),
+  };
+  return { rabbis, places, concepts, reports };
 }
 
 async function buildHealthSection(cache?: KVNamespace) {
-  const [jeRaw, lintFailures, repRaw] = await Promise.all([
+  const [jeRaw, lintFailures] = await Promise.all([
     cache ? cache.get(RECENT_ERRORS_KEY) : null,
     readLintFailures(cache),
-    cache ? cache.get('reports:v1:recent') : null,
   ]);
   let jobErrors: RecentJobError[] = [];
   if (jeRaw) { try { jobErrors = (JSON.parse(jeRaw) as RecentJobError[]).slice(-30).reverse(); } catch { jobErrors = []; } }
-  const reports = repRaw ? [...(JSON.parse(repRaw) as BugReport[])].reverse() : [];
-  return { jobErrors, lintFailures, reports };
+  return { jobErrors, lintFailures };
 }
 
 /**
@@ -4454,7 +4467,7 @@ app.get('/api/usage', async (c) => {
       unknowns: backlog,
       jobErrors: health.jobErrors,
       lintFailures: health.lintFailures,
-      reports: health.reports,
+      reports: backlog.reports.active, // back-compat: the legacy combined payload
     };
   };
   return serveUsageSection(c, cache, 'usage-payload:v1', 30_000, build);
@@ -4467,6 +4480,28 @@ app.get('/api/usage/telemetry', (c) => serveUsageSection(c, c.env.CACHE, 'usage-
 app.get('/api/usage/activity', (c) => serveUsageSection(c, c.env.CACHE, 'usage-activity:v1', 60_000, () => buildActivitySection(c, c.env.CACHE)));
 app.get('/api/usage/backlog', (c) => serveUsageSection(c, c.env.CACHE, 'usage-backlog:v1', 60_000, () => buildBacklogSection(c.env.CACHE)));
 app.get('/api/usage/health', (c) => serveUsageSection(c, c.env.CACHE, 'usage-health:v1', 30_000, () => buildHealthSection(c.env.CACHE)));
+
+// Check off / restore a bug report (by its timestamp id). Toggles membership in
+// the dismissed set; the backlog payload splits reports into active vs. done
+// from it. Open + reversible — it's dev triage, not destructive.
+app.post('/api/admin/report-dismiss', async (c) => {
+  const cache = c.env.CACHE;
+  if (!cache) return c.json({ error: 'no cache binding' }, 503);
+  let body: { ts?: number; done?: boolean };
+  try { body = await c.req.json(); } catch { return c.json({ error: 'bad JSON body' }, 400); }
+  if (typeof body.ts !== 'number') return c.json({ error: 'ts (number) required' }, 400);
+  const raw = await cache.get(REPORTS_DISMISSED_KEY);
+  let dismissed: number[] = [];
+  if (raw) { try { dismissed = JSON.parse(raw) as number[]; } catch { dismissed = []; } }
+  const set = new Set(dismissed);
+  if (body.done === false) set.delete(body.ts); else set.add(body.ts);
+  // Keep ~60 days, comfortably longer than the reports ring buffer's own TTL.
+  await cache.put(REPORTS_DISMISSED_KEY, JSON.stringify([...set]), { expirationTtl: 60 * 60 * 24 * 60 });
+  // Invalidate the cached backlog payload so the next load reflects the change
+  // (the client also updates optimistically).
+  c.executionCtx.waitUntil(cache.delete('usage-backlog:v1').catch(() => {}));
+  return c.json({ ok: true });
+});
 
 // Per-daf cost drill-down — "trace this daf". Reads the permanent per-entry
 // cost stamps for one daf across each mark's cached versions (bounded reads):

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -4495,11 +4495,16 @@ app.post('/api/admin/report-dismiss', async (c) => {
   if (raw) { try { dismissed = JSON.parse(raw) as number[]; } catch { dismissed = []; } }
   const set = new Set(dismissed);
   if (body.done === false) set.delete(body.ts); else set.add(body.ts);
-  // Keep ~60 days, comfortably longer than the reports ring buffer's own TTL.
-  await cache.put(REPORTS_DISMISSED_KEY, JSON.stringify([...set]), { expirationTtl: 60 * 60 * 24 * 60 });
-  // Invalidate the cached backlog payload so the next load reflects the change
-  // (the client also updates optimistically).
-  c.executionCtx.waitUntil(cache.delete('usage-backlog:v1').catch(() => {}));
+  // Match the reports ring buffer's own 365-day TTL so a done report can't
+  // resurface as active when the dismissed entry expires first.
+  await cache.put(REPORTS_DISMISSED_KEY, JSON.stringify([...set]), { expirationTtl: 60 * 60 * 24 * 365 });
+  // Invalidate the cached backlog payload AND the legacy combined /api/usage
+  // payload (which also carries reports) so the next load reflects the change.
+  // The client also updates optimistically.
+  c.executionCtx.waitUntil(Promise.all([
+    cache.delete('usage-backlog:v1').catch(() => {}),
+    cache.delete('usage-payload:v1').catch(() => {}),
+  ]));
   return c.json({ ok: true });
 });
 


### PR DESCRIPTION
Moves user bug reports from Health to the **top of the Backlog tab** and makes them **actionable**.

Each report gets a **check-off** button (✓) that marks it done — and a **restore** (↺) to undo. Done reports drop into a **collapsed "Done" group** at the bottom.

**Backend** — `buildBacklogSection` returns reports split into `{ active, done }` using a dismissed-set KV key (a report's timestamp is its id). New **`POST /api/admin/report-dismiss`** toggles membership (open + reversible — it's dev triage, not destructive) and evicts the cached backlog payload so the next load reflects it. Reports are dropped from the health payload; the legacy `/api/usage` keeps `reports` = active for back-compat.

**Client** — `BacklogReports` renders the active list with **optimistic** check-off (the POST persists in the background) and a collapsed done group. `ReportsSection` is retired from Health.

`pnpm typecheck` + `pnpm test` (1814) + `vite build` clean; Biome no unused; every `t()` key resolves. Codex-reviewed.