### PR TITLE
Rabbi resolution: one standardized path for both attach routes + de-cruft

### DIFF
--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -89,7 +89,7 @@ import {
 import { wrapEnv, gatewayStatus, gatewayActive } from '@corpus/core/llm/ai-gateway';
 import { runLLM, type LLMModelId, type LLMResult, type LLMUsage, type CostAttribution } from '@corpus/core/llm/llm';
 import { checkBudget, isBudgetPaused, budgetStatus, clearPauses, type BudgetScope } from '@corpus/core/llm/budget';
-import { lookupRelationships, slugToName, resolveRabbiSlug, groundRabbiInstances } from './rabbi-graph';
+import { lookupRelationships, groundRabbiInstances, groundRabbiNames } from './rabbi-graph';
 import { runPasses } from '../lib/check/passes';
 import { composeTypeProfile, sectionHasNamedSpeaker, type LayerId, type LayerInstance, type TypeProfile, type UnitRange } from '../lib/typing/profile';
 import { findMarkers } from '../lib/typing/markers';
@@ -1011,21 +1011,18 @@ async function readSectionRabbis(env: Bindings, tractate: string, page: string):
       const vhit = await readCachedResult(env, keyForEnrichment(voicesDef, iid, { tractate, page }));
       const voices = (vhit?.parsed as { voices?: { name?: unknown; nameHe?: unknown }[] } | null)?.voices;
       if (Array.isArray(voices)) {
+        // Same registry-first + relational resolver as the direct rabbi mark,
+        // with the daf's cast as relational context (groundRabbiNames). A voice
+        // is kept only if it resolves; the chip shows the canonical name.
+        const items = voices
+          .map((v) => ({ name: typeof v.name === 'string' ? v.name.trim() : '', he: typeof v.nameHe === 'string' ? v.nameHe : undefined }))
+          .filter((v) => v.name)
+          .map((v) => ({ name: v.name, nameHe: v.he ?? genHint.get(v.name.toLowerCase())?.nameHe, generation: genHint.get(v.name.toLowerCase())?.generation }));
         const seen = new Set<string>();
-        for (const v of voices) {
-          const name = typeof v.name === 'string' ? v.name.trim() : '';
-          if (!name) continue;
-          const hint = genHint.get(name.toLowerCase());
-          const nameHe = (typeof v.nameHe === 'string' ? v.nameHe : undefined) ?? hint?.nameHe;
-          // Registry-first + relational homonym disambiguation. coRabbis = the
-          // rest of the daf's cast (this voice excluded as context for itself).
-          const { slug } = resolveRabbiSlug(name, nameHe, {
-            coRabbis: coRabbis.filter((n) => n.toLowerCase() !== name.toLowerCase()),
-            generation: hint?.generation,
-          });
-          if (!slug || seen.has(slug)) continue; // drop unresolved/ambiguous + dupes
-          seen.add(slug);
-          rabbis.push({ slug, name: slugToName(slug) });
+        for (const g of groundRabbiNames(items, coRabbis)) {
+          if (!g.slug || seen.has(g.slug)) continue; // drop unresolved/ambiguous + dupes
+          seen.add(g.slug);
+          rabbis.push({ slug: g.slug, name: g.canonical ?? g.name });
         }
       }
     }

--- a/packages/talmud/src/worker/rabbi-graph.ts
+++ b/packages/talmud/src/worker/rabbi-graph.ts
@@ -188,8 +188,10 @@ function buildIndex(): IndexBuilt {
 const INDEX = buildIndex();
 
 /** Find a node by name (English or Hebrew). When generation is supplied,
- *  prefer the slug whose generation matches. Returns slug or null. */
-export function findSlug(name: string, nameHe?: string, generation?: string): string | null {
+ *  prefer the slug whose generation matches. Returns slug or null. Internal —
+ *  callers use resolveRabbiSlug / groundRabbiNames (registry-first + relational);
+ *  findSlug is the single-best context resolver those build on. */
+function findSlug(name: string, nameHe?: string, generation?: string): string | null {
   // 1. Hand-curated alias table — short-form names like "Reish Lakish".
   const norm = normalizeName(name);
   if (ALIASES[norm]) return ALIASES[norm];
@@ -316,15 +318,48 @@ export function resolveRabbiSlug(
   return { slug: null, basis: 'ambiguous' };
 }
 
+export interface GroundedRabbi {
+  name: string;
+  slug: string | null;
+  canonical: string | null;
+  generation: string | null;
+  genSource: ResolveBasis;
+}
+
 /**
- * Ground a rabbi MARK's instances' `generation` through the registry, using the
- * daf's full cast for relational homonym disambiguation (resolveRabbiSlug). The
- * mark's LLM emits a freeform per-daf generation guess; this replaces it with
- * the authoritative registry value when the rabbi is identified, and — for a
- * homonym we CANNOT pin from the daf's cast (e.g. which Rav Kahana) — sets
- * `unknown` so the era color is neutral rather than a confident-wrong red/blue.
- * A name absent from the registry keeps the LLM's guess (no registry opinion).
- * Also stamps `slug` + `canonical` + `genSource` (provenance) on each instance.
+ * THE one rabbi-resolution entry point, used by BOTH ways rabbis attach to the
+ * text — the direct rabbi mark and the through-arguments voices. Resolves each
+ * name registry-first with relational homonym disambiguation off the combined
+ * cast (the items themselves + any extra co-occurring `context`), and returns a
+ * uniform grounded record:
+ *   - slug/canonical: null when not in the registry ('none') or an unpinnable
+ *     homonym ('ambiguous') — we never invent or confidently-mis-pick a rabbi.
+ *   - generation: the authoritative registry era when resolved; 'unknown' for an
+ *     ambiguous homonym (neutral, not a confident-wrong guess); else the input.
+ *   - genSource: provenance (unique | relational | generation | ambiguous | none).
+ */
+export function groundRabbiNames(
+  items: readonly { name: string; nameHe?: string; generation?: string }[],
+  context: readonly string[] = [],
+): GroundedRabbi[] {
+  const cast = [...items.map((i) => i.name), ...context];
+  return items.map((it) => {
+    const { slug, basis } = resolveRabbiSlug(it.name, it.nameHe, {
+      coRabbis: cast.filter((n) => n.toLowerCase() !== it.name.toLowerCase()),
+      generation: it.generation,
+    });
+    const generation = slug
+      ? (generationOf(slug) ?? it.generation ?? null)
+      : (basis === 'ambiguous' ? 'unknown' : (it.generation ?? null));
+    return { name: it.name, slug, canonical: slug ? slugToName(slug) : null, generation, genSource: basis };
+  });
+}
+
+/**
+ * Ground a rabbi MARK's instances in place via groundRabbiNames (the daf's own
+ * cast is the relational context). Stamps slug + canonical + genSource and
+ * rewrites generation (authoritative registry era, or 'unknown' for an
+ * unpinnable homonym so the era color is neutral, not a confident-wrong guess).
  * Mutates and returns `parsed`.
  */
 export function groundRabbiInstances(parsed: unknown): unknown {
@@ -335,31 +370,21 @@ export function groundRabbiInstances(parsed: unknown): unknown {
     (i && typeof i === 'object' && (i as { fields?: unknown }).fields && typeof (i as { fields?: unknown }).fields === 'object'
       ? ((i as { fields: Record<string, unknown> }).fields)
       : null);
-  // The daf's full cast — relational context for homonym disambiguation.
-  const cast: string[] = [];
-  for (const i of insts) { const n = fieldsOf(i)?.name; if (typeof n === 'string' && n.trim()) cast.push(n.trim()); }
-
+  const targets: { f: Record<string, unknown>; item: { name: string; nameHe?: string; generation?: string } }[] = [];
   for (const inst of insts) {
     const f = fieldsOf(inst);
     if (!f) continue;
     const name = typeof f.name === 'string' ? f.name.trim() : '';
     if (!name) continue;
-    const nameHe = typeof f.nameHe === 'string' ? f.nameHe : undefined;
-    const llmGen = typeof f.generation === 'string' ? f.generation : undefined;
-    const { slug, basis } = resolveRabbiSlug(name, nameHe, {
-      coRabbis: cast.filter((n) => n.toLowerCase() !== name.toLowerCase()),
-      generation: llmGen,
-    });
-    f.genSource = basis;
-    if (slug) {
-      f.slug = slug;
-      f.canonical = slugToName(slug);
-      const g = generationOf(slug);
-      if (g) f.generation = g;               // authoritative registry era
-    } else if (basis === 'ambiguous') {
-      f.generation = 'unknown';              // can't pin the homonym → neutral, don't assert
-    }                                        // basis 'none' → keep the LLM generation
+    targets.push({ f, item: { name, nameHe: typeof f.nameHe === 'string' ? f.nameHe : undefined, generation: typeof f.generation === 'string' ? f.generation : undefined } });
   }
+  const grounded = groundRabbiNames(targets.map((t) => t.item));
+  grounded.forEach((g, i) => {
+    const f = targets[i].f;
+    f.genSource = g.genSource;
+    if (g.slug) { f.slug = g.slug; f.canonical = g.canonical; }
+    if (g.generation) f.generation = g.generation;
+  });
   return parsed;
 }
 

--- a/packages/talmud/tests/rabbi-resolve.test.ts
+++ b/packages/talmud/tests/rabbi-resolve.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { rabbiCandidates, resolveRabbiSlug, generationOf, groundRabbiInstances } from '../src/worker/rabbi-graph';
+import { rabbiCandidates, resolveRabbiSlug, generationOf, groundRabbiInstances, groundRabbiNames } from '../src/worker/rabbi-graph';
 import hier from '../src/lib/data/rabbi-hierarchy.json';
 
 // Registry-first rabbi resolution with relational homonym disambiguation.
@@ -124,5 +124,25 @@ describe('groundRabbiInstances — registry-grounded generation on rabbi mark in
       expect(f.genSource).toBe('relational');
       expect(f.generation).toBe(generationOf(picked.cand));
     }
+  });
+});
+
+describe('groundRabbiNames — the shared entry point for both attach paths', () => {
+  it('resolves a batch against its own cast + extra context, uniform records', () => {
+    // Rav Kahana + Rav in the batch → relational pin; an alias → unique; a
+    // non-registry name → none. One call, the contract both paths rely on.
+    const out = groundRabbiNames(
+      [{ name: 'Rav Kahana' }, { name: 'Reish Lakish' }, { name: 'Totally Made Up' }],
+      ['Rav'], // extra co-occurring context (e.g. the daf's rabbi-mark cast)
+    );
+    const byName = Object.fromEntries(out.map((g) => [g.name, g]));
+    expect(byName['Reish Lakish'].slug).toBe('rabbi-shimon-b-lakish');
+    expect(byName['Reish Lakish'].genSource).toBe('unique');
+    expect(byName['Totally Made Up'].slug).toBeNull();
+    expect(byName['Totally Made Up'].genSource).toBe('none');
+    // Rav Kahana resolves relationally off "Rav" in the context (his registry edge).
+    expect(byName['Rav Kahana'].genSource).toBe('relational');
+    expect(byName['Rav Kahana'].slug).toContain('kahana');
+    expect(byName['Rav Kahana'].generation).toBe(generationOf(byName['Rav Kahana'].slug!));
   });
 });


### PR DESCRIPTION
Rabbis attach to the text two ways — **directly** (the rabbi mark) and **through the arguments** (voices → spine chips). Both already resolved through the registry, but each re-implemented cast-gathering + the resolve loop and they diverged in what they stamped.

**Standardized on one entry point** — `groundRabbiNames(items, context)` (rabbi-graph): registry-first + relational homonym disambiguation off the combined cast, returning a uniform grounded record (`slug` / `canonical` / registry-`generation` / `genSource`).
- `groundRabbiInstances` (direct mark) refactored onto it.
- `readSectionRabbis` (voices/spine) refactored onto it — drops its duplicate cast-assembly + per-voice resolve loop; now also benefits from the same context handling.

**Cruft removed:** `findSlug` de-exported (internal-only now — callers use `resolveRabbiSlug`/`groundRabbiNames`); `resolveRabbiSlug` + `slugToName` dropped from `index.ts` imports.

Behavior-preserving for the rabbi mark (no cache bump). 1938 tests pass; added a `groundRabbiNames` contract test.