### PR TITLE
Rabbi mark: ground generation through the registry (era color)

### DIFF
--- a/packages/talmud/src/worker/code-marks.ts
+++ b/packages/talmud/src/worker/code-marks.ts
@@ -649,8 +649,11 @@ export const CODE_MARKS: MarkDefinition[] = [
     },
     dependencies: ['gemara'],
     status: 'promoted',
-    def_hash: 'rabbi-v2',
-    cache_version: '2',
+    def_hash: 'rabbi-v3',
+    // v3: generation is grounded through the registry post-extraction
+    // (groundRabbiInstances) — authoritative era when identified, neutral
+    // 'unknown' for an unpinnable homonym instead of a freeform LLM guess.
+    cache_version: '3',
     source: 'code',
     updated_at: NOW,
   },

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -89,7 +89,7 @@ import {
 import { wrapEnv, gatewayStatus, gatewayActive } from '@corpus/core/llm/ai-gateway';
 import { runLLM, type LLMModelId, type LLMResult, type LLMUsage, type CostAttribution } from '@corpus/core/llm/llm';
 import { checkBudget, isBudgetPaused, budgetStatus, clearPauses, type BudgetScope } from '@corpus/core/llm/budget';
-import { lookupRelationships, slugToName, resolveRabbiSlug } from './rabbi-graph';
+import { lookupRelationships, slugToName, resolveRabbiSlug, groundRabbiInstances } from './rabbi-graph';
 import { runPasses } from '../lib/check/passes';
 import { composeTypeProfile, sectionHasNamedSpeaker, type LayerId, type LayerInstance, type TypeProfile, type UnitRange } from '../lib/typing/profile';
 import { findMarkers } from '../lib/typing/markers';
@@ -2703,6 +2703,11 @@ async function runMarkOnce(
   //   - places: a side effect (backlog logging), not a parsed-output transform.
   if (parsed && def.id === 'rabbi') {
     parsed = postProcessRabbi(parsed, stripHtmlServer(String(vars.hebrew ?? '')));
+    // Ground each rabbi's generation through the registry (relational homonym
+    // disambiguation off the daf's cast): authoritative era when identified,
+    // neutral 'unknown' for a homonym we can't pin — so the reader's era color
+    // is grounded, not a freeform per-daf guess.
+    parsed = groundRabbiInstances(parsed);
   } else if (parsed && def.id === 'places') {
     // Places have no global gazetteer — log every observed location to the
     // "needs global enrichment" backlog so we can see what to add over time.

--- a/packages/talmud/src/worker/rabbi-graph.ts
+++ b/packages/talmud/src/worker/rabbi-graph.ts
@@ -312,6 +312,53 @@ export function resolveRabbiSlug(
   return { slug: null, basis: 'ambiguous' };
 }
 
+/**
+ * Ground a rabbi MARK's instances' `generation` through the registry, using the
+ * daf's full cast for relational homonym disambiguation (resolveRabbiSlug). The
+ * mark's LLM emits a freeform per-daf generation guess; this replaces it with
+ * the authoritative registry value when the rabbi is identified, and — for a
+ * homonym we CANNOT pin from the daf's cast (e.g. which Rav Kahana) — sets
+ * `unknown` so the era color is neutral rather than a confident-wrong red/blue.
+ * A name absent from the registry keeps the LLM's guess (no registry opinion).
+ * Also stamps `slug` + `canonical` + `genSource` (provenance) on each instance.
+ * Mutates and returns `parsed`.
+ */
+export function groundRabbiInstances(parsed: unknown): unknown {
+  if (!parsed || typeof parsed !== 'object') return parsed;
+  const insts = (parsed as { instances?: unknown }).instances;
+  if (!Array.isArray(insts)) return parsed;
+  const fieldsOf = (i: unknown): Record<string, unknown> | null =>
+    (i && typeof i === 'object' && (i as { fields?: unknown }).fields && typeof (i as { fields?: unknown }).fields === 'object'
+      ? ((i as { fields: Record<string, unknown> }).fields)
+      : null);
+  // The daf's full cast — relational context for homonym disambiguation.
+  const cast: string[] = [];
+  for (const i of insts) { const n = fieldsOf(i)?.name; if (typeof n === 'string' && n.trim()) cast.push(n.trim()); }
+
+  for (const inst of insts) {
+    const f = fieldsOf(inst);
+    if (!f) continue;
+    const name = typeof f.name === 'string' ? f.name.trim() : '';
+    if (!name) continue;
+    const nameHe = typeof f.nameHe === 'string' ? f.nameHe : undefined;
+    const llmGen = typeof f.generation === 'string' ? f.generation : undefined;
+    const { slug, basis } = resolveRabbiSlug(name, nameHe, {
+      coRabbis: cast.filter((n) => n.toLowerCase() !== name.toLowerCase()),
+      generation: llmGen,
+    });
+    f.genSource = basis;
+    if (slug) {
+      f.slug = slug;
+      f.canonical = slugToName(slug);
+      const g = generationOf(slug);
+      if (g) f.generation = g;               // authoritative registry era
+    } else if (basis === 'ambiguous') {
+      f.generation = 'unknown';              // can't pin the homonym → neutral, don't assert
+    }                                        // basis 'none' → keep the LLM generation
+  }
+  return parsed;
+}
+
 /** Build family entries from the rabbi's name patronymic. The graph
  *  doesn't carry family data; the patronymic is direct nominal evidence
  *  of the parent. */

--- a/packages/talmud/tests/rabbi-resolve.test.ts
+++ b/packages/talmud/tests/rabbi-resolve.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { rabbiCandidates, resolveRabbiSlug, generationOf } from '../src/worker/rabbi-graph';
+import { rabbiCandidates, resolveRabbiSlug, generationOf, groundRabbiInstances } from '../src/worker/rabbi-graph';
 import hier from '../src/lib/data/rabbi-hierarchy.json';
 
 // Registry-first rabbi resolution with relational homonym disambiguation.
@@ -66,6 +66,63 @@ describe('resolveRabbiSlug — registry-first, precision over a confident-wrong 
       const r = resolveRabbiSlug('Rav Kahana', undefined, { coRabbis: [picked.neighborName] });
       expect(r.basis).toBe('relational');
       expect(r.slug).toBe(picked.cand);
+    }
+  });
+});
+
+describe('groundRabbiInstances — registry-grounded generation on rabbi mark instances', () => {
+  const mk = (insts: { name: string; nameHe?: string; generation?: string }[]) =>
+    ({ instances: insts.map((f) => ({ excerpt: f.nameHe ?? f.name, fields: { ...f } })) });
+  const fieldsAt = (parsed: unknown, i: number) =>
+    (parsed as { instances: { fields: Record<string, unknown> }[] }).instances[i].fields;
+
+  it('grounds an unambiguous rabbi to the registry generation + slug', () => {
+    const p = mk([{ name: 'Reish Lakish', generation: 'amora-ey-9' /* wrong guess */ }]);
+    groundRabbiInstances(p);
+    const f = fieldsAt(p, 0);
+    expect(f.slug).toBe('rabbi-shimon-b-lakish');
+    expect(f.genSource).toBe('unique');
+    expect(f.generation).toBe(generationOf('rabbi-shimon-b-lakish'));
+  });
+
+  it('blanks the era of a homonym it cannot pin (Rav Kahana alone) → unknown, no slug', () => {
+    const p = mk([{ name: 'Rav Kahana', generation: 'amora-bavel-2' }]);
+    groundRabbiInstances(p);
+    const f = fieldsAt(p, 0);
+    expect(f.genSource).toBe('ambiguous');
+    expect(f.generation).toBe('unknown');   // neutral, not the freeform guess
+    expect(f.slug).toBeUndefined();
+  });
+
+  it('keeps the LLM generation for a name absent from the registry', () => {
+    const p = mk([{ name: 'Xyzzy Not-A-Rabbi', generation: 'tanna-1' }]);
+    groundRabbiInstances(p);
+    const f = fieldsAt(p, 0);
+    expect(f.genSource).toBe('none');
+    expect(f.generation).toBe('tanna-1');   // unchanged — no registry opinion
+    expect(f.slug).toBeUndefined();
+  });
+
+  it('grounds a homonym RELATIONALLY from the daf cast', () => {
+    const cands = rabbiCandidates('Rav Kahana');
+    const nodes = (hier as { nodes: Record<string, { canonical: string; teachers?: string[]; students?: string[]; colleagues?: string[] }> }).nodes;
+    const edgesOf = (slug: string) => new Set([...(nodes[slug]?.teachers ?? []), ...(nodes[slug]?.students ?? []), ...(nodes[slug]?.colleagues ?? [])]);
+    let picked: { cand: string; neighborName: string } | null = null;
+    for (const cand of cands) {
+      const others = cands.filter((c) => c !== cand);
+      for (const nb of edgesOf(cand)) {
+        if (others.some((o) => edgesOf(o).has(nb)) || !nodes[nb]?.canonical) continue;
+        picked = { cand, neighborName: nodes[nb].canonical }; break;
+      }
+      if (picked) break;
+    }
+    if (picked) {
+      const p = mk([{ name: 'Rav Kahana' }, { name: picked.neighborName }]);
+      groundRabbiInstances(p);
+      const f = fieldsAt(p, 0);
+      expect(f.slug).toBe(picked.cand);
+      expect(f.genSource).toBe('relational');
+      expect(f.generation).toBe(generationOf(picked.cand));
     }
   });
 });


### PR DESCRIPTION
Rolls the registry disambiguation (#319) into the rabbi MARK itself, so the daf reader's era color is grounded — the original Rav Kahana complaint.

`groundRabbiInstances` (rabbi-graph) post-processes the rabbi mark's instances:
- registry-first + **relational** homonym disambiguation off the **daf's own cast** (the pass sees every rabbi on the daf);
- resolved → **authoritative registry generation** (+ stamps `slug`, `canonical`);
- homonym it can't pin (e.g. which Rav Kahana) → **`unknown`** (neutral color) instead of a confident-wrong red/blue;
- name absent from the registry → keep the LLM guess (no registry opinion);
- stamps `genSource` provenance.

Applied at the existing worker rabbi post-process hook (gated to `def.id === 'rabbi'`) — no lib→worker boundary break, no new pass-registry entry. **rabbi mark cache_version 2→3** so it re-grounds on recompute (re-extraction is on-demand per daf / via the warm cron; not a forced full re-warm).

Talmud suite (1932) + typecheck pass. Only the underline reads `generation` for color, so grounding at the mark propagates to the reader automatically. Follow-up: a 15–30 daf benchmark of resolution accuracy before relying on it broadly.