### PR TITLE
Inspect: focus the generation (enrichment), not the mark; per-instance run-tree

### DIFF
--- a/src/client/MarkEnrichmentCards.tsx
+++ b/src/client/MarkEnrichmentCards.tsx
@@ -38,13 +38,13 @@ const [openInspectorKey, setOpenInspectorKey] = createSignal<string | null>(null
 // drawer focused on its leaf.
 const [inspectorView, setInspectorView] = createSignal<string | null>(null);
 
-/** Open the build inspector focused on the producer that `leafId` belongs to —
- *  the whole-daf MARK (always cached), so the Inspect panel shows a real DAG.
- *  `instanceKey` is kept for signature compatibility with existing call sites.
- *  Replaces the old per-instance bottom drawer: now routes to RunTreeDock. */
+/** Open the build inspector focused on `leafId` — the ENRICHMENT (the
+ *  generation), e.g. 'argument.voices' / 'rabbi.relationships'. Focus that, not
+ *  its parent mark, so the DAG shows the generation + its sub-enrichments rather
+ *  than the raw source extraction. Routes to RunTreeDock (the old per-instance
+ *  bottom drawer is retired). */
 export function openInstanceInspector(instanceKey: string, leafId: string | null = null): void {
-  const piece = leafId ? (leafId.split('.')[0] || leafId) : instanceKey;
-  requestInspect(piece);
+  requestInspect(leafId ?? instanceKey);
 }
 
 /** The small circular "i" affordance. Dev-mode only. Drop next to any section
@@ -708,8 +708,10 @@ export default function MarkEnrichmentCards(props: Props) {
     // toggleHighlight wrapper). Stop propagation so the inspector affordance
     // doesn't double as a highlight toggle.
     if (e) e.stopPropagation();
-    // The card's own (i) inspects this card's whole-daf mark in the Inspect panel.
-    requestInspect(props.markId);
+    // The card's own (i) inspects this card's GENERATION — its aggregate
+    // (synthesis) enrichment, at THIS instance — so the DAG shows the synthesis
+    // breaking down into its sub-enrichments, with the real cached output.
+    requestInspect(aggregates()[0]?.id ?? props.markId, props.instance);
   };
 
   // Sidebar card: production view in all modes — clean synthesis output in

--- a/src/client/RunTreeDock.tsx
+++ b/src/client/RunTreeDock.tsx
@@ -270,19 +270,29 @@ export default function RunTreeDock(props: {
       .filter((r) => typeFilter().has(variantOf(r)))
       .sort((a, b) => (live.has(b.id) ? 1 : 0) - (live.has(a.id) ? 1 : 0));
   });
-  const openPiece = (id: string) => { setPieceId(id); setExpanded(new Set([id])); setSelected(id); setView('dag'); };
+  // Per-instance focus (a mark_input) when an (i) inspects e.g. one section's
+  // synthesis; null = whole-daf. Cleared when navigating via the waterfall.
+  const [focusInstance, setFocusInstance] = createSignal<unknown>(null);
+  const openPiece = (id: string, instance: unknown = null) => { setPieceId(id); setFocusInstance(instance); setExpanded(new Set([id])); setSelected(id); setView('dag'); };
 
   // An (i) / card affordance anywhere asked to inspect a piece — focus its DAG.
   // (DafViewer opens the panel on the same request.)
   createEffect(() => {
     const req = inspectRequest();
-    if (req) { setTab('build'); openPiece(req.piece); }
+    if (req) { setTab('build'); openPiece(req.piece, req.instance ?? null); }
   });
 
+  // The instance query-string for the ROOT piece (omitted for whole-daf).
+  const instanceQS = (): string => {
+    const inst = focusInstance();
+    if (!inst || (typeof inst === 'object' && Object.keys(inst as object).length === 0)) return '';
+    return `&instance=${encodeURIComponent(JSON.stringify(inst))}`;
+  };
+
   const [tree] = createResource(
-    () => (props.open && view() === 'dag' ? `${props.tractate}|${props.page}|${pieceId()}|${lang()}` : null),
+    () => (props.open && view() === 'dag' ? `${props.tractate}|${props.page}|${pieceId()}|${lang()}|${instanceQS()}` : null),
     async (): Promise<RunTree | null> => {
-      const r = await fetch(`/api/run-tree/${encodeURIComponent(props.tractate)}/${encodeURIComponent(props.page)}/${encodeURIComponent(pieceId())}?lang=${lang()}`);
+      const r = await fetch(`/api/run-tree/${encodeURIComponent(props.tractate)}/${encodeURIComponent(props.page)}/${encodeURIComponent(pieceId())}?lang=${lang()}${instanceQS()}`);
       if (!r.ok) return null;
       return (await r.json()) as RunTree;
     },
@@ -306,11 +316,14 @@ export default function RunTreeDock(props: {
   const isIncident = (e: LaidEdge) => e.fromId === selected() || e.toId === selected();
 
   const [detail] = createResource(
-    () => { const id = selected(); const n = id ? nodeOf(id) : null; return n && n.kind !== 'source' && n.producer ? { id, producer: n.producer } : null; },
+    () => { const id = selected(); const n = id ? nodeOf(id) : null; return n && n.kind !== 'source' && n.producer ? { id, producer: n.producer, root: id === pieceId() } : null; },
     async (sel): Promise<RunResult | null> => {
+      // The clicked root resolves at its instance (so a per-section synthesis
+      // shows its real generation); other nodes at whole-daf.
+      const markInput = sel.root ? (focusInstance() ?? { fields: {} }) : { fields: {} };
       const body = sel.producer === 'mark'
         ? { mark_id: sel.id, tractate: props.tractate, page: props.page, lang: lang() }
-        : { enrichment_id: sel.id, tractate: props.tractate, page: props.page, mark_input: { fields: {} }, lang: lang() };
+        : { enrichment_id: sel.id, tractate: props.tractate, page: props.page, mark_input: markInput, lang: lang() };
       const r = await fetch('/api/run', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
       const j = await r.json() as { status?: string; result?: RunResult } | RunResult;
       if (j && typeof j === 'object' && 'status' in j) return j.status === 'ok' ? j.result ?? null : null;

--- a/src/client/inspectBridge.ts
+++ b/src/client/inspectBridge.ts
@@ -10,14 +10,16 @@
 
 import { createSignal } from 'solid-js';
 
-export interface InspectRequest { piece: string; nonce: number; }
+export interface InspectRequest { piece: string; instance?: unknown; nonce: number; }
 
 const [inspectRequest, setInspectRequest] = createSignal<InspectRequest | null>(null);
 let nonce = 0;
 
 export { inspectRequest };
 
-/** Ask the Inspect panel to open and focus `pieceId`'s build DAG. */
-export function requestInspect(pieceId: string): void {
-  setInspectRequest({ piece: pieceId, nonce: ++nonce });
+/** Ask the Inspect panel to open and focus `pieceId`'s build DAG. `instance`
+ *  (a mark_input) makes a per-instance piece — e.g. one section's synthesis —
+ *  resolve to its actual cached generation instead of the whole-daf default. */
+export function requestInspect(pieceId: string, instance?: unknown): void {
+  setInspectRequest({ piece: pieceId, instance, nonce: ++nonce });
 }

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -940,6 +940,11 @@ app.get('/api/run-tree/:tractate/:page/:id', async (c) => {
   const page = c.req.param('page');
   const id = c.req.param('id');
   const lang: 'en' | 'he' = c.req.query('lang') === 'he' ? 'he' : 'en';
+  // Optional instance (mark_input JSON) for a per-instance ROOT — e.g. one
+  // section's synthesis. Applied to the root only; whole-daf deps keep {fields:{}}.
+  let rootInstance: unknown = { fields: {} };
+  const instanceRaw = c.req.query('instance');
+  if (instanceRaw) { try { rootInstance = JSON.parse(instanceRaw); } catch { /* keep default */ } }
 
   const defs = [...CODE_MARKS, ...CODE_ENRICHMENTS];
   const byId = new Map(defs.map((d) => [d.id, d]));
@@ -979,7 +984,7 @@ app.get('/api/run-tree/:tractate/:page/:id', async (c) => {
     const isLLM = ext?.kind === 'llm';
     const job = (isMark
       ? { mark_id: nid, tractate, page, lang }
-      : { enrichment_id: nid, tractate, page, mark_input: { fields: {} }, lang }) as unknown as JobMessage;
+      : { enrichment_id: nid, tractate, page, mark_input: nid === id ? rootInstance : { fields: {} }, lang }) as unknown as JobMessage;
     const { key } = await cacheKeyForRunBody(c.env, job);
     const res = key ? await readCachedResult(c.env, key) : null;
     const usage = res?.usage as { cost?: number; total_tokens?: number } | undefined;


### PR DESCRIPTION
Fixes two related bugs in the Inspect panel's (i):

**1. It showed the source, not the generation.** Clicking (i) on a Rishonim synthesis opened the raw `rishonim` **mark** (a source, database icon) instead of the **synthesis** (the generation it actually displays). The (i) now roots the DAG at the card's **aggregate enrichment** (the generation), not its parent mark.

**2. The DAG didn't break down.** Aggadatot showed only `aggadata → gemara`. Now it roots at `aggadata.synthesis`, whose real deps are **background / interpretation / parallels** (+ rabbi, daf-background.concepts) — so the synthesis visibly breaks down into the sub-generations it weaves together.

**Per-instance:** a section's synthesis is per-instance, so the generation only resolves with the right `mark_input`. Added:
- `inspectBridge` carries an optional `instance`.
- `GET /api/run-tree` accepts `?instance=<json>` — the ROOT node resolves at that instance (whole-daf deps stay `{fields:{}}`).
- the node-detail for the selected root fetches `/api/run` at that instance, so the **real cached generation text** shows instead of "nothing cached".

typecheck + build + 1814 tests green.