### PR TITLE
Tanach reader: Sefer Torah scroll view + Reading/Scroll toggle

### DIFF
--- a/packages/tanach/index.html
+++ b/packages/tanach/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Tanach</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Frank+Ruhl+Libre:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/packages/tanach/src/client/App.tsx
+++ b/packages/tanach/src/client/App.tsx
@@ -1,4 +1,4 @@
-import { createResource, createSignal, For, Show, type JSX } from 'solid-js';
+import { createMemo, createResource, createSignal, For, Show, type JSX } from 'solid-js';
 import { BOOKS, SECTIONS, type Section } from '../lib/books.ts';
 
 interface Verse {
@@ -17,19 +17,43 @@ interface Chapter {
   error?: string;
 }
 
-/** Parse a Sefaria section ref ("Genesis 2", "I Samuel 3") into book + chapter.
- *  Book names contain spaces, so split on the TRAILING number. */
+type View = 'reading' | 'scroll';
+
+/** Parse a Sefaria section ref ("Genesis 2", "I Samuel 3") into book + chapter. */
 function parseRef(ref: string): { book: string; chapter: number } | null {
   const m = ref.match(/^(.*?)\s+(\d+)$/);
   if (!m) return null;
   return { book: m[1], chapter: Number(m[2]) };
 }
 
-function readUrl(): { book: string; chapter: number } {
+/** Drop niqqud + cantillation (te'amim) for the bare-consonant ktav-STAM look.
+ *  Maqaf (U+05BE) becomes a space so joined words separate; other points/accents
+ *  are removed. Letters (U+05D0–U+05EA) and HTML tags are left intact. */
+function stripNikud(html: string): string {
+  return html.replace(/־/g, ' ').replace(/[֑-ֽֿ-ׇ]/g, '');
+}
+
+/** Turn Sefaria's parsha markers into block/inline breaks for the scroll. */
+function renderParshiyot(html: string): string {
+  return html
+    .replace(/\{[פש]\}/g, '<span class="parsha-open"></span>')
+    .replace(/\{ס\}/g, '<span class="parsha-closed"></span>');
+}
+
+interface Loc {
+  book: string;
+  chapter: number;
+  view: View;
+  nikud: boolean;
+}
+
+function readUrl(): Loc {
   const p = new URLSearchParams(window.location.search);
   const book = p.get('book') ?? 'Genesis';
   const chapter = Number(p.get('chapter') ?? '1') || 1;
-  return { book: BOOKS.some((b) => b.name === book) ? book : 'Genesis', chapter };
+  const view: View = p.get('view') === 'scroll' ? 'scroll' : 'reading';
+  const nikud = p.get('nikud') !== '0';
+  return { book: BOOKS.some((b) => b.name === book) ? book : 'Genesis', chapter, view, nikud };
 }
 
 async function fetchChapter(loc: { book: string; chapter: number }): Promise<Chapter> {
@@ -40,114 +64,142 @@ async function fetchChapter(loc: { book: string; chapter: number }): Promise<Cha
 }
 
 export function App(): JSX.Element {
-  const initial = readUrl();
-  const [loc, setLoc] = createSignal(initial);
-  const [data] = createResource(loc, fetchChapter);
+  const [loc, setLoc] = createSignal(readUrl());
 
-  const go = (book: string, chapter: number) => {
-    const next = { book, chapter };
-    const p = new URLSearchParams({ book, chapter: String(chapter) });
+  const writeUrl = (l: Loc) => {
+    const p = new URLSearchParams({ book: l.book, chapter: String(l.chapter) });
+    if (l.view === 'scroll') p.set('view', 'scroll');
+    if (!l.nikud) p.set('nikud', '0');
     window.history.pushState(null, '', `?${p.toString()}`);
-    setLoc(next);
-    window.scrollTo(0, 0);
   };
+  const update = (patch: Partial<Loc>, scroll = false) => {
+    const next = { ...loc(), ...patch };
+    writeUrl(next);
+    setLoc(next);
+    if (scroll) window.scrollTo(0, 0);
+  };
+
+  // Re-fetch only when book/chapter change (view/nikud are render-only).
+  const chapterKey = createMemo(() => ({ book: loc().book, chapter: loc().chapter }), undefined, {
+    equals: (a, b) => a.book === b.book && a.chapter === b.chapter,
+  });
+  const [data] = createResource(chapterKey, fetchChapter);
 
   window.addEventListener('popstate', () => setLoc(readUrl()));
 
   const heName = (name: string) => BOOKS.find((b) => b.name === name)?.he ?? name;
+  const goto = (book: string, chapter: number) => update({ book, chapter }, true);
+
+  const scrollHtml = createMemo(() => {
+    const ch = data();
+    if (!ch) return '';
+    const joined = ch.verses.map((v) => v.he).join(' ');
+    const withParsha = renderParshiyot(joined);
+    return loc().nikud ? withParsha : stripNikud(withParsha);
+  });
 
   return (
-    <div class="app">
+    <div class="app" classList={{ 'view-scroll': loc().view === 'scroll' }}>
       <header class="topbar">
         <span class="brand">Tanach</span>
-        <select
-          class="book-select"
-          value={loc().book}
-          onChange={(e) => go(e.currentTarget.value, 1)}
-        >
+        <select class="book-select" value={loc().book} onChange={(e) => goto(e.currentTarget.value, 1)}>
           <For each={SECTIONS}>
             {(section: Section) => (
               <optgroup label={section}>
                 <For each={BOOKS.filter((b) => b.section === section)}>
-                  {(b) => (
-                    <option value={b.name}>
-                      {b.name} · {b.he}
-                    </option>
-                  )}
+                  {(b) => <option value={b.name}>{b.name} · {b.he}</option>}
                 </For>
               </optgroup>
             )}
           </For>
         </select>
-        <div class="chapter-nav">
-          <button
-            disabled={loc().chapter <= 1}
-            onClick={() => go(loc().book, loc().chapter - 1)}
-          >
-            ‹
+
+        <div class="view-toggle" role="group" aria-label="View">
+          <button classList={{ active: loc().view === 'reading' }} onClick={() => update({ view: 'reading' })}>
+            Reading
           </button>
+          <button classList={{ active: loc().view === 'scroll' }} onClick={() => update({ view: 'scroll' })}>
+            Scroll
+          </button>
+        </div>
+
+        <Show when={loc().view === 'scroll'}>
+          <button class="nikud-toggle" onClick={() => update({ nikud: !loc().nikud })}>
+            {loc().nikud ? 'נִקּוּד' : 'נקוד'}
+          </button>
+        </Show>
+
+        <div class="chapter-nav">
+          <button disabled={loc().chapter <= 1} onClick={() => goto(loc().book, loc().chapter - 1)}>‹</button>
           <span class="chapter-label">ch. {loc().chapter}</span>
-          <button onClick={() => go(loc().book, loc().chapter + 1)}>›</button>
+          <button onClick={() => goto(loc().book, loc().chapter + 1)}>›</button>
         </div>
       </header>
 
-      <main class="reader">
-        <h1 class="chapter-head">
-          <span class="he" dir="rtl">
-            {heName(loc().book)} {loc().chapter}
-          </span>
-          <span class="en">
-            {loc().book} {loc().chapter}
-          </span>
-        </h1>
+      <Show when={data.loading}>
+        <p class="status">Loading…</p>
+      </Show>
+      <Show when={data.error}>
+        <p class="status error">{(data.error as Error)?.message}</p>
+      </Show>
 
-        <Show when={data.loading}>
-          <p class="status">Loading…</p>
-        </Show>
-        <Show when={data.error}>
-          <p class="status error">{(data.error as Error)?.message}</p>
-        </Show>
+      {/* Reading view — verses with translation */}
+      <Show when={loc().view === 'reading' && data()}>
+        {(ch) => (
+          <main class="reader">
+            <h1 class="chapter-head">
+              <span class="he" dir="rtl">{heName(loc().book)} {loc().chapter}</span>
+              <span class="en">{loc().book} {loc().chapter}</span>
+            </h1>
+            <ol class="verses">
+              <For each={ch().verses}>
+                {(v) => (
+                  <li class="verse">
+                    <span class="vnum">{v.n}</span>
+                    <span class="he" dir="rtl" innerHTML={v.he} />
+                    <span class="en" innerHTML={v.en} />
+                  </li>
+                )}
+              </For>
+            </ol>
+            <ChapterFoot ch={ch()} goto={goto} />
+          </main>
+        )}
+      </Show>
 
-        <Show when={data()}>
-          {(ch) => (
-            <>
-              <ol class="verses">
-                <For each={ch().verses}>
-                  {(v) => (
-                    <li class="verse">
-                      <span class="vnum">{v.n}</span>
-                      <span class="he" dir="rtl" innerHTML={v.he} />
-                      <span class="en" innerHTML={v.en} />
-                    </li>
-                  )}
-                </For>
-              </ol>
-              <nav class="chapter-foot">
-                <Show when={ch().prev} fallback={<span />}>
-                  {(prev) => {
-                    const p = parseRef(prev());
-                    return p ? (
-                      <button onClick={() => go(p.book, p.chapter)}>‹ {prev()}</button>
-                    ) : (
-                      <span />
-                    );
-                  }}
-                </Show>
-                <Show when={ch().next}>
-                  {(next) => {
-                    const p = parseRef(next());
-                    return p ? (
-                      <button onClick={() => go(p.book, p.chapter)}>{next()} ›</button>
-                    ) : (
-                      <span />
-                    );
-                  }}
-                </Show>
-              </nav>
-            </>
-          )}
-        </Show>
-      </main>
+      {/* Scroll view — Sefer Torah band */}
+      <Show when={loc().view === 'scroll' && data()}>
+        {(ch) => (
+          <main class="scroll-main">
+            <div class="scroll-roll">
+              <div class="scroll-edge" />
+              <div class="scroll-band" dir="rtl" innerHTML={scrollHtml()} />
+              <div class="scroll-edge" />
+            </div>
+            <div class="scroll-caption">
+              <span class="he">{ch().heRef}</span>
+              <ChapterFoot ch={ch()} goto={goto} />
+            </div>
+          </main>
+        )}
+      </Show>
     </div>
+  );
+}
+
+function ChapterFoot(props: { ch: Chapter; goto: (b: string, c: number) => void }): JSX.Element {
+  const nav = (ref: string | null, label: (r: string) => string) => (
+    <Show when={ref} fallback={<span />}>
+      {(r) => {
+        const p = parseRef(r());
+        return p ? <button onClick={() => props.goto(p.book, p.chapter)}>{label(r())}</button> : <span />;
+      }}
+    </Show>
+  );
+  return (
+    <nav class="chapter-foot">
+      {nav(props.ch.prev, (r) => `‹ ${r}`)}
+      {nav(props.ch.next, (r) => `${r} ›`)}
+    </nav>
   );
 }

--- a/packages/tanach/src/client/styles.css
+++ b/packages/tanach/src/client/styles.css
@@ -4,6 +4,9 @@
   --line: #e3e0d8;
   --bg: #faf8f3;
   --accent: #7a5c2e;
+  --parchment: #f3e7c9;
+  --parchment-edge: #e6d3a6;
+  --stam: #2a1c0c;
 }
 
 * {
@@ -14,7 +17,7 @@ body {
   margin: 0;
   background: var(--bg);
   color: var(--ink);
-  font-family: Georgia, 'Times New Roman', serif;
+  font-family: 'Frank Ruhl Libre', Georgia, 'Times New Roman', serif;
   line-height: 1.6;
 }
 
@@ -23,19 +26,23 @@ body {
   margin: 0 auto;
   padding: 0 20px 80px;
 }
+.app.view-scroll {
+  max-width: none;
+  padding: 0;
+}
 
+/* ---- top bar ---- */
 .topbar {
   position: sticky;
   top: 0;
   display: flex;
   align-items: center;
-  gap: 14px;
-  padding: 12px 0;
+  gap: 12px;
+  padding: 12px 20px;
   background: var(--bg);
   border-bottom: 1px solid var(--line);
   z-index: 10;
 }
-
 .brand {
   font-weight: 700;
   letter-spacing: 0.04em;
@@ -43,7 +50,6 @@ body {
   font-size: 14px;
   color: var(--accent);
 }
-
 .book-select {
   font-family: inherit;
   font-size: 15px;
@@ -54,13 +60,43 @@ body {
   color: var(--ink);
 }
 
+.view-toggle {
+  display: inline-flex;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  overflow: hidden;
+}
+.view-toggle button {
+  font-family: inherit;
+  font-size: 14px;
+  padding: 5px 12px;
+  border: 0;
+  background: #fff;
+  color: var(--muted);
+  cursor: pointer;
+}
+.view-toggle button.active {
+  background: var(--accent);
+  color: #fff;
+}
+
+.nikud-toggle {
+  font-family: inherit;
+  font-size: 15px;
+  padding: 4px 12px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: #fff;
+  color: var(--ink);
+  cursor: pointer;
+}
+
 .chapter-nav {
   margin-left: auto;
   display: flex;
   align-items: center;
   gap: 8px;
 }
-
 .chapter-nav button,
 .chapter-foot button {
   font-family: inherit;
@@ -72,12 +108,10 @@ body {
   color: var(--ink);
   cursor: pointer;
 }
-
 .chapter-nav button:disabled {
   opacity: 0.4;
   cursor: default;
 }
-
 .chapter-label {
   font-size: 14px;
   color: var(--muted);
@@ -85,6 +119,16 @@ body {
   text-align: center;
 }
 
+.status {
+  color: var(--muted);
+  font-style: italic;
+  padding: 24px 20px;
+}
+.status.error {
+  color: #a23;
+}
+
+/* ---- reading view ---- */
 .chapter-head {
   display: flex;
   align-items: baseline;
@@ -94,33 +138,20 @@ body {
   padding-bottom: 12px;
   border-bottom: 2px solid var(--line);
 }
-
 .chapter-head .he {
   font-size: 30px;
 }
-
 .chapter-head .en {
   font-size: 16px;
   color: var(--muted);
   text-transform: uppercase;
   letter-spacing: 0.06em;
 }
-
-.status {
-  color: var(--muted);
-  font-style: italic;
-}
-
-.status.error {
-  color: #a23;
-}
-
 .verses {
   list-style: none;
   margin: 0;
   padding: 0;
 }
-
 .verse {
   display: grid;
   grid-template-columns: 28px 1fr;
@@ -128,7 +159,6 @@ body {
   padding: 14px 0;
   border-bottom: 1px solid var(--line);
 }
-
 .verse .vnum {
   grid-row: span 2;
   color: var(--accent);
@@ -136,20 +166,86 @@ body {
   font-variant-numeric: tabular-nums;
   padding-top: 6px;
 }
-
 .verse .he {
-  font-size: 23px;
-  line-height: 1.9;
+  font-size: 24px;
+  line-height: 1.95;
   text-align: right;
 }
-
 .verse .en {
   font-size: 17px;
   color: #333;
 }
-
 .chapter-foot {
   display: flex;
   justify-content: space-between;
+  gap: 16px;
   margin-top: 32px;
+}
+
+/* ---- scroll (Sefer Torah) view ---- */
+.scroll-main {
+  background: radial-gradient(ellipse at center, #f6ecd2 0%, #e9d9b4 100%);
+  padding: 30px 24px 36px;
+}
+.scroll-roll {
+  display: flex;
+  align-items: stretch;
+  box-shadow: 0 10px 30px rgba(60, 40, 12, 0.18);
+}
+.scroll-edge {
+  flex: 0 0 20px;
+  background: linear-gradient(to bottom, #5a3c1c, #8a6536 30%, #6b4a23 70%, #4e3417);
+  box-shadow: inset 0 0 7px rgba(0, 0, 0, 0.45);
+  border-radius: 4px;
+}
+.scroll-band {
+  flex: 1 1 auto;
+  height: 74vh;
+  padding: 30px 40px;
+  background: var(--parchment);
+  border-top: 3px solid var(--parchment-edge);
+  border-bottom: 3px solid var(--parchment-edge);
+  color: var(--stam);
+  font-size: clamp(22px, 2.1vw, 31px);
+  line-height: 2.0;
+  text-align: justify;
+  text-justify: inter-word;
+  columns: 16rem auto;
+  column-gap: 2.6rem;
+  column-fill: auto;
+  column-rule: 1px solid rgba(122, 92, 46, 0.14);
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+.scroll-band .parsha-open {
+  display: block;
+  height: 0.9em;
+}
+.scroll-band .parsha-closed {
+  display: inline-block;
+  width: 2.4em;
+}
+.scroll-band big {
+  font-size: 1.5em;
+  line-height: 1;
+}
+.scroll-band small {
+  font-size: 0.7em;
+  vertical-align: super;
+}
+.scroll-caption {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 16px 4px 0;
+}
+.scroll-caption .he {
+  font-size: 21px;
+  color: var(--accent);
+}
+.scroll-caption .chapter-foot {
+  margin-top: 0;
 }


### PR DESCRIPTION
The Tanach reader now has **two modes**, switchable from the top bar and persisted in the URL.

## Scroll (Sefer Torah)
The chapter's Hebrew flows as continuous, justified **RTL columns** in a parchment band with wooden-roller edges — columns read right-to-left, an unrolled scroll. Frank Ruhl Libre typeface.
- **נִקּוּד toggle** drops niqqud + cantillation for the bare **ktav-STAM** look (maqaf → space).
- Sefaria's parsha markers `{פ}`/`{ס}` render as open/closed breaks.

## Reading
The existing verse list with English translation (unchanged behavior), now also in Frank Ruhl Libre.

State (`view`, `nikud`, `book`, `chapter`) lives in the URL, so any view is shareable.

## Scope
**Tanach-client-only** — no worker, core, or talmud changes. Verified live in all four states (scroll vocalized, scroll bare, reading, and the toggle between them). `pnpm --filter tanach typecheck` + `build` clean.