### PR TITLE
Tutorial: open real argument/halacha/overview/Q&A notes; block daf clicks

### DIFF
--- a/src/client/BugReport.tsx
+++ b/src/client/BugReport.tsx
@@ -57,6 +57,7 @@ export function BugReport(props: BugReportProps): JSX.Element {
             when={status() === 'sent'}
             fallback={
               <button
+                data-tour="report"
                 onClick={() => setStatus('open')}
                 style={{
                   background: 'transparent',

--- a/src/client/DafViewer.tsx
+++ b/src/client/DafViewer.tsx
@@ -2398,11 +2398,16 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
     go(formatPage(pageNum(), pageAmud() === 'a' ? 'b' : 'a'));
   };
 
-  // The tutorial coach's note steps open a real note (the whole-daf Overview) —
-  // a side panel on desktop, a drawer on mobile — and close it again when a
-  // non-note step is shown or the tour ends.
+  // The tutorial coach's note steps open a real note — an argument, a halacha,
+  // or the whole-daf Overview (a side panel on desktop, a drawer on mobile) —
+  // and close it again when a non-note step is shown or the tour ends.
   onMount(() => {
-    const onOpen = () => openChip('argument-overview');
+    const onOpen = (e: Event) => {
+      const note = (e as CustomEvent<{ note?: string }>).detail?.note ?? 'overview';
+      if (note === 'argument') openArgument(0);
+      else if (note === 'halacha') openHalacha(0);
+      else openChip('argument-overview');
+    };
     const onClose = () => setSidebar(null);
     const onHeader = (e: Event) => {
       if (!isMobile()) return;

--- a/src/client/TutorialCoach.tsx
+++ b/src/client/TutorialCoach.tsx
@@ -77,8 +77,9 @@ export function TutorialCoach(): JSX.Element {
   const measure = (attempt = 0) => {
     clearTimeout(retryTimer);
     const s = step();
-    if (!s.target) { setRect(null); reposition(); return; }
-    const el = document.querySelector(`[data-tour="${s.target}"]`);
+    const sel = s.selector ?? (s.target ? `[data-tour="${s.target}"]` : null);
+    if (!sel) { setRect(null); reposition(); return; }
+    const el = document.querySelector(sel);
     if (!el) {
       setRect(null);
       reposition();
@@ -130,7 +131,7 @@ export function TutorialCoach(): JSX.Element {
   createEffect(() => {
     const s = step();
     setTutorialHeader(!!s.header);
-    if (s.note) openTutorialNote(); else closeTutorialNote();
+    if (s.note) openTutorialNote(s.note); else closeTutorialNote();
     setPos(null);
     requestAnimationFrame(() => requestAnimationFrame(() => measure()));
   });
@@ -202,13 +203,20 @@ export function TutorialCoach(): JSX.Element {
 
   return (
     <Portal>
+      {/* Click shield — a transparent full-viewport layer that swallows every
+          interaction with the daf during the tour, so clicking the page can't
+          start a selection or open an unrelated note. The coach drives
+          everything; the shield sits below the ring/dim (visual only) and the
+          card (which is above it and stays interactive). */}
+      <div aria-hidden="true" style={{ position: 'fixed', inset: '0', 'z-index': '5999', background: 'transparent' }} />
+
       {/* Backdrop. A target step dims everything except a ring around the real
-          element (via the ring's huge box-shadow), and the ring is
-          pointer-events:none so the control stays usable. A concept step dims
-          uniformly with a real overlay. */}
+          element (via the ring's huge box-shadow); a concept step dims
+          uniformly. Both are visual only (pointer-events:none) — the shield
+          above does the blocking. */}
       <Show
         when={hasRing()}
-        fallback={<div aria-hidden="true" style={{ position: 'fixed', inset: '0', 'z-index': '6000', background: 'rgba(17,24,39,0.55)' }} />}
+        fallback={<div aria-hidden="true" style={{ position: 'fixed', inset: '0', 'z-index': '6000', 'pointer-events': 'none', background: 'rgba(17,24,39,0.55)' }} />}
       >
         <div
           aria-hidden="true"
@@ -245,6 +253,14 @@ export function TutorialCoach(): JSX.Element {
           </div>
           <Show when={step().supplement}>
             {(kind) => <Supplement kind={kind()} />}
+          </Show>
+          <Show when={step().id === 'finish'}>
+            <div style={{ 'margin-top': '14px', 'font-size': '14px', 'line-height': 1.55, color: '#374151' }}>
+              {t('tutorial.finish.contact')}{' '}
+              <a href="mailto:shaunregenbaum@gmail.com" style={{ color: 'var(--accent, #8a2a2b)', 'font-weight': 600 }}>
+                shaunregenbaum@gmail.com
+              </a>
+            </div>
           </Show>
         </div>
 
@@ -373,34 +389,29 @@ function Supplement(props: { kind: TourSupplement }): JSX.Element {
         </div>
       </Show>
 
-      <Show when={props.kind === 'translate'}>
+      <Show when={props.kind === 'translate-word'}>
         <div style={{ display: 'flex', 'align-items': 'center', 'justify-content': 'center', gap: '10px', 'font-size': '17px' }}>
           <span style={{ 'border-bottom': '2px solid var(--accent, #8a2a2b)', 'padding-bottom': '1px' }}>גַּבְרָא</span>
           <span style={{ color: '#9ca3af' }}>→</span>
-          <span style={{ background: '#f3eceb', border: '1px solid #e3cfcf', 'border-radius': '4px', padding: '3px 12px', 'font-size': '15px', color: 'var(--accent-strong, #6f2122)' }}>{t('tutorial.translate.example')}</span>
+          <span style={transChip()}>{t('tutorial.translateWord.example')}</span>
         </div>
       </Show>
 
-      <Show when={props.kind === 'qa'}>
-        <div style={{ display: 'flex', 'flex-direction': 'column', gap: '8px' }}>
-          <div style={{ display: 'flex', gap: '6px', 'flex-wrap': 'wrap' }}>
-            <span style={pill()}>{t('tutorial.qa.example1')}</span>
-            <span style={pill()}>{t('tutorial.qa.example2')}</span>
-          </div>
-          <div style={{ display: 'flex', 'align-items': 'center', gap: '8px', border: '1px solid var(--line, #d1d5db)', 'border-radius': '4px', padding: '8px 11px', 'font-size': '13px', color: '#9ca3af', background: '#fbfaf8' }}>
-            <span style={{ flex: '1 1 auto' }}>{t('tutorial.qa.placeholder')}</span>
-            <span style={{ color: 'var(--accent, #8a2a2b)', 'font-weight': 700 }}>↵</span>
-          </div>
+      <Show when={props.kind === 'translate-phrase'}>
+        <div style={{ display: 'flex', 'align-items': 'center', 'justify-content': 'center', gap: '10px', 'font-size': '17px', 'flex-wrap': 'wrap' }}>
+          <span dir="rtl" style={{ 'border-bottom': '2px solid var(--accent, #8a2a2b)', 'padding-bottom': '1px' }}>{t('tutorial.translatePhrase.exampleHe')}</span>
+          <span style={{ color: '#9ca3af' }}>→</span>
+          <span style={transChip()}>{t('tutorial.translatePhrase.exampleEn')}</span>
         </div>
       </Show>
     </div>
   );
 }
 
-function pill(): JSX.CSSProperties {
+function transChip(): JSX.CSSProperties {
   return {
-    'font-size': '12px', background: '#f3eceb', color: 'var(--accent-strong, #6f2122)',
-    border: '1px solid #e3cfcf', 'border-radius': '999px', padding: '3px 10px', 'white-space': 'nowrap',
+    background: '#f3eceb', border: '1px solid #e3cfcf', 'border-radius': '4px',
+    padding: '3px 12px', 'font-size': '15px', color: 'var(--accent-strong, #6f2122)',
   };
 }
 function SpectrumRow(props: { labelKey: string; ids: GenerationId[] }): JSX.Element {

--- a/src/client/i18n.ts
+++ b/src/client/i18n.ts
@@ -908,12 +908,20 @@ const CATALOG = {
     he: 'בחרו מסכת ודף כאן, או דפדפו קדימה ואחורה עם החצים. "הדף היומי" מקפיץ אתכם לדף היומי של היום.',
   },
 
-  'tutorial.translate.title': { en: 'Translate any word', he: 'תרגום כל מילה' },
-  'tutorial.translate.body': {
-    en: 'On a computer, click any word in the text to see its English translation — or select several words to translate a whole phrase. On a phone, switch the bottom bar to "Translate" and tap. You can also select a run of text to highlight and keep it.',
-    he: 'במחשב, לחצו על כל מילה בטקסט כדי לראות את תרגומה לעברית — או סמנו כמה מילים כדי לתרגם ביטוי שלם. בטלפון, העבירו את הסרגל התחתון ל"תרגום" והקישו על מילה. אפשר גם לסמן רצף טקסט כדי להדגיש ולשמור אותו.',
+  'tutorial.translateWord.title': { en: 'Translate any word', he: 'תרגום כל מילה' },
+  'tutorial.translateWord.body': {
+    en: 'On a computer, click any word in the text to see its translation. On a phone, switch the bottom bar to "Translate" and tap a word.',
+    he: 'במחשב, לחצו על כל מילה בטקסט כדי לראות את תרגומה. בטלפון, העבירו את הסרגל התחתון ל"תרגום" והקישו על מילה.',
   },
-  'tutorial.translate.example': { en: 'man', he: 'אִישׁ' },
+  'tutorial.translateWord.example': { en: 'man', he: 'אִישׁ' },
+
+  'tutorial.translatePhrase.title': { en: '…or a whole phrase', he: '…או ביטוי שלם' },
+  'tutorial.translatePhrase.body': {
+    en: 'Select a run of several words and the whole phrase is translated together — handy when the sense lives in the combination, not the single word. Selecting text also lets you highlight and keep it.',
+    he: 'סמנו רצף של כמה מילים והביטוי כולו יתורגם יחד — נוח כשהמשמעות נמצאת בצירוף ולא במילה הבודדת. סימון טקסט גם מאפשר להדגיש ולשמור אותו.',
+  },
+  'tutorial.translatePhrase.exampleHe': { en: 'כָּל הָעוֹלָם כֻּלּוֹ', he: 'כָּל הָעוֹלָם כֻּלּוֹ' },
+  'tutorial.translatePhrase.exampleEn': { en: 'the whole world', he: 'כל העולם' },
 
   'tutorial.marks.title': { en: 'Notes in the margins', he: 'הערות בשוליים' },
   'tutorial.marks.body': {
@@ -939,10 +947,22 @@ const CATALOG = {
     he: 'הכפתורים שלמעלה פותחים הערות על כל הדף ולא על נקודה אחת: סקירה של הסוגיה, הרקע שכדאי להכיר לפני הלימוד, ולעיתים גם תובנה ששווה לשים לב אליה.',
   },
 
-  'tutorial.card.title': { en: 'Inside a note', he: 'בתוך הערה' },
-  'tutorial.card.body': {
-    en: "Here's a note open beside the daf — a short summary at the top, then sections you can expand: the players and sides of a dispute, key terms, sources, and more. Tap a part of a note to highlight the matching text on the page.",
-    he: 'הנה הערה פתוחה לצד הדף — סיכום קצר בראש, ואז קטעים שניתן להרחיב: הדמויות והצדדים במחלוקת, מונחי מפתח, מקורות ועוד. הקישו על חלק בהערה כדי להדגיש את הטקסט המתאים בדף.',
+  'tutorial.argument.title': { en: 'Following the argument', he: 'מעקב אחר מהלך הסוגיה' },
+  'tutorial.argument.body': {
+    en: "Here's a real argument note open beside the daf. It lays out who is speaking and the sides of the dispute — the voices — so you can see how the sugya builds its case. Tap a part of the note to highlight the matching text on the page.",
+    he: 'הנה הערת מהלך אמיתית פתוחה לצד הדף. היא מציגה מי מדבר ומהם צדדי המחלוקת — הקולות — כדי שתראו כיצד הסוגיה בונה את טיעונה. הקישו על חלק בהערה כדי להדגיש את הטקסט המתאים בדף.',
+  },
+
+  'tutorial.halacha.title': { en: 'The practical ruling', he: 'הפסיקה למעשה' },
+  'tutorial.halacha.body': {
+    en: 'A halacha note traces how the discussion settles into law — the codification, from the Gemara through the Rishonim to the Shulchan Aruch.',
+    he: 'הערת הלכה עוקבת אחר האופן שבו הדיון מתגבש לפסיקה — מהגמרא דרך הראשונים ועד השולחן ערוך.',
+  },
+
+  'tutorial.overview.title': { en: 'The whole-daf overview', he: 'סקירת כל הדף' },
+  'tutorial.overview.body': {
+    en: 'This note zooms out to the whole page: a short summary, a map of how the discussion flows, key terms, and cross-references to where the sugya continues. A good place to get your bearings before diving in.',
+    he: 'הערה זו מתרחקת אל כל הדף: סיכום קצר, מפה של מהלך הדיון, מונחי מפתח, והפניות למקום שבו הסוגיה ממשיכה. מקום טוב להתמצא בו לפני הצלילה ללימוד.',
   },
 
   'tutorial.underline.title': { en: 'The colored names', he: 'השמות הצבעוניים' },
@@ -959,14 +979,20 @@ const CATALOG = {
     en: 'At the bottom of a note you can pick a suggested question or type your own about the passage — the answer is written for you and grounded in the text.',
     he: 'בתחתית ההערה אפשר לבחור שאלה מוצעת או להקליד שאלה משלכם על הקטע — התשובה נכתבת עבורכם ומעוגנת בטקסט.',
   },
-  'tutorial.qa.example1': { en: 'Why this order?', he: 'למה הסדר הזה?' },
-  'tutorial.qa.example2': { en: 'Who disagrees?', he: 'מי חולק?' },
-  'tutorial.qa.placeholder': { en: 'Ask about this passage…', he: 'שאלו על הקטע הזה…' },
+  'tutorial.report.title': { en: 'Spot a problem?', he: 'מצאתם תקלה?' },
+  'tutorial.report.body': {
+    en: 'These notes are generated and not perfect. If something looks wrong — a mistranslation, a misplaced note, a bad reading — use "Report a problem" at the bottom of the daf to flag it. It genuinely helps.',
+    he: 'ההערות נוצרות אוטומטית ואינן מושלמות. אם משהו נראה שגוי — תרגום, מיקום הערה, או קריאה — השתמשו ב"דיווח על תקלה" בתחתית הדף כדי לסמן זאת. זה באמת עוזר.',
+  },
 
   'tutorial.finish.title': { en: "You're ready", he: 'אתם מוכנים' },
   'tutorial.finish.body': {
     en: 'That\'s the tour. You can reopen it anytime from the Help button. Enjoy learning.',
     he: 'זה הסיור. אפשר לפתוח אותו שוב בכל עת מכפתור העזרה. למידה נעימה.',
+  },
+  'tutorial.finish.contact': {
+    en: 'Questions, ideas, or feedback? Feel free to reach out:',
+    he: 'שאלות, רעיונות או משוב? אתם מוזמנים לכתוב לי:',
   },
 
   // — First-visit banner on the reader —

--- a/src/client/sidebar/primitives.tsx
+++ b/src/client/sidebar/primitives.tsx
@@ -615,12 +615,14 @@ export function QASection(props: {
   page: string;
 }): JSX.Element {
   return (
-    <QAPanel
-      mark={props.mark}
-      instanceId={props.instanceId}
-      instance={props.instance}
-      tractate={props.tractate}
-      page={props.page}
-    />
+    <div data-tour="qa-section">
+      <QAPanel
+        mark={props.mark}
+        instanceId={props.instanceId}
+        instance={props.instance}
+        tractate={props.tractate}
+        page={props.page}
+      />
+    </div>
   );
 }

--- a/src/client/tutorial.ts
+++ b/src/client/tutorial.ts
@@ -21,10 +21,14 @@
  *  and quoted verses, so every note type is represented. */
 export const FEATURED_DAF = { tractate: 'Berakhot', page: '62b' } as const;
 
-/** A small legend / illustration drawn inside the coach card to supplement a
- *  step that teaches a concept rather than a single control (the mark glyphs,
- *  the generation colour scale, the click-to-translate gesture, the Q&A box). */
-export type TourSupplement = 'icons' | 'spectrum' | 'translate' | 'qa';
+/** Which real note a step opens behind the coach. The coach asks the embedded
+ *  DafViewer to open it; the reader sees the genuine panel / drawer. */
+export type TourNote = 'overview' | 'argument' | 'halacha';
+
+/** A small legend / demo drawn inside the coach card to supplement a step that
+ *  teaches a concept rather than spotlighting a single element (the mark
+ *  glyphs, the generation colour scale, the click-to-translate gesture). */
+export type TourSupplement = 'icons' | 'spectrum' | 'translate-word' | 'translate-phrase';
 
 export interface TourStep {
   id: string;
@@ -32,25 +36,25 @@ export interface TourStep {
   chapterKey: string;
   titleKey: string;
   bodyKey: string;
-  /** `data-tour` value of a real element on the embedded daf to spotlight.
-   *  Omit for a step that teaches a concept and centres instead. */
+  /** `data-tour` value of a real element on the embedded daf to spotlight. */
   target?: string;
-  /** Open the whole-daf Overview note (real side panel / drawer) while this
-   *  step is showing, so the reader sees an actual note. */
-  note?: boolean;
+  /** Raw CSS selector to spotlight instead of a `data-tour` target (used for
+   *  generated daf content like a rabbi name). Takes precedence over `target`. */
+  selector?: string;
+  /** Open a real note (panel on desktop, drawer on mobile) for this step. */
+  note?: TourNote;
   /** Keep the mobile top header drawer (tractate / nav / language) open for
-   *  this step — its target lives inside it. On desktop the header is always
-   *  visible, so this is a no-op there. */
+   *  this step — its target lives inside it. No-op on desktop. */
   header?: boolean;
-  /** Legend drawn under the body for concept steps. */
+  /** Legend / demo drawn under the body for concept steps. */
   supplement?: TourSupplement;
 }
 
 /**
- * The ordered walk around the daf. Chrome that is always present (language,
- * page nav, the margin icons, the chip bar, an open note) is spotlighted on the
- * real element; concepts that have no single anchor (the translate gesture, the
- * name-colour scale) centre with a small legend.
+ * The ordered walk around the daf. We spotlight real chrome (language, nav, the
+ * margin icons, the chip bar), open real notes (an argument, a halacha, the
+ * whole-daf overview, the Q&A), and highlight real daf content (a rabbi name).
+ * A couple of concept steps (the translate gesture) centre with a small demo.
  */
 export const TOUR_STEPS: TourStep[] = [
   {
@@ -76,11 +80,18 @@ export const TOUR_STEPS: TourStep[] = [
     bodyKey: 'tutorial.nav.body',
   },
   {
-    id: 'translate',
+    id: 'translate-word',
     chapterKey: 'tutorial.chapter.reading',
-    titleKey: 'tutorial.translate.title',
-    bodyKey: 'tutorial.translate.body',
-    supplement: 'translate',
+    titleKey: 'tutorial.translateWord.title',
+    bodyKey: 'tutorial.translateWord.body',
+    supplement: 'translate-word',
+  },
+  {
+    id: 'translate-phrase',
+    chapterKey: 'tutorial.chapter.reading',
+    titleKey: 'tutorial.translatePhrase.title',
+    bodyKey: 'tutorial.translatePhrase.body',
+    supplement: 'translate-phrase',
   },
   {
     id: 'marks',
@@ -91,6 +102,22 @@ export const TOUR_STEPS: TourStep[] = [
     supplement: 'icons',
   },
   {
+    id: 'argument',
+    chapterKey: 'tutorial.chapter.marks',
+    target: 'note-panel',
+    note: 'argument',
+    titleKey: 'tutorial.argument.title',
+    bodyKey: 'tutorial.argument.body',
+  },
+  {
+    id: 'halacha',
+    chapterKey: 'tutorial.chapter.marks',
+    target: 'note-panel',
+    note: 'halacha',
+    titleKey: 'tutorial.halacha.title',
+    bodyKey: 'tutorial.halacha.body',
+  },
+  {
     id: 'chips',
     chapterKey: 'tutorial.chapter.marks',
     target: 'chips',
@@ -98,28 +125,35 @@ export const TOUR_STEPS: TourStep[] = [
     bodyKey: 'tutorial.chips.body',
   },
   {
-    id: 'card',
+    id: 'overview',
     chapterKey: 'tutorial.chapter.marks',
     target: 'note-panel',
-    note: true,
-    titleKey: 'tutorial.card.title',
-    bodyKey: 'tutorial.card.body',
+    note: 'overview',
+    titleKey: 'tutorial.overview.title',
+    bodyKey: 'tutorial.overview.body',
   },
   {
     id: 'qa',
     chapterKey: 'tutorial.chapter.marks',
-    target: 'note-panel',
-    note: true,
+    target: 'qa-section',
+    note: 'argument',
     titleKey: 'tutorial.qa.title',
     bodyKey: 'tutorial.qa.body',
-    supplement: 'qa',
   },
   {
     id: 'underline',
     chapterKey: 'tutorial.chapter.marks',
+    selector: 'span.rabbi-underline',
     titleKey: 'tutorial.underline.title',
     bodyKey: 'tutorial.underline.body',
     supplement: 'spectrum',
+  },
+  {
+    id: 'report',
+    chapterKey: 'tutorial.chapter.done',
+    target: 'report',
+    titleKey: 'tutorial.report.title',
+    bodyKey: 'tutorial.report.body',
   },
   {
     id: 'finish',
@@ -130,17 +164,18 @@ export const TOUR_STEPS: TourStep[] = [
 ];
 
 /** Custom events the embedded DafViewer listens for so the note steps open a
- *  real note (the whole-daf Overview) — a side panel on desktop, a drawer on
- *  mobile — and close it again when a non-note step is shown / the tour ends.
- *  The header events open/collapse the mobile top drawer (no-op on desktop). */
-export const TUTORIAL_OPEN_NOTE_EVENT = 'tutorial-open-note';
+ *  real note — an argument, a halacha, or the whole-daf overview — a side panel
+ *  on desktop, a drawer on mobile, closed again when a non-note step is shown /
+ *  the tour ends. The header events open/collapse the mobile top drawer (no-op
+ *  on desktop). */
+export const TUTORIAL_OPEN_NOTE_EVENT = 'tutorial-open-note'; // detail: { note: TourNote }
 export const TUTORIAL_CLOSE_NOTE_EVENT = 'tutorial-close-note';
 export const TUTORIAL_HEADER_EVENT = 'tutorial-header'; // detail: { open: boolean }
 
-/** Ask the embedded DafViewer to open the whole-daf Overview note. */
-export function openTutorialNote(): void {
+/** Ask the embedded DafViewer to open a real note of the given kind. */
+export function openTutorialNote(note: TourNote): void {
   if (typeof window === 'undefined') return;
-  window.dispatchEvent(new CustomEvent(TUTORIAL_OPEN_NOTE_EVENT));
+  window.dispatchEvent(new CustomEvent(TUTORIAL_OPEN_NOTE_EVENT, { detail: { note } }));
 }
 
 /** Close the note opened for the tour. */


### PR DESCRIPTION
## Why

Follow-up to #264. The walkthrough should open **real notes** and highlight **real content** as it walks you around the daf — and clicking the daf mid-tour shouldn't break anything.

## What

- **Steps reworked (now 14):**
  - **Translate** splits into a *word* demo and a *phrase* demo.
  - After the margin-icon legend, the coach opens a real **argument** note (voices) then a real **halacha** note (codification).
  - The chip step is followed by opening the whole-daf **Overview** and walking through it — this absorbs the old generic "Inside a note" step.
  - **Q&A** step opens a note and spotlights the real "ask your own question" section.
  - **Colored names** highlights an actual rabbi name on the daf.
  - New **Report a problem** step spotlights that button.
  - **Final** step invites contact (`shaunregenbaum@gmail.com`, mailto).
- The note-open event carries a kind (`overview | argument | halacha`); the embedded DafViewer opens the matching real note (`openArgument(0)` / `openHalacha(0)` / overview chip).
- The coach gains **CSS-selector targets** (for the rabbi-name span) and a transparent full-viewport **click shield** so interacting with the daf during the tour can't start a selection or open an unrelated note. The spotlight ring / dim are now visual-only; the shield does the blocking.
- `data-tour` anchors added: `report` (BugReport button), `qa-section` (QASection).
- i18n: `translateWord` / `translatePhrase`, `argument`, `halacha`, `overview`, `report`, `finish.contact` added; dead `translate` / `card` / qa-mock keys removed.

## Verification

- `pnpm typecheck` clean; `pnpm test` 1814 passing; `vite build` succeeds.
- Drove the full 14-step walkthrough headlessly. Locally verified: the click shield intercepts daf clicks (no selection, no stray sidebar), both translate demos, the Report-a-problem spotlight, the overview note opening, and the contact mailto on the final step.
- Confirmed on **production Berakhot 62b** that the data the AI-backed steps rely on exists: **8 argument** marks, **4 halacha** marks, **41 rabbi-name** underlines, pasuk/rishonim/aggada, and the report button — so the argument/halacha/overview/Q&A/rabbi-name steps resolve once deployed (local dev has no LLM key, so that content can't render locally).