### PR TITLE
Tutorial: make the Q&A step reliable (overview note + Q&A demo)

### DIFF
--- a/src/client/DafViewer.tsx
+++ b/src/client/DafViewer.tsx
@@ -2408,7 +2408,6 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
       const note = (e as CustomEvent<{ note?: string }>).detail?.note ?? 'overview';
       if (note === 'argument') openArgument(0);
       else if (note === 'halacha') openHalacha(0);
-      else if (note === 'aggadata') openStory(0);
       else openChip('argument-overview');
     };
     const onClose = () => setSidebar(null);

--- a/src/client/TutorialCoach.tsx
+++ b/src/client/TutorialCoach.tsx
@@ -404,6 +404,19 @@ function Supplement(props: { kind: TourSupplement }): JSX.Element {
           <span style={transChip()}>{t('tutorial.translatePhrase.exampleEn')}</span>
         </div>
       </Show>
+
+      <Show when={props.kind === 'qa'}>
+        <div style={{ display: 'flex', 'flex-direction': 'column', gap: '8px' }}>
+          <div style={{ display: 'flex', gap: '6px', 'flex-wrap': 'wrap' }}>
+            <span style={qaPill()}>{t('tutorial.qa.example1')}</span>
+            <span style={qaPill()}>{t('tutorial.qa.example2')}</span>
+          </div>
+          <div style={{ display: 'flex', 'align-items': 'center', gap: '8px', border: '1px solid var(--line, #d1d5db)', 'border-radius': '4px', padding: '8px 11px', 'font-size': '13px', color: '#9ca3af', background: '#fbfaf8' }}>
+            <span style={{ flex: '1 1 auto' }}>{t('tutorial.qa.placeholder')}</span>
+            <span style={{ color: 'var(--accent, #8a2a2b)', 'font-weight': 700 }}>↵</span>
+          </div>
+        </div>
+      </Show>
     </div>
   );
 }
@@ -412,6 +425,12 @@ function transChip(): JSX.CSSProperties {
   return {
     background: '#f3eceb', border: '1px solid #e3cfcf', 'border-radius': '4px',
     padding: '3px 12px', 'font-size': '15px', color: 'var(--accent-strong, #6f2122)',
+  };
+}
+function qaPill(): JSX.CSSProperties {
+  return {
+    'font-size': '12px', background: '#f3eceb', color: 'var(--accent-strong, #6f2122)',
+    border: '1px solid #e3cfcf', 'border-radius': '999px', padding: '3px 10px', 'white-space': 'nowrap',
   };
 }
 function SpectrumRow(props: { labelKey: string; ids: GenerationId[] }): JSX.Element {

--- a/src/client/i18n.ts
+++ b/src/client/i18n.ts
@@ -985,9 +985,12 @@ const CATALOG = {
 
   'tutorial.qa.title': { en: 'Ask your own question', he: 'שאלו שאלה משלכם' },
   'tutorial.qa.body': {
-    en: 'At the bottom of a note you can pick a suggested question or type your own about the passage — the answer is written for you and grounded in the text.',
-    he: 'בתחתית ההערה אפשר לבחור שאלה מוצעת או להקליד שאלה משלכם על הקטע — התשובה נכתבת עבורכם ומעוגנת בטקסט.',
+    en: 'Most notes end with a Q&A box like this. Pick a suggested question or type your own about the passage — the answer is written for you and grounded in the text.',
+    he: 'רוב ההערות מסתיימות בתיבת שאלות ותשובות כזו. בחרו שאלה מוצעת או הקלידו שאלה משלכם על הקטע — התשובה נכתבת עבורכם ומעוגנת בטקסט.',
   },
+  'tutorial.qa.example1': { en: 'Why this order?', he: 'למה הסדר הזה?' },
+  'tutorial.qa.example2': { en: 'Who disagrees?', he: 'מי חולק?' },
+  'tutorial.qa.placeholder': { en: 'Ask about this passage…', he: 'שאלו על הקטע הזה…' },
   'tutorial.report.title': { en: 'Spot a problem?', he: 'מצאתם תקלה?' },
   'tutorial.report.body': {
     en: 'These notes are generated and not perfect. If something looks wrong — a mistranslation, a misplaced note, a bad reading — use "Report a problem" at the bottom of the daf to flag it. It genuinely helps.',

--- a/src/client/sidebar/primitives.tsx
+++ b/src/client/sidebar/primitives.tsx
@@ -615,14 +615,12 @@ export function QASection(props: {
   page: string;
 }): JSX.Element {
   return (
-    <div data-tour="qa-section">
-      <QAPanel
-        mark={props.mark}
-        instanceId={props.instanceId}
-        instance={props.instance}
-        tractate={props.tractate}
-        page={props.page}
-      />
-    </div>
+    <QAPanel
+      mark={props.mark}
+      instanceId={props.instanceId}
+      instance={props.instance}
+      tractate={props.tractate}
+      page={props.page}
+    />
   );
 }

--- a/src/client/tutorial.ts
+++ b/src/client/tutorial.ts
@@ -23,12 +23,13 @@ export const FEATURED_DAF = { tractate: 'Berakhot', page: '62b' } as const;
 
 /** Which real note a step opens behind the coach. The coach asks the embedded
  *  DafViewer to open it; the reader sees the genuine panel / drawer. */
-export type TourNote = 'overview' | 'argument' | 'halacha' | 'aggadata';
+export type TourNote = 'overview' | 'argument' | 'halacha';
 
 /** A small legend / demo drawn inside the coach card to supplement a step that
  *  teaches a concept rather than spotlighting a single element (the mark
- *  glyphs, the generation colour scale, the click-to-translate gesture). */
-export type TourSupplement = 'icons' | 'spectrum' | 'translate-word' | 'translate-phrase';
+ *  glyphs, the generation colour scale, the click-to-translate gesture, the
+ *  Q&A box). */
+export type TourSupplement = 'icons' | 'spectrum' | 'translate-word' | 'translate-phrase' | 'qa';
 
 export interface TourStep {
   id: string;
@@ -135,8 +136,9 @@ export const TOUR_STEPS: TourStep[] = [
   {
     id: 'qa',
     chapterKey: 'tutorial.chapter.marks',
-    target: 'qa-section',
-    note: 'aggadata',
+    target: 'note-panel',
+    note: 'overview',
+    supplement: 'qa',
     titleKey: 'tutorial.qa.title',
     bodyKey: 'tutorial.qa.body',
   },


### PR DESCRIPTION
Follow-up to #270/#273. The Q&A step tried to spotlight the live "ask your own question" panel, but reliably opening a note that renders it from the tour proved data-dependent: only **aggadata** notes carry the Q&A panel, and on the featured daf the typed `aggadata()` analysis is empty (the aggada gutter marks are a separate producer), so `openStory(0)` no-ops; the argument and overview notes don't carry the panel on this daf.

Rather than ship a step that silently shows nothing, the Q&A step now opens the **whole-daf overview** (which always opens) and the card carries a faithful Q&A demo (suggested-question pills + input). Reverts the `aggadata` note kind and the unused `qa-section` anchor.

typecheck clean; 1814 tests pass.