### PR TITLE
Tutorial: Q&A step opens an aggadata note (has the Q&A panel)

### DIFF
--- a/src/client/DafViewer.tsx
+++ b/src/client/DafViewer.tsx
@@ -2406,6 +2406,7 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
       const note = (e as CustomEvent<{ note?: string }>).detail?.note ?? 'overview';
       if (note === 'argument') openArgument(0);
       else if (note === 'halacha') openHalacha(0);
+      else if (note === 'aggadata') openStory(0);
       else openChip('argument-overview');
     };
     const onClose = () => setSidebar(null);

--- a/src/client/tutorial.ts
+++ b/src/client/tutorial.ts
@@ -23,7 +23,7 @@ export const FEATURED_DAF = { tractate: 'Berakhot', page: '62b' } as const;
 
 /** Which real note a step opens behind the coach. The coach asks the embedded
  *  DafViewer to open it; the reader sees the genuine panel / drawer. */
-export type TourNote = 'overview' | 'argument' | 'halacha';
+export type TourNote = 'overview' | 'argument' | 'halacha' | 'aggadata';
 
 /** A small legend / demo drawn inside the coach card to supplement a step that
  *  teaches a concept rather than spotlighting a single element (the mark
@@ -136,7 +136,7 @@ export const TOUR_STEPS: TourStep[] = [
     id: 'qa',
     chapterKey: 'tutorial.chapter.marks',
     target: 'qa-section',
-    note: 'argument',
+    note: 'aggadata',
     titleKey: 'tutorial.qa.title',
     bodyKey: 'tutorial.qa.body',
   },


### PR DESCRIPTION
Tiny follow-up to #270. On prod I confirmed the first **argument** section of Berakhot 62b is a baraita with no follow-up Q&A panel, so the Q&A step's `qa-section` anchor wasn't found and it fell back to a centered card. **Aggadata** notes always render the "ask your own question" panel (verified on prod: opening an aggada note shows `[data-tour=qa-section]`), so the Q&A step now opens an aggadata note (`note: 'aggadata'` → `openStory(0)`).

typecheck clean; 1814 tests pass; build succeeds.