### PR TITLE
Tanach views: widen Mikraot Gedolot, scroll to two dense columns

### DIFF
--- a/packages/tanach/src/client/MikraotGedolot.tsx
+++ b/packages/tanach/src/client/MikraotGedolot.tsx
@@ -1,4 +1,4 @@
-import { createResource, Show, type JSX } from 'solid-js';
+import { createResource, createSignal, onCleanup, Show, type JSX } from 'solid-js';
 import { DafRenderer } from '../lib/daf-render/index.ts';
 
 interface MG {
@@ -26,8 +26,21 @@ const FAM = 'Frank Ruhl Libre';
 /** The Mikraot Gedolot framed view: the pasuk text (center) wrapped by Rashi
  *  (inner) and Targum Onkelos (outer), laid out by the shared daf-renderer's
  *  tzurat-hadaf engine — the same renderer the Talmud reader uses. */
+/** A wide content width that uses most of the viewport (the Mikraot Gedolot
+ *  page is a broad spread, unlike the Talmud's narrow "sacred" daf). */
+function wideWidth(): number {
+  const vw = typeof window !== 'undefined' ? window.innerWidth : 1280;
+  return Math.min(1500, Math.max(720, vw - 48));
+}
+
 export function MikraotGedolot(props: { book: string; chapter: number }): JSX.Element {
   const [data] = createResource(() => ({ book: props.book, chapter: props.chapter }), fetchMG);
+  const [width, setWidth] = createSignal(wideWidth());
+  const onResize = () => setWidth(wideWidth());
+  if (typeof window !== 'undefined') {
+    window.addEventListener('resize', onResize);
+    onCleanup(() => window.removeEventListener('resize', onResize));
+  }
 
   return (
     <main class="mg-main">
@@ -46,11 +59,11 @@ export function MikraotGedolot(props: { book: string; chapter: number }): JSX.El
                 inner={d().rashi || ' '}
                 outer={d().targum || ' '}
                 options={{
-                  contentWidth: 860,
+                  contentWidth: width(),
                   mainWidth: 0.5,
                   fontFamily: { main: FAM, inner: FAM, outer: FAM },
-                  fontSize: { main: 21, side: 15 },
-                  lineHeight: { main: 30, side: 22 },
+                  fontSize: { main: 22, side: 16 },
+                  lineHeight: { main: 32, side: 23 },
                 }}
               />
             </div>

--- a/packages/tanach/src/client/styles.css
+++ b/packages/tanach/src/client/styles.css
@@ -188,17 +188,16 @@ body {
   padding: 36px 40px 28px;
 }
 .scroll-band {
-  height: 76vh;
+  max-width: 1080px;
+  margin: 0 auto;
   color: var(--stam);
-  font-size: clamp(19px, 1.55vw, 24px);
-  line-height: 1.72;
+  font-size: 16px;
+  line-height: 1.5;
   text-align: justify;
   text-justify: inter-word;
-  columns: 15rem auto;
-  column-gap: 3.4rem;
-  column-fill: auto;
-  overflow-x: auto;
-  overflow-y: hidden;
+  column-count: 2;
+  column-gap: 3rem;
+  column-rule: 1px solid rgba(122, 92, 46, 0.14);
 }
 .scroll-band .parsha-open {
   display: block;


### PR DESCRIPTION
Per feedback:

- **Mikraot Gedolot** —  now tracks the viewport () instead of a fixed 860px, so the framed daf uses the full width with a much larger center (panim) column. Resize-aware.
- **Scroll** — exactly **two columns** at ~16px / 1.5 line-height (the dense, Talmud-main-text feel), instead of the wide auto-column band.

Tanach-client-only. Verified live (both views screenshotted).