### PR TITLE
Cross-flow producer: precision pass from the Berakhot link audit

### DIFF
--- a/packages/talmud/src/lib/typing/crossFlow.ts
+++ b/packages/talmud/src/lib/typing/crossFlow.ts
@@ -53,7 +53,7 @@ export function buildCrossFlowPrompt(
   const list = (secs: readonly CrossFlowSection[]): string =>
     secs.map((s, i) => `  [${i}] ${s.title ?? '(untitled)'} — ${s.summary ?? ''}`).join('\n');
   return [
-    `Two consecutive dapim of Talmud (${fromDaf.tractate} ${fromDaf.page} → ${toDaf.page}). Identify how the argument sections of the FIRST daf relate to sections of the SECOND, ONLY where there is a clear, specific relationship across the page boundary.`,
+    `Two consecutive dapim of Talmud (${fromDaf.tractate} ${fromDaf.page} → ${toDaf.page}). Map how the FIRST daf's argument sections relate to the SECOND daf's — ONLY clear, specific relationships across the page boundary.`,
     '',
     `FIRST daf (${fromDaf.page}) sections:`,
     list(from),
@@ -61,27 +61,43 @@ export function buildCrossFlowPrompt(
     `SECOND daf (${toDaf.page}) sections:`,
     list(to),
     '',
-    'Relations:',
-    '  continues   — the same sugya thread carries directly forward',
-    '  resolves    — a section answers a question/difficulty raised in the other',
-    '  depends-on  — presupposes a result established in the other',
-    '  parallels   — an independent but structurally analogous discussion',
-    '  contrasts   — an opposing position, case, or outcome',
-    '  generalizes — states the general rule of a specific case (or vice versa)',
+    'Relations — pick the MOST precise one (the right word is usually already in how you would describe the link):',
+    '  continues   — the SAME sugya thread runs directly forward to its next step. NOT for a new question, an objection, or a competing view.',
+    '  resolves    — one section directly ANSWERS a question or difficulty posed in the other.',
+    '  depends-on  — one section PRESUPPOSES / builds on a ruling established in the other.',
+    '  contrasts   — an OPPOSING position, competing formulation, objection, or a baraita that challenges the other. If your reason uses words like "challenges", "objects", "contradicts", "alternative formulation", or "difficulty from" — it is contrasts (or depends-on), NEVER continues.',
+    '  parallels   — an INDEPENDENT but structurally analogous discussion (same dispute shape / question-answer form / mirrored list). NOT a generic shared theme.',
+    '  generalizes — abstracts a general RULE from a specific case, or applies a general rule to a case. NOT mere restatement or elaboration (that is continues).',
     '',
-    'Output edges { fromSection (index in FIRST), toSection (index in SECOND), relation, note }.',
-    'PRECISION over recall: emit an edge ONLY when the relationship is specific and defensible from the summaries. Most section pairs have NO edge — return few edges, or none. Never connect sections merely for sharing a tractate or a broad theme.',
+    'Hard rules:',
+    '1. AT MOST ONE `continues` edge per FIRST-daf section — choose the SINGLE strongest end→start carry-forward. Never fan one section out to several consecutive targets.',
+    '2. Emit FEW edges. Most daf boundaries have 0–2 real cross-daf links; a long list from one section is wrong.',
+    '3. Self-check before writing `continues`: if your own reason describes opposition / objection / challenge, relabel to contrasts or depends-on.',
+    '4. Every edge MUST name a concrete shared anchor in `note` — the specific ruling, question, figure, or verse tying source to target. If the only link is a broad theme, emit NO edge.',
+    '5. Do not assume continuity just because the dapim are adjacent: confirm the source section actually concerns the claimed subject. Distinct figures with similar names (e.g. Rav Yehuda the amora vs Rabbi Yehuda the tanna; the several Rav Kahanas) are NOT the same — never link on a confused identity.',
+    '',
+    'Output edges { fromSection (index in FIRST), toSection (index in SECOND), relation, note }. PRECISION over recall: a wrong link is worse than no link.',
   ].join('\n');
 }
 
 /** Validate + clamp the raw LLM verdict into in-range, well-typed edges. Drops
  *  any edge whose indices fall outside the real section lists or whose relation
- *  isn't recognised, and dedupes identical edges. */
+ *  isn't recognised, and dedupes identical edges.
+ *
+ *  Deterministic anti-fan-out guards (the audit's top finding — one source
+ *  section emitting many 'continues' edges into consecutive next-daf sections
+ *  when only one is the real continuation):
+ *   - at most ONE 'continues' edge per source section (keep the first), and
+ *   - at most MAX_PER_SOURCE edges total per source section.
+ *  These cap the model even when the prompt's "few edges" instruction is ignored. */
+const MAX_PER_SOURCE = 2;
 export function parseCrossFlowEdges(raw: unknown, fromCount: number, toCount: number): CrossFlowEdge[] {
   const arr = (raw && typeof raw === 'object' ? (raw as { edges?: unknown }).edges : null);
   if (!Array.isArray(arr)) return [];
   const out: CrossFlowEdge[] = [];
   const seen = new Set<string>();
+  const continuesFrom = new Set<number>();        // source sections that already have a 'continues'
+  const totalFrom = new Map<number, number>();    // edges kept per source section
   for (const e of arr) {
     if (!e || typeof e !== 'object') continue;
     const o = e as Record<string, unknown>;
@@ -93,7 +109,11 @@ export function parseCrossFlowEdges(raw: unknown, fromCount: number, toCount: nu
     if (typeof relation !== 'string' || !CROSS_FLOW_RELATIONS.includes(relation as CrossFlowRelation)) continue;
     const dedup = `${fromSection} ${toSection} ${relation}`;
     if (seen.has(dedup)) continue;
+    if (relation === 'continues' && continuesFrom.has(fromSection)) continue; // ≤1 continues per source
+    if ((totalFrom.get(fromSection) ?? 0) >= MAX_PER_SOURCE) continue;        // cap fan-out per source
     seen.add(dedup);
+    if (relation === 'continues') continuesFrom.add(fromSection);
+    totalFrom.set(fromSection, (totalFrom.get(fromSection) ?? 0) + 1);
     out.push({
       fromSection,
       toSection,

--- a/packages/talmud/src/worker/cache-keys.ts
+++ b/packages/talmud/src/worker/cache-keys.ts
@@ -216,7 +216,9 @@ export function prefixForRabbiObs(slug: string): string {
  *  (the relation-typed successor to keyForBridge's boolean). Keyed per anchor
  *  daf (forward window of 1), same raw shape family as the bridge key. */
 export function keyForCrossFlow(tractate: string, page: string): string {
-  return `cross-flow:v1:${slugDaf(tractate, page)}`;
+  // v2: precision pass after the Berakhot audit — tighter relation defs +
+  // anti-fan-out cap (≤1 continues / ≤2 total per source) + entity guard.
+  return `cross-flow:v2:${slugDaf(tractate, page)}`;
 }
 
 /** The whole-tractate link graph (spineLinks aggregator), materialized on the

--- a/packages/talmud/tests/cross-flow.test.ts
+++ b/packages/talmud/tests/cross-flow.test.ts
@@ -39,6 +39,41 @@ describe('parseCrossFlowEdges', () => {
     expect(edges[0].relation).toBe('parallels');
   });
 
+  it('caps fan-out: at most ONE continues per source section (the audit fix)', () => {
+    // The classic failure: 2a§1 emits continues to 2b §3/§4/§6.
+    const edges = parseCrossFlowEdges(
+      { edges: [
+        { fromSection: 0, toSection: 0, relation: 'continues', note: 'a' },
+        { fromSection: 0, toSection: 1, relation: 'continues', note: 'b' },
+        { fromSection: 0, toSection: 2, relation: 'continues', note: 'c' },
+      ] },
+      1, 5,
+    );
+    expect(edges.length).toBe(1);
+    expect(edges[0].toSection).toBe(0); // keeps the first
+  });
+
+  it('caps total edges per source section to 2', () => {
+    const edges = parseCrossFlowEdges(
+      { edges: [
+        { fromSection: 0, toSection: 0, relation: 'continues', note: '' },
+        { fromSection: 0, toSection: 1, relation: 'contrasts', note: '' },
+        { fromSection: 0, toSection: 2, relation: 'parallels', note: '' },
+      ] },
+      1, 5,
+    );
+    expect(edges.length).toBe(2);
+    // different source sections are independent
+    const two = parseCrossFlowEdges(
+      { edges: [
+        { fromSection: 0, toSection: 0, relation: 'continues', note: '' },
+        { fromSection: 1, toSection: 1, relation: 'continues', note: '' },
+      ] },
+      2, 5,
+    );
+    expect(two.length).toBe(2);
+  });
+
   it('returns [] for malformed input', () => {
     expect(parseCrossFlowEdges(null, 2, 2)).toEqual([]);
     expect(parseCrossFlowEdges({}, 2, 2)).toEqual([]);


### PR DESCRIPTION
A 58-link Berakhot audit of the AI cross-daf links found ~43% clean; the rest were dominated by two systemic errors:
1. **Fan-out over-linking** — one source section emits several `continues` edges into consecutive next-daf sections when only one is the real continuation.
2. **`continues` mislabeling** — challenges/contradictions (a baraita challenging a Mishnah, an objection) tagged as forward flow.

Fixes:
- **buildCrossFlowPrompt**: tighter relation definitions; a continues-vs-opposition self-check; an evidence-anchor requirement (name the shared ruling/figure/verse, else no edge); an entity-identity guard (Rav Yehuda amora vs Rabbi Yehuda tanna; the several Rav Kahanas); and a hard "≤1 `continues` per source section" rule.
- **parseCrossFlowEdges**: deterministic anti-fan-out cap independent of model compliance — ≤1 `continues` per source, ≤2 edges total per source.
- **keyForCrossFlow v1→v2** so the re-warm regenerates fresh.
- Tests for the caps.

Talmud suite (1921) + typecheck pass. (`tanach` package test failure is pre-existing — empty test set in the new scaffold.)