### PR TITLE
Monorepo skeleton: pnpm workspace + @corpus/core stub

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@corpus/core",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "//": "Corpus-agnostic engine shared by the talmud and tanach apps: coordinate/anchor model, KV cache key builders + freshness, LLM/budget plumbing, producer-registry grammar, dependency graph, and the recipe-based sidebar DSL. Ships raw .ts sources (no build step) — consumers bundle via Vite with moduleResolution: bundler, and tsc resolves the @corpus/core/* path alias from tsconfig.base.json. Subpaths are populated incrementally as modules are extracted out of packages/talmud (see plan PR-3..6).",
+  "exports": {
+    "./context/*": "./src/context/*.ts",
+    "./registry/*": "./src/registry/*.ts",
+    "./sidebar/*": "./src/sidebar/*.ts",
+    "./llm/*": "./src/llm/*.ts",
+    "./studio/*": "./src/studio/*.ts",
+    "./cache/*": "./src/cache/*.ts"
+  }
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'packages/*'

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,29 @@
+{
+  "//": "Shared compiler options for every workspace package. Each package's own tsconfig.json extends this and supplies its own `include`. The @corpus/core/* path alias lets tsc resolve the shared package's TS sources directly (it ships raw .ts; both apps bundle via Vite with moduleResolution: bundler). TS 5.x resolves `paths` relative to THIS file's location, so the targets are repo-root-relative.",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["@cloudflare/workers-types", "vite/client"],
+
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js",
+
+    "strict": true,
+    "noImplicitOverride": true,
+
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+
+    "paths": {
+      "@corpus/core/*": ["./packages/core/src/*"]
+    }
+  }
+}


### PR DESCRIPTION
First step toward a Tanach sister app (tanach.shaunregenbaum.com) built on a shared, corpus-agnostic core. This PR is the **safe, additive foundation** — no code moves, the app still lives at the repo root and builds identically.

## What this adds
- **pnpm-workspace.yaml** — registers `packages/*`, turning the repo into a pnpm workspace (root `talmud` package + `@corpus/core`).
- **tsconfig.base.json** — shared compiler options + the `@corpus/core/*` path alias. Dormant until packages adopt it (the root app's tsconfig is untouched).
- **packages/core** — an empty `@corpus/core` stub with the subpath `exports` map it will grow into (`context`, `registry`, `sidebar`, `llm`, `studio`, `cache`) as agnostic modules are extracted out of the app in later PRs.

## Why
The framework is ~70% corpus-agnostic (coords, KV cache + freshness, LLM/budget, producer registry, dep graph, recipe sidebar). Extracting that into `@corpus/core` lets a Tanach app reuse the engine while each app keeps its own worker, KV, AI Gateway, and domain. Full plan: monorepo conversion (behavior-preserving) → stand up the tanach package → tanach producers.

## Verification
- `pnpm typecheck` passes (root app, unchanged).
- `vite build` emits the same 133-module bundle.
- `pnpm ls -r` shows both workspace packages resolve.

## Next
PR-2 is the one disruptive step: `git mv` the app into `packages/talmud/` (pure renames, zero content edits). It's isolated so it can fast-merge during a worktree lull, since git rename-detection re-homes other agents' in-flight diffs.