### PR TITLE
Terms registry (PR4): shrink the Form A/B prompt block

### DIFF
--- a/src/lib/hebrewTerms.ts
+++ b/src/lib/hebrewTerms.ts
@@ -111,11 +111,19 @@ export function canonicalDictEntries(): Record<string, string> {
   return out;
 }
 
-/** Build the prompt's "ALWAYS hebraize" bullet block — one indented
- *  `translit → hebrew (gloss)` line per term. Column alignment is cosmetic and
- *  intentionally dropped; the LLM reads content, not whitespace. */
+/** Build the prompt's "ALWAYS hebraize" bullet block — one indented line per
+ *  term, rendered in the term's own display orientation so the canonical list
+ *  doesn't contradict the per-term `display` policy:
+ *    - hebrew-first (Form A): `translit → hebrew (gloss)`
+ *    - english-first (Form B): `en (hebrew)`
+ *  Column alignment is cosmetic and intentionally dropped; the LLM reads
+ *  content, not whitespace. */
 export function alwaysHebraizeBlock(): string {
   return CANONICAL_HEBREW_TERMS
-    .map((t) => `    ${t.translit} → ${t.hebrew} (${t.gloss})`)
+    .map((t) =>
+      t.display === 'english' && t.en
+        ? `    ${t.en} (${t.hebrew})`
+        : `    ${t.translit} → ${t.hebrew} (${t.gloss})`,
+    )
     .join('\n');
 }

--- a/src/worker/code-marks.ts
+++ b/src/worker/code-marks.ts
@@ -996,47 +996,27 @@ export const CODE_MARKS: MarkDefinition[] = [
  */
 const HEBREW_GLOSS_STYLE = `STYLE — Hebrew + English mixing (apply UNIFORMLY across all prose):
 
-FORM A — Hebrew script first, English gloss in parens. Use when the Hebrew word IS the subject of the clause OR when the Hebrew is the standard term in rabbinic discourse:
-  "performed לכתחילה (the ideal standard)"
-  "בדיעבד (after the fact) the meat is permitted"
-  "applies the rule of יצא (an excluded case)"
-  "the gemara invokes a גזירה שווה (verbal analogy from a shared word)"
-  "the principle of רוב (the majority)"
-  "from the כלל ופרט (general followed by specific)"
-  "the verse 'בשכבך ובקומך' (when you lie down and when you rise)"
+Plain English is the BASE; Hebrew script is the technical anchor — use it only where a word is genuinely the technical concept, not on every common word.
 
-FORM B — English first, Hebrew script in parens. Use when the English term flows naturally as a parenthetical aid:
-  "a leading Tanna (תנא) at Yavneh (יבנה)"
-  "the evening Shema (קריאת שמע של ערבית)"
-  "atonement (כפרה) does not delay the priest's eating"
-  "the rabbi is classified as a halachist (הלכתי)"
+FORM A (DEFAULT) — Hebrew script first, English gloss in parens. Use for technical/halachic terms and verbatim daf language:
+  "performed לכתחילה (the ideal standard)", "a גזירה שווה (verbal analogy)", "the verse 'בשכבך ובקומך' (when you lie down and when you rise)"
+
+FORM B — English first, Hebrew in parens. Use ONLY for proper nouns and standing English-first terms:
+  "Rabbi Yochanan (רבי יוחנן)", "at Yavneh (יבנה)", "court (בית דין)", "kosher (כשר)"
+
+GLOSS ONCE: gloss a term on its FIRST use only; write it bare afterwards. Every term carries a hover tooltip, so a repeated parenthetical is just clutter.
 
 HARD RULES (output is rejected if violated):
-- NEVER write a transliteration alone in parens. "(terumah)", "(gezeira shava)", "(lechatchila)" — all forbidden. Always pair Hebrew script with English meaning, not transliteration with itself.
-- NEVER use bare transliteration as a standalone term either. "Lechatchila, one may eat…" is wrong — use "לכתחילה (the ideal standard), one may eat…" OR "Performed לכתחילה, one may eat…".
-- NEVER calque-translate a fixed Hebrew/Aramaic halachic phrase into bare English. A "calque" is a word-for-word literal translation that produces grammatically marked or meaningless English. If the English would only make sense to someone who already knows the underlying Hebrew term, the term IS the technical concept and MUST appear in Hebrew script. The English is then a gloss in parens — not a replacement.
-    BAD:  "Eli's broken neck occurred without most flesh"                  (calque of רוב בשר)
-    BAD:  "the requirement of severing most of the flesh"                  (same calque, padded)
-    BAD:  "a son of his year"                                               (calque of בן שנתו)
-    BAD:  "the house of justice"                                            (calque of בית דין — use 'בית דין' or English 'court')
-    BAD:  "the sons of Noah's commandments"                                 (calque of שבע מצוות בני נח)
-    BAD:  "great in fear of Heaven"                                         (calque of גדול ביראת שמים)
-    GOOD: "Eli's broken neck occurred without רוב בשר (the majority of surrounding flesh that normally must tear with the spine)"
-    GOOD: "a בן שנתו (year-old animal)"
-    GOOD: "the שבע מצוות בני נח (Noahide laws)"
-  Heuristic: read the sentence aloud in English. If a reader who doesn't know the term has to stop and ask "wait, most WHAT?" or "year of what?", you've calqued. Restore the Hebrew.
-- Common terms to ALWAYS hebraize (any time you use them, pair with Hebrew script):
+- NEVER write a transliteration — not in parens "(terumah)", not bare "Lechatchila, one may eat…". Pair Hebrew script with an English meaning, OR lead with the Hebrew: "לכתחילה (the ideal standard), one may eat…".
+- NEVER calque a fixed Hebrew/Aramaic phrase into bare English (a word-for-word literal that only makes sense if you already know the term). Keep the term in Hebrew, gloss in parens.
+    BAD:  "without most flesh" (רוב בשר) · "a son of his year" (בן שנתו) · "the house of justice" (בית דין)
+    GOOD: "without רוב בשר (the majority of surrounding flesh)" · "a בן שנתו (year-old animal)" · "court (בית דין)"
+  Heuristic: read it aloud in English — if a reader who doesn't know the term must ask "most WHAT?", you calqued. Restore the Hebrew.
+- ALWAYS hebraize these (pair with Hebrew script whenever used):
 ${alwaysHebraizeBlock()}
-- Verbatim daf / pasuk excerpts go in Hebrew script with quote marks, optionally followed by an English gloss in parens.
-- HARD RULE — verbatim daf words in quotes ('…' or "…") MUST be Hebrew/Aramaic script, NEVER transliteration. The single-quoted form is a signal that what's inside is a direct quote from the daf, and direct quotes are by definition in the source language.
-    BAD:  "the gemara uses 'hutz'u' to describe how they were brought out"
-    BAD:  "the term 'amar' indicates direct attribution"
-    GOOD: "the gemara uses 'הוצאו' (they were brought out) to describe…"
-    GOOD: "the term 'אמר' indicates direct attribution"
-  If you don't remember the Hebrew/Aramaic verbatim, paraphrase in English instead of writing the transliteration in quotes. NEVER fake a verbatim quote with transliteration.
-- Plain English is the BASE; Hebrew script is the technical anchor. Don't pile Hebrew script on every common word — only where the term is genuinely the technical concept.
-- THE DAF'S OWN GLOSSARY IS AUTHORITATIVE. If the prompt gives you this daf's background terms (each an English label + its Hebrew + a gloss), treat that list as the definitive set of terms to show in Hebrew here. Whenever your prose uses one of them, write it in Form A/B using EXACTLY that Hebrew spelling — e.g. given "Tevul Yom / טבול יום", write "טבול יום (one who immersed that day)" rather than "tevul yom" or English alone; given "Midnight / חצות", write "חצות (halakhic midnight)". This keeps the prose consistent with the glossary the reader sees on the daf and lets each term carry its own tooltip.
-- SCRIPT HYGIENE: write ONLY in English, with Hebrew/Aramaic script for terms and quotes. Never emit any other language or writing system — no Korean, Cyrillic, Arabic, CJK, Devanagari, emoji, etc. Every character must be plain Latin or Hebrew script (plus ordinary punctuation). If you reach for a non-English word, use its plain English equivalent instead.`;
+- Verbatim daf/pasuk quotes go in Hebrew/Aramaic script inside quote marks — NEVER transliteration in quotes ('hutz'u' is wrong; 'הוצאו' is right). If you don't recall the Hebrew, paraphrase in English rather than fake a transliterated quote.
+- THE DAF'S OWN GLOSSARY IS AUTHORITATIVE: when the prompt provides this daf's background terms (English label + Hebrew + gloss), use EXACTLY that Hebrew spelling — given "Tevul Yom / טבול יום", write "טבול יום (one who immersed that day)", never "tevul yom" or English alone.
+- SCRIPT HYGIENE: emit ONLY English + Hebrew/Aramaic script (plus ordinary punctuation). No other writing system — no Korean, Cyrillic, Arabic, CJK, Devanagari, emoji. If you reach for a non-English word, use its plain English equivalent.`;
 
 /**
  * Hebrew-output style guide — the lang='he' counterpart of HEBREW_GLOSS_STYLE.

--- a/tests/hebrew-terms.test.ts
+++ b/tests/hebrew-terms.test.ts
@@ -77,17 +77,24 @@ describe('canonical terms resolve through hebraize() (dict side)', () => {
   }
 });
 
-describe('alwaysHebraizeBlock — renders every canonical term (prompt side)', () => {
+describe('alwaysHebraizeBlock — renders every canonical term in its display orientation', () => {
   const block = alwaysHebraizeBlock();
   for (const t of CANONICAL_HEBREW_TERMS) {
-    it(`block lists ${t.translit} → ${t.hebrew}`, () => {
-      expect(block).toContain(`${t.translit} → ${t.hebrew} (${t.gloss})`);
-    });
+    // The list now encodes the per-term display policy so it can't contradict
+    // the prompt's Form A/B rule: english-first terms read "en (hebrew)",
+    // hebrew-first terms read "translit → hebrew (gloss)".
+    if (t.display === 'english' && t.en) {
+      it(`block lists ${t.en} (${t.hebrew}) English-first`, () => {
+        expect(block).toContain(`${t.en} (${t.hebrew})`);
+        expect(block).not.toContain(`${t.translit} → ${t.hebrew}`);
+      });
+    } else {
+      it(`block lists ${t.translit} → ${t.hebrew} (Form A)`, () => {
+        expect(block).toContain(`${t.translit} → ${t.hebrew} (${t.gloss})`);
+      });
+    }
   }
-  // The display field is metadata for the gloss pass, not prompt content — the
-  // always-list block must stay byte-for-byte as it was, so adding `display`
-  // can't silently perturb generation. (Output unchanged is the PR1 contract.)
-  it('block carries no display metadata — translit → hebrew (gloss) only', () => {
+  it('block carries no raw display-enum metadata', () => {
     expect(block).not.toMatch(/hebrew-first-gloss|display/);
   });
 });
@@ -120,6 +127,26 @@ describe('halacha.practical prompt — always-list wiring', () => {
   it('embeds the single-sourced always-hebraize block', () => {
     expect(practicalSys).toContain(alwaysHebraizeBlock());
   });
+});
+
+// The HEBREW_GLOSS_STYLE block was shrunk (PR4) — collapsed the Form A/B example
+// walls and removed the model's freedom to pick a form. These guard that the
+// shrink kept every load-bearing rule, so a future trim can't silently drop one.
+describe('HEBREW_GLOSS_STYLE — hard rules survive the shrink', () => {
+  const required = [
+    'FORM A (DEFAULT)',      // Form A is the default
+    'FORM B',                // Form B reserved for english-first
+    'GLOSS ONCE',            // first-use-only gloss (pairs with the PR3 dedup pass)
+    'calque',                // no-calque rule
+    'SCRIPT HYGIENE',        // english + hebrew script only
+    'AUTHORITATIVE',         // daf glossary is authoritative
+    'transliteration',       // no-transliteration rule
+  ];
+  for (const marker of required) {
+    it(`still states: ${marker}`, () => {
+      expect(practicalSys).toContain(marker);
+    });
+  }
 });
 
 // The applies-when / exceptions chip lists were retired in the shape-aware


### PR DESCRIPTION
Fourth PR of the bilingual-prose-consistency rework. Builds on #298/#300/#301. **Generation change — but prompt-only, zero forced spend.**

## Why now
With every registry term carrying a hover tooltip (#300) and repeat glosses deduped deterministically (#301), the shared `HEBREW_GLOSS_STYLE` block no longer has to walk the model through every inline-gloss decision. The model's *freedom to pick Form A vs B per generation* was the core inconsistency this whole rework targets — so we remove that freedom where the registry already has the answer.

## Changes
- **Shrink** `HEBREW_GLOSS_STYLE` (~40 → ~22 lines): collapse the Form A/B example walls (7+11 → ~2 each). **Form A is the default** for technical terms; **Form B reserved** for proper nouns + the standing english-first terms (`court`/`kosher`).
- **Thread the `display` policy into `alwaysHebraizeBlock()`**: english-display terms now render `en (hebrew)` (Form B) instead of `translit → hebrew (gloss)`, so the canonical list stops contradicting the Form A/B rule.
- **Add "GLOSS ONCE"**: gloss a term on first use only, bare after — the tooltip carries later mentions (pairs with the PR3 dedup pass).
- **Keep every hard rule** (no-transliteration, no-calque *with* its BAD/GOOD examples, verbatim-quotes-in-Hebrew, daf-glossary-authoritative, script-hygiene), condensed.

## Rollout (deliberately conservative)
The warm-cron treats cached entries as hits (no staleness re-warm), so a prompt change without a `cache_version` bump leaves existing cached prose **untouched** — only **future cold generations** adopt the new style. That's intentional here:
- **Zero forced spend, zero regression** to what's live.
- A consistent rollout to already-cached content is a **separate, explicitly-scoped rewarm** (mass `cache_version` bumps are real Shas-wide LLM cost and shouldn't be a side effect of a prompt edit).

## Validation
- `hebrew-terms.test.ts`: updated for the display-oriented always-list; new guard that the shrink kept every load-bearing hard rule (transliteration/calque/script-hygiene/authoritative markers).
- Full suite **1898 green**; typecheck clean.
- Codex review + a small eval of regenerated prose (new prompt) before merge.