### PR TITLE
Terms registry (PR1): unified Term model + per-term display policy

### DIFF
--- a/src/lib/hebrewTerms.ts
+++ b/src/lib/hebrewTerms.ts
@@ -17,6 +17,19 @@
  * (tests/hebrew-terms.test.ts) fails if either consumer falls out of sync.
  */
 
+/** Reader-facing display policy for a term. Authored per-term so the same term
+ *  renders the same way on every daf instead of being re-decided per generation.
+ *  Consumed by the first-mention gloss pass (PR3 of the terms-registry rework);
+ *  not yet wired, so today's output is unchanged.
+ *    - 'hebrew': the Hebrew script is the term surface in prose.
+ *    - 'english': the English label (`en`) is the surface; Hebrew is parenthetical/tooltip.
+ *    - 'hebrew-first-gloss': Hebrew surface, English gloss on first mention only. */
+export type TermDisplay = 'hebrew' | 'english' | 'hebrew-first-gloss';
+
+/** Glossary grouping, aligned with the daf-background.concepts categories so the
+ *  global list and the per-daf list share one taxonomy. */
+export type TermCategory = 'legal-concepts' | 'realia' | 'assumed-prior';
+
 export interface CanonicalHebrewTerm {
   /** Canonical romanization, shown verbatim in the prompt's always-list. */
   translit: string;
@@ -28,54 +41,62 @@ export interface CanonicalHebrewTerm {
    *  Only spellings that DON'T already collapse under normalizeKey (which
    *  folds ch/kh/ḥ and strips apostrophes/diacritics) need listing here. */
   variants?: string[];
+  /** Per-term display policy. Required so every canonical term carries an
+   *  explicit, auditable verdict. */
+  display: TermDisplay;
+  /** English surface to show in prose when `display === 'english'`. */
+  en?: string;
+  /** Optional glossary grouping (left unset on most globals for now; the
+   *  per-daf concepts carry their own category). */
+  category?: TermCategory;
 }
 
 /** Ordered exactly as the prompt presents them, so the generated bullet list
  *  reads in the same sequence a human author would expect. */
 export const CANONICAL_HEBREW_TERMS: readonly CanonicalHebrewTerm[] = [
-  { translit: 'lechatchila', hebrew: 'לכתחילה', gloss: 'the ideal standard / a-priori', variants: ['le-chatchila'] },
-  { translit: 'bedieved', hebrew: 'בדיעבד', gloss: 'after the fact', variants: ['bediavad', 'be-dieved'] },
-  { translit: 'mitzvah', hebrew: 'מצוה', gloss: 'commandment' },
-  { translit: 'halacha', hebrew: 'הלכה', gloss: 'binding law', variants: ['halakhah'] },
-  { translit: 'sugya', hebrew: 'סוגיא', gloss: 'Talmudic discussion', variants: ['sugiya'] },
-  { translit: 'psak', hebrew: 'פסק', gloss: 'ruling', variants: ['pesak'] },
-  { translit: 'rov', hebrew: 'רוב', gloss: 'majority principle' },
-  { translit: 'chazaka', hebrew: 'חזקה', gloss: 'presumption', variants: ['chazakah'] },
-  { translit: 'safek', hebrew: 'ספק', gloss: 'doubt' },
-  { translit: "tum'ah", hebrew: 'טומאה', gloss: 'ritual impurity' },
-  { translit: 'tahara', hebrew: 'טהרה', gloss: 'ritual purity', variants: ['taharah'] },
-  { translit: 'terumah', hebrew: 'תרומה', gloss: 'priestly portion', variants: ['teruma'] },
-  { translit: 'maaser', hebrew: 'מעשר', gloss: 'tithe', variants: ["ma'aser"] },
-  { translit: 'chametz', hebrew: 'חמץ', gloss: 'leaven', variants: ['hametz'] },
-  { translit: 'matzah', hebrew: 'מצה', gloss: 'unleavened bread', variants: ['matza'] },
-  { translit: 'treif', hebrew: 'טריפה', gloss: 'ritually unfit', variants: ['trefah'] },
-  { translit: 'kosher', hebrew: 'כשר', gloss: 'ritually fit', variants: ['kasher'] },
-  { translit: 'pesach', hebrew: 'פסח', gloss: 'Passover' },
-  { translit: 'shabbat', hebrew: 'שבת', gloss: 'Sabbath' },
-  { translit: 'yom tov', hebrew: 'יום טוב', gloss: 'festival day' },
-  { translit: 'bracha', hebrew: 'ברכה', gloss: 'blessing' },
-  { translit: 'tefillah', hebrew: 'תפילה', gloss: 'prayer' },
-  { translit: 'tzitzit', hebrew: 'ציצית', gloss: 'ritual fringes' },
-  { translit: 'tefillin', hebrew: 'תפילין', gloss: 'phylacteries' },
-  { translit: 'bet din', hebrew: 'בית דין', gloss: 'court', variants: ['beit din'] },
-  { translit: 'eved', hebrew: 'עבד', gloss: 'slave' },
-  { translit: 'get', hebrew: 'גט', gloss: 'bill of divorce' },
-  { translit: 'kiddushin', hebrew: 'קידושין', gloss: 'betrothal' },
-  { translit: 'chayav', hebrew: 'חייב', gloss: 'liable / obligated' },
-  { translit: 'patur', hebrew: 'פטור', gloss: 'exempt' },
-  { translit: 'asur', hebrew: 'אסור', gloss: 'forbidden' },
-  { translit: 'mutar', hebrew: 'מותר', gloss: 'permitted' },
-  { translit: 'rov basar', hebrew: 'רוב בשר', gloss: 'majority of surrounding flesh — shechita / neveila threshold', variants: ['rov besar'] },
-  { translit: 'mafreket', hebrew: 'מפרקת', gloss: 'spinal column / nape — neveila context' },
-  { translit: 'siman', hebrew: 'סימן', gloss: 'a shechita organ (trachea / esophagus)' },
-  { translit: 'simanim', hebrew: 'סימנים', gloss: 'the shechita organs (trachea + esophagus)' },
-  { translit: 'veshet', hebrew: 'ושט', gloss: 'esophagus' },
-  { translit: 'kaneh', hebrew: 'קנה', gloss: 'trachea / windpipe' },
-  { translit: 'bnei Noach', hebrew: 'בני נח', gloss: 'Noahides — NEVER "sons of Noah"', variants: ['bnei noah'] },
-  { translit: 'sheva mitzvot bnei Noach', hebrew: 'שבע מצוות בני נח', gloss: 'Noahide laws — NEVER "seven commandments of the sons of Noah"', variants: ['sheva mitzvot bnei noah'] },
-  { translit: 'ben shnato', hebrew: 'בן שנתו', gloss: 'a one-year-old [animal] — NEVER "son of his year"', variants: ['ben shenato'] },
-  { translit: 'bekhor', hebrew: 'בכור', gloss: 'firstborn', variants: ['bechor'] },
-  { translit: 'pidyon haben', hebrew: 'פדיון הבן', gloss: 'redemption of the firstborn son' },
+  { translit: 'lechatchila', hebrew: 'לכתחילה', gloss: 'the ideal standard / a-priori', variants: ['le-chatchila'], display: 'hebrew' },
+  { translit: 'bedieved', hebrew: 'בדיעבד', gloss: 'after the fact', variants: ['bediavad', 'be-dieved'], display: 'hebrew' },
+  { translit: 'mitzvah', hebrew: 'מצוה', gloss: 'commandment', display: 'hebrew' },
+  { translit: 'halacha', hebrew: 'הלכה', gloss: 'binding law', variants: ['halakhah'], display: 'hebrew' },
+  { translit: 'sugya', hebrew: 'סוגיא', gloss: 'Talmudic discussion', variants: ['sugiya'], display: 'hebrew' },
+  { translit: 'psak', hebrew: 'פסק', gloss: 'ruling', variants: ['pesak'], display: 'hebrew' },
+  { translit: 'rov', hebrew: 'רוב', gloss: 'majority principle', display: 'hebrew' },
+  { translit: 'chazaka', hebrew: 'חזקה', gloss: 'presumption', variants: ['chazakah'], display: 'hebrew' },
+  { translit: 'safek', hebrew: 'ספק', gloss: 'doubt', display: 'hebrew' },
+  { translit: "tum'ah", hebrew: 'טומאה', gloss: 'ritual impurity', display: 'hebrew' },
+  { translit: 'tahara', hebrew: 'טהרה', gloss: 'ritual purity', variants: ['taharah'], display: 'hebrew' },
+  { translit: 'terumah', hebrew: 'תרומה', gloss: 'priestly portion', variants: ['teruma'], display: 'hebrew' },
+  { translit: 'maaser', hebrew: 'מעשר', gloss: 'tithe', variants: ["ma'aser"], display: 'hebrew' },
+  { translit: 'chametz', hebrew: 'חמץ', gloss: 'leaven', variants: ['hametz'], display: 'hebrew' },
+  { translit: 'matzah', hebrew: 'מצה', gloss: 'unleavened bread', variants: ['matza'], display: 'hebrew' },
+  { translit: 'treif', hebrew: 'טריפה', gloss: 'ritually unfit', variants: ['trefah'], display: 'hebrew' },
+  { translit: 'kosher', hebrew: 'כשר', gloss: 'ritually fit', variants: ['kasher'], display: 'english', en: 'kosher' },
+  { translit: 'pesach', hebrew: 'פסח', gloss: 'Passover', display: 'hebrew' },
+  { translit: 'shabbat', hebrew: 'שבת', gloss: 'Sabbath', display: 'hebrew' },
+  { translit: 'yom tov', hebrew: 'יום טוב', gloss: 'festival day', display: 'hebrew' },
+  { translit: 'bracha', hebrew: 'ברכה', gloss: 'blessing', display: 'hebrew' },
+  { translit: 'tefillah', hebrew: 'תפילה', gloss: 'prayer', display: 'hebrew' },
+  { translit: 'tzitzit', hebrew: 'ציצית', gloss: 'ritual fringes', display: 'hebrew' },
+  { translit: 'tefillin', hebrew: 'תפילין', gloss: 'phylacteries', display: 'hebrew' },
+  { translit: 'bet din', hebrew: 'בית דין', gloss: 'court', variants: ['beit din'], display: 'english', en: 'court' },
+  { translit: 'eved', hebrew: 'עבד', gloss: 'slave', display: 'english', en: 'slave' },
+  { translit: 'get', hebrew: 'גט', gloss: 'bill of divorce', display: 'hebrew' },
+  { translit: 'kiddushin', hebrew: 'קידושין', gloss: 'betrothal', display: 'hebrew' },
+  { translit: 'chayav', hebrew: 'חייב', gloss: 'liable / obligated', display: 'hebrew' },
+  { translit: 'patur', hebrew: 'פטור', gloss: 'exempt', display: 'hebrew' },
+  { translit: 'asur', hebrew: 'אסור', gloss: 'forbidden', display: 'hebrew' },
+  { translit: 'mutar', hebrew: 'מותר', gloss: 'permitted', display: 'hebrew' },
+  { translit: 'rov basar', hebrew: 'רוב בשר', gloss: 'majority of surrounding flesh — shechita / neveila threshold', variants: ['rov besar'], display: 'hebrew' },
+  { translit: 'mafreket', hebrew: 'מפרקת', gloss: 'spinal column / nape — neveila context', display: 'hebrew' },
+  { translit: 'siman', hebrew: 'סימן', gloss: 'a shechita organ (trachea / esophagus)', display: 'hebrew' },
+  { translit: 'simanim', hebrew: 'סימנים', gloss: 'the shechita organs (trachea + esophagus)', display: 'hebrew' },
+  { translit: 'veshet', hebrew: 'ושט', gloss: 'esophagus', display: 'hebrew' },
+  { translit: 'kaneh', hebrew: 'קנה', gloss: 'trachea / windpipe', display: 'hebrew' },
+  { translit: 'bnei Noach', hebrew: 'בני נח', gloss: 'Noahides — NEVER "sons of Noah"', variants: ['bnei noah'], display: 'hebrew' },
+  { translit: 'sheva mitzvot bnei Noach', hebrew: 'שבע מצוות בני נח', gloss: 'Noahide laws — NEVER "seven commandments of the sons of Noah"', variants: ['sheva mitzvot bnei noah'], display: 'hebrew' },
+  { translit: 'ben shnato', hebrew: 'בן שנתו', gloss: 'a one-year-old [animal] — NEVER "son of his year"', variants: ['ben shenato'], display: 'hebrew' },
+  { translit: 'bekhor', hebrew: 'בכור', gloss: 'firstborn', variants: ['bechor'], display: 'hebrew' },
+  { translit: 'pidyon haben', hebrew: 'פדיון הבן', gloss: 'redemption of the firstborn son', display: 'hebrew' },
 ];
 
 /** Flatten to the translit→Hebrew pairs the client dict spreads in. Keys are

--- a/src/lib/terms/registry.ts
+++ b/src/lib/terms/registry.ts
@@ -1,0 +1,109 @@
+/**
+ * Unified term registry — one `Term` shape behind three things that used to be
+ * forked: the hebraization always-list (CANONICAL_HEBREW_TERMS), the per-daf
+ * background glossary (the daf-background.concepts enrichment), and the prose
+ * tooltip pool (ConceptTerm in src/client/conceptLinks.tsx).
+ *
+ * This is PR1 of the terms-registry rework: it lands the model and the merge
+ * resolver, fully unit-tested, but does NOT yet rewire any route or renderer —
+ * so reader output is unchanged. Later PRs consume it:
+ *   - PR2 feeds globalTerms() into the conceptLinks matcher (tooltip on every
+ *     registry term, not just the daf's background concepts).
+ *   - PR3 reads `display` for the first-mention-per-section gloss pass.
+ *
+ * Identity is the Hebrew surface (`hebrew`): the per-daf list overrides a global
+ * of the same Hebrew so a daf can sharpen a generic gloss for its own context.
+ */
+import {
+  CANONICAL_HEBREW_TERMS,
+  type TermCategory,
+  type TermDisplay,
+} from '../hebrewTerms';
+
+export type { TermCategory, TermDisplay } from '../hebrewTerms';
+
+/** Where a term came from: the always-known global list, or this daf's
+ *  extracted background concepts. */
+export type TermScope = 'global' | 'daf';
+
+/** The unified runtime term. Globals and per-daf concepts both normalize to
+ *  this so everything downstream (hebraize, tooltip, glossary card, gloss pass)
+ *  reads one shape. */
+export interface Term {
+  /** Canonical Hebrew surface — the identity key for merge/override. */
+  hebrew: string;
+  /** Primary romanization. Present on globals; per-daf concepts may lack one. */
+  translit?: string;
+  /** Alternate romanizations (globals only). */
+  variants?: string[];
+  /** English label — the surface shown in prose when `display === 'english'`. */
+  en?: string;
+  /** Short English meaning (tooltip + first-mention gloss). */
+  gloss: string;
+  /** Per-term display policy (see TermDisplay). */
+  display: TermDisplay;
+  /** Glossary grouping. */
+  category?: TermCategory;
+  /** Provenance. */
+  scope: TermScope;
+}
+
+/** The shape a daf-background.concepts term arrives in (the enrichment output:
+ *  `groups[].terms[]`). Kept local so src/lib stays free of any client import. */
+export interface DafConcept {
+  /** English label. */
+  term: string;
+  /** Hebrew script (optional in the wild; concepts without it can't be a term). */
+  termHe?: string;
+  gloss: string;
+  category?: TermCategory;
+}
+
+const TERM_CATEGORIES: ReadonlySet<string> = new Set<TermCategory>([
+  'legal-concepts',
+  'realia',
+  'assumed-prior',
+]);
+
+const asCategory = (c: string | undefined): TermCategory | undefined =>
+  c !== undefined && TERM_CATEGORIES.has(c) ? (c as TermCategory) : undefined;
+
+/** The always-known global terms, normalized to `Term`. */
+export function globalTerms(): Term[] {
+  return CANONICAL_HEBREW_TERMS.map((t) => ({
+    hebrew: t.hebrew,
+    translit: t.translit,
+    variants: t.variants ? [...t.variants] : undefined,
+    en: t.en,
+    gloss: t.gloss,
+    display: t.display,
+    category: t.category,
+    scope: 'global' as const,
+  }));
+}
+
+/** Normalize one daf-background concept to a `Term`. Returns null when the
+ *  concept has no Hebrew surface (nothing to anchor or hebraize). Daf concepts
+ *  default to 'hebrew-first-gloss': Hebrew anchor, glossed on first mention. */
+export function conceptToTerm(c: DafConcept): Term | null {
+  const hebrew = c.termHe?.trim();
+  if (!hebrew) return null;
+  return {
+    hebrew,
+    en: c.term,
+    gloss: c.gloss,
+    display: 'hebrew-first-gloss',
+    category: asCategory(c.category),
+    scope: 'daf',
+  };
+}
+
+/** The glossary in effect for a daf: globals ∪ this daf's terms, with the daf's
+ *  term winning on a Hebrew-key collision. Order is globals first (stable input
+ *  order), then daf-only terms in input order. */
+export function glossaryForDaf(dafTerms: readonly Term[]): Term[] {
+  const byHebrew = new Map<string, Term>();
+  for (const t of globalTerms()) byHebrew.set(t.hebrew, t);
+  for (const t of dafTerms) byHebrew.set(t.hebrew, t);
+  return [...byHebrew.values()];
+}

--- a/tests/hebrew-terms.test.ts
+++ b/tests/hebrew-terms.test.ts
@@ -84,6 +84,12 @@ describe('alwaysHebraizeBlock — renders every canonical term (prompt side)', (
       expect(block).toContain(`${t.translit} → ${t.hebrew} (${t.gloss})`);
     });
   }
+  // The display field is metadata for the gloss pass, not prompt content — the
+  // always-list block must stay byte-for-byte as it was, so adding `display`
+  // can't silently perturb generation. (Output unchanged is the PR1 contract.)
+  it('block carries no display metadata — translit → hebrew (gloss) only', () => {
+    expect(block).not.toMatch(/hebrew-first-gloss|display/);
+  });
 });
 
 describe('canonicalDictEntries — closes the historical drift gaps', () => {

--- a/tests/terms-registry.test.ts
+++ b/tests/terms-registry.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { CANONICAL_HEBREW_TERMS } from '../src/lib/hebrewTerms';
+import {
+  globalTerms,
+  conceptToTerm,
+  glossaryForDaf,
+  type Term,
+} from '../src/lib/terms/registry';
+
+// ---------------------------------------------------------------------------
+// display policy — every global carries an explicit, valid verdict, and the
+// 'english' display implies an English surface to render. These guard the
+// authoring invariants the first-mention gloss pass (PR3) will rely on.
+// ---------------------------------------------------------------------------
+
+const VALID_DISPLAY = new Set(['hebrew', 'english', 'hebrew-first-gloss']);
+
+describe('canonical display policy', () => {
+  for (const t of CANONICAL_HEBREW_TERMS) {
+    it(`${t.translit} has a valid display`, () => {
+      expect(VALID_DISPLAY.has(t.display)).toBe(true);
+    });
+  }
+  it("every display:'english' term has an `en` surface", () => {
+    for (const t of CANONICAL_HEBREW_TERMS) {
+      if (t.display === 'english') expect(t.en, t.translit).toBeTruthy();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// globalTerms — faithful, isolated projection of the canonical list to Term.
+// ---------------------------------------------------------------------------
+
+describe('globalTerms', () => {
+  const g = globalTerms();
+  it('projects every canonical term, scoped global', () => {
+    expect(g.length).toBe(CANONICAL_HEBREW_TERMS.length);
+    expect(g.every((t) => t.scope === 'global')).toBe(true);
+  });
+  it('carries display + gloss + hebrew through', () => {
+    const halacha = g.find((t) => t.hebrew === 'הלכה');
+    expect(halacha).toMatchObject({ display: 'hebrew', gloss: 'binding law', translit: 'halacha' });
+  });
+  it('does not alias the source variants array (mutation safety)', () => {
+    const src = CANONICAL_HEBREW_TERMS.find((t) => t.translit === 'halacha');
+    const proj = g.find((t) => t.hebrew === 'הלכה');
+    expect(proj!.variants).not.toBe(src!.variants);
+    expect(proj!.variants).toEqual(src!.variants);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// conceptToTerm — normalize a daf-background concept to Term; drop the ones
+// with no Hebrew surface (nothing to anchor).
+// ---------------------------------------------------------------------------
+
+describe('conceptToTerm', () => {
+  it('normalizes a concept with Hebrew to a daf-scoped Term', () => {
+    expect(
+      conceptToTerm({ term: 'Twilight', termHe: 'בין השמשות', gloss: 'the dusk window', category: 'realia' }),
+    ).toEqual<Term>({
+      hebrew: 'בין השמשות',
+      en: 'Twilight',
+      gloss: 'the dusk window',
+      display: 'hebrew-first-gloss',
+      category: 'realia',
+      scope: 'daf',
+    });
+  });
+  it('returns null when the concept has no Hebrew surface', () => {
+    expect(conceptToTerm({ term: 'Twilight', gloss: 'x' })).toBeNull();
+    expect(conceptToTerm({ term: 'Twilight', termHe: '   ', gloss: 'x' })).toBeNull();
+  });
+  it('drops an unknown category rather than passing it through', () => {
+    const t = conceptToTerm({ term: 'X', termHe: 'איקס', gloss: 'g', category: 'bogus' as never });
+    expect(t!.category).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// glossaryForDaf — globals ∪ daf, daf wins on a Hebrew-key collision.
+// ---------------------------------------------------------------------------
+
+describe('glossaryForDaf', () => {
+  it('with no daf terms equals the globals', () => {
+    expect(glossaryForDaf([])).toEqual(globalTerms());
+  });
+  it('appends daf-only terms after the globals', () => {
+    const daf = conceptToTerm({ term: 'Twilight', termHe: 'בין השמשות', gloss: 'dusk' })!;
+    const out = glossaryForDaf([daf]);
+    expect(out.length).toBe(globalTerms().length + 1);
+    expect(out.at(-1)).toEqual(daf);
+  });
+  it('lets a daf term override a global of the same Hebrew, in place', () => {
+    const sharpened: Term = {
+      hebrew: 'הלכה',
+      gloss: 'binding law as this sugya applies it',
+      display: 'hebrew',
+      scope: 'daf',
+    };
+    const out = glossaryForDaf([sharpened]);
+    expect(out.length).toBe(globalTerms().length); // no growth — overrode
+    const hit = out.filter((t) => t.hebrew === 'הלכה');
+    expect(hit.length).toBe(1);
+    expect(hit[0]).toEqual(sharpened); // daf won
+  });
+});


### PR DESCRIPTION
First PR of the bilingual-prose-consistency rework. **Foundation only — behavior-preserving.** No change to generated prose, the reader, or the always-hebraize prompt block.

## Why
Today the same Hebrew term renders inconsistently across dapim because the per-term display+gloss decision lives inside the model, decided fresh every generation, stored nowhere. The vocabulary is also forked three ways that don't talk to each other:
- `CANONICAL_HEBREW_TERMS` (hebrewTerms.ts) — drives hebraization
- `daf-background.concepts` — drives the Background card
- `ConceptTerm` (conceptLinks.tsx) — drives prose tooltips

## What this PR does
Lands **one `Term` model** behind all three, plus an authored **per-term `display` policy** — without consuming either yet.

- **`hebrewTerms.ts`**: add a required `display` (`hebrew | english | hebrew-first-gloss`), optional `en` and `category`. Authored for all 45 globals (`english`: bet din, eved, kosher; rest `hebrew`). First-pass defaults — easy to flip per-term later since the registry is the point.
- **`src/lib/terms/registry.ts`** (new): the unified `Term` + `globalTerms()`, `conceptToTerm()` (drops concepts with no Hebrew surface), `glossaryForDaf()` (globals ∪ daf, daf wins on a Hebrew-key collision, in place). Pure functions; not wired into any route/renderer.

## Not in this PR (each its own later PR)
- PR2: feed `globalTerms()` into the conceptLinks matcher → tooltip on every registry term.
- PR3: read `display` for the first-mention-per-section gloss pass (the behavior change).
- PR4: shrink the Form A/B prompt block.
- PR5: surface the registry as the glossary card; fold in the dormant dafyomi glossary.

## Safety / tests
- `display` is metadata only, not yet consumed. The always-hebraize prompt block is **byte-for-byte unchanged** — locked by a new assertion.
- New `tests/terms-registry.test.ts`: display invariants (every `english` term has an `en`), projection, `conceptToTerm` null handling, merge/override ordering.
- `pnpm typecheck` clean; full unit suite **1868 green**.
- Reviewed with `codex exec --sandbox read-only` — findings: none (independently confirmed the prompt block is identical to HEAD, the merge logic is sound, and the existing `halachaLint` consumer is unaffected).