### PR TITLE
Tutorial (mobile): keep the translation popup on-screen; make the note drawer scrollable

### DIFF
--- a/src/client/DafViewer.tsx
+++ b/src/client/DafViewer.tsx
@@ -55,7 +55,7 @@ import type { GenerationId } from './generations';
 import { GENERATION_BY_ID } from './generations';
 import { resolveVoiceGroup, voiceGroupNames } from './voiceGroups';
 import { t, lang, setLang } from './i18n';
-import { hasCompletedTutorial, hasDismissedBanner, TUTORIAL_OPEN_NOTE_EVENT, TUTORIAL_CLOSE_NOTE_EVENT, TUTORIAL_HEADER_EVENT, TUTORIAL_TRANSLATE_EVENT } from './tutorial';
+import { hasCompletedTutorial, hasDismissedBanner, tutorialNoteInteractive, TUTORIAL_OPEN_NOTE_EVENT, TUTORIAL_CLOSE_NOTE_EVENT, TUTORIAL_HEADER_EVENT, TUTORIAL_TRANSLATE_EVENT } from './tutorial';
 import { TutorialBanner } from './TutorialBanner';
 
 /** Normalize a rabbi name for fuzzy lookup: drop honorific prefixes, lower
@@ -3484,6 +3484,9 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
             'flex-direction': 'column',
             gap: '0.4rem',
             overflow: 'auto',
+            // During a tutorial note step, lift above the coach's click-shield
+            // (z 5999) so the panel stays scrollable; normal stacking otherwise.
+            'z-index': tutorialNoteInteractive() ? 6001 : undefined,
           }}
         >
           <Show when={sidebar() !== null}>

--- a/src/client/MobileShelf.tsx
+++ b/src/client/MobileShelf.tsx
@@ -1,6 +1,7 @@
 import { Show, type JSX } from 'solid-js';
 import DafLoadProgress from './DafLoadProgress';
 import { t } from './i18n';
+import { tutorialNoteInteractive } from './tutorial';
 import { ArgumentSidebar, type SidebarContent } from './ArgumentSidebar';
 import type { ConceptTerm } from './conceptLinks';
 import type { GenerationId } from './generations';
@@ -54,7 +55,9 @@ export function MobileShelf(props: MobileShelfProps): JSX.Element {
         background: '#fff',
         'border-top': '1px solid #d6d3d1',
         'box-shadow': '0 -4px 12px rgba(0, 0, 0, 0.06)',
-        'z-index': 100,
+        // Normally sits under the daf chrome; during a tutorial note step it
+        // lifts above the coach's click-shield (z 5999) so it stays scrollable.
+        'z-index': tutorialNoteInteractive() ? 6001 : 100,
         'max-height': '65vh',
         display: 'flex',
         'flex-direction': 'column',

--- a/src/client/TranslationPopup.tsx
+++ b/src/client/TranslationPopup.tsx
@@ -118,8 +118,22 @@ export function TranslationPopup(props: TranslationPopupProps): JSX.Element {
 
   const GAP = 8;        // space between popup and the selected words
   const TOP_MARGIN = 8; // min gap from the viewport top
+  const SIDE_MARGIN = 8; // min gap from the viewport sides
 
   const liveAnchor = (): Rect => props.getAnchorRect?.() ?? props.anchor;
+
+  // Keep the popup on-screen horizontally. It's centred on the word via
+  // translateX(-50%), so a word near either edge would otherwise push half the
+  // popup off-screen (badly so for the wide Hebrew column). Clamp the centre so
+  // both edges stay inside the viewport; if the popup is wider than the
+  // viewport, just centre it.
+  const clampCenterX = (center: number): number => {
+    const w = popupRef?.offsetWidth ?? 240;
+    const vw = window.innerWidth;
+    const half = w / 2;
+    if (w + 2 * SIDE_MARGIN >= vw) return vw / 2;
+    return Math.min(Math.max(center, half + SIDE_MARGIN), vw - half - SIDE_MARGIN);
+  };
 
   // — Desktop: above if there's room, else below (static, from the click anchor).
   const popupStyle = (): JSX.CSSProperties => {
@@ -131,7 +145,7 @@ export function TranslationPopup(props: TranslationPopupProps): JSX.Element {
     return {
       position: 'fixed',
       top: `${top}px`,
-      left: `${centerX}px`,
+      left: `${clampCenterX(centerX)}px`,
       transform: 'translateX(-50%)',
       'z-index': '1000',
     };
@@ -151,7 +165,7 @@ export function TranslationPopup(props: TranslationPopupProps): JSX.Element {
       window.scrollBy({ top: -deficit });
       requestAnimationFrame(() => placeAbove(false));
     }
-    setMobilePos({ top: Math.max(TOP_MARGIN, a.top - h - GAP), left: (a.left + a.right) / 2 });
+    setMobilePos({ top: Math.max(TOP_MARGIN, a.top - h - GAP), left: clampCenterX((a.left + a.right) / 2) });
   };
   // Reposition (with a scroll if needed) whenever the selection changes.
   createEffect(() => {
@@ -172,7 +186,7 @@ export function TranslationPopup(props: TranslationPopupProps): JSX.Element {
     const p = mobilePos();
     const a = liveAnchor();
     const top = p ? p.top : Math.max(TOP_MARGIN, a.top - 80 - GAP);
-    const left = p ? p.left : (a.left + a.right) / 2;
+    const left = p ? p.left : clampCenterX((a.left + a.right) / 2);
     return {
       position: 'fixed',
       top: `${top}px`,

--- a/src/client/TutorialCoach.tsx
+++ b/src/client/TutorialCoach.tsx
@@ -27,6 +27,7 @@ import {
   setTutorialHeader,
   triggerTutorialTranslate,
   setTutorialPrefetch,
+  setTutorialNoteInteractive,
   type TourSupplement,
 } from './tutorial';
 import { GutterGlyph, colorForKind, type GutterKind } from './GutterIcons';
@@ -37,6 +38,7 @@ const PAD = 12;
 const MIN_VERT = 200;
 const MIN_HORIZ = 320;
 const MOBILE_BAR = 72; // room left for the mobile mode bar at the very bottom
+const MOBILE_POPUP_ROOM = 150; // headroom a translation popup needs above its word
 
 type Pos =
   | { mode: 'center' }
@@ -138,7 +140,18 @@ export function TutorialCoach(): JSX.Element {
     // free strip just below the handle.
     if (!fromObserver) {
       if (isMobile() && mobileAnchor() === 'bottom') {
-        const y = window.scrollY + lead.getBoundingClientRect().top - mobileTopInset() - GAP;
+        const lr = lead.getBoundingClientRect();
+        // Translate steps are special: the translation popup renders ABOVE the
+        // word and self-scrolls to make room, so yanking the word to the top
+        // fights it and shoves the popup off-screen. Instead drop the word to
+        // the bottom of the free strip (just above the coach sheet) so the
+        // popup sits in the clear space above it and neither scroll fights.
+        let desired = mobileTopInset() + GAP;
+        if (step().translate) {
+          const sheetTop = cardEl ? cardEl.getBoundingClientRect().top : Math.round(window.innerHeight * 0.54);
+          desired = Math.max(mobileTopInset() + MOBILE_POPUP_ROOM, sheetTop - lr.height - GAP - 8);
+        }
+        const y = window.scrollY + lr.top - desired;
         window.scrollTo({ top: Math.max(0, y), behavior: 'smooth' });
       } else {
         lead.scrollIntoView({ block: 'center', inline: 'center', behavior: 'smooth' });
@@ -197,6 +210,9 @@ export function TutorialCoach(): JSX.Element {
   createEffect(() => {
     const s = step();
     setTutorialHeader(!!s.header);
+    // Lift the note panel above the click-shield on note steps so the reader
+    // can scroll/explore it; non-note steps keep the shield fully blocking.
+    setTutorialNoteInteractive(!!s.note);
     if (s.note !== prevNote) {
       if (s.note) openTutorialNote(s.note); else closeTutorialNote();
       prevNote = s.note;
@@ -253,7 +269,7 @@ export function TutorialCoach(): JSX.Element {
   // While the tour is up, QAPanels pre-warm a few suggested answers so the Q&A
   // step's questions click through instantly.
   setTutorialPrefetch(true);
-  onCleanup(() => { closeTutorialNote(); setTutorialHeader(false); triggerTutorialTranslate('clear'); setTutorialPrefetch(false); });
+  onCleanup(() => { closeTutorialNote(); setTutorialHeader(false); triggerTutorialTranslate('clear'); setTutorialPrefetch(false); setTutorialNoteInteractive(false); });
 
   onMount(() => {
     const onKey = (e: KeyboardEvent) => {

--- a/src/client/tutorial.ts
+++ b/src/client/tutorial.ts
@@ -220,6 +220,12 @@ export function setTutorialHeader(open: boolean): void {
 const [tutorialPrefetch, setTutorialPrefetch] = createSignal(false);
 export { tutorialPrefetch, setTutorialPrefetch };
 
+/** While a note step is showing, the opened note panel / drawer is lifted above
+ *  the coach's click-shield so the reader can actually scroll and explore it
+ *  (the shield otherwise swallows all interaction). The coach toggles this. */
+const [tutorialNoteInteractive, setTutorialNoteInteractive] = createSignal(false);
+export { tutorialNoteInteractive, setTutorialNoteInteractive };
+
 const COMPLETED_KEY = 'tutorial:completed';
 const BANNER_DISMISSED_KEY = 'tutorial:banner-dismissed';
 


### PR DESCRIPTION
Follow-up to #295. Two more mobile tutorial fixes, found by walking the live `/tutorial` page at 390×844.

## 1. Translation popup pushed off-screen

The mobile popup centres on the word (`left: centerX; transform: translateX(-50%)`) with **no horizontal viewport clamp**, so a word near an edge shoved half the popup off-screen — measured `left:-46` for a word in the right column. This affected all mobile translations near the edges, not just the tutorial.

- **Clamp the popup centre** so both edges stay inside the viewport (`TranslationPopup.tsx`); if it's wider than the viewport, centre it.
- On the **translate tour steps**, the coach's "scroll the target just below the sticky handle" (from #295) fought the popup's own "scroll to make room above the word" logic, leaving the popup disconnected/off-screen. Now translate steps **drop the word to the bottom of the free strip** (just above the coach sheet) so the popup sits in the clear space above it and neither scroll fights.

## 2. Note drawer/sidebar not scrollable during the tour

The coach renders a full-screen click-shield (`z 5999`) that swallows all interaction so the coach drives everything. The note drawer (`MobileShelf`, `z 100`) and desktop sidebar sat *below* it, so the reader couldn't scroll the note once it loaded.

- Add a `tutorialNoteInteractive` signal; on **note steps** the opened panel lifts above the shield (`z 6001`) so it's scrollable/explorable. Non-note steps keep the shield fully blocking; outside the tour, stacking is unchanged.

## Verification

Local build (`pnpm dev`, mobile-emulated):
- Translate step: popup now fully on-screen ("אשה" → "woman" + hint), word at the bottom of the ring with the popup in the clear space above — no left-clipping.
- Note step: `[data-tour="note-panel"]` computes `z-index:6001` and `elementFromPoint` over it returns the panel (not the shield), confirming the shield no longer intercepts it.

`pnpm typecheck` clean, `pnpm test` 1814/1814 pass.