### PR TITLE
Worker: extract rabbi static data + resolver into rabbi-places.ts

### DIFF
--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -60,7 +60,14 @@ import { gcStaleCache } from './cache-gc';
 import { runYomiWarmCron } from './yomi-cron';
 import { GENERATION_IDS, GENERATION_BY_ID, GENERATIONS_PROMPT_REFERENCE, type GenerationId } from '../client/generations';
 import { stripEchoParens } from '../client/hebraize';
-import rabbiPlacesData from '../lib/data/rabbi-places.json';
+import {
+  RABBI_PLACES,
+  resolveRabbi,
+  resolveRabbiByName,
+  resolveRabbiName,
+  type RabbiPlacesEntry,
+  type Movement,
+} from './rabbi-places';
 import type { EntityPiece } from '../lib/registry/entity';
 import { extractTalmudContent } from '../lib/sefref/alignment';
 import { fetchHebrewBooksDaf } from '../lib/sefref/hebrewbooks/client';
@@ -155,29 +162,6 @@ import {
   type ObservationSlice,
 } from './rabbi-observations';
 
-type Movement = 'bavel->israel' | 'israel->bavel' | 'both' | null;
-interface RabbiPlacesEntry {
-  canonical: string;
-  canonicalHe?: string | null;
-  aliases: string[];
-  places: string[];
-  region: 'israel' | 'bavel' | null;
-  numSources?: number | null;
-  generation?: string | null;
-  moved?: Movement;
-  bio?: string | null;
-  bioSource?: 'sefaria' | 'wikipedia' | null;
-  image?: string | null;
-  wiki?: string | null;
-}
-interface RabbiPlacesFile {
-  generatedAt: string;
-  source: string;
-  cityRegions: Record<string, 'israel' | 'bavel'>;
-  rabbis: Record<string, RabbiPlacesEntry>;
-  aliasIndex: Record<string, string>;
-}
-const RABBI_PLACES = rabbiPlacesData as unknown as RabbiPlacesFile;
 
 // `Bindings` and `JobMessage` now live in ./types (a neutral module so route
 // slices / telemetry / crons can import them without cycling through this entry
@@ -4383,96 +4367,6 @@ registerCommentaryRoutes(app);
  *   GET  /api/rabbi-places?names=Rabbi%20Akiva,Rav%20Huna
  *   POST /api/rabbi-places   { "names": ["Rabbi Akiva", "Rav Huna"] }
  */
-interface RabbiResolution { slug: string; entry: RabbiPlacesEntry }
-
-// Precomputed: normalized canonicalHe → slug. Used to resolve from the
-// Hebrew form in the daf text, which is more reliable than the model's
-// English rendering (Gemma occasionally emits "Rabbah" for Hebrew רבא = Rava).
-// Normalize a Hebrew name for resolver indexing/lookup: strip nikkud +
-// cantillation, drop parenthetical disambiguators (`רב (שם אמורא)` →
-// `רב`), strip punctuation, collapse whitespace.
-function normalizeHeForResolve(s: string): string {
-  return s
-    .replace(/[֑-ׇ]/g, '')
-    .replace(/\([^)]*\)/g, ' ')     // remove parenthetical groups entirely
-    .replace(/\[[^\]]*\]/g, ' ')    // same for square-bracket groups
-    .replace(/[.,:;?!"'״׳()[\]{}]/g, '')
-    .replace(/\s+/g, ' ')
-    .trim();
-}
-
-const BY_CANONICAL_HE: Record<string, string> = (() => {
-  const out: Record<string, string> = {};
-  for (const [slug, r] of Object.entries(RABBI_PLACES.rabbis)) {
-    if (!r.canonicalHe) continue;
-    const key = normalizeHeForResolve(r.canonicalHe);
-    if (key && !out[key]) out[key] = slug;
-  }
-  return out;
-})();
-
-export function resolveRabbiByHe(rawHe: string): RabbiResolution | null {
-  if (!rawHe) return null;
-  const key = normalizeHeForResolve(rawHe);
-  if (!key) return null;
-  const slug = BY_CANONICAL_HE[key];
-  if (slug) {
-    const entry = RABBI_PLACES.rabbis[slug];
-    if (entry) return { slug, entry };
-  }
-  return null;
-}
-
-export function resolveRabbiByName(raw: string): RabbiResolution | null {
-  const key = raw.toLowerCase().trim();
-  if (!key) return null;
-  const direct = RABBI_PLACES.aliasIndex[key];
-  if (direct) {
-    const entry = RABBI_PLACES.rabbis[direct];
-    if (entry) return { slug: direct, entry };
-  }
-  // Patronymic fallback ("Rabbi Eliezer b. Yose" → "Rabbi Eliezer"). Risky
-  // for names like "Rabbah b. Rav Huna" that reduce to bare "Rabbah" (which
-  // the aliasIndex points at a DIFFERENT rabbi). Gate on: the stripped form
-  // must not start with a bare single-word title whose aliasIndex target
-  // canonical differs meaningfully from the input. In practice we accept the
-  // fallback ONLY when the stripped key has > 1 token after the title (e.g.
-  // "Rabbi Eliezer" — two tokens — is OK; bare "Rabbah" is not).
-  const stripped = key
-    .replace(/\s+\b(b\.|ben|bar)\s+.+$/, '')
-    .replace(/\s+/g, ' ')
-    .trim();
-  if (stripped !== key) {
-    const tokens = stripped.split(' ');
-    const isBareTitle = tokens.length < 2;
-    if (!isBareTitle) {
-      const s = RABBI_PLACES.aliasIndex[stripped];
-      if (s) {
-        const entry = RABBI_PLACES.rabbis[s];
-        if (entry) return { slug: s, entry };
-      }
-    }
-  }
-  return null;
-}
-
-/**
- * Resolve a rabbi mention to a dataset entry. Hebrew form (if provided) is
- * authoritative — it comes verbatim from the daf text. English is consulted
- * only when Hebrew gives no match.
- */
-export function resolveRabbi(name: string, nameHe?: string | null): RabbiResolution | null {
-  if (nameHe) {
-    const he = resolveRabbiByHe(nameHe);
-    if (he) return he;
-  }
-  return resolveRabbiByName(name);
-}
-
-// Back-compat shim: many call sites take just the canonical English name.
-function resolveRabbiName(raw: string): RabbiPlacesEntry | null {
-  return resolveRabbiByName(raw)?.entry ?? null;
-}
 
 // Bio-sidebar nav: given a Sefaria topic slug (as linked from the bio text),
 // return the same IdentifiedRabbi shape the dafContext uses, so the sidebar

--- a/src/worker/rabbi-places.ts
+++ b/src/worker/rabbi-places.ts
@@ -1,0 +1,125 @@
+// Rabbi static dataset (rabbi-places.json) + the name/Hebrew -> entry resolver.
+// Neutral module: RABBI_PLACES and the resolvers are used across index.ts (the
+// rabbi routes, the rabbi mark path, and the daf payload), so they live here to
+// avoid cycling through the entry file. Pure data + pure functions — no Bindings,
+// no run engine. This is the foundation the rabbi identity/enrichment layer sits on.
+
+import rabbiPlacesData from '../lib/data/rabbi-places.json';
+
+export type Movement = 'bavel->israel' | 'israel->bavel' | 'both' | null;
+
+export interface RabbiPlacesEntry {
+  canonical: string;
+  canonicalHe?: string | null;
+  aliases: string[];
+  places: string[];
+  region: 'israel' | 'bavel' | null;
+  numSources?: number | null;
+  generation?: string | null;
+  moved?: Movement;
+  bio?: string | null;
+  bioSource?: 'sefaria' | 'wikipedia' | null;
+  image?: string | null;
+  wiki?: string | null;
+}
+
+export interface RabbiPlacesFile {
+  generatedAt: string;
+  source: string;
+  cityRegions: Record<string, 'israel' | 'bavel'>;
+  rabbis: Record<string, RabbiPlacesEntry>;
+  aliasIndex: Record<string, string>;
+}
+
+export const RABBI_PLACES = rabbiPlacesData as unknown as RabbiPlacesFile;
+
+export interface RabbiResolution { slug: string; entry: RabbiPlacesEntry }
+
+// Normalize a Hebrew name for resolver indexing/lookup: strip nikkud +
+// cantillation, drop parenthetical disambiguators (`רב (שם אמורא)` ->
+// `רב`), strip punctuation, collapse whitespace.
+function normalizeHeForResolve(s: string): string {
+  return s
+    .replace(/[֑-ׇ]/g, '')
+    .replace(/\([^)]*\)/g, ' ')     // remove parenthetical groups entirely
+    .replace(/\[[^\]]*\]/g, ' ')    // same for square-bracket groups
+    .replace(/[.,:;?!"'״׳()[\]{}]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+// Precomputed: normalized canonicalHe -> slug. Used to resolve from the Hebrew
+// form in the daf text, which is more reliable than the model's English
+// rendering (Gemma occasionally emits "Rabbah" for Hebrew רבא = Rava).
+const BY_CANONICAL_HE: Record<string, string> = (() => {
+  const out: Record<string, string> = {};
+  for (const [slug, r] of Object.entries(RABBI_PLACES.rabbis)) {
+    if (!r.canonicalHe) continue;
+    const key = normalizeHeForResolve(r.canonicalHe);
+    if (key && !out[key]) out[key] = slug;
+  }
+  return out;
+})();
+
+export function resolveRabbiByHe(rawHe: string): RabbiResolution | null {
+  if (!rawHe) return null;
+  const key = normalizeHeForResolve(rawHe);
+  if (!key) return null;
+  const slug = BY_CANONICAL_HE[key];
+  if (slug) {
+    const entry = RABBI_PLACES.rabbis[slug];
+    if (entry) return { slug, entry };
+  }
+  return null;
+}
+
+export function resolveRabbiByName(raw: string): RabbiResolution | null {
+  const key = raw.toLowerCase().trim();
+  if (!key) return null;
+  const direct = RABBI_PLACES.aliasIndex[key];
+  if (direct) {
+    const entry = RABBI_PLACES.rabbis[direct];
+    if (entry) return { slug: direct, entry };
+  }
+  // Patronymic fallback ("Rabbi Eliezer b. Yose" -> "Rabbi Eliezer"). Risky
+  // for names like "Rabbah b. Rav Huna" that reduce to bare "Rabbah" (which
+  // the aliasIndex points at a DIFFERENT rabbi). Gate on: the stripped form
+  // must not start with a bare single-word title whose aliasIndex target
+  // canonical differs meaningfully from the input. In practice we accept the
+  // fallback ONLY when the stripped key has > 1 token after the title (e.g.
+  // "Rabbi Eliezer" — two tokens — is OK; bare "Rabbah" is not).
+  const stripped = key
+    .replace(/\s+\b(b\.|ben|bar)\s+.+$/, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (stripped !== key) {
+    const tokens = stripped.split(' ');
+    const isBareTitle = tokens.length < 2;
+    if (!isBareTitle) {
+      const s = RABBI_PLACES.aliasIndex[stripped];
+      if (s) {
+        const entry = RABBI_PLACES.rabbis[s];
+        if (entry) return { slug: s, entry };
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve a rabbi mention to a dataset entry. Hebrew form (if provided) is
+ * authoritative — it comes verbatim from the daf text. English is consulted
+ * only when Hebrew gives no match.
+ */
+export function resolveRabbi(name: string, nameHe?: string | null): RabbiResolution | null {
+  if (nameHe) {
+    const he = resolveRabbiByHe(nameHe);
+    if (he) return he;
+  }
+  return resolveRabbiByName(name);
+}
+
+// Back-compat shim: many call sites take just the canonical English name.
+export function resolveRabbiName(raw: string): RabbiPlacesEntry | null {
+  return resolveRabbiByName(raw)?.entry ?? null;
+}

--- a/tests/rabbi-resolver.test.ts
+++ b/tests/rabbi-resolver.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveRabbi, resolveRabbiByHe, resolveRabbiByName } from '../src/worker/index';
+import { resolveRabbi, resolveRabbiByHe, resolveRabbiByName } from '../src/worker/rabbi-places';
 
 // Cases are laid out as [name, nameHe, expectedSlug, note?]. Add new ones
 // below whenever you find a case the resolver gets wrong. Empty string for


### PR DESCRIPTION
Second **Batch-3** slice — continues decomposing `src/worker/index.ts`.

**The keystone for rabbi:** `RABBI_PLACES` was inline in index.ts but used in 15+ places (rabbi routes, the rabbi mark path, the daf payload) — exactly the cross-cutting role `Bindings` played for the rest. Lifting the data + lookup layer into a neutral module is the prerequisite for moving the rabbi routes themselves.

### New module `src/worker/rabbi-places.ts`
- `Movement`, `RabbiPlacesEntry`, `RabbiPlacesFile`, `RABBI_PLACES` (+ the `rabbi-places.json` import)
- `RabbiResolution` + `normalizeHeForResolve` / `BY_CANONICAL_HE` / `resolveRabbiByHe` / `resolveRabbiByName` / `resolveRabbi` / `resolveRabbiName`

### Stays in index.ts (for a later slice)
The identity/enrichment layer — `enrichRabbi`, `resolveGeneration`, `enrichAll`, `isRabbinicEntry` — plus all the rabbi routes. They now import the data/resolvers from `./rabbi-places`.

### Properties
- **Pure move, behavior-preserving** (resolver logic identical — Hebrew-first order, patronymic-fallback gating).
- **No cycle** — rabbi-places.ts imports only the json, never `./index`.
- `tests/rabbi-resolver.test.ts` redirected to import the resolvers from their new home.
- **index.ts: 7,872 → 7,720.**

Verification: `pnpm typecheck` clean, `pnpm test` **1814 passed**, Codex read-only review: PASS.