### PR TITLE
Worker: extract types + telemetry + commentary from index.ts

### DIFF
--- a/src/worker/commentary.ts
+++ b/src/worker/commentary.ts
@@ -1,0 +1,229 @@
+// Commentary works for a daf (Sefaria links, grouped by work) + on-demand
+// translation of a single comment. Extracted from index.ts as the first
+// route-slice: registerCommentaryRoutes(app) wires the two endpoints, and
+// fetchCommentaryWorks is re-exported for the other in-file callers.
+
+import { Hono } from 'hono';
+import type { Bindings } from './types';
+import { runLLM, type LLMModelId } from './llm';
+import { getSefariaSegmentsCached } from './source-cache';
+import { keyForCommentaryWorks, keyForCommentaryText } from './cache-keys';
+import { recordTelemetry, classifyError } from './telemetry';
+
+interface CommentaryComment {
+  anchorRef: string;                // e.g. "Berakhot 5a:3" or "Berakhot 5a:3:1-4"
+  anchorSegIdx: number;             // zero-based index into Sefaria segments
+  sourceRef: string;                // commentary's own ref, e.g. "Ramban on Berakhot 5a:3:1"
+  textHe: string;
+  textEn: string;
+}
+
+interface CommentaryWork {
+  title: string;
+  titleHe: string;
+  count: number;
+  comments: CommentaryComment[];
+}
+
+/** Parse the first segment number out of a Sefaria ref like "Berakhot 5a:3"
+ *  or "Berakhot 5a:3:1-4". Returns zero-based index, or -1 if unparseable. */
+function parseAnchorSegment(anchorRef: string): number {
+  const m = anchorRef.match(/:(\d+)/);
+  if (!m) return -1;
+  const n = parseInt(m[1], 10);
+  return Number.isFinite(n) && n > 0 ? n - 1 : -1;
+}
+
+// (Rashi / Tosafot are rendered inline on the daf, but we STILL surface them
+// in the picker — selecting them highlights the main-text segments they
+// anchor to, and clicking a segment also highlights the gloss in the inner
+// or outer column. So no work titles are filtered here.)
+
+/** Shared fetch — returns the grouped commentary works for a daf. Cached.
+ *  Used by both /api/commentaries (legacy endpoint) and the `commentary`
+ *  mark/enrichment path. */
+export async function fetchCommentaryWorks(
+  env: Bindings,
+  tractate: string,
+  page: string,
+  bypassCache = false,
+): Promise<{ works: CommentaryWork[]; tractate: string; page: string; fetchedAt: string } | { error: string }> {
+  const cache = env.CACHE;
+  const cacheKey = keyForCommentaryWorks(tractate, page);
+  if (cache && !bypassCache) {
+    const hit = await cache.get(cacheKey);
+    if (hit !== null) {
+      try { return JSON.parse(hit) as { works: CommentaryWork[]; tractate: string; page: string; fetchedAt: string }; }
+      catch { /* fall through to refetch */ }
+    }
+  }
+  const ref = `${tractate} ${page}`;
+  const url = `https://www.sefaria.org/api/links/${encodeURIComponent(ref)}?with_text=1`;
+  let res: Response;
+  try {
+    res = await fetch(url, { headers: { accept: 'application/json' } });
+  } catch (err) {
+    return { error: String(err) };
+  }
+  if (!res.ok) return { error: `Sefaria ${res.status}` };
+
+  const raw = (await res.json()) as Array<{
+    ref?: string;
+    sourceRef?: string;
+    anchorRef?: string;
+    category?: string;
+    collectiveTitle?: { en?: string; he?: string };
+    index_title?: string;
+    he?: string | string[];
+    text?: string | string[];
+  }>;
+
+  const joinText = (x: string | string[] | undefined): string => {
+    if (!x) return '';
+    if (Array.isArray(x)) return x.map((t) => String(t ?? '')).join(' ').trim();
+    return String(x).trim();
+  };
+
+  const byWork = new Map<string, CommentaryWork>();
+  for (const l of raw) {
+    if (l.category !== 'Commentary') continue;
+    const title = l.collectiveTitle?.en ?? l.index_title ?? 'Unknown';
+    const titleHe = l.collectiveTitle?.he ?? '';
+    const anchorRef = l.anchorRef ?? '';
+    const anchorSegIdx = parseAnchorSegment(anchorRef);
+    if (anchorSegIdx < 0) continue;
+    const comment: CommentaryComment = {
+      anchorRef,
+      anchorSegIdx,
+      sourceRef: l.sourceRef ?? l.ref ?? '',
+      textHe: joinText(l.he),
+      textEn: joinText(l.text),
+    };
+    let work = byWork.get(title);
+    if (!work) {
+      work = { title, titleHe, count: 0, comments: [] };
+      byWork.set(title, work);
+    }
+    work.comments.push(comment);
+    work.count++;
+  }
+  // Sort works by count desc so popular ones (Meiri, Ramban, Rashba…) lead.
+  const works = Array.from(byWork.values()).sort((a, b) => b.count - a.count);
+
+  const payload = { works, tractate, page, fetchedAt: new Date().toISOString() };
+  if (cache) {
+    await cache.put(cacheKey, JSON.stringify(payload), { expirationTtl: 60 * 60 * 24 * 30 });
+  }
+  return payload;
+}
+
+// --- Commentary translation ----------------------------------------------
+// On-demand English translation of a single commentary comment (used when
+// Sefaria has no `text` for it, which is common for Rishonim). Kimi K2.5 is
+// the primary translator (no thinking, fast); Gemma-4 26B is the fallback.
+// Results are cached forever per Sefaria sourceRef.
+
+interface CommentaryTranslateBody {
+  sourceRef: string;
+  textHe: string;
+  tractate?: string;
+  page?: string;
+  anchorSegIdx?: number;
+}
+
+const COMMENTARY_TX_SYSTEM =
+  'You are a scholarly translator of rabbinic commentary on the Talmud. Translate the given Hebrew/Aramaic commentary text into clear, accurate English. ' +
+  'Output ONLY the translation — no preamble, no explanation, no quotation marks around the whole thing. ' +
+  'Match the register of standard academic Talmud editions (Soncino / Koren-Steinsaltz). Preserve technical terminology where standard ("Mishnah", "Gemara", "Tanna"). ' +
+  'The commentary glosses a specific passage of the daf — use the provided source segment to anchor pronouns and references, but translate the commentary (not the source).';
+
+/** Register the commentary routes on the worker app. */
+export function registerCommentaryRoutes(app: Hono<{ Bindings: Bindings }>): void {
+  app.get('/api/commentaries/:tractate/:page', async (c) => {
+    const tractate = c.req.param('tractate');
+    const page = c.req.param('page');
+    const bypassCache = c.req.query('refresh') === '1';
+    const result = await fetchCommentaryWorks(c.env, tractate, page, bypassCache);
+    if ('error' in result) return c.json(result, 502);
+    return c.json({ ...result, _cached: !bypassCache });
+  });
+
+  app.post('/api/commentary-translate', async (c) => {
+    let body: CommentaryTranslateBody;
+    try { body = await c.req.json<CommentaryTranslateBody>(); }
+    catch { return c.json({ error: 'Invalid JSON body' }, 400); }
+
+    const sourceRef = (body.sourceRef ?? '').trim();
+    const textHe = (body.textHe ?? '').trim();
+    if (!sourceRef || !textHe) return c.json({ error: 'Missing sourceRef or textHe' }, 400);
+
+    const cache = c.env.CACHE;
+    const cacheKey = keyForCommentaryText(sourceRef);
+    const t0 = Date.now();
+    if (cache) {
+      const cached = await cache.get(cacheKey);
+      if (cached !== null) {
+        return c.json({ translation: cached, cached: true });
+      }
+    }
+    if (!c.env.AI) return c.json({ error: 'AI binding not available' }, 503);
+
+    // Pull the matching daf segment as bilingual anchor context.
+    let segHe = '';
+    let segEn = '';
+    if (body.tractate && body.page && typeof body.anchorSegIdx === 'number') {
+      const segments = await getSefariaSegmentsCached(cache, body.tractate, body.page);
+      if (segments && body.anchorSegIdx >= 0 && body.anchorSegIdx < segments.he.length) {
+        segHe = segments.he[body.anchorSegIdx] ?? '';
+        segEn = segments.en[body.anchorSegIdx] ?? '';
+      }
+    }
+
+    // Strip HTML from the commentary text (Sefaria sometimes embeds <b>/<i>).
+    const cleanHe = textHe.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+
+    const userParts: string[] = [];
+    if (segHe) {
+      userParts.push(
+        `Daf segment this commentary anchors to:\nHebrew/Aramaic: ${segHe}` +
+        (segEn ? `\nEnglish: ${segEn}` : ''),
+      );
+    }
+    userParts.push(`Commentary source: ${sourceRef}`);
+    userParts.push(`Commentary text (translate this):\n${cleanHe}`);
+
+    const models: Array<{ id: LLMModelId; label: string }> = [
+      { id: '@cf/moonshotai/kimi-k2.5',        label: 'kimi-k2.5'   },
+      { id: '@cf/google/gemma-4-26b-a4b-it',   label: 'gemma-4-26b' },
+    ];
+
+    const attempts: string[] = [];
+    for (const m of models) {
+      try {
+        const r = await runLLM(c.env, {
+          model: m.id,
+          messages: [
+            { role: 'system', content: COMMENTARY_TX_SYSTEM },
+            { role: 'user', content: userParts.join('\n\n') },
+          ],
+          max_tokens: 800,
+          temperature: 0.2,
+          thinking: false,
+          tag: 'commentary-translate',
+          attribution: { kind: 'translate', ...(body.tractate && body.page ? { tractate: body.tractate, page: body.page } : {}) },
+        });
+        const translation = r.content.trim().replace(/^["\']|["\']$/g, '');
+        if (!translation) { attempts.push(`${m.label}: empty`); continue; }
+        if (cache) {
+          await cache.put(cacheKey, translation, { expirationTtl: 60 * 60 * 24 * 365 });
+        }
+        recordTelemetry(c, { endpoint: 'translate', tractate: body.tractate, page: body.page, cache_hit: false, model: m.label, ms: Date.now() - t0, ok: true });
+        return c.json({ translation, cached: false, _model: m.label });
+      } catch (err) {
+        attempts.push(`${m.label}: ${String(err).slice(0, 200)}`);
+      }
+    }
+    recordTelemetry(c, { endpoint: 'translate', tractate: body.tractate, page: body.page, cache_hit: false, ms: Date.now() - t0, ok: false, error_kind: classifyError(attempts.join(' ')) });
+    return c.json({ error: 'All translation models failed', attempts }, 502);
+  });
+}

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -10,6 +10,9 @@ import {
 import { getDafyomiMasechet } from '../lib/sefref/dafyomi/masechtos';
 import { collectContext } from './context-providers';
 import { readJsonBody, getRabbiEntryOr404 } from './http-helpers';
+import type { Bindings, JobMessage } from './types';
+import { recordTelemetry, runTelemetryRec, classifyError, type TelemetryRecord } from './telemetry';
+import { fetchCommentaryWorks, registerCommentaryRoutes } from './commentary';
 import { curatedParallelsForDaf, type CuratedYerushalmiParallel } from '../lib/yerushalmiParallels';
 import { flattenYerushalmiOutline, alignOutlineToSegments, yerushalmiFloorGroups, type YerushalmiFloorGroup } from '../lib/yerushalmiAlign';
 import { placeRevachWithAi } from './revach-ai-place';
@@ -43,7 +46,6 @@ import {
   getWarmTotal,
   readSefariaWarmCursor,
   sefariaWarmProgressProcessed,
-  type EmailBinding,
 } from './warm-cron';
 import { runBacklogBackfill } from './backfill-backlog';
 import {
@@ -127,8 +129,6 @@ import {
   keyForAnalyzeSkeleton,
   keyForRegion,
   keyForMesorah,
-  keyForCommentaryWorks,
-  keyForCommentaryText,
   keyForReferences,
   keyForBridge,
   keyForPasuk,
@@ -179,82 +179,9 @@ interface RabbiPlacesFile {
 }
 const RABBI_PLACES = rabbiPlacesData as unknown as RabbiPlacesFile;
 
-interface Bindings {
-  ASSETS: Fetcher;
-  AI?: Ai;
-  CACHE?: KVNamespace;
-  EMAIL?: EmailBinding;
-  // AI Gateway routing (see src/worker/ai-gateway.ts).
-  AI_GATEWAY_ID?: string;
-  AI_GATEWAY_DISABLE?: string;
-  // OpenRouter via AI Gateway Universal Endpoint (see src/worker/llm.ts).
-  OPENROUTER_API_KEY?: string;
-  CLOUDFLARE_ACCOUNT_ID?: string;
-  // Cloudflare API token (Account Analytics: Read) for the AI Gateway cost
-  // query in aigw-analytics.ts. Set via `wrangler secret put CF_ANALYTICS_TOKEN`.
-  CF_ANALYTICS_TOKEN?: string;
-  OPENROUTER_GATEWAY_PROVIDER?: string;
-  DEFAULT_LLM_MODEL?: string;
-  // Enrichment job queue — see wrangler.toml + queue handler at the bottom
-  // of this file. /api/run enqueues a JobMessage; the queue consumer
-  // runs the LLM chain and writes the result to KV under `job:{runId}`.
-  ENRICHMENT_QUEUE?: Queue<JobMessage>;
-  // When '1', the background Sefaria Shas walk also enqueues rabbi.observations
-  // per amud (full reverse-index backfill). OFF by default — see WarmEnv.
-  OBSERVATIONS_WARM_SHAS?: string;
-  // Dynamic Worker Loader binding (wrangler.toml `worker_loaders`). Spins up the
-  // isolated sandbox the code-mode MCP `execute` tool runs in. Optional: when
-  // unset, GET/POST /mcp returns 503 and the rest of the worker is unaffected.
-  LOADER?: WorkerLoader;
-  // Shared secret gating the privileged /api/run knobs (ad_hoc,
-  // model_override, bypass_cache) and the admin mutation endpoints. Presented
-  // by trusted tools as the `x-studio-secret` header. UNSET => every request is
-  // treated as untrusted (fail-safe): the public app still works (it only uses
-  // the safe subset), but no one can use the worker as a free LLM proxy.
-  // Set via `wrangler secret put STUDIO_SECRET`.
-  STUDIO_SECRET?: string;
-  // Spend-budget overrides (USD) read by ./budget. Default 300 / 10 when unset.
-  DAILY_BUDGET_USD?: string;
-  HOURLY_CUSTOM_BUDGET_USD?: string;
-}
-
-// Message shape on the enrichment queue. Carries everything the consumer
-// needs to recreate the run-handler context: which mark/enrichment to run,
-// the daf, optional mark_input + model_override + bypass_cache.
-// Exported so yomi-cron.ts can enqueue warm jobs directly (type-only import,
-// erased at build — no runtime cycle with this entry module).
-export interface JobMessage {
-  runId: string;
-  mark_id?: string;
-  enrichment_id?: string;
-  ad_hoc?: unknown;
-  tractate: string;
-  page: string;
-  model_override?: string;
-  mark_input?: unknown;
-  bypass_cache?: boolean;
-  /** Free-text input that becomes part of the enrichment's cache key (via
-   *  qualifierHash) and is exposed to its prompt as {{user_question}}. Used
-   *  by argument-move.qa today. Empty/undefined means a vanilla run. */
-  user_question?: string;
-  /** Output language for enrichments. 'he' selects the *_he prompt variant
-   *  and a `:he`-namespaced cache key; omitted/'en' is the default English
-   *  path. Marks ignore this (language-neutral output). */
-  lang?: 'en' | 'he';
-  /** Deep-warm job: run this daf's structural marks, then fan out a warm job
-   *  for every per-instance enrichment (synthesis + suggested-questions). Used
-   *  by /api/warm-daf to comprehensively pre-warm an adjacent daf so navigation
-   *  lands on a fully-cached page. Mutually exclusive with mark_id/enrichment_id. */
-  warm_deep?: boolean;
-  /** With `warm_deep`, restrict the warm to this set of enrichment ids (the
-   *  re-warm cascade) and EVICT their cache entries so they regenerate. A recipe
-   *  edit leaves the key unchanged, so the cascade must be evicted to actually
-   *  regenerate — but only the cascade, so unchanged dependencies still cache-hit
-   *  (see deepWarmDaf `evict`). Covers the deep-warm surface (synthesis /
-   *  suggested-questions / overview); cascade ids outside it regenerate on their
-   *  next on-demand request. */
-  rewarm_only?: string[];
-}
+// `Bindings` and `JobMessage` now live in ./types (a neutral module so route
+// slices / telemetry / crons can import them without cycling through this entry
+// file). Both are imported at the top of this file.
 
 // ---------------------------------------------------------------------------
 // Request trust + spend-pause helpers (see ./budget for the budget guard).
@@ -3961,67 +3888,8 @@ app.post('/api/qa/click', async (c) => {
 //
 // New entries don't need a code change — /api/usage rolls up dynamically over
 // whatever endpoint values it sees in the ring buffer.
-type TelemetryEndpoint = string;
-
-// String-typed so composed labels like `stage-a-<classifyError>` work without
-// requiring a combinatorial explosion of literal types. Classifier values are
-// still the core vocabulary; two-stage handlers prefix with `stage-a-` /
-// `stage-b-` to distinguish which pipeline step errored.
-type TelemetryErrorKind = string;
-
-interface TelemetryRecord {
-  ts: number;
-  endpoint: TelemetryEndpoint;
-  tractate?: string;
-  page?: string;
-  cache_hit: boolean;
-  model?: string;
-  ms: number;
-  ok: boolean;
-  error_kind?: TelemetryErrorKind;
-  /** Set when endpoint === 'studio-mark'. */
-  mark_id?: string;
-  /** Set when endpoint === 'studio-enrichment'. */
-  enrichment_id?: string;
-  /** Token usage + estimated USD cost for the (recent-window) cost view.
-   *  cost_usd is null when the model has no known list price. */
-  tokens_in?: number;
-  tokens_out?: number;
-  cost_usd?: number | null;
-}
-
-function classifyError(detail: string): TelemetryErrorKind {
-  if (/empty payload/i.test(detail)) return 'empty-payload';
-  if (/non-json|SyntaxError/i.test(detail)) return 'non-json';
-  if (/schema mismatch/i.test(detail)) return 'schema-mismatch';
-  if (/1031|UpstreamError/i.test(detail)) return 'upstream-1031';
-  if (/^HTTP \d|status \d/i.test(detail)) return 'http';
-  return 'other';
-}
-
-// Fire-and-forget telemetry recorder: does NOT block the response. Caller
-// should pass c.executionCtx so the write finishes after the client is served.
-function recordTelemetry(
-  ctx: { env: Bindings; executionCtx: ExecutionContext },
-  rec: Omit<TelemetryRecord, 'ts'>,
-): void {
-  const full: TelemetryRecord = { ts: Date.now(), ...rec };
-  ctx.executionCtx.waitUntil(logTelemetry(ctx.env.CACHE, full));
-}
-
-async function logTelemetry(cache: KVNamespace | undefined, rec: TelemetryRecord): Promise<void> {
-  if (!cache) return;
-  try {
-    const key = 'telemetry:v1:recent';
-    const existing = await cache.get(key);
-    const arr = existing ? (JSON.parse(existing) as TelemetryRecord[]) : [];
-    arr.push(rec);
-    while (arr.length > 500) arr.shift();
-    await cache.put(key, JSON.stringify(arr), { expirationTtl: 60 * 60 * 24 * 30 });
-  } catch (err) {
-    console.warn('[telemetry] KV write failed:', String(err));
-  }
-}
+// Telemetry types + recorders (TelemetryRecord, classifyError, recordTelemetry,
+// runTelemetryRec) now live in ./telemetry; imported at the top of this file.
 
 /**
  * Cost attribution for one freshly-computed LLM result. Increments the
@@ -4050,35 +3918,6 @@ function captureLlmUsage(
     markId: args.kind === 'mark' ? args.id : undefined,
     enrichmentId: args.kind === 'enrichment' ? args.id : undefined,
   });
-}
-
-/** Build a studio-run telemetry record (latency + cache-hit + tokens/cost) for
- *  a mark or enrichment run. Used at the queue-job boundary and the producer
- *  cache-hit fast path so per-mark / per-enrichment latency + hit-rate reflect
- *  the real pipeline (translate was previously the only thing recording). */
-function runTelemetryRec(
-  job: { mark_id?: string; enrichment_id?: string; tractate: string; page: string },
-  result: { model?: string; usage?: unknown; parse_error?: string | null; cache_hit?: boolean },
-  ms: number,
-): Omit<TelemetryRecord, 'ts'> {
-  const { input, output } = normalizeUsage(result.usage as Parameters<typeof normalizeUsage>[0]);
-  const cost = priceCostUsd(result.model, result.usage as Parameters<typeof priceCostUsd>[1]);
-  const isMark = !!job.mark_id;
-  return {
-    endpoint: isMark ? 'studio-mark' : job.enrichment_id ? 'studio-enrichment' : 'studio-adhoc',
-    tractate: job.tractate,
-    page: job.page,
-    cache_hit: result.cache_hit ?? false,
-    model: result.model,
-    ms,
-    ok: !result.parse_error,
-    error_kind: result.parse_error ? classifyError(result.parse_error) : undefined,
-    mark_id: job.mark_id,
-    enrichment_id: job.enrichment_id,
-    tokens_in: input,
-    tokens_out: output,
-    cost_usd: cost,
-  };
 }
 
 /** Record every place instance the `places` mark emitted into the observed-place
@@ -4384,226 +4223,10 @@ app.get('/api/usage/daf/:tractate/:page', (c) => {
   });
 });
 
-// --- Commentaries list --------------------------------------------------
-// Per-daf list of Rishonim / Acharonim commentaries (beyond the Rashi and
-// Tosafot rendered inline on the daf). Each comment carries its anchor
-// Sefaria segment index so the client can highlight the exact span the
-// commentary is anchored to, using the data-seg alignment we injected.
-
-interface CommentaryComment {
-  anchorRef: string;                // e.g. "Berakhot 5a:3" or "Berakhot 5a:3:1-4"
-  anchorSegIdx: number;             // zero-based index into Sefaria segments
-  sourceRef: string;                // commentary's own ref, e.g. "Ramban on Berakhot 5a:3:1"
-  textHe: string;
-  textEn: string;
-}
-
-interface CommentaryWork {
-  title: string;
-  titleHe: string;
-  count: number;
-  comments: CommentaryComment[];
-}
-
-/** Parse the first segment number out of a Sefaria ref like "Berakhot 5a:3"
- *  or "Berakhot 5a:3:1-4". Returns zero-based index, or -1 if unparseable. */
-function parseAnchorSegment(anchorRef: string): number {
-  const m = anchorRef.match(/:(\d+)/);
-  if (!m) return -1;
-  const n = parseInt(m[1], 10);
-  return Number.isFinite(n) && n > 0 ? n - 1 : -1;
-}
-
-// (Rashi / Tosafot are rendered inline on the daf, but we STILL surface them
-// in the picker — selecting them highlights the main-text segments they
-// anchor to, and clicking a segment also highlights the gloss in the inner
-// or outer column. So no work titles are filtered here.)
-
-/** Shared fetch — returns the grouped commentary works for a daf. Cached.
- *  Used by both /api/commentaries (legacy endpoint) and the `commentary`
- *  mark's computed extractor. */
-export async function fetchCommentaryWorks(
-  env: Bindings,
-  tractate: string,
-  page: string,
-  bypassCache = false,
-): Promise<{ works: CommentaryWork[]; tractate: string; page: string; fetchedAt: string } | { error: string }> {
-  const cache = env.CACHE;
-  const cacheKey = keyForCommentaryWorks(tractate, page);
-  if (cache && !bypassCache) {
-    const hit = await cache.get(cacheKey);
-    if (hit !== null) {
-      try { return JSON.parse(hit) as { works: CommentaryWork[]; tractate: string; page: string; fetchedAt: string }; }
-      catch { /* fall through to refetch */ }
-    }
-  }
-  const ref = `${tractate} ${page}`;
-  const url = `https://www.sefaria.org/api/links/${encodeURIComponent(ref)}?with_text=1`;
-  let res: Response;
-  try {
-    res = await fetch(url, { headers: { accept: 'application/json' } });
-  } catch (err) {
-    return { error: String(err) };
-  }
-  if (!res.ok) return { error: `Sefaria ${res.status}` };
-
-  const raw = (await res.json()) as Array<{
-    ref?: string;
-    sourceRef?: string;
-    anchorRef?: string;
-    category?: string;
-    collectiveTitle?: { en?: string; he?: string };
-    index_title?: string;
-    he?: string | string[];
-    text?: string | string[];
-  }>;
-
-  const joinText = (x: string | string[] | undefined): string => {
-    if (!x) return '';
-    if (Array.isArray(x)) return x.map((t) => String(t ?? '')).join(' ').trim();
-    return String(x).trim();
-  };
-
-  const byWork = new Map<string, CommentaryWork>();
-  for (const l of raw) {
-    if (l.category !== 'Commentary') continue;
-    const title = l.collectiveTitle?.en ?? l.index_title ?? 'Unknown';
-    const titleHe = l.collectiveTitle?.he ?? '';
-    const anchorRef = l.anchorRef ?? '';
-    const anchorSegIdx = parseAnchorSegment(anchorRef);
-    if (anchorSegIdx < 0) continue;
-    const comment: CommentaryComment = {
-      anchorRef,
-      anchorSegIdx,
-      sourceRef: l.sourceRef ?? l.ref ?? '',
-      textHe: joinText(l.he),
-      textEn: joinText(l.text),
-    };
-    let work = byWork.get(title);
-    if (!work) {
-      work = { title, titleHe, count: 0, comments: [] };
-      byWork.set(title, work);
-    }
-    work.comments.push(comment);
-    work.count++;
-  }
-  // Sort works by count desc so popular ones (Meiri, Ramban, Rashba…) lead.
-  const works = Array.from(byWork.values()).sort((a, b) => b.count - a.count);
-
-  const payload = { works, tractate, page, fetchedAt: new Date().toISOString() };
-  if (cache) {
-    await cache.put(cacheKey, JSON.stringify(payload), { expirationTtl: 60 * 60 * 24 * 30 });
-  }
-  return payload;
-}
-
-app.get('/api/commentaries/:tractate/:page', async (c) => {
-  const tractate = c.req.param('tractate');
-  const page = c.req.param('page');
-  const bypassCache = c.req.query('refresh') === '1';
-  const result = await fetchCommentaryWorks(c.env, tractate, page, bypassCache);
-  if ('error' in result) return c.json(result, 502);
-  return c.json({ ...result, _cached: !bypassCache });
-});
-
-// --- Commentary translation ----------------------------------------------
-// On-demand English translation of a single commentary comment (used when
-// Sefaria has no `text` for it, which is common for Rishonim). Kimi K2.5 is
-// the primary translator (no thinking, fast); Gemma-4 26B is the fallback.
-// Results are cached forever per Sefaria sourceRef.
-
-interface CommentaryTranslateBody {
-  sourceRef: string;
-  textHe: string;
-  tractate?: string;
-  page?: string;
-  anchorSegIdx?: number;
-}
-
-const COMMENTARY_TX_SYSTEM =
-  'You are a scholarly translator of rabbinic commentary on the Talmud. Translate the given Hebrew/Aramaic commentary text into clear, accurate English. ' +
-  'Output ONLY the translation — no preamble, no explanation, no quotation marks around the whole thing. ' +
-  'Match the register of standard academic Talmud editions (Soncino / Koren-Steinsaltz). Preserve technical terminology where standard ("Mishnah", "Gemara", "Tanna"). ' +
-  'The commentary glosses a specific passage of the daf — use the provided source segment to anchor pronouns and references, but translate the commentary (not the source).';
-
-app.post('/api/commentary-translate', async (c) => {
-  let body: CommentaryTranslateBody;
-  try { body = await c.req.json<CommentaryTranslateBody>(); }
-  catch { return c.json({ error: 'Invalid JSON body' }, 400); }
-
-  const sourceRef = (body.sourceRef ?? '').trim();
-  const textHe = (body.textHe ?? '').trim();
-  if (!sourceRef || !textHe) return c.json({ error: 'Missing sourceRef or textHe' }, 400);
-
-  const cache = c.env.CACHE;
-  const cacheKey = keyForCommentaryText(sourceRef);
-  const t0 = Date.now();
-  if (cache) {
-    const cached = await cache.get(cacheKey);
-    if (cached !== null) {
-      return c.json({ translation: cached, cached: true });
-    }
-  }
-  if (!c.env.AI) return c.json({ error: 'AI binding not available' }, 503);
-
-  // Pull the matching daf segment as bilingual anchor context.
-  let segHe = '';
-  let segEn = '';
-  if (body.tractate && body.page && typeof body.anchorSegIdx === 'number') {
-    const segments = await getSefariaSegmentsCached(cache, body.tractate, body.page);
-    if (segments && body.anchorSegIdx >= 0 && body.anchorSegIdx < segments.he.length) {
-      segHe = segments.he[body.anchorSegIdx] ?? '';
-      segEn = segments.en[body.anchorSegIdx] ?? '';
-    }
-  }
-
-  // Strip HTML from the commentary text (Sefaria sometimes embeds <b>/<i>).
-  const cleanHe = textHe.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
-
-  const userParts: string[] = [];
-  if (segHe) {
-    userParts.push(
-      `Daf segment this commentary anchors to:\nHebrew/Aramaic: ${segHe}` +
-      (segEn ? `\nEnglish: ${segEn}` : ''),
-    );
-  }
-  userParts.push(`Commentary source: ${sourceRef}`);
-  userParts.push(`Commentary text (translate this):\n${cleanHe}`);
-
-  const models: Array<{ id: LLMModelId; label: string }> = [
-    { id: '@cf/moonshotai/kimi-k2.5',        label: 'kimi-k2.5'   },
-    { id: '@cf/google/gemma-4-26b-a4b-it',   label: 'gemma-4-26b' },
-  ];
-
-  const attempts: string[] = [];
-  for (const m of models) {
-    try {
-      const r = await runLLM(c.env, {
-        model: m.id,
-        messages: [
-          { role: 'system', content: COMMENTARY_TX_SYSTEM },
-          { role: 'user', content: userParts.join('\n\n') },
-        ],
-        max_tokens: 800,
-        temperature: 0.2,
-        thinking: false,
-        tag: 'commentary-translate',
-        attribution: { kind: 'translate', ...(body.tractate && body.page ? { tractate: body.tractate, page: body.page } : {}) },
-      });
-      const translation = r.content.trim().replace(/^["\']|["\']$/g, '');
-      if (!translation) { attempts.push(`${m.label}: empty`); continue; }
-      if (cache) {
-        await cache.put(cacheKey, translation, { expirationTtl: 60 * 60 * 24 * 365 });
-      }
-      recordTelemetry(c, { endpoint: 'translate', tractate: body.tractate, page: body.page, cache_hit: false, model: m.label, ms: Date.now() - t0, ok: true });
-      return c.json({ translation, cached: false, _model: m.label });
-    } catch (err) {
-      attempts.push(`${m.label}: ${String(err).slice(0, 200)}`);
-    }
-  }
-  recordTelemetry(c, { endpoint: 'translate', tractate: body.tractate, page: body.page, cache_hit: false, ms: Date.now() - t0, ok: false, error_kind: classifyError(attempts.join(' ')) });
-  return c.json({ error: 'All translation models failed', attempts }, 502);
-});
+// --- Commentaries -------------------------------------------------------
+// The commentary list + on-demand translation routes (and fetchCommentaryWorks,
+// re-exported above for the other in-file callers) now live in ./commentary.
+registerCommentaryRoutes(app);
 
 /**
  * Reverse references — every source in the Sefaria corpus that links to a

--- a/src/worker/telemetry.ts
+++ b/src/worker/telemetry.ts
@@ -1,0 +1,101 @@
+// Recent-window request telemetry (latency / cache-hit / tokens / cost),
+// extracted from index.ts. Buffers the last 500 records in KV under
+// `telemetry:v1:recent`; the admin/usage routes roll these up for the dashboard.
+//
+// This is the cross-cutting recorder every route reaches for, so it lives in a
+// neutral module (importing only ./types + ./pricing) — see types.ts on why.
+// captureLlmUsage / recordObserved* stay in index.ts: they depend on RunCtx,
+// which is core to the run engine, not telemetry.
+
+import type { Bindings } from './types';
+import { costUsd as priceCostUsd, normalizeUsage } from './pricing';
+
+// String-typed so composed labels like `stage-a-<classifyError>` work without
+// requiring a combinatorial explosion of literal types. Classifier values are
+// still the core vocabulary; two-stage handlers prefix with `stage-a-` /
+// `stage-b-` to distinguish which pipeline step errored.
+export type TelemetryEndpoint = string;
+export type TelemetryErrorKind = string;
+
+export interface TelemetryRecord {
+  ts: number;
+  endpoint: TelemetryEndpoint;
+  tractate?: string;
+  page?: string;
+  cache_hit: boolean;
+  model?: string;
+  ms: number;
+  ok: boolean;
+  error_kind?: TelemetryErrorKind;
+  /** Set when endpoint === 'studio-mark'. */
+  mark_id?: string;
+  /** Set when endpoint === 'studio-enrichment'. */
+  enrichment_id?: string;
+  /** Token usage + estimated USD cost for the (recent-window) cost view.
+   *  cost_usd is null when the model has no known list price. */
+  tokens_in?: number;
+  tokens_out?: number;
+  cost_usd?: number | null;
+}
+
+export function classifyError(detail: string): TelemetryErrorKind {
+  if (/empty payload/i.test(detail)) return 'empty-payload';
+  if (/non-json|SyntaxError/i.test(detail)) return 'non-json';
+  if (/schema mismatch/i.test(detail)) return 'schema-mismatch';
+  if (/1031|UpstreamError/i.test(detail)) return 'upstream-1031';
+  if (/^HTTP \d|status \d/i.test(detail)) return 'http';
+  return 'other';
+}
+
+// Fire-and-forget telemetry recorder: does NOT block the response. Caller
+// should pass c.executionCtx so the write finishes after the client is served.
+export function recordTelemetry(
+  ctx: { env: Bindings; executionCtx: ExecutionContext },
+  rec: Omit<TelemetryRecord, 'ts'>,
+): void {
+  const full: TelemetryRecord = { ts: Date.now(), ...rec };
+  ctx.executionCtx.waitUntil(logTelemetry(ctx.env.CACHE, full));
+}
+
+async function logTelemetry(cache: KVNamespace | undefined, rec: TelemetryRecord): Promise<void> {
+  if (!cache) return;
+  try {
+    const key = 'telemetry:v1:recent';
+    const existing = await cache.get(key);
+    const arr = existing ? (JSON.parse(existing) as TelemetryRecord[]) : [];
+    arr.push(rec);
+    while (arr.length > 500) arr.shift();
+    await cache.put(key, JSON.stringify(arr), { expirationTtl: 60 * 60 * 24 * 30 });
+  } catch (err) {
+    console.warn('[telemetry] KV write failed:', String(err));
+  }
+}
+
+/** Build a studio-run telemetry record (latency + cache-hit + tokens/cost) for
+ *  a mark or enrichment run. Used at the queue-job boundary and the producer
+ *  cache-hit fast path so per-mark / per-enrichment latency + hit-rate reflect
+ *  the real pipeline (translate was previously the only thing recording). */
+export function runTelemetryRec(
+  job: { mark_id?: string; enrichment_id?: string; tractate: string; page: string },
+  result: { model?: string; usage?: unknown; parse_error?: string | null; cache_hit?: boolean },
+  ms: number,
+): Omit<TelemetryRecord, 'ts'> {
+  const { input, output } = normalizeUsage(result.usage as Parameters<typeof normalizeUsage>[0]);
+  const cost = priceCostUsd(result.model, result.usage as Parameters<typeof priceCostUsd>[1]);
+  const isMark = !!job.mark_id;
+  return {
+    endpoint: isMark ? 'studio-mark' : job.enrichment_id ? 'studio-enrichment' : 'studio-adhoc',
+    tractate: job.tractate,
+    page: job.page,
+    cache_hit: result.cache_hit ?? false,
+    model: result.model,
+    ms,
+    ok: !result.parse_error,
+    error_kind: result.parse_error ? classifyError(result.parse_error) : undefined,
+    mark_id: job.mark_id,
+    enrichment_id: job.enrichment_id,
+    tokens_in: input,
+    tokens_out: output,
+    cost_usd: cost,
+  };
+}

--- a/src/worker/types.ts
+++ b/src/worker/types.ts
@@ -1,0 +1,82 @@
+// Shared worker types, extracted from index.ts so any module (route slices,
+// telemetry, crons) can reference them WITHOUT importing index.ts. index.ts is
+// the entry point that wires everything together, so importing it back from a
+// helper module creates a cycle — these neutral types break that.
+
+import type { EmailBinding } from './warm-cron';
+
+/** Queue message for one enrichment/mark run. `/api/run` enqueues a JobMessage;
+ *  the queue consumer (bottom of index.ts) runs the LLM chain and writes the
+ *  result to KV under `job:{runId}`. */
+export interface JobMessage {
+  runId: string;
+  mark_id?: string;
+  enrichment_id?: string;
+  ad_hoc?: unknown;
+  tractate: string;
+  page: string;
+  model_override?: string;
+  mark_input?: unknown;
+  bypass_cache?: boolean;
+  /** Free-text input that becomes part of the enrichment's cache key (via
+   *  qualifierHash) and is exposed to its prompt as {{user_question}}. Used
+   *  by argument-move.qa today. Empty/undefined means a vanilla run. */
+  user_question?: string;
+  /** Output language for enrichments. 'he' selects the *_he prompt variant
+   *  and a `:he`-namespaced cache key; omitted/'en' is the default English
+   *  path. Marks ignore this (language-neutral output). */
+  lang?: 'en' | 'he';
+  /** Deep-warm job: run this daf's structural marks, then fan out a warm job
+   *  for every per-instance enrichment (synthesis + suggested-questions). Used
+   *  by /api/warm-daf to comprehensively pre-warm an adjacent daf so navigation
+   *  lands on a fully-cached page. Mutually exclusive with mark_id/enrichment_id. */
+  warm_deep?: boolean;
+  /** With `warm_deep`, restrict the warm to this set of enrichment ids (the
+   *  re-warm cascade) and EVICT their cache entries so they regenerate. A recipe
+   *  edit leaves the key unchanged, so the cascade must be evicted to actually
+   *  regenerate — but only the cascade, so unchanged dependencies still cache-hit
+   *  (see deepWarmDaf `evict`). Covers the deep-warm surface (synthesis /
+   *  suggested-questions / overview); cascade ids outside it regenerate on their
+   *  next on-demand request. */
+  rewarm_only?: string[];
+}
+
+/** Worker environment bindings (declared in wrangler.toml). */
+export interface Bindings {
+  ASSETS: Fetcher;
+  AI?: Ai;
+  CACHE?: KVNamespace;
+  EMAIL?: EmailBinding;
+  // AI Gateway routing (see src/worker/ai-gateway.ts).
+  AI_GATEWAY_ID?: string;
+  AI_GATEWAY_DISABLE?: string;
+  // OpenRouter via AI Gateway Universal Endpoint (see src/worker/llm.ts).
+  OPENROUTER_API_KEY?: string;
+  CLOUDFLARE_ACCOUNT_ID?: string;
+  // Cloudflare API token (Account Analytics: Read) for the AI Gateway cost
+  // query in aigw-analytics.ts. Set via `wrangler secret put CF_ANALYTICS_TOKEN`.
+  CF_ANALYTICS_TOKEN?: string;
+  OPENROUTER_GATEWAY_PROVIDER?: string;
+  DEFAULT_LLM_MODEL?: string;
+  // Enrichment job queue — see wrangler.toml + queue handler at the bottom
+  // of index.ts. /api/run enqueues a JobMessage; the queue consumer
+  // runs the LLM chain and writes the result to KV under `job:{runId}`.
+  ENRICHMENT_QUEUE?: Queue<JobMessage>;
+  // When '1', the background Sefaria Shas walk also enqueues rabbi.observations
+  // per amud (full reverse-index backfill). OFF by default — see WarmEnv.
+  OBSERVATIONS_WARM_SHAS?: string;
+  // Dynamic Worker Loader binding (wrangler.toml `worker_loaders`). Spins up the
+  // isolated sandbox the code-mode MCP `execute` tool runs in. Optional: when
+  // unset, GET/POST /mcp returns 503 and the rest of the worker is unaffected.
+  LOADER?: WorkerLoader;
+  // Shared secret gating the privileged /api/run knobs (ad_hoc,
+  // model_override, bypass_cache) and the admin mutation endpoints. Presented
+  // by trusted tools as the `x-studio-secret` header. UNSET => every request is
+  // treated as untrusted (fail-safe): the public app still works (it only uses
+  // the safe subset), but no one can use the worker as a free LLM proxy.
+  // Set via `wrangler secret put STUDIO_SECRET`.
+  STUDIO_SECRET?: string;
+  // Spend-budget overrides (USD) read by ./budget. Default 300 / 10 when unset.
+  DAILY_BUDGET_USD?: string;
+  HOURLY_CUSTOM_BUDGET_USD?: string;
+}

--- a/src/worker/warm-cron.ts
+++ b/src/worker/warm-cron.ts
@@ -19,7 +19,7 @@ import {
 import { listDafyomiMasechtos } from '../lib/sefref/dafyomi/masechtos';
 import { computeCacheStats, writeCachedCacheStats } from './cache-stats';
 import { keyForHebrewBooks, keyForSefariaBundle, keyForSefariaSegments, keyForDafyomi } from './cache-keys';
-import type { JobMessage } from './index';
+import type { JobMessage } from './types';
 
 const CURSOR_KEY = 'warm-cursor:v1';
 const SEFARIA_CURSOR_KEY = 'warm-cursor-sefaria:v1';

--- a/src/worker/yomi-cron.ts
+++ b/src/worker/yomi-cron.ts
@@ -19,7 +19,7 @@
  */
 
 import { instanceIdOf } from './cache-keys';
-import type { JobMessage } from './index';
+import type { JobMessage } from './types';
 
 const SEFARIA_CALENDAR_URL = 'https://www.sefaria.org/api/calendars';
 const WARM_MARKS = ['rabbi', 'argument', 'halacha', 'aggadata', 'yerushalmi', 'pesukim'] as const;


### PR DESCRIPTION
First **Batch-3** route slice — begins decomposing the ~8,060-line `src/worker/index.ts`.

**The keystone:** `Bindings` was defined inline in index.ts, so *any* extracted module needing the env type would import-cycle back through the entry file. Lifting it into a neutral module unblocks all future route slicing.

### New modules
- **`types.ts`** — `Bindings` + `JobMessage`. Crons (`warm-cron`, `yomi-cron`) now import `JobMessage` from here instead of `./index`.
- **`telemetry.ts`** — `TelemetryRecord` + `classifyError`/`recordTelemetry`/`logTelemetry`/`runTelemetryRec`. (`captureLlmUsage` + `recordObserved*` stay in index.ts — they depend on `RunCtx`, core to the run engine.)
- **`commentary.ts`** — `fetchCommentaryWorks` + the two routes (`GET /api/commentaries/:tractate/:page`, `POST /api/commentary-translate`) via `registerCommentaryRoutes(app)`.

### Properties
- **Pure move, behavior-preserving** — route paths, request/response bodies, cache keys, model lists, and telemetry calls all unchanged.
- **No import cycles** — new files never import `./index`; `types.ts`↔`warm-cron` is type-only (erased).
- **index.ts: 8,063 → 7,687 lines.**

Verification: `pnpm typecheck` clean, `pnpm test` **1806 passed**, Codex read-only review confirmed the move is behavior-preserving (and caught 2 now-dead imports, removed).