### PR TITLE
Overview synthesis: open with where the daf comes from (merged background)

### DIFF
--- a/src/worker/cache-stats.ts
+++ b/src/worker/cache-stats.ts
@@ -399,7 +399,7 @@ async function mergedMarks(cache: KVNamespace): Promise<MergedMark[]> {
  *  ('gemara', 'context', …) → null. Powers the per-mark "depends on" chips. */
 // Source-string deps (Content-In inputs) a producer reads, as opposed to the
 // {mark}/{enrichment} graph edges. See MarkDependency/EnrichmentDependency.
-const SOURCE_DEPS = new Set(['gemara', 'commentaries', 'mishna', 'context', 'context-light', 'halacha-refs', 'yerushalmi-text']);
+const SOURCE_DEPS = new Set(['gemara', 'commentaries', 'mishna', 'context', 'context-light', 'halacha-refs', 'yerushalmi-text', 'incoming']);
 function sourceDepOf(dep: unknown): string | null {
   return typeof dep === 'string' && SOURCE_DEPS.has(dep) ? dep : null;
 }

--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -2525,16 +2525,17 @@ Ordered argument sections on this daf (index = position in this list, starting a
 
 Emit the connections BETWEEN these sections per the schema. Reason about how each sugya relates to the others (continues / resolves / depends-on / parallels / contrasts / generalizes / cites).`;
 
-const ARGUMENT_OVERVIEW_SYNTHESIS_SYSTEM_PROMPT = `You are a Talmud scholar. You'll receive a full daf, its argument sections, the connections between those sections, and study-aid context. Compose ONE tight paragraph orienting a reader to the WHOLE page: its central question(s), the main named positions, how the sections connect, and where the daf lands.
+const ARGUMENT_OVERVIEW_SYNTHESIS_SYSTEM_PROMPT = `You are a Talmud scholar. You'll receive a full daf, its argument sections, the connections between those sections, study-aid context, and — when the discussion carries over — a grounded note on how this daf continues the previous one. Compose ONE tight paragraph that first ORIENTS the reader to where the daf comes from, then covers the WHOLE page: its central question(s), the main named positions, how the sections connect, and where it lands.
 
 Output STRICT JSON only:
 
 {
-  "synthesis": "ONE paragraph, MAX 4 sentences. Each sentence MAX 25 words. (1) The daf's central question or topic. (2) The main named positions, one terse clause each. (3) ONE optional sentence on how the sections connect. (4) ONE closing sentence: where the daf lands (open / resolved / shifts on). Do NOT recap section by section."
+  "synthesis": "ONE paragraph, MAX 5 sentences. Each sentence MAX 25 words. (1) ENTRY FRAME — where the daf comes from: if an incoming-context note is given, say what carries over from the previous daf; else if the daf expounds a Mishnah (in the study context), name its question; else state the daf's topic. (2) The daf's central question. (3) The main named positions, one terse clause each. (4) ONE optional sentence on how the sections connect. (5) ONE closing sentence: where the daf lands (open / resolved / shifts on). Do NOT recap section by section."
 }
 
 HARD RULES:
-- MAX 4 sentences. MAX 25 words per sentence. Cut, don't pad.
+- MAX 5 sentences. MAX 25 words per sentence. Cut, don't pad. When the entry frame and the central question are the same thing, fuse them into one sentence.
+- GROUND the entry frame. State cross-daf continuation ONLY if the incoming-context note provides it; name a Mishnah ONLY if it is in the study context. NEVER recall from memory what the previous daf said.
 - Whole-daf orientation, not a section recap. Per-section detail lives in argument.synthesis.
 - NO puff. Forbidden: "this teaches us", "we see that", "highlights", "underscores", "intricate", "profound", "lens", "captures".
 - Hebrew script (not transliteration) for technical terms in parentheses.
@@ -2542,6 +2543,9 @@ HARD RULES:
 ${HEBREW_GLOSS_STYLE}`;
 
 const ARGUMENT_OVERVIEW_SYNTHESIS_USER_TEMPLATE = `Tractate: {{tractate}}, page {{page}}.
+
+How this daf connects to the previous one (a grounded note; empty if it opens a fresh discussion — in that case orient via the Mishnah in the study context, or the daf's topic):
+{{incoming}}
 
 Full daf:
 {{gemara}}
@@ -2552,27 +2556,31 @@ Argument sections on this daf:
 Connections between the sections (indices into the list above):
 {{depends.argument-overview.flow}}
 
-Study-aid context (dafyomi.co.il):
+Study-aid context (dafyomi.co.il) — includes the Mishnah this daf expounds when there is one:
 {{context}}
 
 Write the whole-daf overview paragraph per the schema.`;
 
-const ARGUMENT_OVERVIEW_SYNTHESIS_SYSTEM_PROMPT_HE = `אתה תלמיד חכם הבקיא בש"ס. תקבל דף שלם, את מקטעי הטיעון שבו, את הקשרים בין המקטעים, ותוכן לימוד נלווה. חבר פסקה אחת הדוקה המכוונת את הקורא בדף כולו: שאלתו המרכזית, העמדות הנקובות העיקריות, כיצד המקטעים מתחברים, והיכן הדף נוחת.
+const ARGUMENT_OVERVIEW_SYNTHESIS_SYSTEM_PROMPT_HE = `אתה תלמיד חכם הבקיא בש"ס. תקבל דף שלם, את מקטעי הטיעון שבו, את הקשרים בין המקטעים, תוכן לימוד נלווה, וכן — כאשר הדיון נמשך — הערה מבוססת כיצד דף זה ממשיך את הדף הקודם. חבר פסקה אחת הדוקה שתחילה מכוונת את הקורא מהיכן הדף בא, ולאחר מכן מכסה את הדף כולו: שאלתו המרכזית, העמדות הנקובות העיקריות, כיצד המקטעים מתחברים, והיכן הוא נוחת.
 
 החזר JSON תקין בלבד:
 
 {
-  "synthesis": "פסקה אחת, 4 משפטים לכל היותר. כל משפט 25 מילים לכל היותר. (1) השאלה או הנושא המרכזי של הדף. (2) העמדות הנקובות העיקריות, פסוקית תמציתית אחת לכל אחת. (3) משפט אחד אופציונלי על אופן התחברות המקטעים. (4) משפט מסכם אחד: היכן הדף נוחת (פתוח / מיושב / עובר הלאה). אל תסכם מקטע אחר מקטע."
+  "synthesis": "פסקה אחת, 5 משפטים לכל היותר. כל משפט 25 מילים לכל היותר. (1) מסגרת פתיחה — מהיכן הדף בא: אם ניתנה הערת המשכיות, ציין מה נמשך מהדף הקודם; אחרת אם הדף עוסק במשנה (בתוכן הלימוד), ציין את שאלתה; אחרת ציין את נושא הדף. (2) השאלה המרכזית של הדף. (3) העמדות הנקובות העיקריות, פסוקית תמציתית לכל אחת. (4) משפט אחד אופציונלי על אופן התחברות המקטעים. (5) משפט מסכם אחד: היכן הדף נוחת (פתוח / מיושב / עובר הלאה). אל תסכם מקטע אחר מקטע."
 }
 
 כללים נוקשים:
-- 4 משפטים לכל היותר. 25 מילים למשפט לכל היותר. קצץ, אל תמלא.
+- 5 משפטים לכל היותר. 25 מילים למשפט לכל היותר. קצץ, אל תמלא. כאשר מסגרת הפתיחה והשאלה המרכזית הן אותו דבר, מזג אותן למשפט אחד.
+- בסס את מסגרת הפתיחה. ציין המשכיות בין־דפית רק אם הערת ההמשכיות מספקת זאת; הזכר משנה רק אם היא בתוכן הלימוד. לעולם אל תשחזר מהזיכרון את שנאמר בדף הקודם.
 - כיוון לכל הדף, לא סיכום מקטע. פירוט לכל מקטע שייך ל-argument.synthesis.
 - ללא מליצה. אסור: "מכאן אנו למדים", "אנו רואים ש", "מדגיש", "מבליט", "מורכב", "עמוק", "עדשה", "לוכד".
 
 ${HEBREW_NATIVE_STYLE}`;
 
 const ARGUMENT_OVERVIEW_SYNTHESIS_USER_TEMPLATE_HE = `מסכת: {{tractate}}, דף {{page}}.
+
+כיצד דף זה מתחבר לקודמו (הערה מבוססת; ריק אם הדף פותח דיון חדש — במקרה כזה כוון לפי המשנה שבתוכן הלימוד, או לפי נושא הדף):
+{{incoming}}
 
 הדף המלא:
 {{gemara}}
@@ -2583,7 +2591,7 @@ const ARGUMENT_OVERVIEW_SYNTHESIS_USER_TEMPLATE_HE = `מסכת: {{tractate}}, ד
 הקשרים בין המקטעים (אינדקסים לרשימה שלמעלה):
 {{depends.argument-overview.flow}}
 
-תוכן לימוד נלווה (dafyomi.co.il):
+תוכן לימוד נלווה (dafyomi.co.il) — כולל את המשנה שהדף עוסק בה כאשר יש כזו:
 {{context}}
 
 כתוב את פסקת הסקירה של הדף כולו לפי הסכימה.`;
@@ -2609,17 +2617,22 @@ CODE_ENRICHMENTS.push(
   ),
   makeSynthesis(
     'argument-overview', 'argument-overview.synthesis',
-    'One tight paragraph orienting a reader to the whole daf: its question, the main positions, how the sections connect, where it lands.',
+    'One tight paragraph orienting a reader to the whole daf: where it comes from, its question, the main positions, how the sections connect, where it lands.',
     ARGUMENT_OVERVIEW_SYNTHESIS_SYSTEM_PROMPT, ARGUMENT_OVERVIEW_SYNTHESIS_USER_TEMPLATE,
     {
       dependencies: [
         'gemara',
         'context',
+        // The grounded cross-daf continuation note ({{incoming}}) so the
+        // paragraph can open with where this daf comes from instead of recalling
+        // it. Empty when the daf opens fresh — the prompt falls back to the
+        // Mishnah (in `context`) or the daf's topic.
+        'incoming',
         { enrichment: 'argument-overview.flow' },
         { mark: 'argument' },
         { mark: 'rabbi' },
       ],
-      defHash: 'argument-overview.synthesis-v2', cacheVersion: '4', // v4: native Hebrew prompt (he mode no longer falls back to English)
+      defHash: 'argument-overview.synthesis-v3', cacheVersion: '5', // v5: merged entry frame (incoming continuation + Mishnah framing); v4: native Hebrew prompt
       model: ARGUMENT_FLASH_MODEL,
       systemPromptHe: ARGUMENT_OVERVIEW_SYNTHESIS_SYSTEM_PROMPT_HE,
       userPromptTemplateHe: ARGUMENT_OVERVIEW_SYNTHESIS_USER_TEMPLATE_HE,

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -920,7 +920,7 @@ app.get('/api/dependents/:id', (c) => {
 // classify a dependency id as a SOURCE leaf (fetched/assembled, no LLM) vs a
 // producer (mark/enrichment). Mirrors validateEnrichmentDependencies' allowlist.
 const SOURCE_DEP_KEYS = new Set([
-  'gemara', 'commentaries', 'mishna', 'context', 'context-light', 'halacha-refs', 'yerushalmi-text',
+  'gemara', 'commentaries', 'mishna', 'context', 'context-light', 'halacha-refs', 'yerushalmi-text', 'incoming',
 ]);
 
 // GET /api/run-tree/:tractate/:page/:id — the build PROVENANCE of one piece on
@@ -1744,6 +1744,33 @@ async function resolveDependencies(
       out.vars.yerushalmi = formatYerushalmiForPrompt(bundle, curated, outline, floor);
       out.vars.__yerushalmiFloor = floor;
       recordSource(out, 'yerushalmi-text', out.vars.yerushalmi);
+      return;
+    }
+    if (dep === 'incoming') {
+      // How this daf connects to the PREVIOUS one. Read the prev->this bridge
+      // (computeDafBridge on the previous daf judges its last argument section
+      // against this daf's first). When the sugya carries over, expose its
+      // grounded note so a whole-daf overview can open with where the page comes
+      // from — never recalled from the model's memory. Empty when the daf opens
+      // fresh, the previous daf isn't warmed, or this is the tractate's first
+      // daf. In the inspector's sourcesOnly pass, read cache-only so it never
+      // triggers the bridge model. Best-effort: any failure contributes nothing.
+      try {
+        const prevPage = adjacentAmud(tractate, page, -1);
+        if (prevPage) {
+          let bridge: DafBridge | null = null;
+          if (sourcesOnly) {
+            const c = rc.env.CACHE ? await rc.env.CACHE.get(keyForBridge(tractate, prevPage)) : null;
+            if (c) { try { bridge = JSON.parse(c) as DafBridge; } catch { /* ignore */ } }
+          } else {
+            bridge = await computeDafBridge(rc.env, tractate, prevPage);
+          }
+          if (bridge?.continues && typeof bridge.note === 'string' && bridge.note.trim()) {
+            out.vars.incoming = `Continues the discussion from the previous daf (${tractate} ${prevPage}): ${bridge.note.trim()}`;
+          }
+        }
+      } catch { /* no incoming context */ }
+      recordSource(out, 'incoming', (out.vars.incoming as string) ?? '');
       return;
     }
     if (dep === 'context' || dep === 'context-light') {

--- a/src/worker/studio-registry.ts
+++ b/src/worker/studio-registry.ts
@@ -214,13 +214,13 @@ function validateEnrichmentDependencies(input: unknown): { ok: true; deps: Enric
   if (!Array.isArray(input)) return { ok: false, error: 'dependencies must be an array' };
   const out: EnrichmentDependency[] = [];
   for (const e of input) {
-    if (e === 'gemara' || e === 'commentaries' || e === 'mishna' || e === 'context' || e === 'context-light' || e === 'halacha-refs' || e === 'yerushalmi-text') { out.push(e); continue; }
+    if (e === 'gemara' || e === 'commentaries' || e === 'mishna' || e === 'context' || e === 'context-light' || e === 'halacha-refs' || e === 'yerushalmi-text' || e === 'incoming') { out.push(e); continue; }
     if (e && typeof e === 'object') {
       const o = e as { mark?: unknown; enrichment?: unknown };
       if (typeof o.mark === 'string') { out.push({ mark: o.mark }); continue; }
       if (typeof o.enrichment === 'string') { out.push({ enrichment: o.enrichment }); continue; }
     }
-    return { ok: false, error: 'each dep must be "gemara" | "commentaries" | "mishna" | "context" | "halacha-refs" | "yerushalmi-text" | { mark: string } | { enrichment: string }' };
+    return { ok: false, error: 'each dep must be "gemara" | "commentaries" | "mishna" | "context" | "halacha-refs" | "yerushalmi-text" | "incoming" | { mark: string } | { enrichment: string }' };
   }
   return { ok: true, deps: out };
 }

--- a/src/worker/studio-schema.ts
+++ b/src/worker/studio-schema.ts
@@ -337,6 +337,12 @@ export type Extractor = LLMExtractor | SefariaExtractor | ComputedExtractor | Ma
 //                          a producer contrasts Bavli vs Yerushalmi against the
 //                          source rather than recalling it. The token is
 //                          distinct from the `yerushalmi` mark id on purpose.)
+//   'incoming'           → {{incoming}}  (how this daf connects to the PREVIOUS
+//                          one: the grounded cross-daf continuation note from the
+//                          cached prev→this bridge, when the sugya carries over.
+//                          Empty when the daf opens a fresh discussion. Lets a
+//                          whole-daf overview orient the reader with where the
+//                          page comes from instead of recalling it.)
 //   { enrichment: id }   → {{depends.<id>}}    (recursively resolved)
 //   { mark: id }         → {{anchors.<id>}}    (mark extractor for same daf)
 //
@@ -359,6 +365,9 @@ export type EnrichmentDependency =
   | 'context-light'
   | 'halacha-refs'
   | 'yerushalmi-text'
+  // The cross-daf continuation note from the previous daf (see {{incoming}}
+  // above). A source leaf — assembled from the cached prev→this bridge.
+  | 'incoming'
   // `{ enrichment: id }` resolves the dep for the CONSUMER's own instance.
   // `fanOut: true` instead runs a PER-INSTANCE enrichment for EVERY instance of
   // its target mark on the daf and exposes the array under {{depends.<id>}} —

--- a/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
+++ b/tests/__snapshots__/code-enrichments-snapshot.test.ts.snap
@@ -13,7 +13,7 @@ exports[`CODE_ENRICHMENTS cache identity > per-enrichment fingerprint is stable 
   "argument-move.suggested-questions@3 mode=augment-content scope=local mark=argument-move schema=argument_move_suggested_questions[questions] deps=[gemara|m:argument-move|e:argument-move.synthesis]",
   "argument-move.synthesis@5 mode=aggregate scope=local mark=argument-move schema=argument_move_synthesis[synthesis] deps=[gemara|e:argument-move.commentaries|m:argument-move|m:rabbi]",
   "argument-overview.flow@1 mode=augment-content scope=local mark=argument-overview schema=argument_overview_flow[connections] deps=[m:argument]",
-  "argument-overview.synthesis@4 mode=aggregate scope=local mark=argument-overview schema=argument_overview_synthesis[synthesis] deps=[gemara|context|e:argument-overview.flow|m:argument|m:rabbi]",
+  "argument-overview.synthesis@5 mode=aggregate scope=local mark=argument-overview schema=argument_overview_synthesis[synthesis] deps=[gemara|context|incoming|e:argument-overview.flow|m:argument|m:rabbi]",
   "argument.background@5 mode=augment-content scope=local mark=argument schema=argument_background[background] deps=[gemara|commentaries|mishna|context]",
   "argument.narrative@3 mode=augment-content scope=local mark=argument schema=argument_narrative[summary,actors,beats] deps=[gemara|m:argument-move|m:rabbi]",
   "argument.synthesis@12 mode=aggregate scope=local mark=argument schema=argument_synthesis[synthesis] deps=[gemara|commentaries|mishna|e:argument.voices|e:argument.background|m:rabbi|m:argument-move|e:daf-background.concepts]",

--- a/tests/dep-graph-validate.test.ts
+++ b/tests/dep-graph-validate.test.ts
@@ -7,7 +7,7 @@ import { CODE_MARKS, CODE_ENRICHMENTS } from '../src/worker/code-marks';
 // 'yerushalmi-text' feeds the real parallel Jerusalem Talmud text into the
 // yerushalmi mark (named distinctly from the `yerushalmi` mark id so it reads
 // as a slice input, not a `{ mark: 'yerushalmi' }` producer reference).
-const SOURCES = new Set(['gemara', 'commentaries', 'context', 'context-light', 'mishna', 'halacha-refs', 'yerushalmi-text']);
+const SOURCES = new Set(['gemara', 'commentaries', 'context', 'context-light', 'mishna', 'halacha-refs', 'yerushalmi-text', 'incoming']);
 
 describe('validateProducerGraph — unit', () => {
   it('flags a dependency on a nonexistent producer/source as dangling', () => {


### PR DESCRIPTION
## What

The whole-daf **Overview** synthesis now opens with **where the daf comes from**, then summarizes the argument — the "merged" background option.

- **Entry frame:** the paragraph leads with the daf's starting point. On a Mishnah daf it names the Mishnah's question; otherwise it states the topic.
- **Cross-daf continuation:** a new `incoming` source dependency exposes `{{incoming}}` — the **grounded** continuation note from the cached prev→this bridge — so the frame can say what carries over from the previous daf. Empty when the daf opens fresh.

## Grounding (precision over recall)

The model states continuation **only** from `{{incoming}}` and names a Mishnah **only** from `{{context}}` — never recalled from memory. Validated against real data: the production bridge notes are accurate and specific, and `/api/run-sources` confirms `{{incoming}}` resolves correctly (populated on continuing dapim, empty on the first daf, with `context-mishnah` present for the Mishnah fallback).

## Wiring

- `incoming` added to `EnrichmentDependency` + all source-dep allowlists (`studio-registry`, `cache-stats` `SOURCE_DEPS`, `index` `SOURCE_DEP_KEYS`) and the dep-graph validator's known-sources set. Resolved cache-only in the inspector `sourcesOnly` pass so it never triggers a model.
- EN + HE prompts updated in parallel; sentence budget 4 → 5 for the added frame.
- `cache_version` 4 → 5 (def_hash v3). The cache-identity snapshot updated, scoped to exactly `argument-overview.synthesis`. **Stale-while-revalidate** serves v4 until v5 warms — no reader waits.

## Eval

Input path validated end-to-end on real data (bridge notes + `{{incoming}}` resolution + Mishnah-context fallback). Full pipeline confirmed under `wrangler dev` (queue consumer resolves deps, builds the prompt, calls the model) — local final-prose generation was blocked only by the dev OpenRouter key's weekly quota, so the generated-prose check runs on production under SWR after deploy.

`pnpm typecheck` + `pnpm test` (1868) green.
