### PR TITLE
Terms registry (PR2): Hebrew terms get tooltips; matcher on unified Term

### DIFF
--- a/src/client/ArgumentSidebar.tsx
+++ b/src/client/ArgumentSidebar.tsx
@@ -5,7 +5,8 @@ import { GENERATION_BY_ID, generationLabelHe, type GenerationId } from './genera
 import type { IdentifiedRabbi } from './dafContext';
 import { Hebraized } from './Hebraized';
 import { RabbiText, RabbiLinkProvider, HebraizedWithRabbis } from './rabbiLinks';
-import { ConceptLinkProvider, buildConceptMatcher, type ConceptTerm } from './conceptLinks';
+import { ConceptLinkProvider, buildConceptMatcher } from './conceptLinks';
+import type { Term } from '../lib/terms/registry';
 
 import RabbiLineageTree, { type RelationshipsData, type RelationshipsEvidence } from './RabbiLineageTree';
 import { type GeographyData, type GeographyEvidence } from './RabbiGeographyCard';
@@ -168,9 +169,10 @@ export interface ArgumentSidebarProps {
    *  rabbi-places dataset has gaps). Matched in prose; routing falls
    *  through pushRabbi's name-lookup chain. */
   dafRabbiNames: string[];
-  /** This daf's background terms (daf-background.concepts, flattened across
-   *  groups). Mentions of these in any card's prose get a gloss tooltip. */
-  dafBackgroundTerms: ConceptTerm[];
+  /** The daf's glossary pool: the always-known global terms ∪ this daf's
+   *  background concepts (src/lib/terms/registry). Mentions of any of these in a
+   *  card's prose — in Hebrew or English — get a gloss tooltip. */
+  glossaryTerms: Term[];
   /** Highlights a contiguous segment range on the daf. Used when the user
    *  clicks an argument-move card so the corresponding sub-range of the
    *  section is painted. Pass null to clear. `key` is a stable id (e.g. the
@@ -2287,8 +2289,8 @@ export function VoiceGroupBody(props: { group: { name: string; nameHe: string; b
 }
 
 export function ArgumentSidebar(props: ArgumentSidebarProps): JSX.Element {
-  // Compile the daf's background-term matcher once (not per prose fragment).
-  const conceptMatcher = createMemo(() => buildConceptMatcher(props.dafBackgroundTerms));
+  // Compile the daf's glossary matcher once (not per prose fragment).
+  const conceptMatcher = createMemo(() => buildConceptMatcher(props.glossaryTerms));
 
   const onKey = (e: KeyboardEvent) => {
     if (e.key === 'Escape') props.onClose();

--- a/src/client/DafViewer.tsx
+++ b/src/client/DafViewer.tsx
@@ -32,7 +32,7 @@ import { GutterOverlay } from './GutterOverlay';
 import { ArgumentSidebar, type SidebarContent, type PlaceInstance } from './ArgumentSidebar';
 import { enqueueEnrichmentRun } from './MarkEnrichmentCards';
 import { orderBackgroundGroups, type BackgroundGroup } from './backgroundGroups';
-import type { ConceptTerm } from './conceptLinks';
+import { conceptToTerm, glossaryForDaf, type Term } from '../lib/terms/registry';
 import { BugReport } from './BugReport';
 import { type CommentaryWork, type CommentaryComment } from './CommentaryPicker';
 import { CommentaryStrip } from './CommentaryStrip';
@@ -829,15 +829,22 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
       try {
         const r = await enqueueEnrichmentRun('daf-background.synthesis', tractate(), page(), { fields: {} }, 'daf-background:daf', ac.signal);
         const concepts = r.deps_resolved?.['daf-background.concepts'] as { groups?: BackgroundGroup[] } | undefined;
-        const out: ConceptTerm[] = [];
+        const out: Term[] = [];
         for (const g of orderBackgroundGroups(concepts?.groups)) {
-          for (const tm of g.terms) out.push({ term: tm.term, termHe: tm.termHe ?? '', gloss: tm.gloss, category: g.category });
+          for (const tm of g.terms) {
+            const t = conceptToTerm({ term: tm.term, termHe: tm.termHe, gloss: tm.gloss, category: g.category });
+            if (t) out.push(t);
+          }
         }
         return out;
       } catch { return []; }
     },
   );
-  const dafBackgroundTerms = createMemo<ConceptTerm[]>(() => dafBackgroundTermsRes() ?? []);
+  // The tooltip pool: the always-known globals ∪ this daf's background concepts
+  // (daf wins on a Hebrew-key collision). Wrapping with glossaryForDaf here —
+  // not inside the resource — keeps the globals present even before the daf
+  // enrichment resolves or if it errors.
+  const glossaryTerms = createMemo<Term[]>(() => glossaryForDaf(dafBackgroundTermsRes() ?? []));
 
   // TODO(geography-rederive): the rabbiPlaces memo previously fed
   // GeographyMap from the legacy dafContext fetch. Removed pending a
@@ -3507,7 +3514,7 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
               onBack={popSidebar}
               dafRabbis={dafRabbis()}
               dafRabbiNames={dafRabbiNames()}
-              dafBackgroundTerms={dafBackgroundTerms()}
+              glossaryTerms={glossaryTerms()}
               onHighlightRange={setArgumentMoveHighlight}
               onOpenRabbiSlug={openRabbiSlug}
               generationByName={generationByName()}
@@ -3539,7 +3546,7 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
           onBack={popSidebar}
           dafRabbis={dafRabbis()}
           dafRabbiNames={dafRabbiNames()}
-          dafBackgroundTerms={dafBackgroundTerms()}
+          glossaryTerms={glossaryTerms()}
           onHighlightRange={setArgumentMoveHighlight}
           onOpenRabbiSlug={openRabbiSlug}
           generationByName={generationByName()}

--- a/src/client/MobileShelf.tsx
+++ b/src/client/MobileShelf.tsx
@@ -3,7 +3,7 @@ import DafLoadProgress from './DafLoadProgress';
 import { t } from './i18n';
 import { tutorialNoteInteractive } from './tutorial';
 import { ArgumentSidebar, type SidebarContent } from './ArgumentSidebar';
-import type { ConceptTerm } from './conceptLinks';
+import type { Term } from '../lib/terms/registry';
 import type { GenerationId } from './generations';
 import type { IdentifiedRabbi } from './dafContext';
 import type { Section } from './shapes';
@@ -29,7 +29,7 @@ interface MobileShelfProps {
   onBack: () => void;
   dafRabbis: IdentifiedRabbi[];
   dafRabbiNames: string[];
-  dafBackgroundTerms: ConceptTerm[];
+  glossaryTerms: Term[];
   onOpenRabbiSlug: (slug: string) => void;
   generationByName: Map<string, GenerationId>;
   dafSections?: Section[];
@@ -162,7 +162,7 @@ function ExpansionView(props: MobileShelfProps): JSX.Element {
           onBack={props.onBack}
           dafRabbis={props.dafRabbis}
           dafRabbiNames={props.dafRabbiNames}
-          dafBackgroundTerms={props.dafBackgroundTerms}
+          glossaryTerms={props.glossaryTerms}
           onHighlightRange={props.onHighlightRange}
           onOpenRabbiSlug={props.onOpenRabbiSlug}
           generationByName={props.generationByName}

--- a/src/client/conceptLinks.tsx
+++ b/src/client/conceptLinks.tsx
@@ -1,14 +1,14 @@
 /**
- * Concept-link utilities: wrap mentions of the current daf's background terms
- * (the daf-background.concepts enrichment — legal-concepts / realia /
- * assumed-prior) in prose with a hover tooltip showing the term's gloss.
+ * Concept-link utilities: wrap mentions of glossary terms in prose with a hover
+ * tooltip showing the term's gloss — the reader-facing half of "if there's
+ * Hebrew, the translation is one hover away".
  *
- * This is the local, same-daf, high-precision half of the concept glossary:
- * the pool is THIS daf's curated background terms, so a match is a term the
- * daf itself defined — no cross-daf identity resolution, no anchoring. The
- * canonical cross-daf glossary (built from the observed-concept backlog) is a
- * later step; this just connects a term a reader meets in the overview/halacha
- * prose to the definition the Background card already produced.
+ * The pool is the unified term registry for the daf (src/lib/terms/registry):
+ * the always-known globals (CANONICAL_HEBREW_TERMS) ∪ THIS daf's curated
+ * background concepts, the daf's term winning on a Hebrew-key collision. A term
+ * is matched by every surface a reader might see it as — its Hebrew script (the
+ * dominant form after hebraization) AND its English label — so a Hebrew
+ * technical term in prose links to its gloss just as an English one does.
  *
  * Layering: rabbi mentions take priority (RabbiText tokenizes first, then hands
  * its plain-text parts to ConceptAwareText), so a rabbi name is never also
@@ -21,18 +21,32 @@
 import { For, Show, createContext, createMemo, createSignal, useContext, type Accessor, type JSX } from 'solid-js';
 import { Portal } from 'solid-js/web';
 import { Hebraized } from './Hebraized';
+import type { Term } from '../lib/terms/registry';
 
-export interface ConceptTerm {
-  term: string;     // English label (the match surface, e.g. "Kohen")
-  termHe: string;   // Hebrew script (shown in the tooltip)
-  gloss: string;    // 1-2 sentence explanation
-  category?: string;
+/** The surfaces a reader might actually SEE for a term in prose: the Hebrew
+ *  script (the dominant form after hebraization) and the English label, if any.
+ *  Deliberately NOT the romanization/variants — "get", "rov", "siman" etc. are
+ *  common English words and matching them would mis-fire. Hebrew script can't
+ *  collide with English, so it's the safe, high-precision surface. */
+export function surfacesOf(t: Term): string[] {
+  const out: string[] = [];
+  for (const s of [t.hebrew, t.en]) {
+    const v = (s || '').trim();
+    if (v.length >= 2) out.push(v);
+  }
+  return out;
+}
+
+/** The bold label shown atop the tooltip — the English reading when we have one,
+ *  else the romanization, else the Hebrew itself. */
+export function termLabel(t: Term): string {
+  return t.en || t.translit || t.hebrew;
 }
 
 /** A compiled term matcher: a regex over the term surfaces + a lowercased
  *  surface -> term map for gloss lookup. Built once per terms array (hoisted to
  *  the provider) rather than per prose fragment. */
-export interface ConceptMatcher { re: RegExp; bySurface: Map<string, ConceptTerm> }
+export interface ConceptMatcher { re: RegExp; bySurface: Map<string, Term> }
 
 export interface ConceptLinkContextValue {
   /** Pre-compiled matcher for this daf's terms. Null when there's nothing to
@@ -70,21 +84,23 @@ export function ConceptAwareText(props: { text: string | undefined | null }): JS
 export interface ConceptTextPart {
   kind: 'text' | 'concept';
   value: string;
-  term?: ConceptTerm;
+  term?: Term;
 }
 
 /** Compile a whole-word, case-insensitive matcher over the English term labels,
  *  longest-first so "oral law" beats "law". Word boundaries are Unicode-aware
  *  (a term may carry transliteration diacritics, e.g. "ḥerem", that ASCII `\b`
  *  splits wrongly). Null when there's nothing to match. */
-export function buildConceptMatcher(terms: ConceptTerm[]): ConceptMatcher | null {
-  const bySurface = new Map<string, ConceptTerm>();
+export function buildConceptMatcher(terms: readonly Term[]): ConceptMatcher | null {
+  const bySurface = new Map<string, Term>();
   for (const t of terms) {
-    const surface = (t.term || '').trim();
-    if (surface.length < 2) continue; // 1-char labels are too noisy to link
-    const key = surface.toLowerCase();
-    // First term to claim a surface wins (deterministic; dedupes repeats).
-    if (!bySurface.has(key)) bySurface.set(key, t);
+    // A term contributes every surface it can appear as in prose (Hebrew +
+    // English label), so a mention in either script links to the same gloss.
+    for (const surface of surfacesOf(t)) {
+      const key = surface.toLowerCase();
+      // First term to claim a surface wins (deterministic; dedupes repeats).
+      if (!bySurface.has(key)) bySurface.set(key, t);
+    }
   }
   if (bySurface.size === 0) return null;
   const surfaces = [...bySurface.keys()]
@@ -123,7 +139,7 @@ export function tokenizeWithMatcher(text: string, matcher: ConceptMatcher | null
 
 /** Convenience for callers that have terms but no compiled matcher (tests).
  *  Whole-word, case-insensitive, longest-first. Pure + exported for tests. */
-export function tokenizeConceptMentions(text: string, terms: ConceptTerm[]): ConceptTextPart[] {
+export function tokenizeConceptMentions(text: string, terms: readonly Term[]): ConceptTextPart[] {
   return tokenizeWithMatcher(text, buildConceptMatcher(terms));
 }
 
@@ -164,7 +180,7 @@ const tooltipStyle: JSX.CSSProperties = {
  *  clip (`.daf-aside { overflow: auto }`) which was cutting it off; once its
  *  size is known (ref callback at mount) we clamp it inside the viewport and
  *  flip above the term when there isn't room below. */
-function ConceptMention(props: { value: string; term: ConceptTerm }): JSX.Element {
+function ConceptMention(props: { value: string; term: Term }): JSX.Element {
   const [open, setOpen] = createSignal(false);
   const [pos, setPos] = createSignal<{ left: number; top: number }>({ left: 0, top: 0 });
   let termRef: HTMLSpanElement | undefined;
@@ -199,7 +215,7 @@ function ConceptMention(props: { value: string; term: ConceptTerm }): JSX.Elemen
       style={termStyle}
       tabindex={0}
       role="button"
-      aria-label={`${props.term.term}: ${props.term.gloss}`}
+      aria-label={`${termLabel(props.term)}: ${props.term.gloss}`}
       onMouseEnter={openTip}
       onMouseLeave={() => setOpen(false)}
       onFocus={openTip}
@@ -209,9 +225,9 @@ function ConceptMention(props: { value: string; term: ConceptTerm }): JSX.Elemen
       <Show when={open()}>
         <Portal>
           <span ref={place} style={{ ...tooltipStyle, left: `${pos().left}px`, top: `${pos().top}px` }} dir="ltr" onClick={(e) => e.stopPropagation()}>
-            <span style={{ 'font-weight': 600 }}>{props.term.term}</span>
-            <Show when={props.term.termHe}>
-              <span dir="rtl" style={{ 'margin-left': '0.35rem', color: '#cbd5e1' }}>{props.term.termHe}</span>
+            <span style={{ 'font-weight': 600 }}>{termLabel(props.term)}</span>
+            <Show when={props.term.hebrew && props.term.hebrew !== termLabel(props.term)}>
+              <span dir="rtl" style={{ 'margin-left': '0.35rem', color: '#cbd5e1' }}>{props.term.hebrew}</span>
             </Show>
             <span style={{ display: 'block', 'margin-top': '0.25rem', color: '#e5e7eb' }}>{props.term.gloss}</span>
           </span>

--- a/tests/concept-links.test.ts
+++ b/tests/concept-links.test.ts
@@ -1,18 +1,30 @@
 import { describe, it, expect } from 'vitest';
-import { tokenizeConceptMentions, type ConceptTerm } from '../src/client/conceptLinks';
+import {
+  tokenizeConceptMentions,
+  surfacesOf,
+  termLabel,
+} from '../src/client/conceptLinks';
+import { globalTerms, type Term } from '../src/lib/terms/registry';
 
-// The concept-tooltip layer wraps mentions of THIS daf's background terms in
-// prose so a reader can see the gloss inline. tokenizeConceptMentions is the
-// pure splitter; these guard the matching (whole-word, case-insensitive,
-// longest-first) and the parenthetical-Hebrew case the feature targets.
+// The concept-tooltip layer wraps mentions of the daf's glossary terms in prose
+// so a reader sees the gloss inline. A term is matched by EVERY surface it can
+// appear as — its English label AND its Hebrew script — so a Hebrew technical
+// term links to its gloss just as an English one does. tokenizeConceptMentions
+// is the pure splitter; these guard matching + the Hebrew-surface behavior.
 
-const TERMS: ConceptTerm[] = [
-  { term: 'Kohen', termHe: 'כהן', gloss: 'A descendant of Aharon who serves in the Temple.' },
-  { term: 'Oral Law', termHe: 'תורה שבעל פה', gloss: 'The transmitted interpretation of the Written Torah.' },
-  { term: 'law', termHe: 'דין', gloss: 'A legal ruling.' },
+const mk = (t: Partial<Term> & Pick<Term, 'hebrew' | 'gloss'>): Term => ({
+  display: 'hebrew-first-gloss',
+  scope: 'daf',
+  ...t,
+});
+
+const TERMS: Term[] = [
+  mk({ en: 'Kohen', hebrew: 'כהן', gloss: 'A descendant of Aharon who serves in the Temple.' }),
+  mk({ en: 'Oral Law', hebrew: 'תורה שבעל פה', gloss: 'The transmitted interpretation of the Written Torah.' }),
+  mk({ en: 'law', hebrew: 'דין', gloss: 'A legal ruling.' }),
 ];
 
-describe('tokenizeConceptMentions', () => {
+describe('tokenizeConceptMentions — English surfaces', () => {
   it('wraps a known term and carries its gloss; surrounding text stays plain', () => {
     const parts = tokenizeConceptMentions('Only a Kohen may eat terumah.', TERMS);
     expect(parts).toEqual([
@@ -20,13 +32,6 @@ describe('tokenizeConceptMentions', () => {
       { kind: 'concept', value: 'Kohen', term: TERMS[0] },
       { kind: 'text', value: ' may eat terumah.' },
     ]);
-  });
-
-  it('leaves the parenthetical Hebrew as text (the English label is the match)', () => {
-    const parts = tokenizeConceptMentions('a Kohen (כהן) may not', TERMS);
-    expect(parts.map((p) => p.kind)).toEqual(['text', 'concept', 'text']);
-    expect(parts[1]).toMatchObject({ kind: 'concept', value: 'Kohen' });
-    expect(parts[2].value).toBe(' (כהן) may not'); // Hebrew + rest untouched
   });
 
   it('matches case-insensitively but preserves the matched casing verbatim', () => {
@@ -43,16 +48,13 @@ describe('tokenizeConceptMentions', () => {
 
   it('matches whole words only — never mid-word', () => {
     const parts = tokenizeConceptMentions('The lawyer outlawed it.', TERMS);
-    // "law" must not fire inside "lawyer" / "outlawed"
     expect(parts.every((p) => p.kind === 'text')).toBe(true);
   });
 
   it('handles transliteration diacritics with Unicode word boundaries', () => {
-    const terms: ConceptTerm[] = [{ term: 'ḥerem', termHe: 'חרם', gloss: 'A ban / excommunication.' }];
-    // matches as a standalone word...
+    const terms = [mk({ en: 'ḥerem', hebrew: 'חרם', gloss: 'A ban / excommunication.' })];
     const hit = tokenizeConceptMentions('They declared ḥerem on him.', terms);
     expect(hit[1]).toMatchObject({ kind: 'concept', value: 'ḥerem' });
-    // ...but not as a substring of a longer diacritic-bearing word
     const miss = tokenizeConceptMentions('the ḥeremite stayed', terms);
     expect(miss.every((p) => p.kind === 'text')).toBe(true);
   });
@@ -62,15 +64,76 @@ describe('tokenizeConceptMentions', () => {
     expect(tokenizeConceptMentions('', TERMS)).toEqual([]);
   });
 
-  it('skips 1-char labels (too noisy) and dedupes repeated surfaces', () => {
-    const noisy: ConceptTerm[] = [
-      { term: 'a', termHe: '', gloss: 'x' },
-      { term: 'Get', termHe: 'גט', gloss: 'A bill of divorce.' },
-      { term: 'Get', termHe: 'גט', gloss: 'duplicate' },
+  it('skips <2-char labels and dedupes repeated surfaces (first claimant wins)', () => {
+    const noisy = [
+      mk({ en: 'a', hebrew: '', gloss: 'x' }), // both surfaces too short -> no surface
+      mk({ en: 'Get', hebrew: 'גט', gloss: 'A bill of divorce.' }),
+      mk({ en: 'Get', hebrew: 'גט', gloss: 'duplicate' }),
     ];
     const parts = tokenizeConceptMentions('She received a Get today.', noisy);
     const concepts = parts.filter((p) => p.kind === 'concept');
     expect(concepts).toHaveLength(1);
-    expect(concepts[0].term?.gloss).toBe('A bill of divorce.'); // first claimant wins
+    expect(concepts[0].term?.gloss).toBe('A bill of divorce.');
+  });
+});
+
+// The feature this PR adds: a Hebrew technical term in prose is hoverable too.
+describe('tokenizeConceptMentions — Hebrew surfaces', () => {
+  it('matches the Hebrew script form and links it to the same gloss', () => {
+    const parts = tokenizeConceptMentions('נחלקו אם כהן רשאי לאכול.', TERMS);
+    const concepts = parts.filter((p) => p.kind === 'concept');
+    expect(concepts).toHaveLength(1);
+    expect(concepts[0]).toMatchObject({ value: 'כהן', term: TERMS[0] });
+  });
+
+  it('tags BOTH the English and the parenthetical Hebrew (Form B prose)', () => {
+    // The old behavior left the parenthetical Hebrew as plain text; now it
+    // links too, so either script a reader hovers reaches the gloss.
+    const parts = tokenizeConceptMentions('a Kohen (כהן) may not', TERMS);
+    const concepts = parts.filter((p) => p.kind === 'concept');
+    expect(concepts.map((c) => c.value)).toEqual(['Kohen', 'כהן']);
+  });
+
+  it('does not fire on a Hebrew term carrying a prefix letter (precision over recall)', () => {
+    // כהן inside הכהן ("the kohen") is preceded by a Hebrew letter, so the
+    // word-boundary lookbehind correctly declines — we accept the miss.
+    const parts = tokenizeConceptMentions('הכהן עבד במקדש.', TERMS);
+    expect(parts.every((p) => p.kind === 'text')).toBe(true);
+  });
+});
+
+// Globals are now in the pool on every daf, matched by their Hebrew surface.
+describe('global terms in the matcher pool', () => {
+  const g = globalTerms();
+  const byHe = (he: string): Term => g.find((t) => t.hebrew === he)!;
+
+  it('matches a canonical Hebrew term (הלכה) in prose', () => {
+    const parts = tokenizeConceptMentions('כאן יש הלכה ברורה.', g);
+    const concepts = parts.filter((p) => p.kind === 'concept');
+    expect(concepts.some((c) => c.value === 'הלכה')).toBe(true);
+  });
+
+  it("matches a display:'english' global by its English label (court -> בית דין)", () => {
+    const parts = tokenizeConceptMentions('The court ruled today.', g);
+    const hit = parts.find((p) => p.kind === 'concept');
+    expect(hit?.value).toBe('court');
+    expect(hit?.term?.hebrew).toBe('בית דין');
+  });
+
+  it('never matches a romanization as an English word (rov / get stay plain)', () => {
+    // 'rov' and 'get' are common English words; only their Hebrew is a surface.
+    expect(tokenizeConceptMentions('a rov of the cases', g).every((p) => p.kind === 'text')).toBe(true);
+    expect(tokenizeConceptMentions('please get the book', g).every((p) => p.kind === 'text')).toBe(true);
+  });
+
+  it('surfacesOf: Hebrew always, English label only when present; never the romanization', () => {
+    expect(surfacesOf(byHe('הלכה'))).toEqual(['הלכה']); // hebrew display, no en
+    expect(surfacesOf(byHe('בית דין'))).toEqual(['בית דין', 'court']); // english display
+  });
+
+  it('termLabel: English reading, else romanization, else Hebrew', () => {
+    expect(termLabel(byHe('בית דין'))).toBe('court'); // en
+    expect(termLabel(byHe('הלכה'))).toBe('halacha'); // translit
+    expect(termLabel(mk({ hebrew: 'פלוני', gloss: 'g' }))).toBe('פלוני'); // bare
   });
 });


### PR DESCRIPTION
Second PR of the bilingual-prose-consistency rework. Builds on #298.

## What this delivers
The reader-facing half of "**if there's Hebrew, the translation is one hover away**". The prose concept-tooltip layer now matches a term by **every surface a reader might see** — its Hebrew script *and* its English label — so a Hebrew technical term (`הלכה`, `כהן`) links to its gloss exactly as an English one already did. And the always-known **global terms are now in the pool on every daf**, not just the daf's extracted background concepts.

## Changes
- **`conceptLinks.tsx`**: retire the bespoke `ConceptTerm` shape; the matcher + tooltip consume the unified `Term` (from #298's `src/lib/terms/registry`).
  - `surfacesOf(term)` = Hebrew + English label, **never the romanization** (`get`/`rov`/`siman` are common English words — matching them would mis-fire; Hebrew script can't collide with English, so it's the high-precision surface).
  - `termLabel(term)` = English reading, else romanization, else Hebrew (tooltip title).
  - `buildConceptMatcher` registers every surface; existing Unicode-aware word boundaries already handle Hebrew.
- **`DafViewer`**: build the daf concepts as `Term[]` (via `conceptToTerm`) and merge the globals with `glossaryForDaf` — pool = globals ∪ daf concepts, with globals present **immediately** (before the daf-background enrichment resolves). Prop renamed `dafBackgroundTerms` → `glossaryTerms` (it's no longer daf-only) across DafViewer / ArgumentSidebar / MobileShelf.

## Retires (cruft)
- The `ConceptTerm` shape.
- English-label-only matching, which left Hebrew terms in prose untooltipped (its old test asserted exactly that behavior).

## Behavior notes
- Form-B prose (`a Kohen (כהן)`) now tags **both** scripts — redundant parenthetical Hebrew is removed in PR3 (the first-mention gloss pass), which subsumes it.
- A Hebrew term carrying a prefix letter (`הכהן`) intentionally does **not** match — precision over recall; documented in a test.

## Tests
- `concept-links.test.ts` rewritten for `Term` + new Hebrew-surface coverage (Hebrew matches; both-scripts in Form B; prefix-letter declines; globals in pool; romanizations never matched as English; `surfacesOf`/`termLabel` units).
- Full suite **1875 green**; `typecheck` clean.
- Reviewed with `codex exec --sandbox read-only`: **no real issues** (matcher boundaries, overfire risk, Solid reactivity, prop-rename path all checked).