### PR TITLE
Tutorial: translate main text, keep popup bright, ring full note, prebake Q&A

### DIFF
--- a/src/client/DafViewer.tsx
+++ b/src/client/DafViewer.tsx
@@ -2423,10 +2423,14 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
     const onTranslate = (e: Event) => {
       const kind = (e as CustomEvent<{ kind?: string }>).detail?.kind ?? 'word';
       if (kind === 'clear') { clearActive(); return; }
-      const words = Array.from(document.querySelectorAll<HTMLElement>('.daf-word'));
+      // Only the main gemara text (.daf-main .daf-text) — never Rashi / Tosafot.
+      let words = Array.from(document.querySelectorAll<HTMLElement>('.daf-main .daf-text .daf-word'));
+      if (words.length < 4) words = Array.from(document.querySelectorAll<HTMLElement>('.daf-word'));
       if (words.length < 4) return;
       if (isMobile()) setMobileMode('translate');
-      const start = Math.floor(words.length * 0.35);
+      // A bit past the opening so it's clear of the chrome, but solidly inside
+      // the main column.
+      const start = Math.floor(words.length * 0.4);
       const picked = kind === 'phrase' ? words.slice(start, start + 3) : [words[start]];
       picked[0].scrollIntoView({ block: 'center', inline: 'center' });
       setActiveFromWordEls(picked);

--- a/src/client/QAPanel.tsx
+++ b/src/client/QAPanel.tsx
@@ -27,7 +27,8 @@
  * `user_question` in the body.
  */
 
-import { createSignal, createResource, For, Show, type JSX } from 'solid-js';
+import { createSignal, createResource, onMount, For, Show, type JSX } from 'solid-js';
+import { tutorialPrefetch } from './tutorial';
 import { Hebraized } from './Hebraized';
 import { hebraize } from './hebraize';
 import { trackAI } from './aiActivity';
@@ -200,7 +201,33 @@ function pickQALoadingCopy(): string {
   return QA_LOADING_OPTIONS[Math.floor(Math.random() * QA_LOADING_OPTIONS.length)];
 }
 
+// Bounds the tutorial's background answer pre-warm: only the first couple of
+// panels, only their first few questions, deduped, so we don't fan out the
+// whole open note into a burst of LLM calls.
+const qaPrefetched = new Set<string>();
+let qaPrefetchPanels = 0;
+const MAX_QA_PREFETCH_PANELS = 2;
+const MAX_QA_PREFETCH_QUESTIONS = 3;
+
 export default function QAPanel(props: QAPanelProps): JSX.Element {
+  // During the tutorial, quietly warm a few suggested-question answers so the
+  // Q&A step's questions click through instantly instead of generating live.
+  onMount(() => {
+    if (!tutorialPrefetch()) return;
+    const key = `${props.mark}:${props.instanceId}`;
+    if (qaPrefetched.has(key) || qaPrefetchPanels >= MAX_QA_PREFETCH_PANELS) return;
+    qaPrefetched.add(key);
+    qaPrefetchPanels++;
+    void (async () => {
+      try {
+        const qs = await fetchSuggested(props.mark, props.tractate, props.page, props.instanceId, props.instance);
+        for (const q of qs.slice(0, MAX_QA_PREFETCH_QUESTIONS)) {
+          await runEnrichmentDirect(`${props.mark}.qa`, props.tractate, props.page, props.instance, q.q).catch(() => {});
+        }
+      } catch { /* best-effort cache warm */ }
+    })();
+  });
+
   const mark = (): 'argument-move' | 'pesukim' | 'aggadata' => props.mark;
   const instanceId = (): string => props.instanceId;
   const instance = (): unknown => props.instance;

--- a/src/client/TutorialCoach.tsx
+++ b/src/client/TutorialCoach.tsx
@@ -26,6 +26,7 @@ import {
   closeTutorialNote,
   setTutorialHeader,
   triggerTutorialTranslate,
+  setTutorialPrefetch,
   type TourSupplement,
 } from './tutorial';
 import { GutterGlyph, colorForKind, type GutterKind } from './GutterIcons';
@@ -36,9 +37,6 @@ const PAD = 12;
 const MIN_VERT = 200;
 const MIN_HORIZ = 320;
 const MOBILE_BAR = 72; // room left for the mobile mode bar at the very bottom
-// A note panel is very tall; ring only its top (title + summary) instead of the
-// whole sidebar, which reads as "everything is highlighted" and looks wrong.
-const MAX_RING_H = 240;
 
 type Pos =
   | { mode: 'center' }
@@ -116,16 +114,14 @@ export function TutorialCoach(): JSX.Element {
       const block = isMobile() && mobileAnchor() === 'bottom' ? 'start' : 'center';
       lead.scrollIntoView({ block: block as ScrollLogicalPosition, inline: 'center', behavior: 'smooth' });
     }
-    // Union bounding box of the targets.
+    // Union bounding box of the targets — the whole note panel (it's measured
+    // after the content populates, via the ResizeObserver + settle re-measures
+    // below), the rabbi name, or the word + its translation popup.
     const rs = targets.map((el) => el.getBoundingClientRect());
     const left = Math.min(...rs.map((r) => r.left));
     const top = Math.min(...rs.map((r) => r.top));
     const right = Math.max(...rs.map((r) => r.right));
-    let bottom = Math.max(...rs.map((r) => r.bottom));
-    // On desktop a note panel is very tall — ring only its top (title +
-    // summary) so it doesn't read as "the whole sidebar is highlighted". On
-    // mobile the note IS the drawer, so ring its full (populated) height.
-    if (!isMobile() && bottom - top > MAX_RING_H) bottom = top + MAX_RING_H;
+    const bottom = Math.max(...rs.map((r) => r.bottom));
     setRect(new DOMRect(left, top, right - left, bottom - top));
     reposition();
   };
@@ -216,7 +212,10 @@ export function TutorialCoach(): JSX.Element {
   });
 
   // Leaving the tour: restore the reader's chrome.
-  onCleanup(() => { closeTutorialNote(); setTutorialHeader(false); triggerTutorialTranslate('clear'); });
+  // While the tour is up, QAPanels pre-warm a few suggested answers so the Q&A
+  // step's questions click through instantly.
+  setTutorialPrefetch(true);
+  onCleanup(() => { closeTutorialNote(); setTutorialHeader(false); triggerTutorialTranslate('clear'); setTutorialPrefetch(false); });
 
   onMount(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -337,7 +336,7 @@ export function TutorialCoach(): JSX.Element {
           </Show>
         </div>
 
-        <div style={{ padding: '12px 20px 16px', 'border-top': '1px solid #f1efea', flex: '0 0 auto' }}>
+        <div style={{ padding: '14px 20px 22px', 'border-top': '1px solid #f1efea', flex: '0 0 auto' }}>
           <Dots index={i()} onJump={setI} />
           <div style={{ display: 'flex', 'align-items': 'center', 'justify-content': 'space-between', gap: '8px', 'margin-top': '12px' }}>
             <Show when={!isLast()} fallback={<span />}>

--- a/src/client/tutorial.ts
+++ b/src/client/tutorial.ts
@@ -1,3 +1,5 @@
+import { createSignal } from 'solid-js';
+
 /**
  * Tutorial data + persistence. The walkthrough (#tutorial) renders the REAL
  * reader pinned to a fixed daf and a coach (TutorialCoach.tsx) walks you around
@@ -92,7 +94,7 @@ export const TOUR_STEPS: TourStep[] = [
   {
     id: 'translate-word',
     chapterKey: 'tutorial.chapter.reading',
-    selector: '.daf-word-active',
+    selector: '.daf-word-active, .translation-popup',
     translate: 'word',
     titleKey: 'tutorial.translateWord.title',
     bodyKey: 'tutorial.translateWord.body',
@@ -100,7 +102,7 @@ export const TOUR_STEPS: TourStep[] = [
   {
     id: 'translate-phrase',
     chapterKey: 'tutorial.chapter.reading',
-    selector: '.daf-word-active',
+    selector: '.daf-word-active, .translation-popup',
     translate: 'phrase',
     titleKey: 'tutorial.translatePhrase.title',
     bodyKey: 'tutorial.translatePhrase.body',
@@ -211,6 +213,12 @@ export function setTutorialHeader(open: boolean): void {
   if (typeof window === 'undefined') return;
   window.dispatchEvent(new CustomEvent(TUTORIAL_HEADER_EVENT, { detail: { open } }));
 }
+
+/** While the tour is running, QAPanels pre-fetch a few of their suggested
+ *  answers in the background so the Q&A step's questions click through
+ *  instantly instead of generating on demand. The coach toggles this. */
+const [tutorialPrefetch, setTutorialPrefetch] = createSignal(false);
+export { tutorialPrefetch, setTutorialPrefetch };
 
 const COMPLETED_KEY = 'tutorial:completed';
 const BANNER_DISMISSED_KEY = 'tutorial:banner-dismissed';


### PR DESCRIPTION
Latest round of feedback.

- **Translate the main gemara, popup stays bright.** The translate steps pick a word/phrase from `.daf-main .daf-text` (never Rashi/Tosafot), and the spotlight rings the **union of the active word(s) and the translation popup** so the translation isn't dimmed by the backdrop.
- **Ring the whole note after it populates.** Dropped the height clamp — the ResizeObserver + settle re-measures already wait for the note to fill in, so the ring now covers the full populated panel (desktop and mobile), which is what was wanted ("not highlighting everything").
- **Pre-bake the tutorial daf's Q&A.** While the tour runs, QAPanels quietly warm a few suggested-question answers in the background (bounded to the first couple panels / first few questions, deduped). Answers cache in shared KV, so once warmed, the Q&A step's questions click through instantly for everyone — a one-time warm.
- **Carousel padding.** A bit more bottom padding in the coach card footer.

typecheck clean; 1814 tests pass; build succeeds. Verifying on production after deploy.