### PR TITLE
Tutorial: keep the argument note open across the Q&A step

### DIFF
--- a/src/client/TutorialCoach.tsx
+++ b/src/client/TutorialCoach.tsx
@@ -140,11 +140,18 @@ export function TutorialCoach(): JSX.Element {
     setPos({ mode: 'center' });
   };
 
-  // Drive the page for each step, then measure once layout settles.
+  // Drive the page for each step, then measure once layout settles. Only
+  // open/close a note when the kind actually changes between steps — so the
+  // Q&A step (same argument note as the previous step) doesn't remount the
+  // panel and lose the expanded state we're about to spotlight.
+  let prevNote: string | undefined;
   createEffect(() => {
     const s = step();
     setTutorialHeader(!!s.header);
-    if (s.note) openTutorialNote(s.note); else closeTutorialNote();
+    if (s.note !== prevNote) {
+      if (s.note) openTutorialNote(s.note); else closeTutorialNote();
+      prevNote = s.note;
+    }
     setPos(null);
     requestAnimationFrame(() => requestAnimationFrame(() => measure()));
     // Expand the in-note Q&A panel so its real suggested questions show. Runs


### PR DESCRIPTION
Small fix on top of #277. The Q&A step opens the same argument note as the previous step; re-opening it remounted the panel and lost the expanded QUESTIONS state the coach spotlights. Now the coach only opens/closes a note when the kind changes between steps, so the argument note stays mounted and the Q&A panel expands + spotlights reliably.

typecheck clean; 1814 tests pass.