### PR TITLE
Tutorial: feature Berakhot 8a; tighter spotlights, real Q&A, warm + notice

### DIFF
--- a/src/client/QAPanel.tsx
+++ b/src/client/QAPanel.tsx
@@ -349,7 +349,7 @@ export default function QAPanel(props: QAPanelProps): JSX.Element {
   };
 
   return (
-    <div style={{
+    <div data-tour="argument-qa" style={{
       'margin-top': '0.6rem',
       'border-top': '1px solid #eee',
       'padding-top': '0.5rem',

--- a/src/client/TutorialCoach.tsx
+++ b/src/client/TutorialCoach.tsx
@@ -35,6 +35,9 @@ const PAD = 12;
 const MIN_VERT = 200;
 const MIN_HORIZ = 320;
 const MOBILE_BAR = 72; // room left for the mobile mode bar at the very bottom
+// A note panel is very tall; ring only its top (title + summary) instead of the
+// whole sidebar, which reads as "everything is highlighted" and looks wrong.
+const MAX_RING_H = 240;
 
 type Pos =
   | { mode: 'center' }
@@ -79,8 +82,8 @@ export function TutorialCoach(): JSX.Element {
     const s = step();
     const sel = s.selector ?? (s.target ? `[data-tour="${s.target}"]` : null);
     if (!sel) { setRect(null); reposition(); return; }
-    const el = document.querySelector(sel);
-    if (!el) {
+    const els = document.querySelectorAll(sel);
+    if (!els.length) {
       setRect(null);
       reposition();
       // Marks / notes load async — keep looking for a few seconds, then settle
@@ -88,10 +91,20 @@ export function TutorialCoach(): JSX.Element {
       if (attempt < 30) retryTimer = setTimeout(() => measure(attempt + 1), 120);
       return;
     }
+    // Pick which match to spotlight (e.g. a rabbi name from the body, not the
+    // first one crammed against the top).
+    let idx = 0;
+    if (s.selectorIndex === 'middle') idx = Math.floor(els.length / 2);
+    else if (typeof s.selectorIndex === 'number') idx = Math.max(0, Math.min(s.selectorIndex, els.length - 1));
+    const el = els[idx];
     // Scroll the target into the area the card won't cover.
     const block = isMobile() && mobileAnchor() === 'bottom' ? 'start' : 'center';
     el.scrollIntoView({ block: block as ScrollLogicalPosition, inline: 'center', behavior: 'smooth' });
-    setRect(el.getBoundingClientRect());
+    const raw = el.getBoundingClientRect();
+    // Ring only the top of a very tall target (a note panel), so we point at the
+    // note's summary rather than appearing to highlight the whole sidebar.
+    const h = Math.min(raw.height, MAX_RING_H);
+    setRect(new DOMRect(raw.left, raw.top, raw.width, h));
     reposition();
   };
   onCleanup(() => clearTimeout(retryTimer));
@@ -134,6 +147,21 @@ export function TutorialCoach(): JSX.Element {
     if (s.note) openTutorialNote(s.note); else closeTutorialNote();
     setPos(null);
     requestAnimationFrame(() => requestAnimationFrame(() => measure()));
+    // Expand the in-note Q&A panel so its real suggested questions show. Runs
+    // once per step entry (after the note has had a beat to render); the
+    // collapsed-state guard keeps repeated measures from toggling it shut.
+    if (s.expandQa) {
+      const tryExpand = (n = 0) => {
+        const toggle = document.querySelector<HTMLButtonElement>('[data-tour="argument-qa"] button[aria-expanded]');
+        if (toggle) {
+          if (toggle.getAttribute('aria-expanded') !== 'true') toggle.click();
+          requestAnimationFrame(() => measure());
+        } else if (n < 20) {
+          setTimeout(() => tryExpand(n + 1), 150);
+        }
+      };
+      setTimeout(() => tryExpand(), 400);
+    }
   });
 
   // Keep the cutout glued to the target through scroll / resize.
@@ -253,6 +281,11 @@ export function TutorialCoach(): JSX.Element {
           </div>
           <Show when={step().supplement}>
             {(kind) => <Supplement kind={kind()} />}
+          </Show>
+          <Show when={step().note}>
+            <div style={{ 'margin-top': '12px', 'font-size': '12px', 'line-height': 1.45, color: 'var(--muted, #6b7280)', 'font-style': 'italic' }}>
+              {t('tutorial.generating.note')}
+            </div>
           </Show>
           <Show when={step().id === 'finish'}>
             <div style={{ 'margin-top': '14px', 'font-size': '14px', 'line-height': 1.55, color: '#374151' }}>

--- a/src/client/TutorialPage.tsx
+++ b/src/client/TutorialPage.tsx
@@ -1,17 +1,36 @@
 /**
  * #tutorial — the guided walkthrough. It renders the REAL reader pinned to a
- * fixed daf (Berakhot 62b) in "embedded" mode (so it never disturbs where the
+ * fixed daf (Berakhot 8a) in "embedded" mode (so it never disturbs where the
  * actual reader sits) and lays the TutorialCoach over it. The coach walks you
  * around the page, spotlighting real controls and opening a real note. Because
  * this is our own dedicated page — fixed daf, no competing routes — the coach's
  * positioning is reliable in a way the old live-page overlay never was.
+ *
+ * On mount we fire a warm request for the featured daf so its marks, notes, and
+ * suggested-question lists are generated ahead of time — the walkthrough then
+ * shows real content instead of "Learning…". (Per-question answers still
+ * generate on click; the coach's note steps say so.)
  */
-import { type JSX } from 'solid-js';
+import { onMount, type JSX } from 'solid-js';
 import DafViewer from './DafViewer';
 import { TutorialCoach } from './TutorialCoach';
 import { FEATURED_DAF } from './tutorial';
+import { lang } from './i18n';
 
 export function TutorialPage(): JSX.Element {
+  onMount(() => {
+    // Fire-and-forget warm so the featured daf is ready when the user arrives.
+    try {
+      void fetch('/api/warm-daf', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ tractate: FEATURED_DAF.tractate, page: FEATURED_DAF.page, lang: lang() }),
+      }).catch(() => {});
+    } catch {
+      /* warming is best-effort */
+    }
+  });
+
   return (
     <>
       <DafViewer initialTractate={FEATURED_DAF.tractate} initialPage={FEATURED_DAF.page} embedded />

--- a/src/client/i18n.ts
+++ b/src/client/i18n.ts
@@ -973,6 +973,10 @@ const CATALOG = {
     en: 'This note zooms out to the whole page: a short summary, a map of how the discussion flows, key terms, and cross-references to where the sugya continues. A good place to get your bearings before diving in.',
     he: 'הערה זו מתרחקת אל כל הדף: סיכום קצר, מפה של מהלך הדיון, מונחי מפתח, והפניות למקום שבו הסוגיה ממשיכה. מקום טוב להתמצא בו לפני הצלילה ללימוד.',
   },
+  'tutorial.generating.note': {
+    en: 'These notes are written by AI. The first time someone opens one it can take a minute or two to generate; after that it loads instantly for everyone.',
+    he: 'ההערות נכתבות בבינה מלאכותית. בפעם הראשונה שמישהו פותח הערה היצירה עשויה לקחת דקה-שתיים; לאחר מכן היא נטענת מיד לכולם.',
+  },
 
   'tutorial.underline.title': { en: 'The colored names', he: 'השמות הצבעוניים' },
   'tutorial.underline.body': {

--- a/src/client/tutorial.ts
+++ b/src/client/tutorial.ts
@@ -15,11 +15,11 @@
  */
 
 /** The daf the tutorial features — pinned so the marks/notes are warm and the
- *  coach always points at the same, known content. Berakhot 62b: Bar Kappara's
- *  life-wisdom maxims (eat when hungry, drink when thirsty, and — the memorable
- *  last one — relieve yourself when you need to), woven with halacha, stories,
- *  and quoted verses, so every note type is represented. */
-export const FEATURED_DAF = { tractate: 'Berakhot', page: '62b' } as const;
+ *  coach always points at the same, known content. Berakhot 8a: a rich early
+ *  daf (the "time of favour", the worth of the synagogue, shnayim mikra) with
+ *  argument, halacha, aggada, quoted verses, and many named rabbis — so every
+ *  note type is represented. */
+export const FEATURED_DAF = { tractate: 'Berakhot', page: '8a' } as const;
 
 /** Which real note a step opens behind the coach. The coach asks the embedded
  *  DafViewer to open it; the reader sees the genuine panel / drawer. */
@@ -42,6 +42,12 @@ export interface TourStep {
   /** Raw CSS selector to spotlight instead of a `data-tour` target (used for
    *  generated daf content like a rabbi name). Takes precedence over `target`. */
   selector?: string;
+  /** Which match of `selector` to spotlight: an index, or 'middle' to pick one
+   *  in the body (so a rabbi-name highlight isn't crammed against the top). */
+  selectorIndex?: number | 'middle';
+  /** Expand the in-note Q&A panel ("ask your own question") for this step, so
+   *  the real suggested questions are visible. */
+  expandQa?: boolean;
   /** Open a real note (panel on desktop, drawer on mobile) for this step. */
   note?: TourNote;
   /** Keep the mobile top header drawer (tractate / nav / language) open for
@@ -111,6 +117,15 @@ export const TOUR_STEPS: TourStep[] = [
     bodyKey: 'tutorial.argument.body',
   },
   {
+    id: 'qa',
+    chapterKey: 'tutorial.chapter.marks',
+    target: 'argument-qa',
+    note: 'argument',
+    expandQa: true,
+    titleKey: 'tutorial.qa.title',
+    bodyKey: 'tutorial.qa.body',
+  },
+  {
     id: 'halacha',
     chapterKey: 'tutorial.chapter.marks',
     target: 'note-panel',
@@ -134,18 +149,10 @@ export const TOUR_STEPS: TourStep[] = [
     bodyKey: 'tutorial.overview.body',
   },
   {
-    id: 'qa',
-    chapterKey: 'tutorial.chapter.marks',
-    target: 'note-panel',
-    note: 'overview',
-    supplement: 'qa',
-    titleKey: 'tutorial.qa.title',
-    bodyKey: 'tutorial.qa.body',
-  },
-  {
     id: 'underline',
     chapterKey: 'tutorial.chapter.marks',
     selector: 'span.rabbi-underline',
+    selectorIndex: 'middle',
     titleKey: 'tutorial.underline.title',
     bodyKey: 'tutorial.underline.body',
     supplement: 'spectrum',


### PR DESCRIPTION
Addresses the latest round of feedback.

- **Featured daf → Berakhot 8a** (the daf you had in mind) — rich in argument, halacha, aggada, verses, and 32 named rabbis.
- **Spotlight no longer rings the whole sidebar.** Note-step ring height is clamped so it highlights just the note's summary (title + synthesis), not the entire panel.
- **Colored names highlights a real rabbi name in the body** — picks the middle `span.rabbi-underline` match (and scrolls it to center) instead of the first one crammed against the top.
- **Q&A uses the real in-note questions.** The Q&A step now follows the argument note and points at the argument move's QUESTIONS panel (`data-tour="argument-qa"`), auto-expanding it so the suggested questions are visible.
- **Prefetch:** entering `#tutorial` fires `/api/warm-daf` for the featured daf so marks, notes, and suggested-question *lists* are generated ahead of time.
- **Notice to the user:** note steps carry a line explaining AI notes can take a minute or two to generate the first time, then load instantly for everyone.

Note: per-question *answers* still generate on click (the notice covers that) — full answer prefetch is a heavier server warm I left out; happy to add it if you want.

typecheck clean; 1814 tests pass; build succeeds. Verifying the visual results on production after deploy (local dev has no LLM key, so the AI notes don't render locally).