### PR TITLE
Tutorial: real word/phrase translation; spotlight waits for populate

### DIFF
--- a/src/client/DafViewer.tsx
+++ b/src/client/DafViewer.tsx
@@ -54,7 +54,7 @@ import type { GenerationId } from './generations';
 import { GENERATION_BY_ID } from './generations';
 import { resolveVoiceGroup, voiceGroupNames } from './voiceGroups';
 import { t, lang, setLang } from './i18n';
-import { hasCompletedTutorial, hasDismissedBanner, TUTORIAL_OPEN_NOTE_EVENT, TUTORIAL_CLOSE_NOTE_EVENT, TUTORIAL_HEADER_EVENT } from './tutorial';
+import { hasCompletedTutorial, hasDismissedBanner, TUTORIAL_OPEN_NOTE_EVENT, TUTORIAL_CLOSE_NOTE_EVENT, TUTORIAL_HEADER_EVENT, TUTORIAL_TRANSLATE_EVENT } from './tutorial';
 import { TutorialBanner } from './TutorialBanner';
 
 /** Normalize a rabbi name for fuzzy lookup: drop honorific prefixes, lower
@@ -2414,13 +2414,29 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
       if (!isMobile()) return;
       setHeaderOpen(!!(e as CustomEvent<{ open: boolean }>).detail?.open);
     };
+    // The translate steps fire a real translation on the daf: pick a word (or a
+    // short run) about a third of the way down so it's clear of the chrome,
+    // scroll it into view, and activate it — the genuine popup then appears.
+    const onTranslate = (e: Event) => {
+      const kind = (e as CustomEvent<{ kind?: string }>).detail?.kind ?? 'word';
+      if (kind === 'clear') { clearActive(); return; }
+      const words = Array.from(document.querySelectorAll<HTMLElement>('.daf-word'));
+      if (words.length < 4) return;
+      if (isMobile()) setMobileMode('translate');
+      const start = Math.floor(words.length * 0.35);
+      const picked = kind === 'phrase' ? words.slice(start, start + 3) : [words[start]];
+      picked[0].scrollIntoView({ block: 'center', inline: 'center' });
+      setActiveFromWordEls(picked);
+    };
     window.addEventListener(TUTORIAL_OPEN_NOTE_EVENT, onOpen);
     window.addEventListener(TUTORIAL_CLOSE_NOTE_EVENT, onClose);
     window.addEventListener(TUTORIAL_HEADER_EVENT, onHeader);
+    window.addEventListener(TUTORIAL_TRANSLATE_EVENT, onTranslate);
     onCleanup(() => {
       window.removeEventListener(TUTORIAL_OPEN_NOTE_EVENT, onOpen);
       window.removeEventListener(TUTORIAL_CLOSE_NOTE_EVENT, onClose);
       window.removeEventListener(TUTORIAL_HEADER_EVENT, onHeader);
+      window.removeEventListener(TUTORIAL_TRANSLATE_EVENT, onTranslate);
     });
   });
 

--- a/src/client/TutorialCoach.tsx
+++ b/src/client/TutorialCoach.tsx
@@ -25,6 +25,7 @@ import {
   openTutorialNote,
   closeTutorialNote,
   setTutorialHeader,
+  triggerTutorialTranslate,
   type TourSupplement,
 } from './tutorial';
 import { GutterGlyph, colorForKind, type GutterKind } from './GutterIcons';
@@ -68,6 +69,7 @@ export function TutorialCoach(): JSX.Element {
   const finish = () => {
     closeTutorialNote();
     setTutorialHeader(false);
+    triggerTutorialTranslate('clear');
     markCompleted();
     window.location.hash = 'daf';
   };
@@ -77,37 +79,57 @@ export function TutorialCoach(): JSX.Element {
   // Where the mobile sheet sits: away from what the step occupies.
   const mobileAnchor = (): 'top' | 'bottom' => (step().note ? 'top' : 'bottom');
 
-  const measure = (attempt = 0) => {
-    clearTimeout(retryTimer);
+  // Watch the spotlit element for size changes (a note panel grows as its
+  // content loads) and re-measure, so the ring waits for the panel to populate
+  // instead of locking onto its empty, pre-load size.
+  const ro = typeof ResizeObserver !== 'undefined'
+    ? new ResizeObserver(() => requestAnimationFrame(() => measure(0, true)))
+    : null;
+  let observed: Element | null = null;
+
+  const measure = (attempt = 0, fromObserver = false) => {
+    if (!fromObserver) clearTimeout(retryTimer);
     const s = step();
     const sel = s.selector ?? (s.target ? `[data-tour="${s.target}"]` : null);
     if (!sel) { setRect(null); reposition(); return; }
-    const els = document.querySelectorAll(sel);
-    if (!els.length) {
+    const all = Array.from(document.querySelectorAll<HTMLElement>(sel));
+    if (!all.length) {
       setRect(null);
       reposition();
       // Marks / notes load async — keep looking for a few seconds, then settle
       // into the centered fallback if the target genuinely never appears.
-      if (attempt < 30) retryTimer = setTimeout(() => measure(attempt + 1), 120);
+      if (!fromObserver && attempt < 30) retryTimer = setTimeout(() => measure(attempt + 1), 120);
       return;
     }
-    // Pick which match to spotlight (e.g. a rabbi name from the body, not the
-    // first one crammed against the top).
-    let idx = 0;
-    if (s.selectorIndex === 'middle') idx = Math.floor(els.length / 2);
-    else if (typeof s.selectorIndex === 'number') idx = Math.max(0, Math.min(s.selectorIndex, els.length - 1));
-    const el = els[idx];
-    // Scroll the target into the area the card won't cover.
-    const block = isMobile() && mobileAnchor() === 'bottom' ? 'start' : 'center';
-    el.scrollIntoView({ block: block as ScrollLogicalPosition, inline: 'center', behavior: 'smooth' });
-    const raw = el.getBoundingClientRect();
-    // Ring only the top of a very tall target (a note panel), so we point at the
-    // note's summary rather than appearing to highlight the whole sidebar.
-    const h = Math.min(raw.height, MAX_RING_H);
-    setRect(new DOMRect(raw.left, raw.top, raw.width, h));
+    // Which match(es) to ring: a specific index (e.g. a rabbi name from the
+    // body), else the union of all matches (e.g. every word of a phrase).
+    let targets = all;
+    if (s.selectorIndex === 'middle') targets = [all[Math.floor(all.length / 2)]];
+    else if (typeof s.selectorIndex === 'number') targets = [all[Math.max(0, Math.min(s.selectorIndex, all.length - 1))]];
+
+    const lead = targets[0];
+    // Observe the element so we re-measure when it grows (content populates).
+    if (observed !== lead) { if (observed) ro?.unobserve(observed); ro?.observe(lead); observed = lead; }
+    // Scroll the target into the area the card won't cover (skip when the
+    // re-measure was triggered by a resize, to avoid scroll fights).
+    if (!fromObserver) {
+      const block = isMobile() && mobileAnchor() === 'bottom' ? 'start' : 'center';
+      lead.scrollIntoView({ block: block as ScrollLogicalPosition, inline: 'center', behavior: 'smooth' });
+    }
+    // Union bounding box of the targets.
+    const rs = targets.map((el) => el.getBoundingClientRect());
+    const left = Math.min(...rs.map((r) => r.left));
+    const top = Math.min(...rs.map((r) => r.top));
+    const right = Math.max(...rs.map((r) => r.right));
+    let bottom = Math.max(...rs.map((r) => r.bottom));
+    // On desktop a note panel is very tall — ring only its top (title +
+    // summary) so it doesn't read as "the whole sidebar is highlighted". On
+    // mobile the note IS the drawer, so ring its full (populated) height.
+    if (!isMobile() && bottom - top > MAX_RING_H) bottom = top + MAX_RING_H;
+    setRect(new DOMRect(left, top, right - left, bottom - top));
     reposition();
   };
-  onCleanup(() => clearTimeout(retryTimer));
+  onCleanup(() => { clearTimeout(retryTimer); ro?.disconnect(); });
 
   const reposition = () => {
     if (isMobile()) { setPos(null); return; } // mobile uses fixed sheets, not side math
@@ -145,6 +167,7 @@ export function TutorialCoach(): JSX.Element {
   // Q&A step (same argument note as the previous step) doesn't remount the
   // panel and lose the expanded state we're about to spotlight.
   let prevNote: string | undefined;
+  let prevTranslate: string | undefined;
   createEffect(() => {
     const s = step();
     setTutorialHeader(!!s.header);
@@ -152,8 +175,18 @@ export function TutorialCoach(): JSX.Element {
       if (s.note) openTutorialNote(s.note); else closeTutorialNote();
       prevNote = s.note;
     }
+    // Fire (or clear) a real translation on the daf for the translate steps.
+    if (s.translate !== prevTranslate) {
+      if (s.translate) triggerTutorialTranslate(s.translate);
+      else if (prevTranslate) triggerTutorialTranslate('clear');
+      prevTranslate = s.translate;
+    }
     setPos(null);
     requestAnimationFrame(() => requestAnimationFrame(() => measure()));
+    // Content (notes, the translation popup) and any autoscroll settle async —
+    // re-measure a few times so the ring lands on the populated, settled target
+    // instead of its empty pre-load size.
+    for (const ms of [250, 600, 1200, 2200]) setTimeout(() => measure(0, true), ms);
     // Expand the in-note Q&A panel so its real suggested questions show. Runs
     // once per step entry (after the note has had a beat to render); the
     // collapsed-state guard keeps repeated measures from toggling it shut.
@@ -183,7 +216,7 @@ export function TutorialCoach(): JSX.Element {
   });
 
   // Leaving the tour: restore the reader's chrome.
-  onCleanup(() => { closeTutorialNote(); setTutorialHeader(false); });
+  onCleanup(() => { closeTutorialNote(); setTutorialHeader(false); triggerTutorialTranslate('clear'); });
 
   onMount(() => {
     const onKey = (e: KeyboardEvent) => {

--- a/src/client/tutorial.ts
+++ b/src/client/tutorial.ts
@@ -50,6 +50,9 @@ export interface TourStep {
   expandQa?: boolean;
   /** Open a real note (panel on desktop, drawer on mobile) for this step. */
   note?: TourNote;
+  /** Trigger a real translation on the daf: select one word, or a short run of
+   *  words, so the genuine translation popup appears. */
+  translate?: 'word' | 'phrase';
   /** Keep the mobile top header drawer (tractate / nav / language) open for
    *  this step — its target lives inside it. No-op on desktop. */
   header?: boolean;
@@ -89,16 +92,18 @@ export const TOUR_STEPS: TourStep[] = [
   {
     id: 'translate-word',
     chapterKey: 'tutorial.chapter.reading',
+    selector: '.daf-word-active',
+    translate: 'word',
     titleKey: 'tutorial.translateWord.title',
     bodyKey: 'tutorial.translateWord.body',
-    supplement: 'translate-word',
   },
   {
     id: 'translate-phrase',
     chapterKey: 'tutorial.chapter.reading',
+    selector: '.daf-word-active',
+    translate: 'phrase',
     titleKey: 'tutorial.translatePhrase.title',
     bodyKey: 'tutorial.translatePhrase.body',
-    supplement: 'translate-phrase',
   },
   {
     id: 'marks',
@@ -180,6 +185,14 @@ export const TOUR_STEPS: TourStep[] = [
 export const TUTORIAL_OPEN_NOTE_EVENT = 'tutorial-open-note'; // detail: { note: TourNote }
 export const TUTORIAL_CLOSE_NOTE_EVENT = 'tutorial-close-note';
 export const TUTORIAL_HEADER_EVENT = 'tutorial-header'; // detail: { open: boolean }
+/** Ask the embedded DafViewer to actually translate a word / phrase / clear it,
+ *  so the translate steps fire the genuine translation popup on the daf. */
+export const TUTORIAL_TRANSLATE_EVENT = 'tutorial-translate'; // detail: { kind: 'word'|'phrase'|'clear' }
+
+export function triggerTutorialTranslate(kind: 'word' | 'phrase' | 'clear'): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent(TUTORIAL_TRANSLATE_EVENT, { detail: { kind } }));
+}
 
 /** Ask the embedded DafViewer to open a real note of the given kind. */
 export function openTutorialNote(note: TourNote): void {


### PR DESCRIPTION
More feedback from the latest round.

- **Translate steps actually translate now.** Instead of the in-card demo, the translate-word and translate-phrase steps fire a real translation on the daf (a `tutorial-translate` event → the embedded DafViewer selects a word / a 3-word run, scrolls it into view, and activates it) so the genuine translation popup appears. Mobile flips to Translate mode first; the selection is cleared when the step is left or the tour ends.
- **Spotlight waits for the note to populate.** The ring was being measured before the note content loaded (and before autoscroll settled), so it didn't cover everything. Now a ResizeObserver on the target plus a few settle re-measures keep the ring in sync as the panel fills in and the page settles.
- **Ring covers the right area.** It now rings the *union* of a multi-match selector (so a phrase rings all its words), and on **mobile** rings the note drawer's full populated height (desktop still rings just the summary, not the whole sidebar).

typecheck clean; 1814 tests pass; build succeeds. Verifying on production after deploy (local dev has no LLM key for the notes).