### PR TITLE
Terms registry (PR3): first-mention gloss pass — gloss once per section

### DIFF
--- a/src/client/conceptLinks.tsx
+++ b/src/client/conceptLinks.tsx
@@ -143,6 +143,84 @@ export function tokenizeConceptMentions(text: string, terms: readonly Term[]): C
   return tokenizeWithMatcher(text, buildConceptMatcher(terms));
 }
 
+// ── First-mention gloss policy ────────────────────────────────────────────────
+// A glossary term is glossed inline on its FIRST mention in a prose unit and
+// runs bare thereafter — the tooltip carries the gloss for every later mention,
+// so the repeated parenthetical is pure clutter. This makes the page consistent
+// (one gloss per term, deterministically) without the model having to remember
+// what it already defined. We only ever STRIP a repeat gloss, never invent one,
+// and only when the parenthetical restates the SAME gloss — a meaningful
+// parenthetical (a qualifier like "(according to Rashi)") is always kept.
+
+/** Normalize a gloss for comparison: lowercase, drop surrounding quotes /
+ *  trailing punctuation, strip a leading article, collapse whitespace. */
+export function glossKey(s: string): string {
+  return (s || '')
+    .toLowerCase()
+    .trim()
+    .replace(/^[('"“”‘’\s]+/, '')
+    .replace(/[)\]'"“”‘’.,;:!?\s]+$/, '')
+    .replace(/^(the|a|an)\s+/, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/** Two glosses count as "the same" when equal, or one contains the other (the
+ *  model often writes a fuller form once, e.g. "binding law" vs the registry's
+ *  "binding law / halacha"). Containment requires ≥4 chars so short words can't
+ *  spuriously match. */
+function glossMatch(a: string, b: string): boolean {
+  if (!a || !b) return false;
+  if (a === b) return true;
+  const [short, long] = a.length <= b.length ? [a, b] : [b, a];
+  return short.length >= 4 && long.includes(short);
+}
+
+/** If `text` opens with an inline gloss parenthetical (only whitespace/quotes
+ *  before the `(`), return its inner text plus the remainder with the
+ *  parenthetical excised and the seam tidied (no doubled space, no space before
+ *  punctuation). Null when there's no leading parenthetical. */
+function leadingGloss(text: string): { inner: string; rest: string } | null {
+  const m = /^(\s*)\(\s*([^()]+?)\s*\)/.exec(text);
+  if (!m) return null;
+  const before = m[1];
+  const after = text.slice(m[0].length);
+  const rest = (before + after)
+    .replace(/^\s+/, ' ')
+    .replace(/\s+([,.;:!?’”)])/g, '$1');
+  return { inner: m[2], rest };
+}
+
+/** Strip every-but-first inline gloss of each glossary term in one prose unit.
+ *  Pure; idempotent (a second pass finds no repeats left to strip), so it's safe
+ *  to apply at more than one layer of the prose pipeline. */
+export function firstMentionGloss(text: string, matcher: ConceptMatcher | null): string {
+  if (!text || !matcher) return text;
+  const parts = tokenizeWithMatcher(text, matcher);
+  const glossed = new Map<Term, string>(); // term -> the gloss kept on first mention
+  for (let i = 0; i < parts.length; i++) {
+    const p = parts[i];
+    if (p.kind !== 'concept' || !p.term) continue;
+    const next = parts[i + 1];
+    if (!next || next.kind !== 'text') continue;
+    const lead = leadingGloss(next.value);
+    if (!lead) continue;
+    const key = glossKey(lead.inner);
+    const prior = glossed.get(p.term);
+    if (prior === undefined) {
+      // First inline gloss this term gets anywhere in the unit — keep it, and
+      // remember it (fall back to the registry gloss if the paren was empty).
+      glossed.set(p.term, key || glossKey(p.term.gloss));
+      continue;
+    }
+    // A later mention: drop the parenthetical only if it restates the gloss.
+    if (glossMatch(key, prior) || glossMatch(key, glossKey(p.term.gloss))) {
+      next.value = lead.rest;
+    }
+  }
+  return parts.map((p) => p.value).join('');
+}
+
 const termStyle: JSX.CSSProperties = {
   'text-decoration': 'underline',
   'text-decoration-style': 'dotted',
@@ -242,7 +320,12 @@ function ConceptMention(props: { value: string; term: Term }): JSX.Element {
  *  load (new matcher) re-tokenizes. The matcher is compiled once at the
  *  provider, so this is just a scan per fragment. */
 export function ConceptText(props: { text: string | undefined | null; matcher: ConceptMatcher | null }): JSX.Element {
-  const parts = createMemo(() => tokenizeWithMatcher(props.text ?? '', props.matcher));
+  // Strip every-but-first inline gloss before tokenizing, then tokenize the
+  // cleaned text so each remaining mention still gets its tooltip.
+  const parts = createMemo(() => {
+    const cleaned = firstMentionGloss(props.text ?? '', props.matcher);
+    return tokenizeWithMatcher(cleaned, props.matcher);
+  });
   return (
     <For each={parts()}>{(p) => {
       if (p.kind === 'text' || !p.term) return <Hebraized text={p.value} />;

--- a/src/client/conceptLinks.tsx
+++ b/src/client/conceptLinks.tsx
@@ -165,58 +165,73 @@ export function glossKey(s: string): string {
     .trim();
 }
 
-/** Two glosses count as "the same" when equal, or one contains the other (the
- *  model often writes a fuller form once, e.g. "binding law" vs the registry's
- *  "binding law / halacha"). Containment requires ≥4 chars so short words can't
- *  spuriously match. */
-function glossMatch(a: string, b: string): boolean {
-  if (!a || !b) return false;
-  if (a === b) return true;
-  const [short, long] = a.length <= b.length ? [a, b] : [b, a];
-  return short.length >= 4 && long.includes(short);
+/** Whether a parenthetical's content is (a restatement of) the term's own gloss
+ *  — the ONLY thing we ever strip. Matching is DIRECTIONAL: the parenthetical
+ *  must equal the registry gloss, or be CONTAINED in it (the model's inline
+ *  gloss is often a shorter form of a longer registry gloss). We never accept
+ *  the reverse (gloss contained in the parenthetical), because a meaningful
+ *  qualifier that happens to include the gloss text — "(not binding law in this
+ *  case)" — must be kept. Containment needs ≥4 chars so a tiny word can't match. */
+function isGlossRestatement(parenKey: string, glossK: string): boolean {
+  if (!parenKey || !glossK) return false;
+  if (parenKey === glossK) return true;
+  return parenKey.length >= 4 && glossK.includes(parenKey);
 }
 
-/** If `text` opens with an inline gloss parenthetical (only whitespace/quotes
- *  before the `(`), return its inner text plus the remainder with the
- *  parenthetical excised and the seam tidied (no doubled space, no space before
- *  punctuation). Null when there's no leading parenthetical. */
-function leadingGloss(text: string): { inner: string; rest: string } | null {
-  const m = /^(\s*)\(\s*([^()]+?)\s*\)/.exec(text);
-  if (!m) return null;
-  const before = m[1];
-  const after = text.slice(m[0].length);
-  const rest = (before + after)
-    .replace(/^\s+/, ' ')
-    .replace(/\s+([,.;:!?’”)])/g, '$1');
-  return { inner: m[2], rest };
+// A leading parenthetical: optional whitespace, then `(...)` tolerating ONE
+// level of nested parens (registry glosses like "a shechita organ (trachea /
+// esophagus)" carry one). `len` is how much of the string it spans (ws + paren);
+// `inner` is the content without the outer parens.
+const LEADING_PAREN_RE = /^(\s*)\(((?:[^()]+|\([^()]*\))*)\)/;
+function matchLeadingParen(s: string): { len: number; inner: string } | null {
+  const m = LEADING_PAREN_RE.exec(s);
+  return m ? { len: m[0].length, inner: m[2] } : null;
 }
 
-/** Strip every-but-first inline gloss of each glossary term in one prose unit.
- *  Pure; idempotent (a second pass finds no repeats left to strip), so it's safe
- *  to apply at more than one layer of the prose pipeline. */
+/** Consume the gloss parentheticals that lead `text` (the fragment right after a
+ *  term mention): keep the FIRST one that restates the term's gloss (recording
+ *  it in `glossed`), strip every later one. Loops so adjacent duplicates all go
+ *  in a single pass (keeps the function idempotent). A non-gloss parenthetical
+ *  (a real qualifier) stops the peel and is left untouched. */
+function peelGlosses(text: string, term: Term, glossed: Set<Term>): string {
+  const glossK = glossKey(term.gloss);
+  let kept = '';
+  let rest = text;
+  let stripped = false;
+  for (let m = matchLeadingParen(rest); m; m = matchLeadingParen(rest)) {
+    if (!isGlossRestatement(glossKey(m.inner), glossK)) break;
+    const after = rest.slice(m.len);
+    if (!glossed.has(term)) {
+      glossed.add(term);
+      kept += rest.slice(0, m.len); // first gloss: keep verbatim, peel past it
+    } else {
+      stripped = true; // a repeat: drop it
+    }
+    rest = after;
+  }
+  let out = kept + rest;
+  if (stripped) {
+    out = out.replace(/ {2,}/g, ' ').replace(/\s+([,.;:!?’”)])/g, '$1');
+    if (kept === '') out = out.replace(/^\s+/, ' '); // single space after the bare term
+  }
+  return out;
+}
+
+/** Strip every-but-first inline gloss of each glossary term in one prose unit:
+ *  a term is glossed on first mention and runs bare after (the tooltip carries
+ *  the gloss). Only a parenthetical that restates the term's OWN gloss is ever
+ *  removed — qualifiers are always kept. Pure; idempotent, so it's safe to apply
+ *  at more than one layer of the prose pipeline. */
 export function firstMentionGloss(text: string, matcher: ConceptMatcher | null): string {
   if (!text || !matcher) return text;
   const parts = tokenizeWithMatcher(text, matcher);
-  const glossed = new Map<Term, string>(); // term -> the gloss kept on first mention
+  const glossed = new Set<Term>();
   for (let i = 0; i < parts.length; i++) {
     const p = parts[i];
     if (p.kind !== 'concept' || !p.term) continue;
     const next = parts[i + 1];
     if (!next || next.kind !== 'text') continue;
-    const lead = leadingGloss(next.value);
-    if (!lead) continue;
-    const key = glossKey(lead.inner);
-    const prior = glossed.get(p.term);
-    if (prior === undefined) {
-      // First inline gloss this term gets anywhere in the unit — keep it, and
-      // remember it (fall back to the registry gloss if the paren was empty).
-      glossed.set(p.term, key || glossKey(p.term.gloss));
-      continue;
-    }
-    // A later mention: drop the parenthetical only if it restates the gloss.
-    if (glossMatch(key, prior) || glossMatch(key, glossKey(p.term.gloss))) {
-      next.value = lead.rest;
-    }
+    next.value = peelGlosses(next.value, p.term, glossed);
   }
   return parts.map((p) => p.value).join('');
 }

--- a/src/client/conceptLinks.tsx
+++ b/src/client/conceptLinks.tsx
@@ -178,43 +178,50 @@ function isGlossRestatement(parenKey: string, glossK: string): boolean {
   return parenKey.length >= 4 && glossK.includes(parenKey);
 }
 
-// A leading parenthetical: optional whitespace, then `(...)` tolerating ONE
-// level of nested parens (registry glosses like "a shechita organ (trachea /
-// esophagus)" carry one). `len` is how much of the string it spans (ws + paren);
-// `inner` is the content without the outer parens.
-const LEADING_PAREN_RE = /^(\s*)\(((?:[^()]+|\([^()]*\))*)\)/;
+/** Match a leading parenthetical: optional whitespace, then a balanced `(...)`
+ *  tolerating nested parens (registry glosses like "a shechita organ (trachea /
+ *  esophagus)" carry one). A linear hand scan, NOT a regex — the obvious
+ *  `(?:[^()]+|\(...\))*` form catastrophically backtracks on an unterminated
+ *  `(`. `len` spans the leading whitespace + the paren; `inner` is the content
+ *  without the outer parens. Null when there's no balanced leading paren. */
 function matchLeadingParen(s: string): { len: number; inner: string } | null {
-  const m = LEADING_PAREN_RE.exec(s);
-  return m ? { len: m[0].length, inner: m[2] } : null;
+  let i = 0;
+  while (i < s.length && /\s/.test(s[i])) i++;
+  if (s[i] !== '(') return null;
+  const open = i;
+  let depth = 0;
+  for (; i < s.length; i++) {
+    if (s[i] === '(') depth++;
+    else if (s[i] === ')' && --depth === 0) {
+      return { len: i + 1, inner: s.slice(open + 1, i) };
+    }
+  }
+  return null; // unterminated
 }
 
 /** Consume the gloss parentheticals that lead `text` (the fragment right after a
  *  term mention): keep the FIRST one that restates the term's gloss (recording
  *  it in `glossed`), strip every later one. Loops so adjacent duplicates all go
  *  in a single pass (keeps the function idempotent). A non-gloss parenthetical
- *  (a real qualifier) stops the peel and is left untouched. */
+ *  (a real qualifier) stops the peel and is left untouched.
+ *
+ *  No seam cleanup is needed: `len` always covers the whitespace BEFORE the
+ *  paren too, so a stripped paren leaves the whitespace that FOLLOWED it intact
+ *  as the single separator — and text further along the fragment is never
+ *  touched. */
 function peelGlosses(text: string, term: Term, glossed: Set<Term>): string {
   const glossK = glossKey(term.gloss);
   let kept = '';
   let rest = text;
-  let stripped = false;
   for (let m = matchLeadingParen(rest); m; m = matchLeadingParen(rest)) {
     if (!isGlossRestatement(glossKey(m.inner), glossK)) break;
-    const after = rest.slice(m.len);
     if (!glossed.has(term)) {
       glossed.add(term);
       kept += rest.slice(0, m.len); // first gloss: keep verbatim, peel past it
-    } else {
-      stripped = true; // a repeat: drop it
-    }
-    rest = after;
+    } // else: a repeat — drop it (don't append)
+    rest = rest.slice(m.len);
   }
-  let out = kept + rest;
-  if (stripped) {
-    out = out.replace(/ {2,}/g, ' ').replace(/\s+([,.;:!?’”)])/g, '$1');
-    if (kept === '') out = out.replace(/^\s+/, ' '); // single space after the bare term
-  }
-  return out;
+  return kept + rest;
 }
 
 /** Strip every-but-first inline gloss of each glossary term in one prose unit:

--- a/src/client/rabbiLinks.tsx
+++ b/src/client/rabbiLinks.tsx
@@ -18,7 +18,7 @@
 import { For, createContext, createMemo, useContext, type Accessor, type JSX } from 'solid-js';
 import type { IdentifiedRabbi } from './dafContext';
 import { Hebraized } from './Hebraized';
-import { ConceptAwareText } from './conceptLinks';
+import { ConceptAwareText, firstMentionGloss, useConceptLinks } from './conceptLinks';
 
 export interface RabbiLinkContextValue {
   rabbis: Accessor<IdentifiedRabbi[]>;
@@ -145,13 +145,22 @@ export function RabbiText(props: {
   onPushRabbi: (name: string) => void;
   extraNames?: string[];
 }): JSX.Element {
+  // The concept layer (if in scope) gives us the daf's glossary matcher. Apply
+  // the first-mention gloss strip to the WHOLE section string here, before it's
+  // split at rabbi names — so a term glossed in one rabbi-gap runs bare in a
+  // later one (true per-section scope, not per-fragment). ConceptText re-applies
+  // it per fragment for cards with no rabbi pool; the pass is idempotent.
+  const concept = useConceptLinks();
   // All reactive reads happen inside this memo so prop changes (e.g.
   // dafContext loading after mount, a new sidebar entry pushing) trigger
   // re-tokenization.
-  const parts = createMemo(() => tokenizeRabbiMentions(props.text ?? '', [
-    ...props.rabbis.map((r) => r.name),
-    ...(props.extraNames ?? []),
-  ]));
+  const parts = createMemo(() => {
+    const cleaned = firstMentionGloss(props.text ?? '', concept?.matcher() ?? null);
+    return tokenizeRabbiMentions(cleaned, [
+      ...props.rabbis.map((r) => r.name),
+      ...(props.extraNames ?? []),
+    ]);
+  });
 
   return (
     <For each={parts()}>{(p) => {

--- a/tests/first-mention-gloss.test.ts
+++ b/tests/first-mention-gloss.test.ts
@@ -51,11 +51,39 @@ describe('firstMentionGloss', () => {
     expect(out).toBe('A Kohen (a Temple priest) serves; כהן again.');
   });
 
-  it('matches a looser repeat via containment against the registry gloss', () => {
-    // First inline gloss is the fuller form; the repeat is a shorter restatement.
-    const t = mk({ en: 'Kohen', hebrew: 'כהן', gloss: 'priest' });
-    const out = gloss('A Kohen (a Temple priest) serves; the Kohen (priest) eats.', [t]);
+  it('strips a shorter restatement contained in the registry gloss', () => {
+    // Registry gloss is the fuller form; a later inline gloss is a shorter
+    // restatement contained in it -> recognized and stripped.
+    const out = gloss('A Kohen (a Temple priest) serves; the Kohen (priest) eats.');
     expect(out).toBe('A Kohen (a Temple priest) serves; the Kohen eats.');
+  });
+
+  // ── Regressions from the codex review of the first cut ──────────────────────
+  it('keeps a repeated QUALIFIER that is not the gloss (not "(according to Rashi)")', () => {
+    const g = buildConceptMatcher(globalTerms());
+    const input = 'הלכה (according to Rashi) is strict; later הלכה (according to Rashi) is lenient.';
+    expect(firstMentionGloss(input, g)).toBe(input);
+  });
+
+  it('keeps a qualifier that merely CONTAINS the gloss text', () => {
+    const g = buildConceptMatcher(globalTerms());
+    const input = 'הלכה (binding law) applies; later הלכה (not binding law in this case) is only custom.';
+    expect(firstMentionGloss(input, g)).toBe(input);
+  });
+
+  it('strips a repeated gloss that itself carries nested parens (סימן)', () => {
+    const out = firstMentionGloss(
+      'סימן (a shechita organ (trachea / esophagus)) is cut; another סימן (a shechita organ (trachea / esophagus)) is checked.',
+      buildConceptMatcher(globalTerms()),
+    );
+    expect(out).toBe('סימן (a shechita organ (trachea / esophagus)) is cut; another סימן is checked.');
+  });
+
+  it('is idempotent even with adjacent duplicate gloss parens', () => {
+    const g = buildConceptMatcher(globalTerms());
+    const once = firstMentionGloss('הלכה (binding law); later הלכה (binding law) (binding law).', g);
+    expect(once).toBe('הלכה (binding law); later הלכה.');
+    expect(firstMentionGloss(once, g)).toBe(once);
   });
 
   it('tidies the seam — no space left before punctuation', () => {

--- a/tests/first-mention-gloss.test.ts
+++ b/tests/first-mention-gloss.test.ts
@@ -86,6 +86,19 @@ describe('firstMentionGloss', () => {
     expect(firstMentionGloss(once, g)).toBe(once);
   });
 
+  it('does not touch text further along the fragment when stripping (no global tidy)', () => {
+    // The double space inside the later quote must survive the strip.
+    const out = gloss('A Kohen (a Temple priest) serves; later Kohen (a Temple priest) quotes "A  B".');
+    expect(out).toBe('A Kohen (a Temple priest) serves; later Kohen quotes "A  B".');
+  });
+
+  it('is linear on an unterminated parenthetical (no catastrophic backtracking)', () => {
+    const input = `A Kohen (${'a'.repeat(5000)}`; // no closing paren
+    const start = Date.now();
+    expect(gloss(input)).toBe(input); // nothing to strip; returns promptly
+    expect(Date.now() - start).toBeLessThan(500);
+  });
+
   it('tidies the seam — no space left before punctuation', () => {
     const out = gloss('A Kohen (a Temple priest) serves; the Kohen (a Temple priest), too.');
     expect(out).toBe('A Kohen (a Temple priest) serves; the Kohen, too.');

--- a/tests/first-mention-gloss.test.ts
+++ b/tests/first-mention-gloss.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import {
+  firstMentionGloss,
+  buildConceptMatcher,
+  glossKey,
+} from '../src/client/conceptLinks';
+import { globalTerms, type Term } from '../src/lib/terms/registry';
+
+// A glossary term is glossed inline on its FIRST mention in a prose unit and
+// runs bare after — the tooltip carries the gloss for later mentions, so the
+// repeated parenthetical is clutter. firstMentionGloss strips every-but-first
+// inline gloss, but only when the parenthetical restates the SAME gloss.
+
+const mk = (t: Partial<Term> & Pick<Term, 'hebrew' | 'gloss'>): Term => ({
+  display: 'hebrew-first-gloss',
+  scope: 'daf',
+  ...t,
+});
+
+const KOHEN = mk({ en: 'Kohen', hebrew: 'כהן', gloss: 'a Temple priest' });
+const gloss = (text: string, terms: Term[] = [KOHEN]): string =>
+  firstMentionGloss(text, buildConceptMatcher(terms));
+
+describe('glossKey', () => {
+  it('normalizes case, articles, trailing punctuation, whitespace', () => {
+    expect(glossKey('The Binding Law.')).toBe('binding law');
+    expect(glossKey('  "after the fact"  ')).toBe('after the fact');
+    expect(glossKey('a Temple priest')).toBe('temple priest');
+  });
+});
+
+describe('firstMentionGloss', () => {
+  it('keeps the first inline gloss and strips a later repeat', () => {
+    const out = gloss('A Kohen (a Temple priest) serves; later the Kohen (a Temple priest) eats.');
+    expect(out).toBe('A Kohen (a Temple priest) serves; later the Kohen eats.');
+  });
+
+  it('keeps a meaningful (non-gloss) parenthetical on a repeat', () => {
+    const out = gloss('A Kohen (a Temple priest) serves; the Kohen (according to Rashi) may.');
+    expect(out).toBe('A Kohen (a Temple priest) serves; the Kohen (according to Rashi) may.');
+  });
+
+  it('promotes the first GLOSS even when the first MENTION was bare', () => {
+    // No gloss on mention 1 -> the gloss on mention 2 is the first one, kept.
+    const out = gloss('The Kohen serves; a Kohen (a Temple priest) eats.');
+    expect(out).toBe('The Kohen serves; a Kohen (a Temple priest) eats.');
+  });
+
+  it('treats the Hebrew and English forms as the same term', () => {
+    const out = gloss('A Kohen (a Temple priest) serves; כהן (a Temple priest) again.');
+    expect(out).toBe('A Kohen (a Temple priest) serves; כהן again.');
+  });
+
+  it('matches a looser repeat via containment against the registry gloss', () => {
+    // First inline gloss is the fuller form; the repeat is a shorter restatement.
+    const t = mk({ en: 'Kohen', hebrew: 'כהן', gloss: 'priest' });
+    const out = gloss('A Kohen (a Temple priest) serves; the Kohen (priest) eats.', [t]);
+    expect(out).toBe('A Kohen (a Temple priest) serves; the Kohen eats.');
+  });
+
+  it('tidies the seam — no space left before punctuation', () => {
+    const out = gloss('A Kohen (a Temple priest) serves; the Kohen (a Temple priest), too.');
+    expect(out).toBe('A Kohen (a Temple priest) serves; the Kohen, too.');
+  });
+
+  it('is idempotent', () => {
+    const once = gloss('A Kohen (a Temple priest); the Kohen (a Temple priest); a Kohen (a Temple priest).');
+    expect(gloss(once)).toBe(once);
+    expect(once).toBe('A Kohen (a Temple priest); the Kohen; a Kohen.');
+  });
+
+  it('returns input unchanged with no matcher or no terms', () => {
+    expect(firstMentionGloss('A Kohen (a Temple priest) again Kohen (a Temple priest).', null))
+      .toBe('A Kohen (a Temple priest) again Kohen (a Temple priest).');
+    expect(gloss('Plain text, nothing to do.')).toBe('Plain text, nothing to do.');
+  });
+
+  it('works on real globals — repeated הלכה gloss collapses to first mention', () => {
+    const out = firstMentionGloss(
+      'A הלכה (binding law) here; another הלכה (binding law) there.',
+      buildConceptMatcher(globalTerms()),
+    );
+    expect(out).toBe('A הלכה (binding law) here; another הלכה there.');
+  });
+});


### PR DESCRIPTION
Third PR of the bilingual-prose-consistency rework. Builds on #298 + #300. **This is the consistency behavior change.**

## What this delivers
A glossary term is now glossed inline on its **first mention in a prose unit** and runs **bare thereafter** — the tooltip (#300) carries the gloss for every later mention, so the repeated parenthetical is pure clutter. A card becomes consistent (one inline gloss per term, deterministically) without the model having to remember what it already defined.

Before → after, within one section:
> A מליקה (one-handed nape slaughter) is performed; later the מליקה ~~(one-handed nape slaughter)~~ is compared to שחיטה (ritual slaughter).

## How
- **`conceptLinks.tsx` — `firstMentionGloss(text, matcher)`**: tokenize, then for each *repeat* mention of a term drop the immediately-following gloss parenthetical — but **only when it restates the same gloss** (the first-seen one, or the registry gloss via containment). A meaningful qualifier like `(according to Rashi)` is always kept. We only ever **strip a repeat, never invent a gloss**; if the first mention was bare, the first *gloss* that appears is the one kept. Pure + **idempotent**. Helpers `glossKey` / `glossMatch` / `leadingGloss` (tidies the seam — no doubled space / space before punctuation).
- **`ConceptText`** applies it before tokenizing (covers cards with no rabbi pool).
- **`RabbiText`** applies it to the **whole section string** before splitting at rabbi names — so a term glossed in one rabbi-gap runs bare in a later one (true **per-section** scope, not per-fragment). Idempotency makes the double-apply safe.

Identity is by `Term`, so a Hebrew-form repeat (`כהן`) collapses against an English-form first mention and vice versa.

## Retires
The model's inconsistent repeat-glossing within a card.

## Safety
- Subtractive only (never adds/rewrites glosses, never reorders scripts). A repeat parenthetical that isn't a restatement of the gloss is untouched.
- Precision over recall: if a nested term splits the parenthetical (no closing paren in the adjacent fragment), the pass declines rather than guessing.

## Tests
- `first-mention-gloss.test.ts`: keep-first/strip-repeat, keep qualifier, promote-first-gloss-when-bare, Hebrew↔English identity, containment match, seam tidy, idempotent, real globals; `glossKey` units.
- Full suite **1885 green**; `typecheck` clean.
- Codex read-only review in progress.

## Note
This is render-only (no generation/cache change). PR4 (shrink the Form A/B prompt) follows separately.