### PR TITLE
Tanach: Mikraot Gedolot view via the daf-renderer

### DIFF
--- a/packages/tanach/src/client/App.tsx
+++ b/packages/tanach/src/client/App.tsx
@@ -1,5 +1,6 @@
 import { createMemo, createResource, createSignal, For, Show, type JSX } from 'solid-js';
 import { BOOKS, SECTIONS, type Section } from '../lib/books.ts';
+import { MikraotGedolot } from './MikraotGedolot.tsx';
 
 interface Verse {
   n: number;
@@ -17,7 +18,7 @@ interface Chapter {
   error?: string;
 }
 
-type View = 'reading' | 'scroll';
+type View = 'reading' | 'scroll' | 'mikraot';
 
 /** Parse a Sefaria section ref ("Genesis 2", "I Samuel 3") into book + chapter. */
 function parseRef(ref: string): { book: string; chapter: number } | null {
@@ -51,7 +52,8 @@ function readUrl(): Loc {
   const p = new URLSearchParams(window.location.search);
   const book = p.get('book') ?? 'Genesis';
   const chapter = Number(p.get('chapter') ?? '1') || 1;
-  const view: View = p.get('view') === 'scroll' ? 'scroll' : 'reading';
+  const vp = p.get('view');
+  const view: View = vp === 'scroll' ? 'scroll' : vp === 'mikraot' ? 'mikraot' : 'reading';
   const nikud = p.get('nikud') !== '0';
   return { book: BOOKS.some((b) => b.name === book) ? book : 'Genesis', chapter, view, nikud };
 }
@@ -68,7 +70,7 @@ export function App(): JSX.Element {
 
   const writeUrl = (l: Loc) => {
     const p = new URLSearchParams({ book: l.book, chapter: String(l.chapter) });
-    if (l.view === 'scroll') p.set('view', 'scroll');
+    if (l.view !== 'reading') p.set('view', l.view);
     if (!l.nikud) p.set('nikud', '0');
     window.history.pushState(null, '', `?${p.toString()}`);
   };
@@ -99,7 +101,7 @@ export function App(): JSX.Element {
   });
 
   return (
-    <div class="app" classList={{ 'view-scroll': loc().view === 'scroll' }}>
+    <div class="app" classList={{ 'view-scroll': loc().view === 'scroll', 'view-mikraot': loc().view === 'mikraot' }}>
       <header class="topbar">
         <span class="brand">Tanach</span>
         <select class="book-select" value={loc().book} onChange={(e) => goto(e.currentTarget.value, 1)}>
@@ -120,6 +122,9 @@ export function App(): JSX.Element {
           </button>
           <button classList={{ active: loc().view === 'scroll' }} onClick={() => update({ view: 'scroll' })}>
             Scroll
+          </button>
+          <button classList={{ active: loc().view === 'mikraot' }} onClick={() => update({ view: 'mikraot' })}>
+            Mikraot Gedolot
           </button>
         </div>
 
@@ -165,6 +170,11 @@ export function App(): JSX.Element {
             <ChapterFoot ch={ch()} goto={goto} />
           </main>
         )}
+      </Show>
+
+      {/* Mikraot Gedolot — pasuk framed by Rashi + Onkelos (daf-renderer) */}
+      <Show when={loc().view === 'mikraot'}>
+        <MikraotGedolot book={loc().book} chapter={loc().chapter} />
       </Show>
 
       {/* Scroll view — Sefer Torah band */}

--- a/packages/tanach/src/client/MikraotGedolot.tsx
+++ b/packages/tanach/src/client/MikraotGedolot.tsx
@@ -1,0 +1,66 @@
+import { createResource, Show, type JSX } from 'solid-js';
+import { DafRenderer } from '../lib/daf-render/index.ts';
+
+interface MG {
+  book: string;
+  chapter: number;
+  ref: string;
+  heRef: string;
+  main: string;
+  rashi: string;
+  targum: string;
+  next: string | null;
+  prev: string | null;
+  error?: string;
+}
+
+async function fetchMG(loc: { book: string; chapter: number }): Promise<MG> {
+  const res = await fetch(`/api/mikraot/${encodeURIComponent(loc.book)}/${loc.chapter}`);
+  const data = (await res.json()) as MG;
+  if (!res.ok) throw new Error(data.error ?? `HTTP ${res.status}`);
+  return data;
+}
+
+const FAM = 'Frank Ruhl Libre';
+
+/** The Mikraot Gedolot framed view: the pasuk text (center) wrapped by Rashi
+ *  (inner) and Targum Onkelos (outer), laid out by the shared daf-renderer's
+ *  tzurat-hadaf engine — the same renderer the Talmud reader uses. */
+export function MikraotGedolot(props: { book: string; chapter: number }): JSX.Element {
+  const [data] = createResource(() => ({ book: props.book, chapter: props.chapter }), fetchMG);
+
+  return (
+    <main class="mg-main">
+      <Show when={data.loading}>
+        <p class="status">Loading commentaries…</p>
+      </Show>
+      <Show when={data.error}>
+        <p class="status error">{(data.error as Error)?.message}</p>
+      </Show>
+      <Show when={data()}>
+        {(d) => (
+          <>
+            <div class="mg-host">
+              <DafRenderer
+                main={d().main}
+                inner={d().rashi || ' '}
+                outer={d().targum || ' '}
+                options={{
+                  contentWidth: 860,
+                  mainWidth: 0.5,
+                  fontFamily: { main: FAM, inner: FAM, outer: FAM },
+                  fontSize: { main: 21, side: 15 },
+                  lineHeight: { main: 30, side: 22 },
+                }}
+              />
+            </div>
+            <p class="mg-caption">
+              <span class="he">{d().heRef}</span>
+              <span class="apparatus">פנים · רש״י · אונקלוס</span>
+            </p>
+          </>
+        )}
+      </Show>
+    </main>
+  );
+}

--- a/packages/tanach/src/client/styles.css
+++ b/packages/tanach/src/client/styles.css
@@ -235,3 +235,33 @@ body {
 .scroll-caption .chapter-foot button {
   background: transparent;
 }
+
+/* ---- Mikraot Gedolot (daf-renderer) view ---- */
+.mg-main {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 28px 20px 56px;
+}
+.mg-host {
+  color: var(--ink);
+}
+.mg-caption {
+  display: flex;
+  gap: 18px;
+  align-items: baseline;
+  margin-top: 22px;
+}
+.mg-caption .he {
+  font-size: 18px;
+  color: var(--accent);
+}
+.mg-caption .apparatus {
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.app.view-mikraot {
+  max-width: none;
+  padding: 0 0 40px;
+}

--- a/packages/tanach/src/lib/daf-render/core/layout.ts
+++ b/packages/tanach/src/lib/daf-render/core/layout.ts
@@ -1,0 +1,179 @@
+import type { DafOptions } from './options';
+import type { DafTexts, SpacerHeights, ColumnGeometry, LayoutCase, Amud } from './types';
+import {
+  measureCommentary,
+  measureMainBottom,
+  type CommentaryMeasure,
+  type CommentaryException,
+} from './measure';
+
+export interface DafGeometry extends ColumnGeometry {
+  topWidth: number;
+}
+
+export function computeGeometry(options: DafOptions): DafGeometry {
+  const content = options.contentWidth;
+  const padH = options.padding.horizontal;
+  const midWidth = content * options.mainWidth - 2 * padH;
+  const sideWidth = (content * (1 - options.mainWidth)) / 2;
+  const topWidth = content * options.halfway - padH;
+  const fullWidth = content - 2 * padH;
+  return { midWidth, sideWidth, fullWidth, totalContentWidth: content, topWidth };
+}
+
+export interface LayoutResult {
+  spacers: SpacerHeights & { innerEnd: number; outerEnd: number };
+  geometry: DafGeometry;
+  totalHeight: number;
+  /** Wall-clock duration of the layout computation. Lets the caller surface
+   *  spacer-calc timing in dev panels without re-instrumenting. */
+  computeMs: number;
+}
+
+export function computeLayout(
+  texts: DafTexts,
+  options: DafOptions,
+  amud: Amud = 'a',
+): LayoutResult {
+  const t0 = typeof performance !== 'undefined' ? performance.now() : 0;
+  const geometry = computeGeometry(options);
+  const hasInner = !!texts.inner;
+  const hasOuter = !!texts.outer;
+  // With both commentaries absent there's no top region to reserve — main
+  // text should flow from y=0 at full content width. Keep the normal top
+  // region whenever at least one commentary is present so the surviving
+  // commentary can anchor it in 'other' mode.
+  const startHeight = (hasInner || hasOuter) ? 4.3 * options.lineHeight.side : 0;
+
+  // --- Pass 1a: default naturals (no exception) ------------------------------
+  const innerNat0 = measureCommentary({
+    which: 'inner', html: texts.inner, options, amud, startHeight,
+    narrowBudget: Infinity, endBudget: 0, exception: 'none',
+  });
+  const outerNat0 = measureCommentary({
+    which: 'outer', html: texts.outer, options, amud, startHeight,
+    narrowBudget: Infinity, endBudget: 0, exception: 'none',
+  });
+
+  // --- Detect exception ------------------------------------------------------
+  // Exception modes fire when exactly one commentary occupies the top region.
+  // A commentary is "absent from top" either because it's entirely missing
+  // (empty html) or because its natural flow fits within startHeight. In
+  // both cases the present/longer commentary moves to 'other' mode (zero-
+  // width start spacer → text flows at full container width in the top
+  // region instead of at halfway).
+  let exception: 0 | 1 | 2 = 0;
+  let innerExc: CommentaryException = 'none';
+  let outerExc: CommentaryException = 'none';
+  if (!hasInner && hasOuter) {
+    exception = 1; innerExc = 'short'; outerExc = 'other';
+  } else if (!hasOuter && hasInner) {
+    exception = 2; innerExc = 'other'; outerExc = 'short';
+  } else if (hasInner && hasOuter) {
+    const innerTooShort = innerNat0.totalHeight <= startHeight;
+    const outerTooShort = outerNat0.totalHeight <= startHeight;
+    if (innerTooShort && !outerTooShort) {
+      exception = 1; innerExc = 'short'; outerExc = 'other';
+    } else if (outerTooShort && !innerTooShort) {
+      exception = 2; innerExc = 'other'; outerExc = 'short';
+    }
+  }
+
+  // --- Pass 1b (if exception): re-measure naturals with exception layout -----
+  const innerNatural = exception ? measureCommentary({
+    which: 'inner', html: texts.inner, options, amud, startHeight,
+    narrowBudget: Infinity, endBudget: 0, exception: innerExc,
+  }) : innerNat0;
+  const outerNatural = exception ? measureCommentary({
+    which: 'outer', html: texts.outer, options, amud, startHeight,
+    narrowBudget: Infinity, endBudget: 0, exception: outerExc,
+  }) : outerNat0;
+
+  // --- Pass 2: main bottom ---------------------------------------------------
+  const mainBottom = measureMainBottom({
+    html: texts.main,
+    options, amud, startHeight,
+    innerBottom: innerNatural.totalHeight,
+    outerBottom: outerNatural.totalHeight,
+  });
+
+  // --- Classify --------------------------------------------------------------
+  const minComm = Math.min(innerNatural.totalHeight, outerNatural.totalHeight);
+  const maxComm = Math.max(innerNatural.totalHeight, outerNatural.totalHeight);
+  const layoutCase: LayoutCase =
+    mainBottom <= minComm ? 'double-wrap'
+    : mainBottom < maxComm ? 'stairs'
+    : 'double-extend';
+
+  const widenBudget = Math.max(0, mainBottom - startHeight);
+
+  // --- Pass 3: case-specific re-measurement, preserving exception ----------
+  const remeasure = (
+    which: 'inner' | 'outer',
+    html: string,
+    natural: CommentaryMeasure,
+    exc: CommentaryException,
+    narrowBudget: number,
+    endBudget: number,
+  ): CommentaryMeasure => {
+    if (natural.totalHeight <= mainBottom) return natural;
+    return measureCommentary({ which, html, options, amud, startHeight, narrowBudget, endBudget, exception: exc });
+  };
+
+  let inner: CommentaryMeasure = innerNatural;
+  let outer: CommentaryMeasure = outerNatural;
+
+  if (layoutCase === 'stairs') {
+    inner = remeasure('inner', texts.inner, innerNatural, innerExc, widenBudget, 0);
+    outer = remeasure('outer', texts.outer, outerNatural, outerExc, widenBudget, 0);
+  } else if (layoutCase === 'double-wrap') {
+    // Shared end = shorter commentary's halfway overflow
+    const innerHalf = measureCommentary({
+      which: 'inner', html: texts.inner, options, amud, startHeight,
+      narrowBudget: widenBudget, endBudget: Infinity, exception: innerExc,
+    });
+    const outerHalf = measureCommentary({
+      which: 'outer', html: texts.outer, options, amud, startHeight,
+      narrowBudget: widenBudget, endBudget: Infinity, exception: outerExc,
+    });
+    const sharedEnd = Math.min(innerHalf.endUsed, outerHalf.endUsed);
+    inner = measureCommentary({
+      which: 'inner', html: texts.inner, options, amud, startHeight,
+      narrowBudget: widenBudget, endBudget: sharedEnd, exception: innerExc,
+    });
+    outer = measureCommentary({
+      which: 'outer', html: texts.outer, options, amud, startHeight,
+      narrowBudget: widenBudget, endBudget: sharedEnd, exception: outerExc,
+    });
+  }
+
+  const totalHeight = Math.max(mainBottom, inner.totalHeight, outer.totalHeight);
+
+  const result: LayoutResult = {
+    spacers: {
+      start: startHeight,
+      inner: inner.narrowUsed,
+      outer: outer.narrowUsed,
+      innerEnd: inner.endUsed,
+      outerEnd: outer.endUsed,
+      end: 0,
+      layoutCase,
+      exception,
+    },
+    geometry,
+    totalHeight,
+    computeMs: typeof performance !== 'undefined' ? performance.now() - t0 : 0,
+  };
+
+  if (typeof window !== 'undefined') {
+    const r = Math.round;
+    console.log(
+      `[daf-render] w=${options.contentWidth} case=${layoutCase} exception=${exception}`,
+      `inner: narrow=${r(inner.narrowUsed)} end=${r(inner.endUsed)}`,
+      `| outer: narrow=${r(outer.narrowUsed)} end=${r(outer.endUsed)}`,
+      `| main=${r(mainBottom)} root=${r(totalHeight)}`,
+    );
+  }
+
+  return result;
+}

--- a/packages/tanach/src/lib/daf-render/core/measure.ts
+++ b/packages/tanach/src/lib/daf-render/core/measure.ts
@@ -1,0 +1,234 @@
+import type { DafOptions } from './options';
+import type { Amud } from './types';
+
+export interface BaseFont {
+  family: string;
+  size: number;
+}
+
+/**
+ * Build the CSS-variable bag used by the daf-render stylesheet. We set all
+ * layout-driving variables via inline style so the hidden measurement root
+ * gets the same cascade as a visible one.
+ */
+function computeCssVars(opts: DafOptions, amud: Amud): Record<string, string> {
+  const sidePercent = ((1 - opts.mainWidth) / 2) * 100;
+  const halfwayPercent = opts.halfway * 100;
+  const remainderPercent = 100 - sidePercent;
+  const amudB = amud === 'b';
+
+  return {
+    '--daf-content-width': `${opts.contentWidth}px`,
+    '--daf-side-percent': `${sidePercent}%`,
+    '--daf-halfway-percent': `${halfwayPercent}%`,
+    '--daf-remainder-percent': `${remainderPercent}%`,
+    '--daf-padding-vertical': `${opts.padding.vertical}px`,
+    '--daf-padding-horizontal': `${opts.padding.horizontal}px`,
+    '--daf-font-main': `"${opts.fontFamily.main}"`,
+    '--daf-font-inner': `"${opts.fontFamily.inner}"`,
+    '--daf-font-outer': `"${opts.fontFamily.outer}"`,
+    '--daf-direction': opts.direction,
+    '--daf-font-size-main': `${opts.fontSize.main}px`,
+    '--daf-font-size-side': `${opts.fontSize.side}px`,
+    '--daf-line-height-main': `${opts.lineHeight.main}px`,
+    '--daf-line-height-side': `${opts.lineHeight.side}px`,
+    '--daf-inner-float': amudB ? 'right' : 'left',
+    '--daf-outer-float': amudB ? 'left' : 'right',
+  };
+}
+
+function makeHost(opts: DafOptions, amud: Amud, extraVars: Record<string, string>): HTMLDivElement {
+  const host = document.createElement('div');
+  host.className = 'daf-root';
+  const vars = { ...computeCssVars(opts, amud), ...extraVars };
+  for (const [k, v] of Object.entries(vars)) host.style.setProperty(k, v);
+  host.style.position = 'fixed';
+  host.style.top = '-99999px';
+  host.style.left = '0';
+  host.style.visibility = 'hidden';
+  host.style.pointerEvents = 'none';
+  return host;
+}
+
+function makeSideColumn(which: 'inner' | 'outer', html: string): HTMLDivElement {
+  const col = document.createElement('div');
+  col.className = `daf-${which}`;
+  const start = document.createElement('div');
+  start.className = 'daf-spacer daf-start';
+  const mid = document.createElement('div');
+  mid.className = 'daf-spacer daf-mid';
+  const end = document.createElement('div');
+  end.className = 'daf-spacer daf-end';
+  const text = document.createElement('div');
+  text.className = 'daf-text';
+  const span = document.createElement('span');
+  span.innerHTML = html;
+  text.appendChild(span);
+  col.appendChild(start);
+  col.appendChild(mid);
+  col.appendChild(end);
+  col.appendChild(text);
+  return col;
+}
+
+function makeMainColumn(html: string): { col: HTMLDivElement; text: HTMLSpanElement } {
+  const col = document.createElement('div');
+  col.className = 'daf-main';
+  const start = document.createElement('div');
+  start.className = 'daf-spacer daf-start';
+  const innerMid = document.createElement('div');
+  innerMid.className = 'daf-spacer daf-inner-mid';
+  const outerMid = document.createElement('div');
+  outerMid.className = 'daf-spacer daf-outer-mid';
+  const text = document.createElement('div');
+  text.className = 'daf-text';
+  const span = document.createElement('span');
+  span.innerHTML = html;
+  text.appendChild(span);
+  col.appendChild(start);
+  col.appendChild(innerMid);
+  col.appendChild(outerMid);
+  col.appendChild(text);
+  return { col, text: span };
+}
+
+export interface CommentaryMeasure {
+  totalHeight: number;
+  narrowUsed: number;
+  endUsed: number;
+}
+
+/**
+ * Exception state for a commentary column (daf-renderer parity).
+ *   'none'  — normal layout: halfway-wide start spacer.
+ *   'short' — this commentary is the one too short to fill the top region.
+ *             Start spacer spans the full column (text pushed below top) and
+ *             a padding-vertical gap is added beneath it.
+ *   'other' — the other commentary in an exception case. Start spacer has
+ *             zero width so text flows at full container width in the top
+ *             region (where the short commentary is absent).
+ */
+export type CommentaryException = 'none' | 'short' | 'other';
+
+/**
+ * Measure a side commentary column. Semantics driven by two budgets and an
+ * optional exception mode:
+ *
+ *   narrowBudget — height of the mid spacer (the narrow-width region).
+ *                  Infinity means unbounded: text stays at sideWidth throughout
+ *                  (natural flow, no widening). Finite means text widens into
+ *                  the end region after this height.
+ *
+ *   endBudget    — height of the end spacer (the halfway-width region past
+ *                  mid). 0 means no end spacer: text overflowing past mid flows
+ *                  at full container width (daf-renderer Stairs semantics).
+ *                  Infinity means unbounded halfway region: text stays at
+ *                  halfway forever. Finite means text is at halfway for
+ *                  endBudget, then overflows at full width.
+ *
+ *   exception    — see CommentaryException. Default 'none'.
+ */
+export function measureCommentary(params: {
+  which: 'inner' | 'outer';
+  html: string;
+  options: DafOptions;
+  amud: Amud;
+  startHeight: number;
+  narrowBudget: number;
+  endBudget: number;
+  exception?: CommentaryException;
+}): CommentaryMeasure {
+  if (!params.html || typeof document === 'undefined') {
+    return { totalHeight: 0, narrowUsed: 0, endUsed: 0 };
+  }
+
+  const midHeight = Number.isFinite(params.narrowBudget)
+    ? Math.max(0, params.narrowBudget)
+    : 99999;
+  const endHeight = Number.isFinite(params.endBudget)
+    ? Math.max(0, params.endBudget)
+    : 99999;
+
+  const exception = params.exception ?? 'none';
+  const startWidth = exception === 'short' ? '100%' : exception === 'other' ? '0%' : `${params.options.halfway * 100}%`;
+  const startPad = exception === 'none' ? `${params.options.padding.horizontal / 2}px` : '0px';
+  const startGap = exception === 'short' ? `${params.options.padding.vertical}px` : '0px';
+
+  const vars: Record<string, string> = {
+    '--daf-start': `${params.startHeight}px`,
+    [params.which === 'inner' ? '--daf-inner' : '--daf-outer']: `${midHeight}px`,
+    [params.which === 'inner' ? '--daf-inner-end' : '--daf-outer-end']: `${endHeight}px`,
+    [params.which === 'inner' ? '--daf-outer' : '--daf-inner']: '0px',
+    [params.which === 'inner' ? '--daf-outer-end' : '--daf-inner-end']: '0px',
+    [`--daf-${params.which}-start-width`]: startWidth,
+    [`--daf-${params.which}-start-pad`]: startPad,
+    [`--daf-${params.which}-start-gap`]: startGap,
+  };
+
+  const host = makeHost(params.options, params.amud, vars);
+  const col = makeSideColumn(params.which, params.html);
+  host.appendChild(col);
+  document.body.appendChild(host);
+
+  const span = col.querySelector('.daf-text span') as HTMLSpanElement;
+  const textRect = span.getBoundingClientRect();
+  const hostRect = host.getBoundingClientRect();
+  const totalHeight = textRect.bottom - hostRect.top;
+
+  host.remove();
+
+  const narrowUsed = Math.max(0, Math.min(totalHeight - params.startHeight, midHeight));
+  const endUsed = Math.max(0, Math.min(totalHeight - params.startHeight - midHeight, endHeight));
+  return { totalHeight, narrowUsed, endUsed };
+}
+
+/**
+ * Measure the main column's rendered bottom (relative to the daf-root top),
+ * given inner/outer commentary heights as obstacles. Uses the real daf DOM
+ * and CSS; inner/outer columns are rendered as sibling obstacles (same
+ * absolute-positioned overlay as in the live render), each with its mid
+ * spacer sized to the provided heights.
+ */
+export function measureMainBottom(params: {
+  html: string;
+  options: DafOptions;
+  amud: Amud;
+  startHeight: number;
+  innerBottom: number;
+  outerBottom: number;
+}): number {
+  if (!params.html || typeof document === 'undefined') return params.startHeight;
+
+  const innerMid = Math.max(0, params.innerBottom - params.startHeight);
+  const outerMid = Math.max(0, params.outerBottom - params.startHeight);
+
+  const vars: Record<string, string> = {
+    '--daf-start': `${params.startHeight}px`,
+    '--daf-inner': `${innerMid}px`,
+    '--daf-outer': `${outerMid}px`,
+    '--daf-inner-end': '0px',
+    '--daf-outer-end': '0px',
+  };
+
+  const host = makeHost(params.options, params.amud, vars);
+
+  // Sibling obstacles mimicking the real inner/outer overlay columns
+  const innerObs = makeSideColumn('inner', '');
+  innerObs.style.opacity = '0';
+  host.appendChild(innerObs);
+  const outerObs = makeSideColumn('outer', '');
+  outerObs.style.opacity = '0';
+  host.appendChild(outerObs);
+
+  const { col: mainCol, text } = makeMainColumn(params.html);
+  host.appendChild(mainCol);
+
+  document.body.appendChild(host);
+
+  const textRect = text.getBoundingClientRect();
+  const hostRect = host.getBoundingClientRect();
+  const mainBottom = textRect.bottom - hostRect.top;
+
+  host.remove();
+  return mainBottom;
+}

--- a/packages/tanach/src/lib/daf-render/core/options.ts
+++ b/packages/tanach/src/lib/daf-render/core/options.ts
@@ -1,0 +1,41 @@
+export interface DafOptions {
+  contentWidth: number;
+  mainWidth: number;
+  padding: { vertical: number; horizontal: number };
+  halfway: number;
+  fontFamily: { main: string; inner: string; outer: string };
+  direction: 'rtl' | 'ltr';
+  fontSize: { main: number; side: number };
+  lineHeight: { main: number; side: number };
+}
+
+export const defaultOptions: DafOptions = {
+  contentWidth: 720,
+  mainWidth: 0.48,
+  padding: { vertical: 10, horizontal: 16 },
+  halfway: 0.5,
+  fontFamily: { main: 'Frank Ruhl Libre', inner: 'Frank Ruhl Libre', outer: 'Frank Ruhl Libre' },
+  direction: 'rtl',
+  fontSize: { main: 15, side: 10.5 },
+  lineHeight: { main: 17, side: 14 },
+};
+
+export type PartialDafOptions = {
+  [K in keyof DafOptions]?: DafOptions[K] extends object
+    ? Partial<DafOptions[K]>
+    : DafOptions[K];
+};
+
+export function resolveOptions(user?: PartialDafOptions): DafOptions {
+  if (!user) return defaultOptions;
+  return {
+    contentWidth: user.contentWidth ?? defaultOptions.contentWidth,
+    mainWidth: user.mainWidth ?? defaultOptions.mainWidth,
+    padding: { ...defaultOptions.padding, ...user.padding },
+    halfway: user.halfway ?? defaultOptions.halfway,
+    fontFamily: { ...defaultOptions.fontFamily, ...user.fontFamily },
+    direction: user.direction ?? defaultOptions.direction,
+    fontSize: { ...defaultOptions.fontSize, ...user.fontSize },
+    lineHeight: { ...defaultOptions.lineHeight, ...user.lineHeight },
+  };
+}

--- a/packages/tanach/src/lib/daf-render/core/types.ts
+++ b/packages/tanach/src/lib/daf-render/core/types.ts
@@ -1,0 +1,25 @@
+export type Amud = 'a' | 'b';
+
+export type LayoutCase = 'double-wrap' | 'stairs' | 'double-extend';
+
+export interface DafTexts {
+  main: string;
+  inner: string;
+  outer: string;
+}
+
+export interface SpacerHeights {
+  start: number;
+  inner: number;
+  outer: number;
+  end: number;
+  layoutCase: LayoutCase;
+  exception: 0 | 1 | 2;
+}
+
+export interface ColumnGeometry {
+  midWidth: number;
+  sideWidth: number;
+  fullWidth: number;
+  totalContentWidth: number;
+}

--- a/packages/tanach/src/lib/daf-render/index.ts
+++ b/packages/tanach/src/lib/daf-render/index.ts
@@ -1,0 +1,7 @@
+export { DafRenderer } from './solid/DafRenderer';
+export type { DafRendererProps } from './solid/DafRenderer';
+export type { DafOptions, PartialDafOptions } from './core/options';
+export { defaultOptions, resolveOptions } from './core/options';
+export type { Amud, DafTexts, SpacerHeights, LayoutCase, ColumnGeometry } from './core/types';
+export { computeLayout, computeGeometry } from './core/layout';
+export type { LayoutResult, DafGeometry } from './core/layout';

--- a/packages/tanach/src/lib/daf-render/solid/DafRenderer.tsx
+++ b/packages/tanach/src/lib/daf-render/solid/DafRenderer.tsx
@@ -1,0 +1,186 @@
+import { createMemo, createSignal, createEffect, Show, type JSX } from 'solid-js';
+import { computeLayout, type LayoutResult } from '../core/layout';
+import { resolveOptions, type PartialDafOptions } from '../core/options';
+import type { Amud } from '../core/types';
+
+import '../styles.css';
+
+export interface DafRendererProps {
+  main: string;
+  inner: string;
+  outer: string;
+  amud?: Amud;
+  options?: PartialDafOptions;
+  onLayout?: (result: LayoutResult) => void;
+}
+
+const [fontsReady, setFontsReady] = createSignal(false);
+if (typeof document !== 'undefined') {
+  // document.fonts.ready only waits for fonts already scheduled to load. On
+  // first page load our @font-face rules may not yet be "in use", so it can
+  // resolve before Mekorot fonts are actually fetched — leading to layout
+  // measurements with fallback font metrics and a broken-looking render that
+  // magically fixes on reload (once the fonts are in HTTP cache).
+  //
+  // Explicitly loading by name forces the browser to fetch those specific
+  // fonts at representative sizes, and only flips fontsReady once all are in.
+  const fontPromises = [
+    '15px "Frank Ruhl Libre"',
+    '10.5px "Frank Ruhl Libre"',
+    '700 15px "Frank Ruhl Libre"',
+    '10.5px "Frank Ruhl Libre"',
+  ].map((spec) => document.fonts.load(spec).catch(() => null));
+  Promise.all(fontPromises)
+    .then(() => document.fonts.ready)
+    .then(() => setFontsReady(true));
+}
+
+export function DafRenderer(props: DafRendererProps): JSX.Element {
+  const options = createMemo(() => resolveOptions(props.options));
+
+  const layout = createMemo(() => {
+    if (!fontsReady()) return null;
+    return computeLayout(
+      { main: props.main, inner: props.inner, outer: props.outer },
+      options(),
+      props.amud ?? 'a',
+    );
+  });
+
+  createEffect(() => {
+    const result = layout();
+    if (result && props.onLayout) props.onLayout(result);
+  });
+
+  const rootStyle = createMemo<JSX.CSSProperties>(() => {
+    const opts = options();
+    const result = layout();
+    const amudB = props.amud === 'b';
+
+    const sidePercent = ((1 - opts.mainWidth) / 2) * 100;
+    const halfwayPercent = opts.halfway * 100;
+    const remainderPercent = 100 - sidePercent;
+
+    const vars: Record<string, string> = {
+      '--daf-content-width': `${opts.contentWidth}px`,
+      '--daf-side-percent': `${sidePercent}%`,
+      '--daf-halfway-percent': `${halfwayPercent}%`,
+      '--daf-remainder-percent': `${remainderPercent}%`,
+      '--daf-padding-vertical': `${opts.padding.vertical}px`,
+      '--daf-padding-horizontal': `${opts.padding.horizontal}px`,
+      '--daf-font-main': `"${opts.fontFamily.main}"`,
+      '--daf-font-inner': `"${opts.fontFamily.inner}"`,
+      '--daf-font-outer': `"${opts.fontFamily.outer}"`,
+      '--daf-direction': opts.direction,
+      '--daf-font-size-main': `${opts.fontSize.main}px`,
+      '--daf-font-size-side': `${opts.fontSize.side}px`,
+      '--daf-line-height-main': `${opts.lineHeight.main}px`,
+      '--daf-line-height-side': `${opts.lineHeight.side}px`,
+      '--daf-inner-float': amudB ? 'right' : 'left',
+      '--daf-outer-float': amudB ? 'left' : 'right',
+      '--daf-start': `${result?.spacers.start ?? 0}px`,
+      '--daf-inner': `${result?.spacers.inner ?? 0}px`,
+      '--daf-outer': `${result?.spacers.outer ?? 0}px`,
+      '--daf-inner-end': `${result?.spacers.innerEnd ?? 0}px`,
+      '--daf-outer-end': `${result?.spacers.outerEnd ?? 0}px`,
+    };
+
+    // Exception-case start spacer overrides
+    const exc = result?.spacers.exception ?? 0;
+    const halfwayStr = `${halfwayPercent}%`;
+    const halfPad = `${opts.padding.horizontal / 2}px`;
+    const vertGap = `${opts.padding.vertical}px`;
+    if (exc === 1) {
+      // Inner too short → inner gets full-width start (text pushed below),
+      // outer gets zero-width start (text flows at fullwidth in top region).
+      vars['--daf-inner-start-width'] = '100%';
+      vars['--daf-inner-start-pad'] = '0px';
+      vars['--daf-inner-start-gap'] = vertGap;
+      vars['--daf-outer-start-width'] = '0%';
+      vars['--daf-outer-start-pad'] = '0px';
+      vars['--daf-outer-start-gap'] = '0px';
+    } else if (exc === 2) {
+      vars['--daf-outer-start-width'] = '100%';
+      vars['--daf-outer-start-pad'] = '0px';
+      vars['--daf-outer-start-gap'] = vertGap;
+      vars['--daf-inner-start-width'] = '0%';
+      vars['--daf-inner-start-pad'] = '0px';
+      vars['--daf-inner-start-gap'] = '0px';
+    } else {
+      vars['--daf-inner-start-width'] = halfwayStr;
+      vars['--daf-inner-start-pad'] = halfPad;
+      vars['--daf-inner-start-gap'] = '0px';
+      vars['--daf-outer-start-width'] = halfwayStr;
+      vars['--daf-outer-start-pad'] = halfPad;
+      vars['--daf-outer-start-gap'] = '0px';
+    }
+
+    return {
+      ...(vars as JSX.CSSProperties),
+      height: result ? `${result.totalHeight}px` : 'auto',
+    };
+  });
+
+  let rootRef: HTMLDivElement | undefined;
+
+  createEffect(() => {
+    if (!layout() || !rootRef) return;
+    queueMicrotask(() => {
+      if (!rootRef) return;
+      const q = (sel: string) => rootRef!.querySelector(sel) as HTMLElement | null;
+      const h = (el: HTMLElement | null) => el ? Math.round(el.getBoundingClientRect().height) : 0;
+      const spans = {
+        main: h(q('.daf-main .daf-text span')),
+        inner: h(q('.daf-inner .daf-text span')),
+        outer: h(q('.daf-outer .daf-text span')),
+      };
+      const spacers = {
+        'main-start': h(q('.daf-main .daf-start')),
+        'main-inner-mid': h(q('.daf-main .daf-inner-mid')),
+        'main-outer-mid': h(q('.daf-main .daf-outer-mid')),
+        'inner-mid': h(q('.daf-inner .daf-mid')),
+        'outer-mid': h(q('.daf-outer .daf-mid')),
+        'inner-end': h(q('.daf-inner .daf-end')),
+        'outer-end': h(q('.daf-outer .daf-end')),
+      };
+      console.log('[daf-render DOM] spans:', spans, 'spacers:', spacers);
+    });
+  });
+
+  return (
+    <div class="daf-root" style={rootStyle()} ref={rootRef}>
+      <Show when={!fontsReady()}>
+        <div style={{ padding: '1rem', color: '#888', 'font-style': 'italic' }}>
+          Loading fonts…
+        </div>
+      </Show>
+
+      <div class="daf-outer">
+        <div class="daf-spacer daf-start" />
+        <div class="daf-spacer daf-mid" />
+        <div class="daf-spacer daf-end" />
+        <div class="daf-text">
+          <span innerHTML={props.outer} />
+        </div>
+      </div>
+
+      <div class="daf-inner">
+        <div class="daf-spacer daf-start" />
+        <div class="daf-spacer daf-mid" />
+        <div class="daf-spacer daf-end" />
+        <div class="daf-text">
+          <span innerHTML={props.inner} />
+        </div>
+      </div>
+
+      <div class="daf-main">
+        <div class="daf-spacer daf-start" />
+        <div class="daf-spacer daf-inner-mid" />
+        <div class="daf-spacer daf-outer-mid" />
+        <div class="daf-text">
+          <span innerHTML={props.main} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/tanach/src/lib/daf-render/styles.css
+++ b/packages/tanach/src/lib/daf-render/styles.css
@@ -1,0 +1,403 @@
+/* Scoped daf-render styles. All state flows through instance-level CSS vars
+   on the .daf-root element (no global stylesheet mutation). */
+
+.daf-root {
+  position: relative;
+  width: var(--daf-content-width);
+  pointer-events: none;
+  box-sizing: content-box;
+}
+
+.daf-root .daf-outer,
+.daf-root .daf-inner,
+.daf-root .daf-main {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: var(--daf-content-width);
+  pointer-events: none;
+  box-sizing: content-box;
+}
+
+/* Spacer defaults */
+.daf-root .daf-spacer {
+  pointer-events: none;
+}
+
+/* Side columns: spacers default to halfway width, mid takes remainder */
+.daf-root .daf-inner .daf-spacer,
+.daf-root .daf-outer .daf-spacer {
+  width: var(--daf-halfway-percent);
+}
+
+.daf-root .daf-inner .daf-mid,
+.daf-root .daf-outer .daf-mid {
+  width: var(--daf-remainder-percent);
+  clear: both;
+}
+
+/* Inner column floats */
+.daf-root .daf-inner .daf-spacer {
+  float: var(--daf-inner-float);
+}
+.daf-root .daf-main .daf-outer-mid {
+  float: var(--daf-inner-float);
+}
+
+/* Outer column floats */
+.daf-root .daf-outer .daf-spacer {
+  float: var(--daf-outer-float);
+}
+.daf-root .daf-main .daf-inner-mid {
+  float: var(--daf-outer-float);
+}
+
+/* Main column: full-width start spacer, side-width mid spacers */
+.daf-root .daf-main .daf-start {
+  width: var(--daf-content-width);
+}
+.daf-root .daf-main .daf-inner-mid,
+.daf-root .daf-main .daf-outer-mid {
+  width: var(--daf-side-percent);
+}
+
+/* Spacer heights driven by the layout engine */
+.daf-root .daf-start {
+  height: var(--daf-start);
+}
+.daf-root .daf-inner .daf-end {
+  height: var(--daf-inner-end);
+}
+.daf-root .daf-outer .daf-end {
+  height: var(--daf-outer-end);
+}
+.daf-root .daf-inner .daf-mid,
+.daf-root .daf-main .daf-inner-mid {
+  height: var(--daf-inner);
+}
+.daf-root .daf-outer .daf-mid,
+.daf-root .daf-main .daf-outer-mid {
+  height: var(--daf-outer);
+}
+
+/* Horizontal padding between spacers and text */
+.daf-root .daf-main .daf-inner-mid,
+.daf-root .daf-main .daf-outer-mid {
+  margin-left: calc(0.5 * var(--daf-padding-horizontal));
+  margin-right: calc(0.5 * var(--daf-padding-horizontal));
+}
+
+.daf-root .daf-end {
+  margin-left: calc(0.5 * var(--daf-padding-horizontal));
+  margin-right: calc(0.5 * var(--daf-padding-horizontal));
+}
+
+/* Main column start spacer: always full-width block with normal horizontal padding */
+.daf-root .daf-main .daf-start {
+  margin-left: calc(0.5 * var(--daf-padding-horizontal));
+  margin-right: calc(0.5 * var(--daf-padding-horizontal));
+}
+
+/* Side column start spacers: per-column overrides to support exception cases
+   (commentary too short to fill top region). Defaults give the standard
+   halfway-wide floating start. Exception overrides can set width to 0% or
+   100% and toggle the bottom gap via --daf-*-start-gap. */
+.daf-root .daf-inner .daf-start {
+  width: var(--daf-inner-start-width, var(--daf-halfway-percent));
+  margin-left: var(--daf-inner-start-pad, calc(0.5 * var(--daf-padding-horizontal)));
+  margin-right: var(--daf-inner-start-pad, calc(0.5 * var(--daf-padding-horizontal)));
+  margin-bottom: var(--daf-inner-start-gap, 0px);
+}
+
+.daf-root .daf-outer .daf-start {
+  width: var(--daf-outer-start-width, var(--daf-halfway-percent));
+  margin-left: var(--daf-outer-start-pad, calc(0.5 * var(--daf-padding-horizontal)));
+  margin-right: var(--daf-outer-start-pad, calc(0.5 * var(--daf-padding-horizontal)));
+  margin-bottom: var(--daf-outer-start-gap, 0px);
+}
+
+/* Vertical padding */
+.daf-root .daf-mid,
+.daf-root .daf-main .daf-text {
+  margin-top: var(--daf-padding-vertical);
+}
+
+.daf-root .daf-mid,
+.daf-root .daf-main .daf-inner-mid,
+.daf-root .daf-main .daf-outer-mid {
+  margin-bottom: var(--daf-padding-vertical);
+}
+
+/* Text */
+.daf-root .daf-text {
+  direction: var(--daf-direction);
+  text-align: justify;
+  text-align-last: center;
+}
+
+.daf-root .daf-text span {
+  pointer-events: auto;
+}
+
+.daf-root .daf-main .daf-text {
+  font-family: var(--daf-font-main);
+  font-size: var(--daf-font-size-main);
+  line-height: var(--daf-line-height-main);
+}
+
+.daf-root .daf-inner .daf-text,
+.daf-root .daf-outer .daf-text {
+  font-size: var(--daf-font-size-side);
+  line-height: var(--daf-line-height-side);
+}
+
+.daf-root .daf-inner .daf-text {
+  font-family: var(--daf-font-inner);
+}
+
+.daf-root .daf-outer .daf-text {
+  font-family: var(--daf-font-outer);
+}
+
+/* HebrewBooks decorative markup classes preserved in the scraped text.
+   `.gdropcap` wraps the first word of a masechet (daf 2a). Rendered as its
+   own centered block line at ~3x size so the opening word reads as an
+   incipit, matching the tradition of the printed Talmud. Scoped to
+   `.daf-main` so any same-class occurrence in commentary columns is
+   unaffected. Ensured present on 2a by src/client/DafViewer.tsx. */
+.daf-root .daf-main .daf-text .gdropcap {
+  display: block;
+  text-align: center;
+  font-size: 3em;
+  font-weight: bold;
+  line-height: 1.1;
+  margin: 0.1em 0 0.3em;
+}
+.daf-root .daf-text .shastitle7 {
+  font-weight: bold;
+}
+.daf-root .daf-text .five {
+  font-weight: bold;
+}
+
+/* Some Sefaria commentary pieces (e.g. Rashi on Eruvin 102a) embed the printed
+   page's geometric diagrams as inline base64 <img> data URIs. With no rule they
+   render baseline-aligned mid-paragraph, inflating that one line box and
+   stranding its few words in a band of whitespace. Render each as its own
+   centered block, capped to the column width, matching the printed page. */
+.daf-root .daf-text img {
+  display: block;
+  margin: 0.5em auto;
+  max-width: 100%;
+  height: auto;
+}
+
+/* HebrewBooks wraps each Tosafot/commentary section in a block-level div with
+   margin-bottom:3px. We want sections to flow inline (short sections continue
+   on the same line as the next section) rather than each taking its own line,
+   which looks unnatural at wider column widths. */
+.daf-root .daf-text div {
+  display: inline;
+}
+
+/* Invisible anchor markers — measured by GutterIcons to place clickable icons
+   in the right-side gutter alongside the daf. Zero-size, no visual. */
+.daf-root .daf-text .daf-argument-anchor,
+.daf-root .daf-text .daf-halacha-anchor,
+.daf-root .daf-text .daf-aggadata-anchor,
+.daf-root .daf-text .daf-aggadata-end-anchor,
+.daf-root .daf-text .daf-pesuk-anchor,
+.daf-root .daf-text .daf-pesuk-end-anchor,
+.daf-root .daf-text .daf-opinion-anchor {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+}
+
+/* Persistent rabbi highlight — applied to `.rabbi-underline` wraps whose
+   data-rabbi matches the currently-selected rabbi in the sidebar. */
+.daf-root .daf-text .rabbi-underline.rabbi-highlighted {
+  background-color: rgba(234, 179, 8, 0.35);
+  border-radius: 2px;
+}
+
+/* City-name marker — injected by src/client/injectCityMarkers.ts around
+   occurrences of KNOWN_CITIES in the Hebrew text. Faint dotted underline so
+   readers know the span is clickable but it doesn't compete visually with
+   rabbi-generation underlines. `.city-highlighted` turns on when a
+   GeographyMap place-dot for that city is the active selection. */
+.daf-root .daf-text .city-marker {
+  border-bottom: 1px dotted #6b7280;
+  padding-bottom: 0;
+  cursor: pointer;
+}
+.daf-root .daf-text .city-marker > .daf-word {
+  color: inherit;
+}
+.daf-root .daf-text .city-marker.city-highlighted {
+  background-color: rgba(59, 130, 246, 0.28);
+  border-radius: 2px;
+}
+
+/* Range highlights are painted as absolute-positioned overlay divs inside
+   .daf-root, one per line of the highlighted range, sized from merged
+   Range.getClientRects(). This bridges the .daf-word padding gaps and the
+   justification whitespace that the CSS Custom Highlight API leaves unpainted.
+   Client logic lives in src/client/DafViewer.tsx (paintRangeOverlay). */
+.daf-root .daf-range-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  /* Sits on top of text, but with semi-transparent backgrounds so the text
+     reads through like a physical highlighter. */
+}
+.daf-root .daf-range-highlight {
+  position: absolute;
+  pointer-events: none;
+}
+/* Round only the outer corners of a multi-line stack so adjacent bands
+   (which share an edge) don't show notches at the seams. A single-band
+   highlight gets all four corners rounded via both classes. */
+.daf-root .daf-range-highlight-first {
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+}
+.daf-root .daf-range-highlight-last {
+  border-bottom-left-radius: 2px;
+  border-bottom-right-radius: 2px;
+}
+.daf-root .daf-range-highlight-section {
+  background-color: rgba(138, 42, 43, 0.18);
+}
+.daf-root .daf-range-highlight-halacha {
+  background-color: rgba(30, 64, 175, 0.25);
+}
+/* Chart highlight (experimental) — cyan tint matching the chart gutter/sidebar
+   accent (#0e7490), painted over the dense region a comparison table covers. */
+.daf-root .daf-range-highlight-chart {
+  background-color: rgba(14, 116, 144, 0.2);
+}
+.daf-root .daf-range-highlight-aggadata {
+  background-color: rgba(124, 58, 237, 0.22);
+}
+/* Yerushalmi highlight — teal tint matching the yerushalmi gutter/sidebar
+   accent (#0f766e), painted over the Bavli span that has the open Jerusalem
+   Talmud parallel. */
+.daf-root .daf-range-highlight-yerushalmi {
+  background-color: rgba(15, 118, 110, 0.18);
+}
+/* Rishonim highlight — slate tint matching the rishonim gutter/sidebar accent
+   (#475569), distinct from section/halacha/aggadata/pesuk. */
+.daf-root .daf-range-highlight-rishonim {
+  background-color: rgba(71, 85, 105, 0.18);
+}
+/* Pesuk highlight — warm amber/orange tint to match the gutter badge color
+   so a Tanach citation reads as visually distinct from sections (red-brown),
+   halacha (blue), aggadata (violet), and commentary (violet). */
+.daf-root .daf-range-highlight-pesuk {
+  background-color: rgba(217, 119, 6, 0.20);
+}
+/* Argument-move highlight — yellow band painted when the user clicks a
+   subsection card in ArgumentSidebar. Brighter than the section tint so a
+   sub-range reads as a focused selection inside the parent section. */
+.daf-root .daf-range-highlight-move {
+  background-color: rgba(234, 179, 8, 0.30);
+}
+/* Commentary highlight uses violet so it reads distinct from the red-brown
+   section/argument tint and the blue halacha tint already in play. */
+.daf-root .daf-range-highlight-commentary {
+  background-color: rgba(124, 58, 237, 0.16);
+  cursor: pointer;
+}
+.daf-root .daf-range-highlight-commentary-active {
+  background-color: rgba(124, 58, 237, 0.32);
+}
+/* Daf↔commentary anchor — clicking a Rashi/Tosafot piece paints a teal
+   band over the daf seg(s) it glosses. Hue picked to be distinct from
+   the rabbi (red), argument-move (yellow), and commentary (violet) tints
+   that might also be on screen. */
+.daf-root .daf-range-highlight-comm-anchor {
+  background-color: rgba(15, 118, 110, 0.22);
+}
+/* User pieces — personal highlights. Background is set inline per-highlight
+   (paintRangeOverlay's bgFor callback) from the chosen palette color; the
+   static rule owns only layout + the highlighter blend so the daf text reads
+   through. Pointer-events stay off so clicks fall through to the daf word
+   (the click handler opens the note popover by hit-testing coordinates). */
+.daf-root .daf-range-highlight-user {
+  pointer-events: none;
+  mix-blend-mode: multiply;
+}
+/* Era stratification tints — background color is set inline per-segment
+   (paintRangeOverlay's bgFor callback) so the static rule only owns layout
+   behaviour. Pointer-events stay off so clicks fall through to the daf word. */
+.daf-root .daf-range-highlight-era-tint {
+  pointer-events: none;
+  mix-blend-mode: multiply;
+}
+.daf-root .daf-range-highlight-era-hover {
+  pointer-events: none;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
+}
+
+/* Anonymous-tannaitic variant: dashed underline. Signals "Tannaitic but
+   specific generation unknown". The underline color is set inline from the
+   generation spectrum (see injectRabbiUnderlines.ts); this rule only switches
+   the stroke to dashed. */
+.daf-root .daf-text .rabbi-underline-anonymous {
+  border-bottom-style: dashed !important;
+}
+
+/* Rabbi-name underline (generation marker). Injected by
+   src/client/injectRabbiUnderlines.ts. Thin colored underline spanning the
+   rabbi's name; shade indicates generation. */
+.daf-root .daf-text .rabbi-underline {
+  border-bottom: 2px solid currentColor;
+  padding-bottom: 0;
+  color: inherit;
+}
+/* When the header "Underline Rabbis" toggle is off, hide the underline
+   styling while keeping the rabbi spans in the DOM so timeline/map clicks
+   can still paint the yellow .rabbi-highlighted background. */
+.daf-no-rabbi-underlines .daf-root .daf-text .rabbi-underline {
+  border-bottom: none;
+}
+.daf-root .daf-text .rabbi-underline > .daf-word {
+  color: inherit;
+}
+/* Per-generation underline colors are set inline by injectRabbiUnderlines.ts
+   from the computed spectrum in src/client/generations.ts (pre-Geonim = red,
+   Geonim onward = blue, dark earlier -> light later). No per-id rules here. */
+
+/* Chapter-closing formula "הדרן עלך <chapter-name>". Displayed as its own
+   block line at a slightly larger size, centered, with a touch of vertical
+   breathing room so the chapter break reads as visually distinct. */
+.daf-root .daf-text .daf-hadran {
+  display: block;
+  font-size: 1.2em;
+  text-align: center;
+  text-align-last: center;
+  margin: 0.6em 0;
+  font-weight: 600;
+}
+
+/* Per-word click target. Tokenized by src/client/tokenize.ts. */
+.daf-root .daf-text .daf-word {
+  cursor: pointer;
+  padding: 0 1px;
+  border-radius: 2px;
+  transition: background-color 120ms;
+}
+.daf-root .daf-text .daf-word:hover {
+  background-color: rgba(138, 42, 43, 0.12);
+}
+.daf-root .daf-text .daf-word.daf-word-active {
+  background-color: rgba(138, 42, 43, 0.22);
+}
+
+/* Daf↔commentary anchor highlight: both directions now paint the continuous
+   teal range-overlay band (.daf-range-highlight-comm-anchor above) — the main
+   column when a piece is clicked, and the Rashi/Tosafot piece in the
+   inner/outer column when a daf word is clicked. No per-piece CSS outline,
+   which broke into a separate box per wrapped line on multi-line pieces. */

--- a/packages/tanach/src/worker/index.ts
+++ b/packages/tanach/src/worker/index.ts
@@ -9,7 +9,7 @@
  */
 
 import { Hono } from 'hono';
-import { SefariaClient } from '@corpus/core/sefaria/client';
+import { SefariaClient, flattenPieces } from '@corpus/core/sefaria/client';
 import { isBook } from '../lib/books.ts';
 
 interface Env {
@@ -75,6 +75,43 @@ app.get('/api/chapter/:book/:chapter', async (c) => {
     verses,
     next: data.next ?? null,
     prev: data.prev ?? null,
+  });
+});
+
+/** Join a Sefaria he/text payload (nested per-verse arrays) into one continuous
+ *  Hebrew string for daf-renderer's flowing columns. */
+function joinHe(v: unknown): string {
+  return flattenPieces(v).join(' ').trim();
+}
+
+// Mikraot Gedolot: the pasuk text framed by Rashi (inner) + Targum Onkelos
+// (outer), fed to daf-renderer on the client. Hebrew only.
+app.get('/api/mikraot/:book/:chapter', async (c) => {
+  const book = c.req.param('book');
+  const chapter = c.req.param('chapter');
+  if (!isBook(book)) return c.json({ error: `Unknown book: ${book}` }, 400);
+  if (!/^\d+$/.test(chapter)) return c.json({ error: `Bad chapter: ${chapter}` }, 400);
+
+  const main = `${book} ${chapter}`;
+  const [pasuk, rashi, targum] = await Promise.all([
+    sefaria.getText(main).catch(() => null),
+    sefaria.getText(`Rashi on ${main}`).catch(() => null),
+    sefaria.getText(`Onkelos ${main}`).catch(() => null),
+  ]);
+  if (!pasuk || pasuk.error) {
+    return c.json({ error: pasuk?.error ?? 'Sefaria fetch failed' }, 502);
+  }
+
+  return c.json({
+    book,
+    chapter: Number(chapter),
+    ref: pasuk.ref ?? main,
+    heRef: pasuk.heRef ?? '',
+    main: joinHe(pasuk.he),
+    rashi: rashi && !rashi.error ? joinHe(rashi.he) : '',
+    targum: targum && !targum.error ? joinHe(targum.he) : '',
+    next: pasuk.next ?? null,
+    prev: pasuk.prev ?? null,
   });
 });
 


### PR DESCRIPTION
A third reader view — **Mikraot Gedolot** — that renders the classic framed page: the pasuk (panim) in the center, **Rashi wrapping the inner side**, **Targum Onkelos the outer**, laid out by the same tzurat-hadaf engine the Talmud reader uses.

The reader now toggles **Reading / Scroll / Mikraot Gedolot** (URL-persisted).

## How
- **worker** — `GET /api/mikraot/:book/:chapter` fetches the pasuk + `Rashi on …` + `Onkelos …` from Sefaria in parallel and returns each as a joined Hebrew string (via the shared `flattenPieces`).
- **client** — `MikraotGedolot.tsx` feeds `main`/`inner`/`outer` to `<DafRenderer>`.

## Renderer choice
The npm `daf-renderer` package’s options don’t apply in this setup (the daf collapses to 0 width). Talmud’s **own** Solid daf-renderer works and matches the Talmud look, so I used that. For now it is **copied** into `packages/tanach/src/lib/daf-render` (fonts repointed Mekorot → Frank Ruhl Libre).

**Follow-up:** de-dup the copied `daf-render` (and the Sefaria client) into shared `@corpus/core` modules. Noted, not blocking.

## Verified
Genesis 1 renders panim + Rashi + Onkelos wrapped correctly (screenshot confirmed). `pnpm --filter tanach typecheck` + `build` clean. No talmud/core changes.