### PR TITLE
#spine: restyle to app style + whole-map zoom controls

### DIFF
--- a/packages/talmud/src/client/SpineCoveragePage.tsx
+++ b/packages/talmud/src/client/SpineCoveragePage.tsx
@@ -1,5 +1,5 @@
 import { createResource, createSignal, createMemo, For, Show, type JSX } from 'solid-js';
-import { FlowLegend, connectionKinds } from './ArgumentFlowGraph';
+import { FlowLegend, connectionKinds, KIND_COLOR } from './ArgumentFlowGraph';
 import SpineFlowGraph, { type SpineViewDaf } from './SpineFlowGraph';
 
 /**
@@ -8,6 +8,10 @@ import SpineFlowGraph, { type SpineViewDaf } from './SpineFlowGraph';
  * cached for that (daf, producer); empty = not built yet. The whole tractate
  * reads as a map that fills in as study/warming progresses. Read-only; backed by
  * GET /api/spine-coverage/:tractate (no piece is computed by opening this page).
+ *
+ * Styled to the app: system-ui + the shared CSS tokens (--bg/--fg/--muted/
+ * --accent/--line), card surfaces, and the .tb-* control vocabulary. Monospace
+ * is reserved for genuinely tabular values only (daf column, coords, run chains).
  */
 
 interface CoverageColumn {
@@ -46,29 +50,28 @@ function coordLabel(key: string): string {
   return seg < 0 ? page : `${page} §${seg}`;
 }
 
-// Relation -> color, mirroring the flow-graph palette intent.
-const RELATION_COLOR: Record<string, string> = {
-  continues: '#0066CC',
-  resolves: '#00A36C',
-  'depends-on': '#FF9900',
-  parallels: '#9933CC',
-  contrasts: '#FF3366',
-  generalizes: '#666666',
-  cites: '#333333',
-  glosses: '#888888',
-};
+// Relation colors come from the daf reader's own muted KIND_COLOR (imported), so
+// #spine never drifts from the reader. `glosses` isn't a flow kind — fall back.
+const relColor = (rel: string): string => (KIND_COLOR as Record<string, string>)[rel] ?? 'var(--muted)';
+
+// Coverage producer kinds, recoloured off neon onto app-native hues.
+const COV_COLOR: Record<string, string> = { source: '#475569', mark: 'var(--accent)', enrichment: '#7c3aed' };
 
 // A modest set of quick-pick tractates (the full set is whatever the server
 // recognises; this is just for convenience). The page also takes free text.
 const PRESETS = ['berakhot', 'shabbat', 'eruvin', 'pesachim', 'sukkah', 'bava_metzia', 'bava_kamma', 'sanhedrin'];
 
-const MONO = "'Berkeley Mono', 'SF Mono', Menlo, Monaco, Consolas, monospace";
+// Reserved ONLY for tabular/coord values, per the app's monospace convention.
+const MONO = "'SF Mono', Menlo, Monaco, Consolas, monospace";
 const HILITE = '#b8860b'; // rabbi-trace highlight (matches SpineFlowGraph)
-const KIND_COLOR: Record<string, string> = {
-  source: '#666666',
-  mark: '#0066CC',
-  enrichment: '#FF3366',
-};
+
+const PANEL: JSX.CSSProperties = { border: '1px solid var(--line)', 'border-radius': '8px', background: '#fff', padding: '0.85rem 1rem', margin: '0 0 1rem' };
+const PANEL_H: JSX.CSSProperties = { 'font-size': '0.78rem', 'text-transform': 'uppercase', 'letter-spacing': '0.07em', color: 'var(--muted)', 'font-weight': 700, margin: 0 };
+const CHIP = (color: string): JSX.CSSProperties => ({
+  display: 'inline-flex', 'align-items': 'center', gap: '0.35rem', padding: '0.1rem 0.5rem',
+  background: '#faf8f3', border: '1px solid #ece7db', 'border-radius': '999px', 'font-size': '0.7rem', color: 'var(--muted)',
+  'border-left': `3px solid ${color}`,
+});
 
 function routeTractate(): string {
   const raw = window.location.hash.replace(/^#/, '');
@@ -128,64 +131,41 @@ export function SpineCoveragePage(): JSX.Element {
     if (slug) window.location.hash = `spine/${slug}`;
   };
 
-  const bar = (pct: number) => {
-    const filled = Math.round(pct / 5);
-    return '█'.repeat(filled) + '░'.repeat(20 - filled);
-  };
-
-  // Short 3-char column codes so the grid stays narrow; full label on hover.
-  const code = (label: string) => label.slice(0, 3);
-
-  const cellChar = '██'; // ██
-  const emptyChar = '··'; // ··
+  const prettyTractate = () => tractate().replace(/_/g, ' ');
 
   return (
-    <main
-      class="page-shell"
-      style={{
-        '--page-max': '980px',
-        'font-family': MONO,
-        color: '#333333',
-        background: '#FAFAFA',
-        'min-height': '100vh',
-        padding: '1.5rem',
-      }}
-    >
-      <header style={{ 'margin-bottom': '1rem' }}>
-        <a href="#daf" style={{ color: '#666', 'text-decoration': 'none', 'font-size': '13px' }}>&larr; back to daf</a>
-        <h1 style={{ margin: '0.4rem 0 0', 'font-size': '20px', 'font-weight': 700, 'letter-spacing': '0.04em' }}>
-          [SPINE] {tractate().toUpperCase().replace(/_/g, ' ')}
+    <main class="page-shell" style={{ '--page-max': '1040px' }}>
+      <header style={{ 'margin-bottom': '1.1rem' }}>
+        <a href="#daf" style={{ color: 'var(--muted)', 'text-decoration': 'none', 'font-size': '0.85rem' }}>&larr; back to daf</a>
+        <h1 style={{ margin: '0.4rem 0 0', 'font-size': '1.5rem', 'letter-spacing': '-0.02em', color: 'var(--fg)', 'text-transform': 'capitalize' }}>
+          Spine &middot; <span style={{ color: 'var(--accent)' }}>{prettyTractate()}</span>
         </h1>
-        <p style={{ margin: '0.2rem 0 0', 'font-size': '12px', color: '#666' }}>
-          coverage map &mdash; which pieces of the whole tractate are computed
+        <p style={{ margin: '0.25rem 0 0', 'font-size': '0.85rem', color: 'var(--muted)' }}>
+          which pieces of the whole tractate are computed, and how they link
         </p>
       </header>
 
       {/* tractate picker */}
-      <div style={{ display: 'flex', 'flex-wrap': 'wrap', gap: '6px', 'align-items': 'center', 'margin-bottom': '1rem' }}>
+      <div class="responsive-row" style={{ 'margin-bottom': '1.1rem', gap: '0.4rem' }}>
         <input
+          class="tb-select"
           value={input()}
           onInput={(e) => setInput(e.currentTarget.value)}
           onKeyDown={(e) => { if (e.key === 'Enter') go(input()); }}
           placeholder="tractate (e.g. bava_metzia)"
-          style={{
-            'font-family': MONO, 'font-size': '12px', padding: '4px 8px',
-            border: '1.5px solid #333', background: '#fff', color: '#333', width: '200px',
-          }}
+          style={{ width: '220px' }}
         />
-        <button
-          onClick={() => go(input())}
-          style={{ 'font-family': MONO, 'font-size': '12px', padding: '4px 10px', border: '1.5px solid #000', background: '#fff', cursor: 'pointer' }}
-        >GO</button>
+        <button class="tb-primary" style={{ 'border-radius': 'var(--tb-radius)' }} onClick={() => go(input())}>Go</button>
         <For each={PRESETS}>
           {(p) => (
             <button
               onClick={() => go(p)}
               style={{
-                'font-family': MONO, 'font-size': '11px', padding: '3px 8px',
-                border: '1px solid #ccc', cursor: 'pointer',
-                background: p === tractate() ? '#333' : '#fff',
-                color: p === tractate() ? '#fff' : '#666',
+                'font-family': 'inherit', 'font-size': '0.78rem', padding: '0.2rem 0.6rem', cursor: 'pointer',
+                'border-radius': '999px',
+                border: p === tractate() ? '1px solid var(--accent)' : '1px solid var(--line)',
+                background: p === tractate() ? 'var(--accent)' : '#fff',
+                color: p === tractate() ? '#fff' : 'var(--muted)',
               }}
             >{p}</button>
           )}
@@ -193,67 +173,64 @@ export function SpineCoveragePage(): JSX.Element {
       </div>
 
       <Show when={report.loading}>
-        <p style={{ 'font-size': '13px', color: '#666' }}>probing cache&hellip;</p>
+        <p style={{ 'font-size': '0.88rem', color: 'var(--muted)', 'font-style': 'italic' }}>probing cache&hellip;</p>
       </Show>
       <Show when={report.error}>
-        <p style={{ 'font-size': '13px', color: '#FF3366' }}>error: {String(report.error?.message || report.error)}</p>
+        <p style={{ 'font-size': '0.88rem', color: '#b3261e' }}>error: {String(report.error?.message || report.error)}</p>
       </Show>
 
       <Show when={report()}>
         {(r) => (
           <>
             {/* summary */}
-            <div style={{ 'margin-bottom': '1rem', 'font-size': '13px' }}>
-              <span style={{ 'font-weight': 700 }}>{r().summary.pct}%</span>{' '}
-              <span style={{ color: KIND_COLOR.mark, 'letter-spacing': '-1px' }}>{bar(r().summary.pct)}</span>{' '}
-              <span style={{ color: '#666' }}>
+            <div style={{ display: 'flex', 'align-items': 'center', gap: '0.7rem', 'margin-bottom': '1.1rem', 'font-size': '0.88rem', 'flex-wrap': 'wrap' }}>
+              <span style={{ 'font-weight': 700, color: 'var(--fg)' }}>{r().summary.pct}%</span>
+              <span style={{ display: 'inline-block', width: '160px', height: '8px', background: 'var(--line)', 'border-radius': '999px', overflow: 'hidden' }}>
+                <span style={{ display: 'block', width: `${r().summary.pct}%`, height: '100%', background: 'var(--accent)' }} />
+              </span>
+              <span style={{ color: 'var(--muted)' }}>
                 {r().summary.computed} / {r().summary.total} pieces &middot; {r().rows.length} dapim &times; {r().columns.length} producers &middot; to {r().endAmud}
               </span>
             </div>
 
             {/* assembled spine graph (loads on demand) */}
-            <div style={{ margin: '0 0 1rem', padding: '10px 12px', border: '1.5px solid #333', background: '#fff' }}>
+            <div style={PANEL}>
               <div style={{ display: 'flex', 'align-items': 'center', 'justify-content': 'space-between', gap: '10px' }}>
-                <span style={{ 'font-size': '12px', 'font-weight': 700 }}>ASSEMBLED SPINE &mdash; tractate link graph (so far)</span>
-                <button
-                  onClick={() => { setGraphTrigger(tractate()); }}
-                  disabled={graph.loading}
-                  style={{ 'font-family': MONO, 'font-size': '11px', padding: '3px 10px', border: '1.5px solid #000', background: graph.loading ? '#eee' : '#fff', cursor: 'pointer' }}
-                >{graph.loading ? 'assembling…' : (graph() ? 'rebuild' : 'assemble')}</button>
+                <span style={PANEL_H}>Assembled spine &mdash; tractate link graph</span>
+                <button class="tb-select" disabled={graph.loading} onClick={() => setGraphTrigger(tractate())}>
+                  {graph.loading ? 'assembling…' : (graph() ? 'rebuild' : 'assemble')}
+                </button>
               </div>
               <Show when={graph.error}>
-                <p style={{ 'font-size': '12px', color: '#FF3366', margin: '6px 0 0' }}>error: {String(graph.error?.message || graph.error)}</p>
+                <p style={{ 'font-size': '0.85rem', color: '#b3261e', margin: '6px 0 0' }}>error: {String(graph.error?.message || graph.error)}</p>
               </Show>
               <Show when={graph()}>
                 {(g) => (
-                  <div style={{ 'margin-top': '8px', 'font-size': '12px' }}>
-                    <div style={{ color: '#666', 'margin-bottom': '6px' }}>
+                  <div style={{ 'margin-top': '0.7rem', 'font-size': '0.85rem' }}>
+                    <div style={{ color: 'var(--muted)', 'margin-bottom': '0.5rem' }}>
                       {g().nodes.length} nodes &middot; {g().edges.length} edges &middot; backbone from {g().coverage.dapimWithLinks} / {g().coverage.dapimTotal} dapim with links
                     </div>
-                    {/* by producer — distinguishes the deterministic layers from the AI cross-daf one */}
-                    <div style={{ 'font-size': '11px', color: '#888', 'margin-bottom': '6px' }}>
+                    <div style={{ 'font-size': '0.78rem', color: 'var(--muted)', 'margin-bottom': '0.5rem' }}>
                       by producer: {Object.entries(g().byVia).map(([v, n]) => `${v} ${n}`).join('  ·  ') || '—'}
                     </div>
                     {/* relation breakdown */}
-                    <div style={{ display: 'flex', 'flex-wrap': 'wrap', gap: '6px', 'margin-bottom': '8px' }}>
+                    <div style={{ display: 'flex', 'flex-wrap': 'wrap', gap: '0.35rem', 'margin-bottom': '0.7rem' }}>
                       <For each={Object.entries(g().byRelation).sort((a, b) => b[1] - a[1])}>
                         {([rel, n]) => (
-                          <span style={{ 'font-size': '11px', padding: '2px 7px', border: `1px solid ${RELATION_COLOR[rel] || '#999'}`, color: RELATION_COLOR[rel] || '#333' }}>
-                            {rel} {n}
-                          </span>
+                          <span style={CHIP(relColor(rel))}>{rel} {n}</span>
                         )}
                       </For>
                     </div>
                     {/* continuity backbone — sugya chains that carry across daf boundaries */}
-                    <Show when={g().continuityRuns.length} fallback={<div style={{ color: '#999' }}>no continuity edges cached yet (warm bridges to grow the backbone)</div>}>
-                      <div style={{ 'font-weight': 700, 'font-size': '11px', 'margin-bottom': '4px', color: RELATION_COLOR.continues }}>
-                        CONTINUITY BACKBONE &mdash; {g().continuityRuns.length} runs
+                    <Show when={g().continuityRuns.length} fallback={<div style={{ color: 'var(--muted)', 'font-style': 'italic' }}>no continuity edges cached yet (warm bridges to grow the backbone)</div>}>
+                      <div style={{ ...PANEL_H, 'margin-bottom': '0.3rem', color: relColor('continues') }}>
+                        Continuity backbone &mdash; {g().continuityRuns.length} runs
                       </div>
-                      <div style={{ 'max-height': '180px', 'overflow-y': 'auto' }}>
+                      <div style={{ 'max-height': '180px', 'overflow-y': 'auto', 'font-family': MONO, 'font-size': '0.8rem' }}>
                         <For each={g().continuityRuns.sort((a, b) => b.length - a.length)}>
                           {(run) => (
-                            <div style={{ 'font-size': '12px', padding: '1px 0', color: '#333' }}>
-                              <span style={{ color: '#999' }}>{String(run.length).padStart(2)} </span>
+                            <div style={{ padding: '1px 0', color: 'var(--fg)' }}>
+                              <span style={{ color: 'var(--muted)' }}>{String(run.length).padStart(2)} </span>
                               {run.join(' → ')}
                             </div>
                           )}
@@ -262,17 +239,17 @@ export function SpineCoveragePage(): JSX.Element {
                     </Show>
                     {/* cross-daf edges — the AI Stage 1 layer (section -> section across the page break) */}
                     <Show when={g().edges.some((e) => e.via === 'cross-flow')}>
-                      <div style={{ 'font-weight': 700, 'font-size': '11px', margin: '10px 0 4px', color: RELATION_COLOR.parallels }}>
-                        CROSS-DAF EDGES (AI) &mdash; {g().edges.filter((e) => e.via === 'cross-flow').length}
+                      <div style={{ ...PANEL_H, margin: '0.7rem 0 0.3rem', color: relColor('parallels') }}>
+                        Cross-daf edges (AI) &mdash; {g().edges.filter((e) => e.via === 'cross-flow').length}
                       </div>
-                      <div style={{ 'max-height': '200px', 'overflow-y': 'auto' }}>
+                      <div style={{ 'max-height': '200px', 'overflow-y': 'auto', 'font-size': '0.83rem' }}>
                         <For each={g().edges.filter((e) => e.via === 'cross-flow')}>
                           {(e) => (
-                            <div style={{ 'font-size': '12px', padding: '1px 0' }}>
-                              <span>{coordLabel(e.source)}</span>
-                              <span style={{ color: RELATION_COLOR[e.relation] || '#666', margin: '0 6px' }}>&mdash;{e.relation}&rarr;</span>
-                              <span>{coordLabel(e.target)}</span>
-                              <Show when={e.note}><span style={{ color: '#999' }}>  {e.note}</span></Show>
+                            <div style={{ padding: '1px 0' }}>
+                              <span style={{ 'font-family': MONO }}>{coordLabel(e.source)}</span>
+                              <span style={{ color: relColor(e.relation), margin: '0 0.4rem' }}>&mdash;{e.relation}&rarr;</span>
+                              <span style={{ 'font-family': MONO }}>{coordLabel(e.target)}</span>
+                              <Show when={e.note}><span style={{ color: 'var(--muted)' }}>  {e.note}</span></Show>
                             </div>
                           )}
                         </For>
@@ -285,17 +262,15 @@ export function SpineCoveragePage(): JSX.Element {
 
             {/* stitched flow view — real per-daf flow graphs down the tractate,
                 connected by the cross-daf edges */}
-            <div style={{ margin: '0 0 1rem', padding: '10px 12px', border: '1.5px solid #333', background: '#fff' }}>
+            <div style={PANEL}>
               <div style={{ display: 'flex', 'align-items': 'center', 'justify-content': 'space-between', gap: '10px' }}>
-                <span style={{ 'font-size': '12px', 'font-weight': 700 }}>STITCHED FLOW &mdash; the argument map down the tractate</span>
-                <button
-                  onClick={() => setViewTrigger(tractate())}
-                  disabled={flowView.loading}
-                  style={{ 'font-family': MONO, 'font-size': '11px', padding: '3px 10px', border: '1.5px solid #000', background: flowView.loading ? '#eee' : '#fff', cursor: 'pointer' }}
-                >{flowView.loading ? 'loading…' : (flowView() ? 'reload' : 'load')}</button>
+                <span style={PANEL_H}>Stitched flow &mdash; the argument map down the tractate</span>
+                <button class="tb-select" disabled={flowView.loading} onClick={() => setViewTrigger(tractate())}>
+                  {flowView.loading ? 'loading…' : (flowView() ? 'reload' : 'load')}
+                </button>
               </div>
               <Show when={flowView.error}>
-                <p style={{ 'font-size': '12px', color: '#FF3366', margin: '6px 0 0' }}>error: {String(flowView.error?.message || flowView.error)}</p>
+                <p style={{ 'font-size': '0.85rem', color: '#b3261e', margin: '6px 0 0' }}>error: {String(flowView.error?.message || flowView.error)}</p>
               </Show>
               <Show when={flowView()}>
                 {(v) => {
@@ -312,8 +287,8 @@ export function SpineCoveragePage(): JSX.Element {
                   const allKinds = createMemo(() => connectionKinds(capped().flatMap((d) => d.flow) as Parameters<typeof connectionKinds>[0]));
                   const crossCount = createMemo(() => capped().reduce((n, d) => n + d.cross.length, 0));
                   return (
-                    <div style={{ 'margin-top': '8px' }}>
-                      <div style={{ 'font-size': '11px', color: '#666', 'margin-bottom': '4px' }}>
+                    <div style={{ 'margin-top': '0.7rem' }}>
+                      <div style={{ 'font-size': '0.8rem', color: 'var(--muted)', 'margin-bottom': '0.3rem' }}>
                         showing {capped().length} of {shown().length} dapim {shown().length > FLOW_VIEW_CAP ? '(capped)' : ''} &middot; {crossCount()} cross-daf arrows (thicker lines span the page break) &middot; click a rabbi to trace
                       </div>
                       <FlowLegend kinds={allKinds()} />
@@ -322,13 +297,13 @@ export function SpineCoveragePage(): JSX.Element {
                           let display = slug();
                           let boxes = 0;
                           for (const d of capped()) for (const s of d.sections) {
-                            const hit = s.rabbis.find((r) => r.slug === slug());
+                            const hit = s.rabbis.find((rb) => rb.slug === slug());
                             if (hit) { boxes++; display = hit.name; }
                           }
                           return (
-                            <div style={{ margin: '6px 0', padding: '4px 10px', border: `1.5px solid ${HILITE}`, background: '#fffaf0', 'font-size': '12px', display: 'inline-block' }}>
+                            <div style={{ margin: '0.5rem 0', padding: '0.3rem 0.6rem', border: `1px solid ${HILITE}`, 'border-radius': '6px', background: '#fffaf0', 'font-size': '0.85rem', display: 'inline-block' }}>
                               tracing <span style={{ 'font-weight': 700, color: HILITE }}>{display}</span> &middot; {boxes} {boxes === 1 ? 'box' : 'boxes'}{' '}
-                              <button onClick={() => setTrace(null)} style={{ 'font-family': MONO, 'font-size': '11px', 'margin-left': '8px', border: '1px solid #999', background: '#fff', cursor: 'pointer' }}>clear</button>
+                              <button class="tb-select" style={{ 'margin-left': '0.5rem', height: 'auto', padding: '0.1rem 0.5rem', 'font-size': '0.78rem' }} onClick={() => setTrace(null)}>clear</button>
                             </div>
                           );
                         }}
@@ -344,79 +319,89 @@ export function SpineCoveragePage(): JSX.Element {
               </Show>
             </div>
 
-            {/* legend */}
-            <div style={{ display: 'flex', gap: '14px', 'margin-bottom': '10px', 'font-size': '11px', color: '#666' }}>
-              <For each={[['source', 'source text'], ['mark', 'mark'], ['enrichment', 'enrichment']]}>
-                {([k, lbl]) => (
-                  <span><span style={{ color: KIND_COLOR[k], 'font-weight': 700 }}>{cellChar}</span> {lbl}</span>
-                )}
-              </For>
-              <span><span style={{ color: '#d0d0d0' }}>{emptyChar}</span> not computed</span>
-            </div>
+            {/* coverage punchcard */}
+            <div style={PANEL}>
+              <span style={PANEL_H}>Coverage &mdash; pieces per daf</span>
+              {/* legend */}
+              <div style={{ display: 'flex', gap: '1rem', 'flex-wrap': 'wrap', margin: '0.6rem 0', 'font-size': '0.78rem', color: 'var(--muted)', 'align-items': 'center' }}>
+                <For each={[['source', 'source text'], ['mark', 'mark'], ['enrichment', 'enrichment']]}>
+                  {([k, lbl]) => (
+                    <span style={{ display: 'inline-flex', 'align-items': 'center', gap: '0.35rem' }}>
+                      <span style={{ display: 'inline-block', width: '11px', height: '11px', 'border-radius': '3px', background: COV_COLOR[k] }} /> {lbl}
+                    </span>
+                  )}
+                </For>
+                <span style={{ display: 'inline-flex', 'align-items': 'center', gap: '0.35rem' }}>
+                  <span style={{ display: 'inline-block', width: '11px', height: '11px', 'border-radius': '3px', border: '1px solid var(--line)' }} /> not computed
+                </span>
+              </div>
 
-            {/* column header */}
-            <div style={{ display: 'flex', 'font-size': '11px', color: '#333', 'margin-bottom': '4px', 'border-bottom': '1.5px solid #333', 'padding-bottom': '4px' }}>
-              <span style={{ width: '44px', 'flex-shrink': 0 }} />
-              <For each={r().columns}>
-                {(col) => (
-                  <span title={`${col.label} (${col.kind} ${col.version})`} style={{ width: '34px', 'flex-shrink': 0, 'text-align': 'center', color: KIND_COLOR[col.kind] }}>
-                    {code(col.label)}
-                  </span>
-                )}
-              </For>
-            </div>
+              {/* column header */}
+              <div style={{ display: 'flex', 'font-size': '0.72rem', color: 'var(--muted)', 'margin-bottom': '0.3rem', 'border-bottom': '1px solid var(--line)', 'padding-bottom': '0.3rem' }}>
+                <span style={{ width: '44px', 'flex-shrink': 0 }} />
+                <For each={r().columns}>
+                  {(col) => (
+                    <span title={`${col.label} (${col.kind} ${col.version})`} style={{ width: '34px', 'flex-shrink': 0, 'text-align': 'center', color: COV_COLOR[col.kind] }}>
+                      {col.label.slice(0, 3)}
+                    </span>
+                  )}
+                </For>
+              </div>
 
-            {/* grid */}
-            <div style={{ 'line-height': 1.15 }}>
-              <For each={r().rows}>
-                {(row) => {
-                  const isOpen = createMemo(() => expanded() === row.page);
-                  const filledCount = createMemo(() => r().columns.filter((c) => row.cells[c.id]).length);
-                  return (
-                    <>
-                      <div
-                        onClick={() => setExpanded(isOpen() ? null : row.page)}
-                        style={{
-                          display: 'flex', 'align-items': 'center', cursor: 'pointer',
-                          'font-size': '12px', padding: '1px 0',
-                          background: isOpen() ? '#eef2f7' : (filledCount() === 0 ? 'transparent' : 'transparent'),
-                        }}
-                      >
-                        <span style={{ width: '44px', 'flex-shrink': 0, color: filledCount() ? '#333' : '#bbb', 'font-weight': isOpen() ? 700 : 400 }}>
-                          {row.page}
-                        </span>
-                        <For each={r().columns}>
-                          {(col) => (
-                            <span
-                              title={`${row.page} · ${col.label}: ${row.cells[col.id] ? 'computed' : 'not computed'}`}
-                              style={{ width: '34px', 'flex-shrink': 0, 'text-align': 'center', color: row.cells[col.id] ? KIND_COLOR[col.kind] : '#dcdcdc' }}
-                            >
-                              {row.cells[col.id] ? cellChar : emptyChar}
-                            </span>
-                          )}
-                        </For>
-                      </div>
-                      <Show when={isOpen()}>
-                        <div style={{ margin: '2px 0 8px 44px', padding: '8px 10px', border: '1px solid #ddd', background: '#fff', 'font-size': '12px' }}>
-                          <div style={{ 'font-weight': 700, 'margin-bottom': '4px' }}>{tractate().replace(/_/g, ' ')} {row.page}</div>
+              {/* grid */}
+              <div>
+                <For each={r().rows}>
+                  {(row) => {
+                    const isOpen = createMemo(() => expanded() === row.page);
+                    const filledCount = createMemo(() => r().columns.filter((c) => row.cells[c.id]).length);
+                    return (
+                      <>
+                        <div
+                          onClick={() => setExpanded(isOpen() ? null : row.page)}
+                          style={{
+                            display: 'flex', 'align-items': 'center', cursor: 'pointer', 'border-radius': '4px',
+                            'font-size': '0.8rem', padding: '0.1rem 0',
+                            background: isOpen() ? '#f2eee4' : 'transparent',
+                          }}
+                        >
+                          <span style={{ width: '44px', 'flex-shrink': 0, 'font-family': MONO, 'font-size': '0.78rem', color: filledCount() ? 'var(--fg)' : 'var(--muted)', 'font-weight': isOpen() ? 700 : 400, 'padding-left': '0.2rem' }}>
+                            {row.page}
+                          </span>
                           <For each={r().columns}>
                             {(col) => (
-                              <div style={{ display: 'flex', 'justify-content': 'space-between', padding: '1px 0' }}>
-                                <span style={{ color: KIND_COLOR[col.kind] }}>
-                                  {col.label} <span style={{ color: '#aaa', 'font-size': '10px' }}>{col.kind}</span>
-                                </span>
-                                <span style={{ color: row.cells[col.id] ? '#0a0' : '#bbb' }}>
-                                  {row.cells[col.id] ? '✓ cached' : '· missing'}
-                                </span>
-                              </div>
+                              <span style={{ width: '34px', 'flex-shrink': 0, display: 'flex', 'justify-content': 'center' }}
+                                title={`${row.page} · ${col.label}: ${row.cells[col.id] ? 'computed' : 'not computed'}`}>
+                                <span style={{
+                                  width: '11px', height: '11px', 'border-radius': '3px',
+                                  background: row.cells[col.id] ? COV_COLOR[col.kind] : 'transparent',
+                                  border: row.cells[col.id] ? 'none' : '1px solid var(--line)',
+                                }} />
+                              </span>
                             )}
                           </For>
                         </div>
-                      </Show>
-                    </>
-                  );
-                }}
-              </For>
+                        <Show when={isOpen()}>
+                          <div style={{ margin: '0.2rem 0 0.5rem 44px', padding: '0.5rem 0.7rem', border: '1px solid #eae8e0', 'border-radius': '6px', background: '#fafaf7', 'font-size': '0.83rem' }}>
+                            <div style={{ 'font-weight': 700, 'margin-bottom': '0.3rem', 'text-transform': 'capitalize' }}>{prettyTractate()} {row.page}</div>
+                            <For each={r().columns}>
+                              {(col) => (
+                                <div style={{ display: 'flex', 'justify-content': 'space-between', padding: '1px 0' }}>
+                                  <span style={{ color: COV_COLOR[col.kind] }}>
+                                    {col.label} <span style={{ color: 'var(--muted)', 'font-size': '0.7rem' }}>{col.kind}</span>
+                                  </span>
+                                  <span style={{ color: row.cells[col.id] ? '#15803d' : 'var(--muted)' }}>
+                                    {row.cells[col.id] ? '✓ cached' : '· missing'}
+                                  </span>
+                                </div>
+                              )}
+                            </For>
+                          </div>
+                        </Show>
+                      </>
+                    );
+                  }}
+                </For>
+              </div>
             </div>
           </>
         )}

--- a/packages/talmud/src/client/SpineFlowGraph.tsx
+++ b/packages/talmud/src/client/SpineFlowGraph.tsx
@@ -12,7 +12,7 @@
  * highlighted. Reuses the daf reader's flow palette + title wrapping.
  * Hidden #spine page only.
  */
-import { For, Show, createMemo, type JSX } from 'solid-js';
+import { For, Show, createMemo, createSignal, type JSX } from 'solid-js';
 import { KIND_COLOR, KIND_DASH, wrapTitle, type FlowConnection } from './ArgumentFlowGraph';
 
 type Kind = FlowConnection['kind'];
@@ -111,14 +111,33 @@ export default function SpineFlowGraph(props: { dapim: SpineViewDaf[]; highlight
     return [`M ${rightX} ${y1}`, `L ${x - r} ${y1}`, `Q ${x} ${y1} ${x} ${y1 + dir * r}`, `L ${x} ${y2 - dir * r}`, `Q ${x} ${y2} ${x - r} ${y2}`, `L ${rightX} ${y2}`].join(' ');
   };
 
+  // Zoom lets you shrink the whole rendered map to read its shape, then scale
+  // back in. The container keeps its own scrollbars for panning; ctrl/cmd+wheel
+  // zooms. "fit" scales the map to the container height.
+  const [zoom, setZoom] = createSignal(1);
+  const clampZoom = (z: number) => Math.max(0.15, Math.min(2, z));
+  let boxRef: HTMLDivElement | undefined;
+  const fit = () => { const h = (boxRef?.clientHeight || 600) - 12; setZoom(clampZoom(h / model().height)); };
+  const onWheel = (e: WheelEvent) => { if (e.ctrlKey || e.metaKey) { e.preventDefault(); setZoom((z) => clampZoom(z * (e.deltaY < 0 ? 1.12 : 0.89))); } };
+  const zbtn: JSX.CSSProperties = { font: 'inherit', 'font-size': '0.78rem', padding: '0.1rem 0.5rem', border: '1px solid var(--line)', 'border-radius': '6px', background: '#fff', cursor: 'pointer', color: 'var(--fg)' };
+
   return (
     <Show when={props.dapim.length > 0}>
-      <div style={{ 'max-height': '78vh', 'overflow-y': 'auto', 'overflow-x': 'auto', border: '1px solid #ece9df', 'border-radius': '8px', background: '#fdfcf9', 'margin-top': '0.6rem', padding: '0.3rem' }}>
+      <>
+      <div style={{ display: 'flex', 'align-items': 'center', gap: '0.35rem', 'margin-top': '0.4rem', 'font-size': '0.78rem', color: 'var(--muted)' }}>
+        <button style={zbtn} title="zoom out" onClick={() => setZoom((z) => clampZoom(z * 0.85))}>&minus;</button>
+        <span style={{ 'min-width': '3ch', 'text-align': 'center' }}>{Math.round(zoom() * 100)}%</span>
+        <button style={zbtn} title="zoom in" onClick={() => setZoom((z) => clampZoom(z * 1.18))}>+</button>
+        <button style={zbtn} onClick={() => setZoom(1)}>1:1</button>
+        <button style={zbtn} onClick={fit}>fit height</button>
+        <span style={{ 'margin-left': '0.3rem' }}>ctrl/&#8984;+scroll to zoom</span>
+      </div>
+      <div ref={boxRef} onWheel={onWheel} style={{ 'max-height': '78vh', 'overflow-y': 'auto', 'overflow-x': 'auto', border: '1px solid #ece9df', 'border-radius': '8px', background: '#fdfcf9', 'margin-top': '0.4rem', padding: '0.3rem' }}>
         {(() => {
           const m = model();
           const hl = () => props.highlight ?? null; // a rabbi slug
           return (
-            <svg width={m.width} height={m.height} viewBox={`0 0 ${m.width} ${m.height}`} style={{ display: 'block' }}>
+            <svg width={m.width * zoom()} height={m.height * zoom()} viewBox={`0 0 ${m.width} ${m.height}`} style={{ display: 'block' }}>
               <defs>
                 <For each={Object.entries(KIND_COLOR)}>{([kind, color]) => (
                   <marker id={`spine-arrow-${kind}`} markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
@@ -133,7 +152,7 @@ export default function SpineFlowGraph(props: { dapim: SpineViewDaf[]; highlight
               <For each={m.dafHeaders}>{(h) => (
                 <>
                   <line x1={0} y1={h.y + DAF_HEADER_H - 6} x2={m.width} y2={h.y + DAF_HEADER_H - 6} stroke="#efece2" stroke-width={1} />
-                  <text x={6} y={h.y + 15} font-size="13" font-weight="700" font-family="'SF Mono', Menlo, monospace" fill="#8a2a2b">{h.page}</text>
+                  <text x={6} y={h.y + 15} font-size="13" font-weight="700" font-family="system-ui, -apple-system, sans-serif" fill="#8a2a2b">{h.page}</text>
                 </>
               )}</For>
 
@@ -190,6 +209,7 @@ export default function SpineFlowGraph(props: { dapim: SpineViewDaf[]; highlight
           );
         })()}
       </div>
+      </>
     </Show>
   );
 }


### PR DESCRIPTION
Hidden #spine page only — the daf reader is untouched.

**(a) App-native restyle** (was monospace/retro punchcard):
- Drop the monospace page font + flat #FAFAFA/#333 inline overrides; inherit system-ui + the app CSS tokens (--bg/--fg/--muted/--accent/--line).
- Real `Spine · <tractate>` h1 (maroon accent) + muted subtitle; drop the [BRACKET]/ALL-CAPS title; panel headers → muted uppercase small-caps.
- Card-surface panels (1px --line, 8px radius), softened borders, `.tb-*` controls + pill preset chips.
- Summary ASCII bar → real progress bar; punchcard glyph cells → rounded swatches; relation breakdown → app legend chips; **import KIND_COLOR from ArgumentFlowGraph** (also fixes a depends-on colour-mapping bug); coverage kinds recoloured off neon. Monospace reserved for tabular only.

**(b) Whole-map legibility:** zoom controls on the stitched SVG (−, %, +, 1:1, fit-height, ctrl/⌘+scroll) so the whole rendered map can be shrunk to read its shape, then scaled in. (Overview-mode / virtualization to show the *entire* tractate at once is a noted follow-up.)

Typecheck (all 3 packages) + 1919 tests pass.

Note: this PR is the UI work. A separate, higher-value follow-up is improving the **cross-flow producer** itself per a 58-link Berakhot audit (43% clean; main issues = fan-out over-linking + 'continues' mislabeling of contradictions).