### PR TITLE
Tutorial: drop AI-generation notice; pre-warm the translate steps

### DIFF
--- a/src/client/DafViewer.tsx
+++ b/src/client/DafViewer.tsx
@@ -2450,6 +2450,33 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
     });
   });
 
+  // Tutorial only: as soon as the daf renders, pre-warm the exact word + phrase
+  // the translate steps will translate (same pick + context), so /api/translate
+  // is server-cached by the time the user reaches those steps and the popup
+  // resolves fast instead of generating live.
+  onMount(() => {
+    if (!props.embedded) return;
+    let tries = 0;
+    const prewarm = () => {
+      const words = Array.from(document.querySelectorAll<HTMLElement>('.daf-main .daf-text .daf-word'));
+      if (words.length < 4) { if (tries++ < 40) setTimeout(prewarm, 300); return; }
+      const start = Math.floor(words.length * 0.4);
+      const groups: HTMLElement[][] = [[words[start]], words.slice(start, start + 3)];
+      for (const els of groups) {
+        const word = els.map((el) => (el.textContent ?? '').trim()).filter(Boolean).join(' ');
+        const { before, after } = collectSurroundingHebrew(els);
+        const segAttr = els[0].getAttribute('data-seg');
+        const segIdx = segAttr !== null ? Number(segAttr) : undefined;
+        void fetch('/api/translate', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ word, tractate: tractate(), page: page(), hebrewBefore: before, hebrewAfter: after, segIdx, lang: lang() }),
+        }).catch(() => {});
+      }
+    };
+    setTimeout(prewarm, 1500);
+  });
+
   const clearActive = () => {
     const current = active();
     if (current) current.els.forEach((el) => el.classList.remove('daf-word-active'));

--- a/src/client/TutorialCoach.tsx
+++ b/src/client/TutorialCoach.tsx
@@ -321,11 +321,6 @@ export function TutorialCoach(): JSX.Element {
           <Show when={step().supplement}>
             {(kind) => <Supplement kind={kind()} />}
           </Show>
-          <Show when={step().note}>
-            <div style={{ 'margin-top': '12px', 'font-size': '12px', 'line-height': 1.45, color: 'var(--muted, #6b7280)', 'font-style': 'italic' }}>
-              {t('tutorial.generating.note')}
-            </div>
-          </Show>
           <Show when={step().id === 'finish'}>
             <div style={{ 'margin-top': '14px', 'font-size': '14px', 'line-height': 1.55, color: '#374151' }}>
               {t('tutorial.finish.contact')}{' '}

--- a/src/client/i18n.ts
+++ b/src/client/i18n.ts
@@ -973,10 +973,6 @@ const CATALOG = {
     en: 'This note zooms out to the whole page: a short summary, a map of how the discussion flows, key terms, and cross-references to where the sugya continues. A good place to get your bearings before diving in.',
     he: 'הערה זו מתרחקת אל כל הדף: סיכום קצר, מפה של מהלך הדיון, מונחי מפתח, והפניות למקום שבו הסוגיה ממשיכה. מקום טוב להתמצא בו לפני הצלילה ללימוד.',
   },
-  'tutorial.generating.note': {
-    en: 'These notes are written by AI. The first time someone opens one it can take a minute or two to generate; after that it loads instantly for everyone.',
-    he: 'ההערות נכתבות בבינה מלאכותית. בפעם הראשונה שמישהו פותח הערה היצירה עשויה לקחת דקה-שתיים; לאחר מכן היא נטענת מיד לכולם.',
-  },
 
   'tutorial.underline.title': { en: 'The colored names', he: 'השמות הצבעוניים' },
   'tutorial.underline.body': {


### PR DESCRIPTION
- **Removed** the "These notes are written by AI. The first time someone opens one it can take a minute or two…" notice from the note steps (and its unused i18n key).
- **Pre-warm translations**: when the embedded tutorial daf renders, fire `/api/translate` for the exact word + phrase the translate steps will translate (same word pick + surrounding context, so the cache keys match the live popup request). The server caches it, so by the time the user reaches the translate steps the popup resolves fast instead of generating live.

typecheck clean; tests pass; build succeeds.