### PR TITLE
Alignment collect band: real cache state + source/mark disambiguation

### DIFF
--- a/src/client/AlignPage.tsx
+++ b/src/client/AlignPage.tsx
@@ -178,12 +178,15 @@ export function AlignPage(): JSX.Element {
       <span class="aw-range">${e.segs.length ? `seg ${e.segs.join(', ')}` : 'no text match'}</span></div>`;
   }
   function collectRowsHtml(range: Set<number>): string {
+    // group by the SOURCE id (not the label) so the two "Halacha" sources
+    // (sefaria-halacha vs dafyomi:halacha) stay distinct and never read as the
+    // Halacha *mark*; show the id so a context source is unambiguous.
     const groups = new Map<string, { label: string; key: string; segs: Set<number>; source: string }>();
     for (const it of onLine()) {
       if (!it.segs.some((s) => range.has(s))) continue;
-      const g = groups.get(it.sourceLabel) ?? { label: it.sourceLabel, key: it.key, segs: new Set(), source: it.source };
+      const g = groups.get(it.source) ?? { label: it.sourceLabel, key: it.key, segs: new Set(), source: it.source };
       it.segs.forEach((s) => g.segs.add(s));
-      groups.set(it.sourceLabel, g);
+      groups.set(it.source, g);
     }
     const rows = [...groups.values()];
     if (!rows.length) return '<div class="aw-note" style="margin:.2rem 0 0">whole-daf context only</div>';
@@ -192,7 +195,7 @@ export function AlignPage(): JSX.Element {
       const t = timing().find((x) => x.sources.includes(g.source));
       const ms = t?.ms ?? 0; const cache = t ? (t.cache === 'hit' ? 'cached' : t.cache === 'miss' ? 'fetched' : t.cache) : '—';
       return `<div class="aw-wfrow aw-src" data-src="${esc(g.key)}" data-hl="${[...g.segs].join(',')}">
-        <div class="aw-wflabel">${dot('#16a34a')}${esc(g.label)}</div>
+        <div class="aw-wflabel">${dot('#16a34a')}${esc(g.label)} <span class="aw-srcid">${esc(g.source)}</span></div>
         <div class="aw-wftrack"><div class="aw-wfbar src" style="width:${Math.max(4, (ms / max) * 100)}%"></div></div>
         <div class="aw-wfmeta">${fmtMs(ms)} · <span class="free">${cache}</span></div></div>`;
     }).join('');
@@ -467,6 +470,7 @@ const STYLE = `
 .aw-wfrow{display:grid;grid-template-columns:130px 1fr 92px;gap:.5rem;align-items:center;cursor:pointer;padding:2px 4px;border-radius:3px}
 .aw-wfrow:hover{background:#f1ece2}
 .aw-wflabel{font-size:11px;color:#334155;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;display:flex;align-items:center;gap:.3rem}
+.aw-srcid{font-family:ui-monospace,Menlo,monospace;font-size:9px;color:#94a3b8}
 .aw-wftrack{position:relative;height:13px;background:#efece4;border-radius:3px}
 .aw-wfbar{position:absolute;top:0;left:0;height:13px;border-radius:3px;min-width:3px}.aw-wfbar.src{background:#c2ccd6}
 .aw-wfmeta{font-family:ui-monospace,Menlo,monospace;font-size:9.5px;color:#64748b;text-align:right;white-space:nowrap}

--- a/src/worker/context-providers.ts
+++ b/src/worker/context-providers.ts
@@ -103,10 +103,10 @@ export async function collectContext(
       (track) => getDafyomiContentCached(cache, env.ASSETS, tractate, page, { assetOrigin: opts.assetOrigin, allowLive, track })),
     rec('sefaria-page', ['sefaria-rashi', 'sefaria-tosafot'], (track) => getSefariaPageCached(cache, tractate, page, track)),
     rec('sefaria-segments', [], (track) => getSefariaSegmentsCached(cache, tractate, page, track)),
-    rec('rishonim', ['sefaria-rishonim'], () => getRishonimCached(cache, tractate, page)),
-    rec('halacha-refs', ['sefaria-halacha'], () => getHalachaRefsCached(cache, tractate, page)),
-    rec('mishna', ['sefaria-mishnah'], () => getMishnaBundleCached(cache, tractate, page)),
-    rec('topics', ['sefaria-topic'], () => getDafTopicsCached(cache, tractate, page)),
+    rec('rishonim', ['sefaria-rishonim'], (track) => getRishonimCached(cache, tractate, page, track)),
+    rec('halacha-refs', ['sefaria-halacha'], (track) => getHalachaRefsCached(cache, tractate, page, track)),
+    rec('mishna', ['sefaria-mishnah'], (track) => getMishnaBundleCached(cache, tractate, page, track)),
+    rec('topics', ['sefaria-topic'], (track) => getDafTopicsCached(cache, tractate, page, track)),
   ]);
 
   const items: ContextItem[] = [];

--- a/src/worker/source-cache.ts
+++ b/src/worker/source-cache.ts
@@ -142,6 +142,7 @@ export async function getRishonimCached(
   cache: KVNamespace | undefined,
   tractate: string,
   page: string,
+  track?: CacheTrack,
 ): Promise<RishonimBundle> {
   // v2: per-comment, segment-anchored RishonComment[] (was a whole-daf blob
   // Record<label, snippet>). v3: expanded the Rishonim allowlist (Yad Ramah,
@@ -151,6 +152,7 @@ export async function getRishonimCached(
   // Bump so cached dapim refetch with the new works.
   const key = keyForRishonim(tractate, page);
   const hit = await readCache<RishonimBundle>(cache, key);
+  track?.onCache?.(hit ? 'hit' : 'miss');
   if (hit) return hit;
   try {
     const data = await sefariaAPI.fetchRishonim(tractate, page);
@@ -165,10 +167,12 @@ export async function getHalachaRefsCached(
   cache: KVNamespace | undefined,
   tractate: string,
   page: string,
+  track?: CacheTrack,
 ): Promise<HalachicRefBundle> {
   // v2: snippets now carry segStart/segEnd (the linked daf segment).
   const key = keyForHalachaRefs(tractate, page);
   const hit = await readCache<HalachicRefBundle>(cache, key);
+  track?.onCache?.(hit ? 'hit' : 'miss');
   if (hit) return hit;
   try {
     const data = await sefariaAPI.fetchHalachicRefs(tractate, page);
@@ -211,9 +215,11 @@ export async function getDafTopicsCached(
   cache: KVNamespace | undefined,
   tractate: string,
   page: string,
+  track?: CacheTrack,
 ): Promise<SefariaTopicBundle> {
   const key = keyForDafTopics(tractate, page);
   const hit = await readCache<SefariaTopicBundle>(cache, key);
+  track?.onCache?.(hit ? 'hit' : 'miss');
   if (hit) return hit;
   try {
     const data = await sefariaAPI.fetchDafTopics(`${tractate}.${page}`);
@@ -233,9 +239,11 @@ export async function getMishnaBundleCached(
   cache: KVNamespace | undefined,
   tractate: string,
   page: string,
+  track?: CacheTrack,
 ): Promise<MishnaBundle> {
   const key = keyForMishnaBundle(tractate, page);
   const hit = await readCache<MishnaBundle>(cache, key);
+  track?.onCache?.(hit ? 'hit' : 'miss');
   if (hit) return hit;
   try {
     const data = await sefariaAPI.fetchMishnaForDaf(tractate, page);


### PR DESCRIPTION
Two small fixes from review of the 'made from' waterfall:

- The 'unknown' cache state on rishonim/halacha-refs/mishna/topics was just because those fetchers didn't report hit/miss; thread CacheTrack through them so the collect band shows cached/fetched.
- The collect band's 'Halacha' is the sefaria-halacha context source, not the Halacha mark. Group collect rows by source id (not label) and show the id, so a context source is unambiguous and the two halacha sources stay distinct.

typecheck clean; 1814 tests pass.