### PR TITLE
Tanach reader: scroll-first, Masoretic breaks, Hebrew verse numbers

### DIFF
--- a/packages/tanach/src/client/App.tsx
+++ b/packages/tanach/src/client/App.tsx
@@ -18,7 +18,7 @@ interface Chapter {
   error?: string;
 }
 
-type View = 'reading' | 'scroll' | 'mikraot';
+type View = 'scroll' | 'mikraot';
 
 /** Parse a Sefaria section ref ("Genesis 2", "I Samuel 3") into book + chapter. */
 function parseRef(ref: string): { book: string; chapter: number } | null {
@@ -27,18 +27,57 @@ function parseRef(ref: string): { book: string; chapter: number } | null {
   return { book: m[1], chapter: Number(m[2]) };
 }
 
-/** Drop niqqud + cantillation (te'amim) for the bare-consonant ktav-STAM look.
- *  Maqaf (U+05BE) becomes a space so joined words separate; other points/accents
- *  are removed. Letters (U+05D0–U+05EA) and HTML tags are left intact. */
+/** Drop niqqud + cantillation for the bare ktav-STAM look. Maqaf -> space. */
 function stripNikud(html: string): string {
   return html.replace(/־/g, ' ').replace(/[֑-ֽֿ-ׇ]/g, '');
 }
 
-/** Turn Sefaria's parsha markers into block/inline breaks for the scroll. */
-function renderParshiyot(html: string): string {
-  return html
-    .replace(/\{[פש]\}/g, '<span class="parsha-open"></span>')
-    .replace(/\{ס\}/g, '<span class="parsha-closed"></span>');
+const PETUCHA = '\u0001';
+const SETUMA = '\u0002';
+
+/**
+ * Build the scroll's paragraphs from a chapter's verses, honouring the Masoretic
+ * parsha breaks exactly as a Torah scroll lays them out (Sefaria marks them with
+ * `mam-spi-pe` / `mam-spi-samekh` spans, also matched bare as a fallback):
+ *   - PETUCHA (פ, "open"): the line ends and the next portion starts on a NEW
+ *     line -> a paragraph boundary (justify leaves the last line short, like the
+ *     scroll's blank line-remainder).
+ *   - SETUMA (ס, "closed"): a gap of a few letters WITHIN the line, text
+ *     continuing on the same line -> an inline tab.
+ */
+function buildParagraphs(verses: Verse[], nikud: boolean): string[] {
+  // Verse number as a Hebrew numeral (gematria): 1->א, 15->טו, 16->טז, 119->קיט.
+  const heNum = (n: number): string => {
+    const units = ['', 'א', 'ב', 'ג', 'ד', 'ה', 'ו', 'ז', 'ח', 'ט'];
+    const tens = ['', 'י', 'כ', 'ל', 'מ', 'נ', 'ס', 'ע', 'פ', 'צ'];
+    const hundreds = ['', 'ק', 'ר', 'ש', 'ת'];
+    let h = Math.floor(n / 100);
+    const rem = n % 100;
+    let s = '';
+    while (h > 4) {
+      s += 'ת';
+      h -= 4;
+    }
+    s += hundreds[h];
+    const t = Math.floor(rem / 10);
+    const u = rem % 10;
+    s += t === 1 && (u === 5 || u === 6) ? (u === 5 ? 'טו' : 'טז') : tens[t] + units[u];
+    return s;
+  };
+  let joined = verses.map((v) => `<span class="vnum">${heNum(v.n)}</span> ${v.he}`).join(' ');
+  joined = joined
+    .replace(/(?:&nbsp;|\s)*<span class="mam-spi-pe[^"]*">\{פ\}<\/span>/g, PETUCHA)
+    .replace(/(?:&nbsp;|\s)*<span class="mam-spi-samekh[^"]*">\{ס\}<\/span>/g, SETUMA)
+    .replace(/(?:&nbsp;|\s)*\{פ\}/g, PETUCHA)
+    .replace(/(?:&nbsp;|\s)*\{[סש]\}/g, SETUMA)
+    .replace(/&nbsp;/g, ' ')
+    .replace(new RegExp(SETUMA, 'g'), '<span class="setuma"></span>');
+  let paras = joined
+    .split(PETUCHA)
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (!nikud) paras = paras.map(stripNikud);
+  return paras;
 }
 
 interface Loc {
@@ -52,8 +91,7 @@ function readUrl(): Loc {
   const p = new URLSearchParams(window.location.search);
   const book = p.get('book') ?? 'Genesis';
   const chapter = Number(p.get('chapter') ?? '1') || 1;
-  const vp = p.get('view');
-  const view: View = vp === 'scroll' ? 'scroll' : vp === 'mikraot' ? 'mikraot' : 'reading';
+  const view: View = p.get('view') === 'mikraot' ? 'mikraot' : 'scroll';
   const nikud = p.get('nikud') !== '0';
   return { book: BOOKS.some((b) => b.name === book) ? book : 'Genesis', chapter, view, nikud };
 }
@@ -70,7 +108,7 @@ export function App(): JSX.Element {
 
   const writeUrl = (l: Loc) => {
     const p = new URLSearchParams({ book: l.book, chapter: String(l.chapter) });
-    if (l.view !== 'reading') p.set('view', l.view);
+    if (l.view === 'mikraot') p.set('view', 'mikraot');
     if (!l.nikud) p.set('nikud', '0');
     window.history.pushState(null, '', `?${p.toString()}`);
   };
@@ -81,7 +119,6 @@ export function App(): JSX.Element {
     if (scroll) window.scrollTo(0, 0);
   };
 
-  // Re-fetch only when book/chapter change (view/nikud are render-only).
   const chapterKey = createMemo(() => ({ book: loc().book, chapter: loc().chapter }), undefined, {
     equals: (a, b) => a.book === b.book && a.chapter === b.chapter,
   });
@@ -89,15 +126,11 @@ export function App(): JSX.Element {
 
   window.addEventListener('popstate', () => setLoc(readUrl()));
 
-  const heName = (name: string) => BOOKS.find((b) => b.name === name)?.he ?? name;
   const goto = (book: string, chapter: number) => update({ book, chapter }, true);
 
-  const scrollHtml = createMemo(() => {
+  const paragraphs = createMemo(() => {
     const ch = data();
-    if (!ch) return '';
-    const joined = ch.verses.map((v) => v.he).join(' ');
-    const withParsha = renderParshiyot(joined);
-    return loc().nikud ? withParsha : stripNikud(withParsha);
+    return ch ? buildParagraphs(ch.verses, loc().nikud) : [];
   });
 
   return (
@@ -117,9 +150,6 @@ export function App(): JSX.Element {
         </select>
 
         <div class="view-toggle" role="group" aria-label="View">
-          <button classList={{ active: loc().view === 'reading' }} onClick={() => update({ view: 'reading' })}>
-            Reading
-          </button>
           <button classList={{ active: loc().view === 'scroll' }} onClick={() => update({ view: 'scroll' })}>
             Scroll
           </button>
@@ -148,40 +178,18 @@ export function App(): JSX.Element {
         <p class="status error">{(data.error as Error)?.message}</p>
       </Show>
 
-      {/* Reading view — verses with translation */}
-      <Show when={loc().view === 'reading' && data()}>
-        {(ch) => (
-          <main class="reader">
-            <h1 class="chapter-head">
-              <span class="he" dir="rtl">{heName(loc().book)} {loc().chapter}</span>
-              <span class="en">{loc().book} {loc().chapter}</span>
-            </h1>
-            <ol class="verses">
-              <For each={ch().verses}>
-                {(v) => (
-                  <li class="verse">
-                    <span class="vnum">{v.n}</span>
-                    <span class="he" dir="rtl" innerHTML={v.he} />
-                    <span class="en" innerHTML={v.en} />
-                  </li>
-                )}
-              </For>
-            </ol>
-            <ChapterFoot ch={ch()} goto={goto} />
-          </main>
-        )}
-      </Show>
-
       {/* Mikraot Gedolot — pasuk framed by Rashi + Onkelos (daf-renderer) */}
       <Show when={loc().view === 'mikraot'}>
         <MikraotGedolot book={loc().book} chapter={loc().chapter} />
       </Show>
 
-      {/* Scroll view — Sefer Torah band */}
+      {/* Scroll — Sefer Torah columns with Masoretic parsha breaks */}
       <Show when={loc().view === 'scroll' && data()}>
         {(ch) => (
           <main class="scroll-main">
-            <div class="scroll-band" dir="rtl" innerHTML={scrollHtml()} />
+            <div class="scroll-band" dir="rtl">
+              <For each={paragraphs()}>{(p) => <p class="scroll-para" innerHTML={p} />}</For>
+            </div>
             <div class="scroll-caption">
               <span class="he">{ch().heRef}</span>
               <ChapterFoot ch={ch()} goto={goto} />

--- a/packages/tanach/src/client/MikraotGedolot.tsx
+++ b/packages/tanach/src/client/MikraotGedolot.tsx
@@ -26,11 +26,11 @@ const FAM = 'Frank Ruhl Libre';
 /** The Mikraot Gedolot framed view: the pasuk text (center) wrapped by Rashi
  *  (inner) and Targum Onkelos (outer), laid out by the shared daf-renderer's
  *  tzurat-hadaf engine — the same renderer the Talmud reader uses. */
-/** A wide content width that uses most of the viewport (the Mikraot Gedolot
- *  page is a broad spread, unlike the Talmud's narrow "sacred" daf). */
+/** A wide content width — broad like a Mikraot Gedolot spread, but leaving side
+ *  gutters so a side panel can sit alongside it (like the Talmud reader). */
 function wideWidth(): number {
   const vw = typeof window !== 'undefined' ? window.innerWidth : 1280;
-  return Math.min(1500, Math.max(720, vw - 48));
+  return Math.min(1300, Math.max(680, vw - 240));
 }
 
 export function MikraotGedolot(props: { book: string; chapter: number }): JSX.Element {

--- a/packages/tanach/src/client/styles.css
+++ b/packages/tanach/src/client/styles.css
@@ -128,53 +128,7 @@ body {
   color: #a23;
 }
 
-/* ---- reading view ---- */
-.chapter-head {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 16px;
-  margin: 36px 0 8px;
-  padding-bottom: 12px;
-  border-bottom: 2px solid var(--line);
-}
-.chapter-head .he {
-  font-size: 30px;
-}
-.chapter-head .en {
-  font-size: 16px;
-  color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-}
-.verses {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-.verse {
-  display: grid;
-  grid-template-columns: 28px 1fr;
-  gap: 6px 12px;
-  padding: 14px 0;
-  border-bottom: 1px solid var(--line);
-}
-.verse .vnum {
-  grid-row: span 2;
-  color: var(--accent);
-  font-size: 13px;
-  font-variant-numeric: tabular-nums;
-  padding-top: 6px;
-}
-.verse .he {
-  font-size: 24px;
-  line-height: 1.95;
-  text-align: right;
-}
-.verse .en {
-  font-size: 17px;
-  color: #333;
-}
+/* shared chapter-nav footer (used by the scroll caption) */
 .chapter-foot {
   display: flex;
   justify-content: space-between;
@@ -182,30 +136,35 @@ body {
   margin-top: 32px;
 }
 
-/* ---- scroll (Sefer Torah) view: dense justified columns, no ornament ---- */
+/* ---- scroll (Sefer Torah / tikun): dense justified columns, no ornament.
+   Side gutters leave room for a future side panel (like the Talmud reader). */
 .scroll-main {
-  background: var(--parchment);
-  padding: 36px 40px 28px;
+  padding: 40px clamp(20px, 7vw, 150px) 48px;
 }
 .scroll-band {
-  max-width: 1080px;
+  max-width: 1000px;
   margin: 0 auto;
-  color: var(--stam);
+  color: var(--ink);
   font-size: 16px;
-  line-height: 1.5;
+  line-height: 1.6;
+  column-count: 2;
+  column-gap: 3.2rem;
+  column-rule: 1px solid var(--line);
+}
+/* Each petucha-delimited portion is its own justified paragraph: the last line
+   ends naturally (start-aligned), like the blank line-remainder in a scroll. */
+.scroll-para {
+  margin: 0 0 0.15em;
   text-align: justify;
   text-justify: inter-word;
-  column-count: 2;
-  column-gap: 3rem;
-  column-rule: 1px solid rgba(122, 92, 46, 0.14);
 }
-.scroll-band .parsha-open {
-  display: block;
-  height: 0.85em;
+.scroll-para:last-child {
+  margin-bottom: 0;
 }
-.scroll-band .parsha-closed {
+/* setuma (closed parsha): a tab/gap within the line; text continues after it. */
+.setuma {
   display: inline-block;
-  width: 2.2em;
+  width: 5ch;
 }
 .scroll-band big {
   font-size: 1.4em;
@@ -216,13 +175,14 @@ body {
   vertical-align: super;
 }
 .scroll-caption {
+  max-width: 1000px;
+  margin: 20px auto 0;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  margin-top: 16px;
   padding-top: 14px;
-  border-top: 1px solid rgba(122, 92, 46, 0.2);
+  border-top: 1px solid var(--line);
 }
 .scroll-caption .he {
   font-size: 19px;
@@ -231,8 +191,18 @@ body {
 .scroll-caption .chapter-foot {
   margin-top: 0;
 }
-.scroll-caption .chapter-foot button {
-  background: transparent;
+
+@media (max-width: 768px) {
+  .scroll-main {
+    padding: 28px 18px 40px;
+  }
+  .scroll-band {
+    column-count: 1;
+    max-width: none;
+  }
+  .scroll-caption {
+    max-width: none;
+  }
 }
 
 /* ---- Mikraot Gedolot (daf-renderer) view ---- */
@@ -263,4 +233,14 @@ body {
 .app.view-mikraot {
   max-width: none;
   padding: 0 0 40px;
+}
+
+/* verse numbers in the scroll: small Hebrew numerals (א ב ג …) */
+.scroll-band .vnum {
+  font-size: 0.56em;
+  color: var(--accent);
+  vertical-align: 0.4em;
+  margin: 0 0.08em 0 0.15em;
+  font-weight: 500;
+  unicode-bidi: isolate;
 }

--- a/packages/tanach/src/worker/index.ts
+++ b/packages/tanach/src/worker/index.ts
@@ -79,9 +79,16 @@ app.get('/api/chapter/:book/:chapter', async (c) => {
 });
 
 /** Join a Sefaria he/text payload (nested per-verse arrays) into one continuous
- *  Hebrew string for daf-renderer's flowing columns. */
+ *  Hebrew string for daf-renderer's flowing columns. Parsha markers (petucha/
+ *  setuma spans + braces) are dropped — daf-renderer flows continuously, so a
+ *  literal "{ס}" would otherwise render mid-text. */
 function joinHe(v: unknown): string {
-  return flattenPieces(v).join(' ').trim();
+  return flattenPieces(v)
+    .join(' ')
+    .replace(/<span class="mam-spi-[^"]*">\{[^}]*\}<\/span>/g, '')
+    .replace(/\{[פסש]\}/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .trim();
 }
 
 // Mikraot Gedolot: the pasuk text framed by Rashi (inner) + Targum Onkelos


### PR DESCRIPTION
Per feedback on the reader:

- **Remove the Reading view.** **Scroll is the default** (a tikun-style page); the toggle is just Scroll / Mikraot Gedolot.
- **Scroll** — drop the parchment background; add side gutters (room for a future side panel like the Talmud reader); single column on mobile.
- **Masoretic parsha breaks**, rendered exactly from Sefarias `mam-spi` markers (deep-checked against the raw data):
  - **Petucha (פ)** = paragraph break — the line ends, next portion starts on a new line.
  - **Setuma (ס)** = an inline tab/gap — text continues on the same line. *(So samech is the tab, peh the line break.)*
- **Verse numbers** as small Hebrew numerals (gematria: א ב ג … and correctly טו/טז), accent-coloured, before each verse.
- **Mikraot Gedolot** — cap the width to keep side gutters (panel room); strip the parsha markers from the panim so no literal `{ס}`/`{פ}` renders.

Tanach client + worker only. Verified live in both views (vocalized + bare ktav).