### PR TITLE
Overview ↔ argument: one navigation stack, drill into the full card

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -639,58 +639,6 @@ export function argumentSynthInstance(section: Section): unknown {
   };
 }
 
-/** Drill-in: one argument section's voice map, fed by that section's
- *  `argument.voices` (the same per-section enrichment the section panel uses;
- *  warmed on daf load, so this is usually a cache hit). */
-function OverviewSectionVoices(props: {
-  section: Section;
-  tractate: string;
-  page: string;
-  onPushRabbi: (name: string) => void;
-}): JSX.Element {
-  const [voices, setVoices] = createSignal<ArgumentVoicesData | null>(null);
-  const [resolved, setResolved] = createSignal(false);
-  const voicesGate = useVoicesGate(() => props.tractate, () => props.page, () => props.section);
-  const instanceKey = () => `${props.section.startSegIdx}-${props.section.endSegIdx}-${props.section.title}`;
-  createEffect(() => { void instanceKey(); setVoices(null); setResolved(false); });
-  const onResolved = (r: { deps_resolved?: Record<string, unknown> }) => {
-    setResolved(true);
-    const v = r.deps_resolved?.['argument.voices'] as ArgumentVoicesData | undefined;
-    if (v && Array.isArray(v.voices)) setVoices(deriveVoiceEdges({ voices: v.voices, edges: Array.isArray(v.edges) ? v.edges : [] }) as ArgumentVoicesData);
-  };
-  return (
-    <div style={{ 'margin-top': '0.6rem', 'border-top': '1px dashed #e5e3dc', 'padding-top': '0.6rem' }}>
-      {/* The section summary was rendered here via HebrewProse (RTL/centered),
-          which mis-styles the English summary AND duplicates the synthesis prose
-          below. Dropped — the Synthesis card is the single prose source, matching
-          the main section panel. */}
-      <Synthesis
-        markId="argument"
-        instance={{
-          startSegIdx: props.section.startSegIdx,
-          endSegIdx: props.section.endSegIdx,
-          fields: {
-            title: props.section.title,
-            summary: props.section.summary,
-            excerpt: props.section.excerpt,
-            rabbiNames: props.section.rabbis.map((r) => r.name),
-          },
-        }}
-        instanceKey={instanceKey()}
-        tractate={props.tractate}
-        page={props.page}
-        onResolved={onResolved}
-      />
-      <Show when={voicesGate.showVoiceMap(voices()) && voices()}>
-        {(data) => <ArgumentVoiceMap data={data()} onClickVoice={props.onPushRabbi} />}
-      </Show>
-      <Show when={voicesGate.showFallback(voices(), resolved()) && voicesGate.profile()?.primary === 'aggadata'}>
-        <ArgumentNarrative section={props.section} tractate={props.tractate} page={props.page} />
-      </Show>
-    </div>
-  );
-}
-
 // Flow kinds that bind two sections into ONE continuous discussion (sugya).
 // The others (parallels / contrasts / generalizes / cites) are cross-references
 // between DISTINCT sugyot, so they don't merge sections into the same map.
@@ -748,15 +696,14 @@ interface DafLinkLite {
 // rest: the daf's argument sections as flow-graph MAPS — one map per discussion
 // (sugya), split where the sections stop binding to each other; maps whose
 // discussion carries over from the previous daf, or continues onto the next, are
-// flagged; clicking a section node drills into its voice map. Below: the unified
-// cross-reference links and the hand-off button into the in-depth card. The daf
-// `sections`, `onPushRabbi`, and `onOpenArgument` arrive via `extras`.
+// flagged; clicking a section node drills straight into that section's full
+// argument card (pushed onto the Overview, with a back chip returning here).
+// Below: the unified cross-reference links. The daf `sections` and
+// `onOpenArgument` arrive via `extras`.
 // ===========================================================================
 function ArgumentOverviewMaps(props: SpecialBlockProps): JSX.Element {
   const sections = (): Section[] => (props.extras?.sections as Section[]) ?? [];
-  const onPushRabbi = (): ((name: string) => void) => (props.extras?.onPushRabbi as ((name: string) => void)) ?? (() => {});
   const onOpenArgument = (): ((index: number) => void) | undefined => props.extras?.onOpenArgument as ((index: number) => void) | undefined;
-  const [active, setActive] = createSignal<number | null>(null);
 
   // The daf-level flow leaf's section connections. Empty until the synthesis
   // resolves; `props.synthesisResolved` is the "flow resolved" gate (a daf can
@@ -766,25 +713,12 @@ function ArgumentOverviewMaps(props: SpecialBlockProps): JSX.Element {
     return flow && Array.isArray(flow.connections) ? flow.connections : [];
   });
 
-  createEffect(() => {
-    void props.instanceKey;
-    setActive(null);
-    props.onHighlightRange?.(null);
-  });
-
-  // Clicking a section card both opens its voices and paints the section's
-  // segment range on the daf (clicking the active card again clears both).
-  const selectSection = (i: number) => {
-    const next = active() === i ? null : i;
-    setActive(next);
-    if (next === null) { props.onHighlightRange?.(null); return; }
-    const s = sections()[i];
-    if (s && s.startSegIdx != null && s.endSegIdx != null) {
-      props.onHighlightRange?.({ start: s.startSegIdx, end: s.endSegIdx, key: `overview:${i}` });
-    } else {
-      props.onHighlightRange?.(null);
-    }
-  };
+  // Clicking a section node drills straight into that section's full argument
+  // card. The card is pushed ONTO the Overview (see openArgument in DafViewer),
+  // so its back chip returns here — the Overview is the entry point and the
+  // section card the deep dive, one navigation stack. The daf's section range is
+  // painted by the argument card itself, so there's no separate highlight here.
+  const openSection = (i: number) => onOpenArgument()?.(i);
 
   // Split the daf's sections into discussion maps. With no flow yet (cold), each
   // section is its own group; once the flow loads they merge into real sugyot.
@@ -919,7 +853,6 @@ function ArgumentOverviewMaps(props: SpecialBlockProps): JSX.Element {
           const hasFirst = grp.includes(0);
           const hasLast = grp.includes(sections().length - 1);
           const grpNodes = grp.map((i) => ({ index: i, title: sections()[i].title }));
-          const activeInGroup = () => active() !== null && grp.includes(active()!);
           return (
             <div style={{ 'margin-bottom': '0.7rem' }}>
               <Show when={hasFirst && bridge()?.fromPrev}>
@@ -928,19 +861,11 @@ function ArgumentOverviewMaps(props: SpecialBlockProps): JSX.Element {
               <ArgumentFlowGraph
                 nodes={grpNodes}
                 connections={connections()}
-                activeIndex={active()}
-                onSelect={selectSection}
+                activeIndex={null}
+                onSelect={openSection}
               />
               <Show when={hasLast && bridge()?.toNext}>
                 {crossLabel(t('overview.continuesOnto', { page: pageRef(bridge()!.next) }))}
-              </Show>
-              <Show when={activeInGroup() && sections()[active()!]}>
-                <OverviewSectionVoices
-                  section={sections()[active()!]}
-                  tractate={props.tractate}
-                  page={props.page}
-                  onPushRabbi={onPushRabbi()}
-                />
               </Show>
             </div>
           );
@@ -980,20 +905,6 @@ function ArgumentOverviewMaps(props: SpecialBlockProps): JSX.Element {
               {t('overview.withinFlow')}: {withinFlowCounts().map((f) => `${f.count} ${relLabel(f.relation)}`).join(' · ')}
             </div>
           </Show>
-        </div>
-      </Show>
-      {/* Hand off into the in-depth argument card. Opens the section the reader
-       *  has drilled into (active), else the start of the argument. */}
-      <Show when={onOpenArgument() && sections().length > 0}>
-        <div style={{ 'margin-top': '0.8rem', 'border-top': '1px solid #f0f0f0', 'padding-top': '0.6rem' }}>
-          <button
-            onClick={() => onOpenArgument()?.(active() ?? 0)}
-            style={{
-              width: '100%', 'text-align': 'center', cursor: 'pointer', 'font-family': 'inherit',
-              'font-size': '0.78rem', color: '#8a2a2b', background: '#fdf3f3',
-              border: '1px solid #f0dcdc', 'border-radius': '7px', padding: '0.45rem 0.6rem',
-            }}
-          >{t('overview.openArgument')}</button>
         </div>
       </Show>
     </>
@@ -2200,7 +2111,7 @@ export const CARD_DEFS: Partial<Record<SidebarContent['kind'], CardDef>> = {
     // overview cache key (which would cold-miss all of Shas).
     synthInstance: () => ({ fields: {} }),
     forwardHighlight: true,
-    extras: (ctx) => ({ sections: ctx.dafSections, onPushRabbi: ctx.onPushRabbi, onOpenArgument: ctx.onOpenArgument }),
+    extras: (ctx) => ({ sections: ctx.dafSections, onOpenArgument: ctx.onOpenArgument }),
   },
   // Whole-daf essay cards: header + synthesis only (the essay renders through
   // the registerMarkRenderer seam). Display instance carries the localized

--- a/src/client/DafViewer.tsx
+++ b/src/client/DafViewer.tsx
@@ -875,6 +875,10 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
   };
   const setSidebar = (content: SidebarContent | null) => {
     setSidebarStack(content ? [content] : []);
+    // Switching the active card (or closing) clears the prior card's transient
+    // move-range band so it can't linger over an unrelated card — e.g. opening
+    // the Overview chip while an argument move was highlighted.
+    setArgumentMoveHighlight(null);
   };
   const pushSidebar = (content: SidebarContent) => {
     setSidebarStack((s) => {
@@ -888,6 +892,10 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
   };
   const popSidebar = () => {
     setSidebarStack((s) => (s.length > 1 ? s.slice(0, -1) : s));
+    // A move-range band belongs to the card being popped (e.g. an argument
+    // section's sub-move); clear it so it doesn't linger over the card beneath
+    // (e.g. the Overview the reader just returned to).
+    setArgumentMoveHighlight(null);
   };
   // Short label for a stack entry — used to title the back chip so the
   // user sees what they're returning to.
@@ -2166,7 +2174,13 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
     if (!a || !a.sections[index]) return;
     clearCommentarySelection();
     setActiveRabbi(null);
-    setSidebar({ kind: 'argument', section: a.sections[index], index });
+    const content = { kind: 'argument', section: a.sections[index], index } as const;
+    // Drilling in from the Overview (a flow-graph node, or a gutter click while
+    // the Overview is open) keeps the Overview underneath so the card's back
+    // chip returns to it — the two are one stack: Overview = entry point,
+    // section card = deep dive. Any other entry replaces outright.
+    if (sidebar()?.kind === 'argument-overview') pushSidebar(content);
+    else setSidebar(content);
     setLastInteractedCard('argument');
   };
 
@@ -2226,6 +2240,9 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
     // clears the span highlight.
     const current = sidebar();
     if (current && current.kind === kind && 'index' in current && current.index === index) {
+      // Toggle off. If this card was pushed onto something (e.g. the Overview),
+      // pop back to it rather than closing the whole panel.
+      if (sidebarStack().length > 1) { popSidebar(); return; }
       setSidebar(null);
       setActiveRabbi(null);
       if (activeCommentarySegIdx() === null) setLastInteractedCard(null);

--- a/src/client/i18n.ts
+++ b/src/client/i18n.ts
@@ -194,7 +194,6 @@ const CATALOG = {
   'overview.withinFlow': { en: 'within-daf flow', he: 'מהלך פנימי בדף' },
   'overview.mapping': { en: 'Mapping the discussion…', he: 'ממפה את הסוגיה…' },
   'overview.goToDaf': { en: 'Go to {daf}', he: 'מעבר ל{daf}' },
-  'overview.openArgument': { en: 'Open the full argument →', he: 'פתח את הסוגיה המלאה ←' },
   // Link-relation labels (the unified link layer, src/lib/context/link.ts).
   'link.rel.cites': { en: 'cites', he: 'מצטט' },
   'link.rel.continues': { en: 'continues', he: 'ממשיך' },


### PR DESCRIPTION
## What

Unifies the whole-daf **Overview** and the per-section **argument** cards into one drill-down, so the Overview is a real entry point into the daf rather than a parallel feature.

- Clicking a **flow-graph node** in the Overview now pushes that section's **full** argument card (Hebrew excerpt + synthesis + voice map + moves) onto the sidebar navigation stack. A **back chip** returns to the Overview — one stack, Overview = entry point, section card = deep dive.
- **Gutter "A" clicks** while the Overview is open push the same way (margin and chip converge). Their toggle pops back to the Overview instead of closing the whole panel.

## Removed

- `OverviewSectionVoices` — a thinner inline drill-in that duplicated the argument card (same `Synthesis` + `ArgumentVoiceMap`).
- The separate "Open the full argument →" handoff button + its i18n key.
- The now-dangling `onPushRabbi` extra on the overview recipe.

Net −77 lines.

## Notes

- The argument card already auto-paints its section range (single-writer highlight effect), so the node click no longer needs a separate highlight call.
- Clears the transient move-range band on card switch (`setSidebar`) and back-navigation (`popSidebar`) so it can't linger over an unrelated card — also closes a latent pre-existing case.
- Reviewed with Codex (read-only); both findings addressed.

`pnpm typecheck` + `pnpm test` (1814) green.
