### PR TITLE
Rabbi resolution: registry-first + relational homonym disambiguation

### DIFF
--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -89,7 +89,7 @@ import {
 import { wrapEnv, gatewayStatus, gatewayActive } from '@corpus/core/llm/ai-gateway';
 import { runLLM, type LLMModelId, type LLMResult, type LLMUsage, type CostAttribution } from '@corpus/core/llm/llm';
 import { checkBudget, isBudgetPaused, budgetStatus, clearPauses, type BudgetScope } from '@corpus/core/llm/budget';
-import { lookupRelationships, findSlug, slugToName } from './rabbi-graph';
+import { lookupRelationships, slugToName, resolveRabbiSlug } from './rabbi-graph';
 import { runPasses } from '../lib/check/passes';
 import { composeTypeProfile, sectionHasNamedSpeaker, type LayerId, type LayerInstance, type TypeProfile, type UnitRange } from '../lib/typing/profile';
 import { findMarkers } from '../lib/typing/markers';
@@ -978,23 +978,29 @@ async function readSortedSections(env: Bindings, tractate: string, page: string)
 
 // Each argument section's rabbis, in reading order — sourced from the per-section
 // argument.voices enrichment (the only piece that ties a rabbi to a SECTION),
-// then RESOLVED through the rabbi registry: a voice is kept ONLY if its name
-// resolves to a real rabbi (findSlug). This drops anonymous/collective labels
-// ("Stam", "Western sages", "First answer") AND unifies spelling variants
-// ("R. Eliezer" / "Rabbi Eliezer") onto one slug, so tracing is exact. The chip
-// shows the registry's canonical name. Read-only; cold sections get [].
+// then RESOLVED registry-first with relational homonym disambiguation
+// (resolveRabbiSlug). A voice is kept ONLY if it resolves to a real rabbi: this
+// drops anonymous/collective labels ("Stam", "Western sages", "First answer")
+// AND ambiguous homonyms we can't pin from the daf's cast (e.g. which Rav
+// Kahana), and unifies spelling variants onto one canonical slug so tracing is
+// exact. The chip shows the registry's canonical name. Read-only; cold → [].
 interface SectionRabbi { slug: string; name: string }
 async function readSectionRabbis(env: Bindings, tractate: string, page: string): Promise<{ start: number; title: string; rabbis: SectionRabbi[] }[]> {
   const insts = await readMarkInstances(env, 'argument', tractate, page).catch(() => []);
   const voicesDef = findCodeEnrichment('argument.voices');
-  // Generation hint from the daf's rabbi mark (which carries generation, voices
-  // don't): lets findSlug disambiguate short names like "Rabbi Eliezer" →
-  // "Rabbi Eliezer b. Hyrcanus" via its generation, instead of dropping them.
+  // The daf's full rabbi cast (from the rabbi mark): names supply the relational
+  // CONTEXT for homonym disambiguation (the Rav Kahana next to Rav resolves to
+  // the Kahana whose registry edges include Rav), and each carries a generation
+  // hint used only as a last-resort tiebreaker.
+  const coRabbis: string[] = [];
   const genHint = new Map<string, { nameHe?: string; generation?: string }>();
   for (const ri of await readMarkInstances(env, 'rabbi', tractate, page).catch(() => [])) {
     const f = ri.fields ?? {};
-    const nm = typeof f.name === 'string' ? f.name.trim().toLowerCase() : '';
-    if (nm && !genHint.has(nm)) genHint.set(nm, { nameHe: typeof f.nameHe === 'string' ? f.nameHe : undefined, generation: typeof f.generation === 'string' ? f.generation : undefined });
+    const nm = typeof f.name === 'string' ? f.name.trim() : '';
+    if (!nm) continue;
+    if (!coRabbis.includes(nm)) coRabbis.push(nm);
+    const key = nm.toLowerCase();
+    if (!genHint.has(key)) genHint.set(key, { nameHe: typeof f.nameHe === 'string' ? f.nameHe : undefined, generation: typeof f.generation === 'string' ? f.generation : undefined });
   }
   const rows: { start: number; title: string; rabbis: SectionRabbi[] }[] = [];
   for (const inst of insts) {
@@ -1011,8 +1017,13 @@ async function readSectionRabbis(env: Bindings, tractate: string, page: string):
           if (!name) continue;
           const hint = genHint.get(name.toLowerCase());
           const nameHe = (typeof v.nameHe === 'string' ? v.nameHe : undefined) ?? hint?.nameHe;
-          const slug = findSlug(name, nameHe, hint?.generation);
-          if (!slug || seen.has(slug)) continue; // drop unresolved + dupes
+          // Registry-first + relational homonym disambiguation. coRabbis = the
+          // rest of the daf's cast (this voice excluded as context for itself).
+          const { slug } = resolveRabbiSlug(name, nameHe, {
+            coRabbis: coRabbis.filter((n) => n.toLowerCase() !== name.toLowerCase()),
+            generation: hint?.generation,
+          });
+          if (!slug || seen.has(slug)) continue; // drop unresolved/ambiguous + dupes
           seen.add(slug);
           rabbis.push({ slug, name: slugToName(slug) });
         }

--- a/packages/talmud/src/worker/rabbi-graph.ts
+++ b/packages/talmud/src/worker/rabbi-graph.ts
@@ -229,6 +229,89 @@ export function slugToName(slug: string): string {
   return INDEX.slugToCanonical.get(slug) ?? slug.replace(/-/g, ' ');
 }
 
+export function generationOf(slug: string): string | null {
+  return DATA.nodes[slug]?.generation ?? null;
+}
+
+// Every (normalizedCanonical, slug) pair, built once — for enumerating ALL
+// registry nodes a name could refer to (homonym candidate set), not just the
+// first match findSlug returns.
+const NORM_INDEX: { norm: string; slug: string }[] = Object.entries(DATA.nodes)
+  .map(([slug, n]) => ({ norm: normalizeName(n.canonical), slug }));
+
+/** ALL registry nodes a name could denote. For a homonym like "Rav Kahana"
+ *  this returns every Kahana node (Rav Kahana (II), Rav Kahana of Pum Nahara,
+ *  …); for an unambiguous name, one. An alias short-form pins its one canonical
+ *  target (aliases encode the intended default). Empty = not in the registry. */
+export function rabbiCandidates(name: string, nameHe?: string): string[] {
+  const norm = normalizeName(name);
+  if (ALIASES[norm]) return [ALIASES[norm]];
+  const out = new Set<string>();
+  // exact canonical, or canonical that EXTENDS the name at a word boundary
+  // ("rav kahana" → "rav kahana (ii)" / "rav kahana of pum nahara").
+  for (const { norm: c, slug } of NORM_INDEX) {
+    if (c === norm || c.startsWith(norm + ' ')) out.add(slug);
+  }
+  const exact = INDEX.nameToSlug.get(norm); if (exact) out.add(exact);
+  if (nameHe) {
+    const cleanHe = nameHe.replace(/\s*\(\d+\)\s*$/, '').trim();
+    const he = INDEX.heToSlug.get(cleanHe); if (he) out.add(he);
+  }
+  return [...out];
+}
+
+export type ResolveBasis = 'unique' | 'relational' | 'generation' | 'ambiguous' | 'none';
+export interface ResolvedRabbi { slug: string | null; basis: ResolveBasis }
+
+/**
+ * Registry-FIRST rabbi resolution with relational homonym disambiguation.
+ *
+ *  - 0 registry candidates → null ('none'): we don't invent a rabbi.
+ *  - 1 candidate          → it ('unique').
+ *  - >1 (a homonym)       → disambiguate by DAF EVIDENCE: score each candidate
+ *    by how many of the co-occurring rabbis on the daf sit in its registry
+ *    teacher/student/colleague edges, and pick the unique best ('relational').
+ *    e.g. the Rav Kahana who sits next to Rav resolves to the Kahana whose
+ *    edges include Rav. If relational gives no clear winner, fall back to a
+ *    generation match ONLY if it singles out one candidate; otherwise return
+ *    null ('ambiguous') rather than guess. Precision over a confident-wrong id.
+ */
+export function resolveRabbiSlug(
+  name: string,
+  nameHe?: string,
+  opts?: { coRabbis?: readonly string[]; generation?: string },
+): ResolvedRabbi {
+  const cands = rabbiCandidates(name, nameHe);
+  if (cands.length === 0) return { slug: null, basis: 'none' };
+  if (cands.length === 1) return { slug: cands[0], basis: 'unique' };
+
+  const candSet = new Set(cands);
+  const coSlugs = new Set<string>();
+  for (const co of opts?.coRabbis ?? []) {
+    const s = findSlug(co);                       // single best for context names
+    if (s && !candSet.has(s)) coSlugs.add(s);
+  }
+  let best: string | null = null;
+  let bestScore = 0;
+  let tie = false;
+  for (const slug of cands) {
+    const node = DATA.nodes[slug];
+    if (!node) continue;
+    const nbrs = new Set<string>([...(node.teachers ?? []), ...(node.students ?? []), ...(node.colleagues ?? [])]);
+    let score = 0;
+    for (const cs of coSlugs) if (nbrs.has(cs)) score++;
+    if (score > bestScore) { bestScore = score; best = slug; tie = false; }
+    else if (score === bestScore && score > 0) tie = true;
+  }
+  if (best && bestScore > 0 && !tie) return { slug: best, basis: 'relational' };
+
+  if (opts?.generation) {
+    const genMatch = cands.filter((s) => DATA.nodes[s]?.generation === opts.generation);
+    if (genMatch.length === 1) return { slug: genMatch[0], basis: 'generation' };
+  }
+  return { slug: null, basis: 'ambiguous' };
+}
+
 /** Build family entries from the rabbi's name patronymic. The graph
  *  doesn't carry family data; the patronymic is direct nominal evidence
  *  of the parent. */

--- a/packages/talmud/tests/rabbi-resolve.test.ts
+++ b/packages/talmud/tests/rabbi-resolve.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { rabbiCandidates, resolveRabbiSlug, generationOf } from '../src/worker/rabbi-graph';
+import hier from '../src/lib/data/rabbi-hierarchy.json';
+
+// Registry-first rabbi resolution with relational homonym disambiguation.
+// Tests run against the real rabbi-hierarchy registry.
+
+describe('rabbiCandidates', () => {
+  it('returns MULTIPLE candidates for a homonym (Rav Kahana)', () => {
+    const cands = rabbiCandidates('Rav Kahana');
+    expect(cands.length).toBeGreaterThanOrEqual(2);
+    // all are Kahana nodes
+    for (const c of cands) expect(c.toLowerCase()).toContain('kahana');
+  });
+
+  it('returns nothing for a name not in the registry', () => {
+    expect(rabbiCandidates('Xyzzy Not-A-Rabbi')).toEqual([]);
+  });
+});
+
+describe('resolveRabbiSlug — registry-first, precision over a confident-wrong id', () => {
+  it('does NOT guess a homonym with no daf context (the Rav Kahana problem)', () => {
+    const r = resolveRabbiSlug('Rav Kahana');
+    expect(r.slug).toBeNull();
+    expect(r.basis).toBe('ambiguous');
+  });
+
+  it('drops a name absent from the registry', () => {
+    expect(resolveRabbiSlug('Western Sages').slug).toBeNull();
+    expect(resolveRabbiSlug('Western Sages').basis).toBe('none');
+  });
+
+  it('resolves an alias short-form uniquely', () => {
+    const r = resolveRabbiSlug('Reish Lakish');
+    expect(r.basis).toBe('unique');
+    expect(r.slug).toBe('rabbi-shimon-b-lakish');
+  });
+
+  it('uses generation only as a last-resort tiebreaker among candidates', () => {
+    const r = resolveRabbiSlug('Rav Kahana', undefined, { generation: 'amora-bavel-3' });
+    expect(r.basis).toBe('generation');
+    expect(r.slug).toBe('rav-kahana-of-pum-nahara');
+    expect(generationOf(r.slug!)).toBe('amora-bavel-3');
+  });
+
+  it('disambiguates a homonym RELATIONALLY from a co-occurring rabbi (daf evidence)', () => {
+    // Pick a Kahana candidate that has a registry edge, and use that neighbor —
+    // unique to this candidate among the candidates — as the co-occurring rabbi.
+    const cands = rabbiCandidates('Rav Kahana');
+    const nodes = (hier as { nodes: Record<string, { canonical: string; teachers?: string[]; students?: string[]; colleagues?: string[] }> }).nodes;
+    const edgesOf = (slug: string) => new Set([...(nodes[slug]?.teachers ?? []), ...(nodes[slug]?.students ?? []), ...(nodes[slug]?.colleagues ?? [])]);
+    let picked: { cand: string; neighborName: string } | null = null;
+    for (const cand of cands) {
+      const others = cands.filter((c) => c !== cand);
+      for (const nb of edgesOf(cand)) {
+        if (others.some((o) => edgesOf(o).has(nb))) continue; // must discriminate
+        if (!nodes[nb]?.canonical) continue;
+        picked = { cand, neighborName: nodes[nb].canonical };
+        break;
+      }
+      if (picked) break;
+    }
+    // Only assert when the registry actually has a discriminating edge (it does
+    // for Kahana; guard keeps the test honest if the data changes).
+    if (picked) {
+      const r = resolveRabbiSlug('Rav Kahana', undefined, { coRabbis: [picked.neighborName] });
+      expect(r.basis).toBe('relational');
+      expect(r.slug).toBe(picked.cand);
+    }
+  });
+});


### PR DESCRIPTION
Addresses the rabbi-attachment hole (the "5 Rav Kahanas — how did you decide the one on Shabbat 21b is 2nd-gen amora?" problem). The old path fed the rabbi mark's freeform per-daf generation guess into findSlug; for a homonym that's unanchored (Shabbat 21b recorded `amora-bavel-2`, which isn't even a registry Kahana).

New `resolveRabbiSlug` (rabbi-graph.ts):
- **Registry-first**: `rabbiCandidates` enumerates ALL nodes a name could denote. 0 → drop; 1 → unique.
- **Relational homonym disambiguation**: score each candidate by how many co-occurring rabbis on the daf sit in its registry teacher/student/colleague edges; pick the unique best. The Rav Kahana next to Rav resolves to the Kahana whose edges include Rav.
- **No guessing**: generation is only a last-resort tiebreaker; otherwise return `null` ('ambiguous') rather than fabricate — precision over a confident-wrong id.
- Wired into the spine rabbi chips (`readSectionRabbis`), passing the daf's cast as context. Read-time; no cache bump.
- Tests: candidates / no-guess-without-context / alias / generation-tiebreak / relational (against the real registry).

Talmud suite (1928) + typecheck pass. NOTE: this is the reusable resolver; rolling it into the rabbi MARK itself (the daf-reader era color) is the next step. A formal 15-30 daf benchmark before broad rollout is still owed.