### PR TITLE
Mikraot Gedolot: verse numbers + commentary cross-highlight

### DIFF
--- a/packages/tanach/src/client/App.tsx
+++ b/packages/tanach/src/client/App.tsx
@@ -1,5 +1,6 @@
 import { createMemo, createResource, createSignal, For, Show, type JSX } from 'solid-js';
 import { BOOKS, SECTIONS, type Section } from '../lib/books.ts';
+import { hebrewNumeral } from '../lib/hebrew.ts';
 import { MikraotGedolot } from './MikraotGedolot.tsx';
 
 interface Verse {
@@ -46,25 +47,7 @@ const SETUMA = '\u0002';
  *     continuing on the same line -> an inline tab.
  */
 function buildParagraphs(verses: Verse[], nikud: boolean): string[] {
-  // Verse number as a Hebrew numeral (gematria): 1->א, 15->טו, 16->טז, 119->קיט.
-  const heNum = (n: number): string => {
-    const units = ['', 'א', 'ב', 'ג', 'ד', 'ה', 'ו', 'ז', 'ח', 'ט'];
-    const tens = ['', 'י', 'כ', 'ל', 'מ', 'נ', 'ס', 'ע', 'פ', 'צ'];
-    const hundreds = ['', 'ק', 'ר', 'ש', 'ת'];
-    let h = Math.floor(n / 100);
-    const rem = n % 100;
-    let s = '';
-    while (h > 4) {
-      s += 'ת';
-      h -= 4;
-    }
-    s += hundreds[h];
-    const t = Math.floor(rem / 10);
-    const u = rem % 10;
-    s += t === 1 && (u === 5 || u === 6) ? (u === 5 ? 'טו' : 'טז') : tens[t] + units[u];
-    return s;
-  };
-  let joined = verses.map((v) => `<span class="vnum">${heNum(v.n)}</span> ${v.he}`).join(' ');
+  let joined = verses.map((v) => `<span class="vnum">${hebrewNumeral(v.n)}</span> ${v.he}`).join(' ');
   joined = joined
     .replace(/(?:&nbsp;|\s)*<span class="mam-spi-pe[^"]*">\{פ\}<\/span>/g, PETUCHA)
     .replace(/(?:&nbsp;|\s)*<span class="mam-spi-samekh[^"]*">\{ס\}<\/span>/g, SETUMA)

--- a/packages/tanach/src/client/MikraotGedolot.tsx
+++ b/packages/tanach/src/client/MikraotGedolot.tsx
@@ -1,14 +1,19 @@
-import { createResource, createSignal, onCleanup, Show, type JSX } from 'solid-js';
+import { createMemo, createResource, createSignal, onCleanup, Show, type JSX } from 'solid-js';
 import { DafRenderer } from '../lib/daf-render/index.ts';
+import { hebrewNumeral } from '../lib/hebrew.ts';
 
+interface MGVerse {
+  n: number;
+  pasuk: string;
+  rashi: string;
+  targum: string;
+}
 interface MG {
   book: string;
   chapter: number;
   ref: string;
   heRef: string;
-  main: string;
-  rashi: string;
-  targum: string;
+  verses: MGVerse[];
   next: string | null;
   prev: string | null;
   error?: string;
@@ -21,11 +26,6 @@ async function fetchMG(loc: { book: string; chapter: number }): Promise<MG> {
   return data;
 }
 
-const FAM = 'Frank Ruhl Libre';
-
-/** The Mikraot Gedolot framed view: the pasuk text (center) wrapped by Rashi
- *  (inner) and Targum Onkelos (outer), laid out by the shared daf-renderer's
- *  tzurat-hadaf engine — the same renderer the Talmud reader uses. */
 /** A wide content width — broad like a Mikraot Gedolot spread, but leaving side
  *  gutters so a side panel can sit alongside it (like the Talmud reader). */
 function wideWidth(): number {
@@ -33,6 +33,17 @@ function wideWidth(): number {
   return Math.min(1300, Math.max(680, vw - 240));
 }
 
+const FAM = 'Frank Ruhl Libre';
+
+/** Each verse / commentary piece is tagged with its verse number so hovering one
+ *  cross-highlights the pasuk and its Rashi + Onkelos together (like the daf). */
+function seg(n: number, html: string, lead = ''): string {
+  return `<span class="mg-seg" data-v="${n}">${lead}${html}</span>`;
+}
+
+/** The Mikraot Gedolot framed view: the pasuk (panim, with Hebrew verse numbers)
+ *  in the center, wrapped by Rashi (inner) and Targum Onkelos (outer), laid out
+ *  by the shared daf-renderer — the same engine the Talmud reader uses. */
 export function MikraotGedolot(props: { book: string; chapter: number }): JSX.Element {
   const [data] = createResource(() => ({ book: props.book, chapter: props.chapter }), fetchMG);
   const [width, setWidth] = createSignal(wideWidth());
@@ -41,6 +52,37 @@ export function MikraotGedolot(props: { book: string; chapter: number }): JSX.El
     window.addEventListener('resize', onResize);
     onCleanup(() => window.removeEventListener('resize', onResize));
   }
+
+  const main = createMemo(() => {
+    const d = data();
+    if (!d) return ' ';
+    return d.verses
+      .map((v) => seg(v.n, v.pasuk, `<span class="vnum">${hebrewNumeral(v.n)}</span> `))
+      .join(' ');
+  });
+  const inner = createMemo(() => {
+    const d = data();
+    if (!d) return ' ';
+    return d.verses.filter((v) => v.rashi).map((v) => seg(v.n, v.rashi)).join(' ') || ' ';
+  });
+  const outer = createMemo(() => {
+    const d = data();
+    if (!d) return ' ';
+    return d.verses.filter((v) => v.targum).map((v) => seg(v.n, v.targum)).join(' ') || ' ';
+  });
+
+  let host: HTMLDivElement | undefined;
+  let curV: string | null = null;
+  const highlight = (v: string | null) => {
+    if (v === curV || !host) return;
+    curV = v;
+    host.querySelectorAll('.mg-seg.hl').forEach((el) => el.classList.remove('hl'));
+    if (v) host.querySelectorAll(`.mg-seg[data-v="${v}"]`).forEach((el) => el.classList.add('hl'));
+  };
+  const onOver = (e: MouseEvent) => {
+    const s = (e.target as HTMLElement).closest('.mg-seg');
+    highlight(s ? s.getAttribute('data-v') : null);
+  };
 
   return (
     <main class="mg-main">
@@ -53,11 +95,11 @@ export function MikraotGedolot(props: { book: string; chapter: number }): JSX.El
       <Show when={data()}>
         {(d) => (
           <>
-            <div class="mg-host">
+            <div class="mg-host" ref={host} onMouseOver={onOver} onMouseLeave={() => highlight(null)}>
               <DafRenderer
-                main={d().main}
-                inner={d().rashi || ' '}
-                outer={d().targum || ' '}
+                main={main()}
+                inner={inner()}
+                outer={outer()}
                 options={{
                   contentWidth: width(),
                   mainWidth: 0.5,

--- a/packages/tanach/src/client/styles.css
+++ b/packages/tanach/src/client/styles.css
@@ -244,3 +244,21 @@ body {
   font-weight: 500;
   unicode-bidi: isolate;
 }
+
+/* Mikraot Gedolot: verse numbers in the panim + cross-highlight by verse */
+.mg-host .vnum {
+  font-size: 0.56em;
+  color: var(--accent);
+  vertical-align: 0.4em;
+  margin: 0 0.08em 0 0.15em;
+  font-weight: 500;
+  unicode-bidi: isolate;
+}
+.mg-seg {
+  border-radius: 2px;
+  transition: background-color 0.08s ease;
+}
+.mg-seg.hl {
+  background: rgba(122, 92, 46, 0.18);
+  box-shadow: 0 0 0 2px rgba(122, 92, 46, 0.18);
+}

--- a/packages/tanach/src/lib/hebrew.ts
+++ b/packages/tanach/src/lib/hebrew.ts
@@ -1,0 +1,24 @@
+/** A number as a Hebrew numeral (gematria): 1->א, 15->טו, 16->טז, 21->כא,
+ *  119->קיט. Handles the special 15/16 (טו/טז, not יה/יו) and >100 (Psalms run
+ *  to 176). Used for verse markers in both reader views. */
+export function hebrewNumeral(n: number): string {
+  const units = ['', 'א', 'ב', 'ג', 'ד', 'ה', 'ו', 'ז', 'ח', 'ט'];
+  const tens = ['', 'י', 'כ', 'ל', 'מ', 'נ', 'ס', 'ע', 'פ', 'צ'];
+  const hundreds = ['', 'ק', 'ר', 'ש', 'ת'];
+  let out = '';
+  let h = Math.floor(n / 100);
+  const rem = n % 100;
+  while (h > 4) {
+    out += 'ת';
+    h -= 4;
+  }
+  out += hundreds[h];
+  const t = Math.floor(rem / 10);
+  const u = rem % 10;
+  if (t === 1 && (u === 5 || u === 6)) {
+    out += u === 5 ? 'טו' : 'טז';
+  } else {
+    out += tens[t] + units[u];
+  }
+  return out;
+}

--- a/packages/tanach/src/worker/index.ts
+++ b/packages/tanach/src/worker/index.ts
@@ -99,24 +99,36 @@ app.get('/api/mikraot/:book/:chapter', async (c) => {
   if (!isBook(book)) return c.json({ error: `Unknown book: ${book}` }, 400);
   if (!/^\d+$/.test(chapter)) return c.json({ error: `Bad chapter: ${chapter}` }, 400);
 
-  const main = `${book} ${chapter}`;
+  const ref = `${book} ${chapter}`;
   const [pasuk, rashi, targum] = await Promise.all([
-    sefaria.getText(main).catch(() => null),
-    sefaria.getText(`Rashi on ${main}`).catch(() => null),
-    sefaria.getText(`Onkelos ${main}`).catch(() => null),
+    sefaria.getText(ref).catch(() => null),
+    sefaria.getText(`Rashi on ${ref}`).catch(() => null),
+    sefaria.getText(`Onkelos ${ref}`).catch(() => null),
   ]);
   if (!pasuk || pasuk.error) {
     return c.json({ error: pasuk?.error ?? 'Sefaria fetch failed' }, 502);
   }
 
+  // Per-verse alignment: Sefaria returns he[] indexed by verse for all three
+  // (Rashi he[i] is the array of comments on verse i+1; Onkelos he[i] is the
+  // verse's Targum). Aligning by index lets the client number verses and
+  // cross-highlight the pasuk <-> its Rashi/Onkelos.
+  const pasukHe = Array.isArray(pasuk.he) ? pasuk.he : [pasuk.he];
+  const rashiHe = rashi && !rashi.error && Array.isArray(rashi.he) ? rashi.he : [];
+  const targumHe = targum && !targum.error && Array.isArray(targum.he) ? targum.he : [];
+  const verses = pasukHe.map((p, i) => ({
+    n: i + 1,
+    pasuk: joinHe(p),
+    rashi: joinHe(rashiHe[i]),
+    targum: joinHe(targumHe[i]),
+  }));
+
   return c.json({
     book,
     chapter: Number(chapter),
-    ref: pasuk.ref ?? main,
+    ref: pasuk.ref ?? ref,
     heRef: pasuk.heRef ?? '',
-    main: joinHe(pasuk.he),
-    rashi: rashi && !rashi.error ? joinHe(rashi.he) : '',
-    targum: targum && !targum.error ? joinHe(targum.he) : '',
+    verses,
     next: pasuk.next ?? null,
     prev: pasuk.prev ?? null,
   });


### PR DESCRIPTION
Applies the scroll polish to the framed view and adds daf-style highlighting.

- **Verse numbers** in the panim (shared `hebrewNumeral`, also used by the scroll).
- **Commentary cross-highlight** — `/api/mikraot` returns per-verse aligned rows (`{n, pasuk, rashi, targum}`); each verse/piece is wrapped in `<span class="mg-seg" data-v=N>`, which the daf-renderer preserves (it sets columns via `innerHTML`), so hovering a verse highlights the pasuk + its Rashi + Onkelos together.

Verified live: verse 3 hover highlights pasuk + Onkelos; 31 numerals render.