### PR TITLE
Scaffold the Tanach app: a working verse reader on @corpus/core

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
     "lint": "biome check .",
     "format": "biome format --write .",
     "dev": "pnpm --filter talmud dev",
+    "dev:tanach": "pnpm --filter tanach dev",
     "ship": "pnpm --filter talmud ship",
-    "ship:talmud": "pnpm --filter talmud ship"
+    "ship:talmud": "pnpm --filter talmud ship",
+    "ship:tanach": "pnpm --filter tanach ship"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.16"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,8 @@
     "./sidebar/*": "./src/sidebar/*.ts",
     "./llm/*": "./src/llm/*.ts",
     "./studio/*": "./src/studio/*.ts",
-    "./cache/*": "./src/cache/*.ts"
+    "./cache/*": "./src/cache/*.ts",
+    "./sefaria/*": "./src/sefaria/*.ts"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260511.1",

--- a/packages/core/src/sefaria/client.ts
+++ b/packages/core/src/sefaria/client.ts
@@ -1,0 +1,147 @@
+/**
+ * Generic Sefaria API client — corpus-agnostic. `getText` / `getTextV3` /
+ * `getRelated` fetch ANY Sefaria ref ("Genesis 1:1", "Rashi on Genesis 1:1",
+ * "Berakhot 2a", a Shulchan Aruch ref, …) identically; the flatten/pick helpers
+ * parse Sefaria's nested text + version shapes. Apps extend `SefariaClient` with
+ * their own corpus-specific fetchers (e.g. the Talmud app's page-with-
+ * commentaries / rishonim / mishnah methods; a Tanach app's verse-with-
+ * commentaries). No app logic lives here.
+ */
+
+export const SEFARIA_API_BASE = 'https://www.sefaria.org/api';
+
+export interface SefariaTextResponse {
+  ref: string;
+  heRef: string;
+  text: string | string[];
+  he: string | string[];
+  /** Present (with a message) when the ref couldn't be resolved — e.g. a
+   *  tractate that has no Yerushalmi. Callers should treat it as "no text". */
+  error?: string;
+  type?: string;
+  book?: string;
+  sections?: number[];
+  toSections?: number[];
+  sectionRef?: string;
+  heSectionRef?: string;
+  isComplex?: boolean;
+  /** Next/previous section refs ("Genesis 2" / null at the book edge), as
+   *  returned by the texts API. Drives chapter navigation without hand-kept
+   *  per-book chapter counts. */
+  next?: string | null;
+  prev?: string | null;
+  versions?: Array<{
+    title: string;
+    language: string;
+    versionTitle: string;
+    versionSource?: string;
+  }>;
+  commentary?: unknown[];
+  sheets?: unknown[];
+  notes?: unknown[];
+  links?: unknown[];
+}
+
+export interface SefariaRelatedResponse {
+  links: Array<{
+    _id: string;
+    index_title: string;
+    category: string;
+    type: string;
+    ref: string;
+    anchorRef: string;
+    sourceRef: string;
+    sourceHeRef: string;
+    anchorRefExpanded?: string[];
+    sourceHasEn: boolean;
+    commentaryNum?: number;
+  }>;
+  sheets: unknown[];
+  notes: unknown[];
+}
+
+export interface SefariaV3Response {
+  ref: string;
+  versions: Array<{
+    language?: string;
+    actualLanguage?: string;
+    text: unknown;
+  }>;
+}
+
+/**
+ * Flatten Sefaria's arbitrarily-nested text array into a flat list of non-empty
+ * strings (depth-first, array order preserved). A plain string yields a
+ * single-element list; scalars and other shapes yield [].
+ */
+export function flattenPieces(text: unknown): string[] {
+  if (typeof text === 'string') return text.length > 0 ? [text] : [];
+  if (!Array.isArray(text)) return [];
+  const out: string[] = [];
+  for (const entry of text) {
+    if (typeof entry === 'string') {
+      if (entry.length > 0) out.push(entry);
+    } else if (Array.isArray(entry)) {
+      out.push(...flattenPieces(entry));
+    }
+  }
+  return out;
+}
+
+/**
+ * Pick the version whose `actualLanguage`/`language` matches the requested
+ * tag. Sefaria returns versions[] in catalog order, which is not necessarily
+ * the language order we asked for.
+ */
+export function pickV3Version(versions: SefariaV3Response['versions'], lang: 'he' | 'en'): unknown {
+  for (const v of versions) {
+    const tag = (v.actualLanguage ?? v.language ?? '').toLowerCase();
+    if (lang === 'he' && (tag === 'he' || tag === 'hebrew')) return v.text;
+    if (lang === 'en' && (tag === 'en' || tag === 'english')) return v.text;
+  }
+  return undefined;
+}
+
+/** The generic Sefaria HTTP surface. Subclass to add corpus-specific fetchers. */
+export class SefariaClient {
+  async getText(
+    ref: string,
+    options?: { lang?: string; version?: string; commentary?: boolean; context?: number },
+  ): Promise<SefariaTextResponse> {
+    const params = new URLSearchParams();
+    if (options?.lang) params.append('lang', options.lang);
+    if (options?.version) params.append('version', options.version);
+    if (options?.commentary !== undefined) params.append('commentary', options.commentary ? '1' : '0');
+    if (options?.context !== undefined) params.append('context', options.context.toString());
+    const queryString = params.toString();
+    const url = `${SEFARIA_API_BASE}/texts/${ref}${queryString ? '?' + queryString : ''}`;
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch text: ${response.statusText}`);
+    }
+    return response.json();
+  }
+
+  /**
+   * Fetch a ref via the v3 texts endpoint, requesting both Hebrew and English
+   * versions in one round-trip. Required for commentary (e.g. Rashi), which v1
+   * silently truncates to its first segment.
+   */
+  async getTextV3(ref: string): Promise<SefariaV3Response> {
+    const url = `${SEFARIA_API_BASE}/v3/texts/${encodeURIComponent(ref)}?version=hebrew&version=english`;
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch v3 text: ${response.statusText}`);
+    }
+    return response.json();
+  }
+
+  async getRelated(ref: string): Promise<SefariaRelatedResponse> {
+    const url = `${SEFARIA_API_BASE}/related/${ref}`;
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch related texts: ${response.statusText}`);
+    }
+    return response.json();
+  }
+}

--- a/packages/tanach/index.html
+++ b/packages/tanach/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tanach</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/client/main.tsx"></script>
+  </body>
+</html>

--- a/packages/tanach/package.json
+++ b/packages/tanach/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "tanach",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "ship": "vite build && wrangler deploy",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@corpus/core": "workspace:*",
+    "hono": "^4.6.0",
+    "solid-js": "^1.9.0",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@cloudflare/vite-plugin": "^1.36.4",
+    "@cloudflare/workers-types": "^4.20260511.1",
+    "typescript": "^5.7.0",
+    "vite": "^6.0.0",
+    "vite-plugin-solid": "^2.11.0",
+    "vitest": "^4.1.5",
+    "wrangler": "^4.90.1"
+  }
+}

--- a/packages/tanach/src/client/App.tsx
+++ b/packages/tanach/src/client/App.tsx
@@ -1,0 +1,153 @@
+import { createResource, createSignal, For, Show, type JSX } from 'solid-js';
+import { BOOKS, SECTIONS, type Section } from '../lib/books.ts';
+
+interface Verse {
+  n: number;
+  he: string;
+  en: string;
+}
+interface Chapter {
+  book: string;
+  chapter: number;
+  ref: string;
+  heRef: string;
+  verses: Verse[];
+  next: string | null;
+  prev: string | null;
+  error?: string;
+}
+
+/** Parse a Sefaria section ref ("Genesis 2", "I Samuel 3") into book + chapter.
+ *  Book names contain spaces, so split on the TRAILING number. */
+function parseRef(ref: string): { book: string; chapter: number } | null {
+  const m = ref.match(/^(.*?)\s+(\d+)$/);
+  if (!m) return null;
+  return { book: m[1], chapter: Number(m[2]) };
+}
+
+function readUrl(): { book: string; chapter: number } {
+  const p = new URLSearchParams(window.location.search);
+  const book = p.get('book') ?? 'Genesis';
+  const chapter = Number(p.get('chapter') ?? '1') || 1;
+  return { book: BOOKS.some((b) => b.name === book) ? book : 'Genesis', chapter };
+}
+
+async function fetchChapter(loc: { book: string; chapter: number }): Promise<Chapter> {
+  const res = await fetch(`/api/chapter/${encodeURIComponent(loc.book)}/${loc.chapter}`);
+  const data = (await res.json()) as Chapter;
+  if (!res.ok) throw new Error(data.error ?? `HTTP ${res.status}`);
+  return data;
+}
+
+export function App(): JSX.Element {
+  const initial = readUrl();
+  const [loc, setLoc] = createSignal(initial);
+  const [data] = createResource(loc, fetchChapter);
+
+  const go = (book: string, chapter: number) => {
+    const next = { book, chapter };
+    const p = new URLSearchParams({ book, chapter: String(chapter) });
+    window.history.pushState(null, '', `?${p.toString()}`);
+    setLoc(next);
+    window.scrollTo(0, 0);
+  };
+
+  window.addEventListener('popstate', () => setLoc(readUrl()));
+
+  const heName = (name: string) => BOOKS.find((b) => b.name === name)?.he ?? name;
+
+  return (
+    <div class="app">
+      <header class="topbar">
+        <span class="brand">Tanach</span>
+        <select
+          class="book-select"
+          value={loc().book}
+          onChange={(e) => go(e.currentTarget.value, 1)}
+        >
+          <For each={SECTIONS}>
+            {(section: Section) => (
+              <optgroup label={section}>
+                <For each={BOOKS.filter((b) => b.section === section)}>
+                  {(b) => (
+                    <option value={b.name}>
+                      {b.name} · {b.he}
+                    </option>
+                  )}
+                </For>
+              </optgroup>
+            )}
+          </For>
+        </select>
+        <div class="chapter-nav">
+          <button
+            disabled={loc().chapter <= 1}
+            onClick={() => go(loc().book, loc().chapter - 1)}
+          >
+            ‹
+          </button>
+          <span class="chapter-label">ch. {loc().chapter}</span>
+          <button onClick={() => go(loc().book, loc().chapter + 1)}>›</button>
+        </div>
+      </header>
+
+      <main class="reader">
+        <h1 class="chapter-head">
+          <span class="he" dir="rtl">
+            {heName(loc().book)} {loc().chapter}
+          </span>
+          <span class="en">
+            {loc().book} {loc().chapter}
+          </span>
+        </h1>
+
+        <Show when={data.loading}>
+          <p class="status">Loading…</p>
+        </Show>
+        <Show when={data.error}>
+          <p class="status error">{(data.error as Error)?.message}</p>
+        </Show>
+
+        <Show when={data()}>
+          {(ch) => (
+            <>
+              <ol class="verses">
+                <For each={ch().verses}>
+                  {(v) => (
+                    <li class="verse">
+                      <span class="vnum">{v.n}</span>
+                      <span class="he" dir="rtl" innerHTML={v.he} />
+                      <span class="en" innerHTML={v.en} />
+                    </li>
+                  )}
+                </For>
+              </ol>
+              <nav class="chapter-foot">
+                <Show when={ch().prev} fallback={<span />}>
+                  {(prev) => {
+                    const p = parseRef(prev());
+                    return p ? (
+                      <button onClick={() => go(p.book, p.chapter)}>‹ {prev()}</button>
+                    ) : (
+                      <span />
+                    );
+                  }}
+                </Show>
+                <Show when={ch().next}>
+                  {(next) => {
+                    const p = parseRef(next());
+                    return p ? (
+                      <button onClick={() => go(p.book, p.chapter)}>{next()} ›</button>
+                    ) : (
+                      <span />
+                    );
+                  }}
+                </Show>
+              </nav>
+            </>
+          )}
+        </Show>
+      </main>
+    </div>
+  );
+}

--- a/packages/tanach/src/client/main.tsx
+++ b/packages/tanach/src/client/main.tsx
@@ -1,0 +1,6 @@
+import { render } from 'solid-js/web';
+import { App } from './App.tsx';
+import './styles.css';
+
+const root = document.getElementById('root');
+if (root) render(() => <App />, root);

--- a/packages/tanach/src/client/styles.css
+++ b/packages/tanach/src/client/styles.css
@@ -1,0 +1,155 @@
+:root {
+  --ink: #1a1a1a;
+  --muted: #6b6b6b;
+  --line: #e3e0d8;
+  --bg: #faf8f3;
+  --accent: #7a5c2e;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: Georgia, 'Times New Roman', serif;
+  line-height: 1.6;
+}
+
+.app {
+  max-width: 820px;
+  margin: 0 auto;
+  padding: 0 20px 80px;
+}
+
+.topbar {
+  position: sticky;
+  top: 0;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 0;
+  background: var(--bg);
+  border-bottom: 1px solid var(--line);
+  z-index: 10;
+}
+
+.brand {
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 14px;
+  color: var(--accent);
+}
+
+.book-select {
+  font-family: inherit;
+  font-size: 15px;
+  padding: 5px 8px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: #fff;
+  color: var(--ink);
+}
+
+.chapter-nav {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.chapter-nav button,
+.chapter-foot button {
+  font-family: inherit;
+  font-size: 15px;
+  padding: 4px 12px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: #fff;
+  color: var(--ink);
+  cursor: pointer;
+}
+
+.chapter-nav button:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.chapter-label {
+  font-size: 14px;
+  color: var(--muted);
+  min-width: 48px;
+  text-align: center;
+}
+
+.chapter-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  margin: 36px 0 8px;
+  padding-bottom: 12px;
+  border-bottom: 2px solid var(--line);
+}
+
+.chapter-head .he {
+  font-size: 30px;
+}
+
+.chapter-head .en {
+  font-size: 16px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.status {
+  color: var(--muted);
+  font-style: italic;
+}
+
+.status.error {
+  color: #a23;
+}
+
+.verses {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.verse {
+  display: grid;
+  grid-template-columns: 28px 1fr;
+  gap: 6px 12px;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.verse .vnum {
+  grid-row: span 2;
+  color: var(--accent);
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+  padding-top: 6px;
+}
+
+.verse .he {
+  font-size: 23px;
+  line-height: 1.9;
+  text-align: right;
+}
+
+.verse .en {
+  font-size: 17px;
+  color: #333;
+}
+
+.chapter-foot {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 32px;
+}

--- a/packages/tanach/src/lib/books.ts
+++ b/packages/tanach/src/lib/books.ts
@@ -1,0 +1,83 @@
+/**
+ * The Tanach corpus registry — the addressable books of the Hebrew Bible, in
+ * Sefaria's English ref names (what `getText('Genesis 1')` expects) plus their
+ * Hebrew names. Grouped Torah / Nevi'im / Ketuvim.
+ *
+ * Chapter COUNTS are intentionally omitted: chapter nav is driven by Sefaria's
+ * own `next`/`prev` section refs in the text response, so we never hand-maintain
+ * (and risk drifting) per-book chapter totals. This list only needs to name the
+ * books for the picker and validate an incoming book param.
+ *
+ * This is the Tanach analogue of the Talmud app's TRACTATE_OPTIONS. In the
+ * shared coordinate model a verse maps as book -> tractate, chapter -> page,
+ * verse -> seg, so @corpus/core's coordLabel renders "Genesis 1:3" unchanged.
+ */
+
+export type Section = 'Torah' | "Nevi'im" | 'Ketuvim';
+
+export interface TanachBook {
+  /** Sefaria English ref name, e.g. "Genesis", "I Samuel". */
+  name: string;
+  /** Hebrew name, e.g. "בְּרֵאשִׁית". */
+  he: string;
+  section: Section;
+}
+
+export const BOOKS: TanachBook[] = [
+  // Torah
+  { name: 'Genesis', he: 'בְּרֵאשִׁית', section: 'Torah' },
+  { name: 'Exodus', he: 'שְׁמוֹת', section: 'Torah' },
+  { name: 'Leviticus', he: 'וַיִּקְרָא', section: 'Torah' },
+  { name: 'Numbers', he: 'בְּמִדְבַּר', section: 'Torah' },
+  { name: 'Deuteronomy', he: 'דְּבָרִים', section: 'Torah' },
+  // Nevi'im
+  { name: 'Joshua', he: 'יְהוֹשֻׁעַ', section: "Nevi'im" },
+  { name: 'Judges', he: 'שׁוֹפְטִים', section: "Nevi'im" },
+  { name: 'I Samuel', he: 'שְׁמוּאֵל א׳', section: "Nevi'im" },
+  { name: 'II Samuel', he: 'שְׁמוּאֵל ב׳', section: "Nevi'im" },
+  { name: 'I Kings', he: 'מְלָכִים א׳', section: "Nevi'im" },
+  { name: 'II Kings', he: 'מְלָכִים ב׳', section: "Nevi'im" },
+  { name: 'Isaiah', he: 'יְשַׁעְיָהוּ', section: "Nevi'im" },
+  { name: 'Jeremiah', he: 'יִרְמְיָהוּ', section: "Nevi'im" },
+  { name: 'Ezekiel', he: 'יְחֶזְקֵאל', section: "Nevi'im" },
+  { name: 'Hosea', he: 'הוֹשֵׁעַ', section: "Nevi'im" },
+  { name: 'Joel', he: 'יוֹאֵל', section: "Nevi'im" },
+  { name: 'Amos', he: 'עָמוֹס', section: "Nevi'im" },
+  { name: 'Obadiah', he: 'עֹבַדְיָה', section: "Nevi'im" },
+  { name: 'Jonah', he: 'יוֹנָה', section: "Nevi'im" },
+  { name: 'Micah', he: 'מִיכָה', section: "Nevi'im" },
+  { name: 'Nahum', he: 'נַחוּם', section: "Nevi'im" },
+  { name: 'Habakkuk', he: 'חֲבַקּוּק', section: "Nevi'im" },
+  { name: 'Zephaniah', he: 'צְפַנְיָה', section: "Nevi'im" },
+  { name: 'Haggai', he: 'חַגַּי', section: "Nevi'im" },
+  { name: 'Zechariah', he: 'זְכַרְיָה', section: "Nevi'im" },
+  { name: 'Malachi', he: 'מַלְאָכִי', section: "Nevi'im" },
+  // Ketuvim
+  { name: 'Psalms', he: 'תְּהִלִּים', section: 'Ketuvim' },
+  { name: 'Proverbs', he: 'מִשְׁלֵי', section: 'Ketuvim' },
+  { name: 'Job', he: 'אִיּוֹב', section: 'Ketuvim' },
+  { name: 'Song of Songs', he: 'שִׁיר הַשִּׁירִים', section: 'Ketuvim' },
+  { name: 'Ruth', he: 'רוּת', section: 'Ketuvim' },
+  { name: 'Lamentations', he: 'אֵיכָה', section: 'Ketuvim' },
+  { name: 'Ecclesiastes', he: 'קֹהֶלֶת', section: 'Ketuvim' },
+  { name: 'Esther', he: 'אֶסְתֵּר', section: 'Ketuvim' },
+  { name: 'Daniel', he: 'דָּנִיֵּאל', section: 'Ketuvim' },
+  { name: 'Ezra', he: 'עֶזְרָא', section: 'Ketuvim' },
+  { name: 'Nehemiah', he: 'נְחֶמְיָה', section: 'Ketuvim' },
+  { name: 'I Chronicles', he: 'דִּבְרֵי הַיָּמִים א׳', section: 'Ketuvim' },
+  { name: 'II Chronicles', he: 'דִּבְרֵי הַיָּמִים ב׳', section: 'Ketuvim' },
+];
+
+const BY_NAME = new Map(BOOKS.map((b) => [b.name, b]));
+
+/** Look up a book by its Sefaria English name. */
+export function bookByName(name: string): TanachBook | undefined {
+  return BY_NAME.get(name);
+}
+
+/** Whether `name` is a valid addressable Tanach book. */
+export function isBook(name: string): boolean {
+  return BY_NAME.has(name);
+}
+
+export const SECTIONS: Section[] = ['Torah', "Nevi'im", 'Ketuvim'];

--- a/packages/tanach/src/worker/index.ts
+++ b/packages/tanach/src/worker/index.ts
@@ -1,0 +1,84 @@
+/**
+ * Tanach worker — Hono on Cloudflare Workers.
+ *
+ * v1 surface: GET /api/chapter/:book/:chapter returns a chapter's verses
+ * (Hebrew + English) plus next/prev chapter refs, fetched live from Sefaria via
+ * the shared @corpus/core SefariaClient. Everything else falls through to the
+ * built Solid client (the ASSETS binding, SPA fallback). No KV / LLM yet — that
+ * arrives with caching + the producers.
+ */
+
+import { Hono } from 'hono';
+import { SefariaClient } from '@corpus/core/sefaria/client';
+import { isBook } from '../lib/books.ts';
+
+interface Env {
+  ASSETS: Fetcher;
+}
+
+const sefaria = new SefariaClient();
+
+/** Strip Sefaria's inline footnote apparatus (the marker + the expanded note
+ *  text), which otherwise renders mid-verse. Keeps benign inline tags like the
+ *  large/small-letter <big>/<small> markup. */
+function stripFootnotes(html: string): string {
+  return html
+    .replace(/<sup class="footnote-marker">.*?<\/sup>/g, '')
+    .replace(/<i class="footnote">.*?<\/i>/g, '')
+    .trim();
+}
+
+/** Sefaria returns he/text as a per-verse string array for a chapter ref (or a
+ *  bare string for a single verse). Normalize to a string[], footnotes stripped. */
+function asVerses(v: string | string[] | undefined): string[] {
+  if (Array.isArray(v)) return v.map((s) => (typeof s === 'string' ? stripFootnotes(s) : ''));
+  return typeof v === 'string' ? [stripFootnotes(v)] : [];
+}
+
+const app = new Hono<{ Bindings: Env }>();
+
+app.get('/api/chapter/:book/:chapter', async (c) => {
+  const book = c.req.param('book');
+  const chapter = c.req.param('chapter');
+  if (!isBook(book)) {
+    return c.json({ error: `Unknown book: ${book}` }, 400);
+  }
+  if (!/^\d+$/.test(chapter)) {
+    return c.json({ error: `Chapter must be a number, got: ${chapter}` }, 400);
+  }
+
+  const ref = `${book} ${chapter}`;
+  let data: Awaited<ReturnType<SefariaClient['getText']>>;
+  try {
+    data = await sefaria.getText(ref);
+  } catch (e) {
+    return c.json({ error: `Sefaria fetch failed: ${(e as Error).message}` }, 502);
+  }
+  if (data.error) {
+    return c.json({ error: data.error }, 404);
+  }
+
+  const he = asVerses(data.he);
+  const en = asVerses(data.text);
+  const count = Math.max(he.length, en.length);
+  const verses = Array.from({ length: count }, (_, i) => ({
+    n: i + 1,
+    he: he[i] ?? '',
+    en: en[i] ?? '',
+  }));
+
+  return c.json({
+    book,
+    chapter: Number(chapter),
+    ref: data.ref ?? ref,
+    heRef: data.heRef ?? '',
+    verses,
+    next: data.next ?? null,
+    prev: data.prev ?? null,
+  });
+});
+
+// Everything else: serve the built SPA (static assets + index.html fallback).
+app.get('*', (c) => c.env.ASSETS.fetch(c.req.raw));
+
+export default app;

--- a/packages/tanach/static/.gitkeep
+++ b/packages/tanach/static/.gitkeep
@@ -1,0 +1,1 @@
+# Tanach static assets

--- a/packages/tanach/tsconfig.json
+++ b/packages/tanach/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules", "dist", ".wrangler"]
+}

--- a/packages/tanach/vite.config.ts
+++ b/packages/tanach/vite.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite';
+import solid from 'vite-plugin-solid';
+import { cloudflare } from '@cloudflare/vite-plugin';
+
+export default defineConfig({
+  plugins: [solid(), cloudflare()],
+  publicDir: 'static',
+});

--- a/packages/tanach/wrangler.toml
+++ b/packages/tanach/wrangler.toml
@@ -1,0 +1,31 @@
+name = "tanach"
+main = "src/worker/index.ts"
+compatibility_date = "2025-04-01"
+compatibility_flags = ["nodejs_compat"]
+
+# The Solid client is built into ./dist/client and served by the Worker via the
+# ASSETS binding; unmatched routes fall through to index.html (SPA).
+[assets]
+directory = "./dist/client"
+binding = "ASSETS"
+not_found_handling = "single-page-application"
+
+[observability]
+enabled = true
+
+# --- Provisioning TODO (added at deploy time, NOT yet live) ---
+# The v1 reader fetches Sefaria live, so none of the below is needed for local
+# `pnpm --filter tanach dev`. Before shipping to the custom domain, add:
+#
+# routes = [{ pattern = "tanach.shaunregenbaum.com", custom_domain = true }]
+#
+# [[kv_namespaces]]            # `wrangler kv namespace create tanach-cache`
+# binding = "CACHE"
+# id = "<fill-in>"
+#
+# [vars]                       # create the `tanach` AI Gateway in the dashboard
+# AI_GATEWAY_ID = "tanach"
+# DEFAULT_LLM_MODEL = "openrouter/deepseek/deepseek-v4-pro"
+#
+# [[queues.producers]] / [[queues.consumers]]  queue = "enrichment-jobs-tanach"
+# secrets: OPENROUTER_API_KEY, STUDIO_SECRET  (`wrangler secret put …`)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,43 @@ importers:
         specifier: ^4.90.1
         version: 4.90.1(@cloudflare/workers-types@4.20260511.1)
 
+  packages/tanach:
+    dependencies:
+      '@corpus/core':
+        specifier: workspace:*
+        version: link:../core
+      hono:
+        specifier: ^4.6.0
+        version: 4.12.14
+      solid-js:
+        specifier: ^1.9.0
+        version: 1.9.12
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@cloudflare/vite-plugin':
+        specifier: ^1.36.4
+        version: 1.36.4(vite@6.4.2)(workerd@1.20260508.1)(wrangler@4.90.1(@cloudflare/workers-types@4.20260511.1))
+      '@cloudflare/workers-types':
+        specifier: ^4.20260511.1
+        version: 4.20260511.1
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.0
+        version: 6.4.2
+      vite-plugin-solid:
+        specifier: ^2.11.0
+        version: 2.11.12(solid-js@1.9.12)(vite@6.4.2)
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(jsdom@29.1.1)(vite@6.4.2)
+      wrangler:
+        specifier: ^4.90.1
+        version: 4.90.1(@cloudflare/workers-types@4.20260511.1)
+
 packages:
 
   '@asamuzakjp/css-color@5.1.11':


### PR DESCRIPTION
The first **visible** piece: `packages/tanach`, a sibling app sharing the engine. v1 is a **locally-runnable reader** — no Cloudflare provisioning yet; the worker fetches Sefaria live.

![Genesis 1 in the Tanach reader](https://github.com/Shaun-Regenbaum/talmud/assets/placeholder)

## What's here
- **`@corpus/core/sefaria/client`** — a generic, corpus-agnostic `SefariaClient` (`getText`/`getTextV3`/`getRelated` + `flattenPieces`/`pickV3Version`). Additive: the Talmud app's own client is untouched (de-duping it to `extends SefariaClient` is a clean follow-up). Added `next`/`prev` to `SefariaTextResponse` for nav.
- **`src/lib/books.ts`** — the 39 addressable Tanach books (Sefaria EN names + Hebrew), grouped Torah / Nevi'im / Ketuvim. Chapter nav uses Sefaria's `next`/`prev` refs, so no hand-kept chapter counts.
- **`src/worker/index.ts`** — Hono worker. `GET /api/chapter/:book/:chapter` returns a chapter's verses (Hebrew + English, footnote apparatus stripped) + next/prev; everything else serves the built SPA.
- **`src/client`** — a Solid reader: book picker, chapter nav, RTL Hebrew + English, URL sync (`?book=&chapter=`).
- **`wrangler.toml`** documents the deploy-time provisioning (KV / AI gateway / domain / queue / secrets), deliberately deferred.

## Verified live (localhost)
- Genesis 1 → 31 verses, `next: "Genesis 2"`, `prev: null`.
- `I Samuel 1` (multi-word book) → 28 verses, `next: "I Samuel 2"`.
- Unknown book → 400; SPA root serves index.html.
- Screenshot confirmed: clean RTL Hebrew + English reading view.

## Verification
- `pnpm -r typecheck` — core + talmud + tanach all clean.
- talmud's **1919 tests still pass** (the core change is additive).
- `pnpm --filter tanach build` + live dev run.

Next: commentary fetch (`TANACH_COMMENTATORS`: Rashi/Ramban/Ibn Ezra) and the AI producers; then provisioning + deploy to tanach.shaunregenbaum.com.