### PR TITLE
First producer: event anchors in the margin + usage page

### DIFF
--- a/packages/tanach/index.html
+++ b/packages/tanach/index.html
@@ -7,7 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Frank+Ruhl+Libre:wght@400;500;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Frank+Ruhl+Libre:wght@400;500;700&family=Noto+Serif+Hebrew:wght@400;500;600&display=swap"
       rel="stylesheet"
     />
   </head>

--- a/packages/tanach/src/client/App.tsx
+++ b/packages/tanach/src/client/App.tsx
@@ -1,4 +1,14 @@
-import { createMemo, createResource, createSignal, For, Show, type JSX } from 'solid-js';
+import {
+  createEffect,
+  createMemo,
+  createResource,
+  createSignal,
+  For,
+  onCleanup,
+  onMount,
+  Show,
+  type JSX,
+} from 'solid-js';
 import { BOOKS, SECTIONS, type Section } from '../lib/books.ts';
 import { hebrewNumeral } from '../lib/hebrew.ts';
 import { MikraotGedolot } from './MikraotGedolot.tsx';
@@ -46,8 +56,21 @@ const SETUMA = '\u0002';
  *   - SETUMA (ס, "closed"): a gap of a few letters WITHIN the line, text
  *     continuing on the same line -> an inline tab.
  */
-function buildParagraphs(verses: Verse[], nikud: boolean): string[] {
-  let joined = verses.map((v) => `<span class="vnum">${hebrewNumeral(v.n)}</span> ${v.he}`).join(' ');
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function buildParagraphs(verses: Verse[], nikud: boolean, labels?: Map<number, string>): string[] {
+  let joined = verses
+    .map((v) => {
+      const label = labels?.get(v.n);
+      // A section-start verse number doubles as the margin anchor's measurable
+      // point (.evt-pt); the label itself is positioned in the margin by App.
+      const cls = label ? 'vnum evt-pt' : 'vnum';
+      const attrs = label ? ` data-v="${v.n}" data-label="${escapeHtml(label)}"` : '';
+      return `<span class="${cls}"${attrs}>${hebrewNumeral(v.n)}</span> ${v.he}`;
+    })
+    .join(' ');
   joined = joined
     .replace(/(?:&nbsp;|\s)*<span class="mam-spi-pe[^"]*">\{פ\}<\/span>/g, PETUCHA)
     .replace(/(?:&nbsp;|\s)*<span class="mam-spi-samekh[^"]*">\{ס\}<\/span>/g, SETUMA)
@@ -86,6 +109,22 @@ async function fetchChapter(loc: { book: string; chapter: number }): Promise<Cha
   return data;
 }
 
+interface EventSection {
+  verse: number;
+  label: string;
+}
+/** The event/section labels for a chapter (first producer). Best-effort: a
+ *  failure just means no margin anchors — the text still renders. */
+async function fetchEvents(loc: { book: string; chapter: number }): Promise<EventSection[]> {
+  try {
+    const res = await fetch(`/api/events/${encodeURIComponent(loc.book)}/${loc.chapter}`);
+    const data = (await res.json()) as { sections?: EventSection[] };
+    return res.ok && Array.isArray(data.sections) ? data.sections : [];
+  } catch {
+    return [];
+  }
+}
+
 export function App(): JSX.Element {
   const [loc, setLoc] = createSignal(readUrl());
 
@@ -106,6 +145,7 @@ export function App(): JSX.Element {
     equals: (a, b) => a.book === b.book && a.chapter === b.chapter,
   });
   const [data] = createResource(chapterKey, fetchChapter);
+  const [events] = createResource(chapterKey, fetchEvents);
 
   window.addEventListener('popstate', () => setLoc(readUrl()));
 
@@ -113,7 +153,49 @@ export function App(): JSX.Element {
 
   const paragraphs = createMemo(() => {
     const ch = data();
-    return ch ? buildParagraphs(ch.verses, loc().nikud) : [];
+    if (!ch) return [];
+    const labels = new Map((events() ?? []).map((s) => [s.verse, s.label] as const));
+    return buildParagraphs(ch.verses, loc().nikud, labels);
+  });
+
+  // Margin anchors: measure each section-start verse number (.evt-pt) and pin its
+  // event label in the outer margin at that vertical position, on whichever side
+  // its column faces. Re-measured on reflow (resize / font load / nikud toggle).
+  let scrollMain: HTMLElement | undefined;
+  let scrollBand: HTMLElement | undefined;
+  const [anchors, setAnchors] = createSignal<{ v: string; label: string; top: number; side: 'left' | 'right' }[]>([]);
+  const [reflow, setReflow] = createSignal(0);
+
+  const measure = () => {
+    if (loc().view !== 'scroll' || !scrollMain || !scrollBand) {
+      setAnchors([]);
+      return;
+    }
+    const m = scrollMain.getBoundingClientRect();
+    const out: { v: string; label: string; top: number; side: 'left' | 'right' }[] = [];
+    scrollBand.querySelectorAll<HTMLElement>('.evt-pt').forEach((pt) => {
+      const r = pt.getBoundingClientRect();
+      if (!r.height) return;
+      const side: 'left' | 'right' = r.left + r.width / 2 - m.left < m.width / 2 ? 'left' : 'right';
+      out.push({ v: pt.dataset.v ?? '', label: pt.dataset.label ?? '', top: r.top - m.top, side });
+    });
+    setAnchors(out);
+  };
+
+  onMount(() => {
+    const bump = () => setReflow((n) => n + 1);
+    window.addEventListener('resize', bump);
+    document.fonts?.ready.then(bump);
+    onCleanup(() => window.removeEventListener('resize', bump));
+  });
+
+  createEffect(() => {
+    // dependencies that change the layout of .evt-pt points
+    paragraphs();
+    reflow();
+    loc().view;
+    loc().nikud;
+    requestAnimationFrame(() => requestAnimationFrame(measure));
   });
 
   return (
@@ -147,6 +229,8 @@ export function App(): JSX.Element {
           </button>
         </Show>
 
+        <a class="usage-link" href="/usage" title="LLM usage">usage</a>
+
         <div class="chapter-nav">
           <button disabled={loc().chapter <= 1} onClick={() => goto(loc().book, loc().chapter - 1)}>‹</button>
           <span class="chapter-label">ch. {loc().chapter}</span>
@@ -169,10 +253,23 @@ export function App(): JSX.Element {
       {/* Scroll — Sefer Torah columns with Masoretic parsha breaks */}
       <Show when={loc().view === 'scroll' && data()}>
         {(ch) => (
-          <main class="scroll-main">
-            <div class="scroll-band" dir="rtl">
+          <main class="scroll-main" ref={(el) => (scrollMain = el)}>
+            <div class="scroll-band" dir="rtl" ref={(el) => (scrollBand = el)}>
               <For each={paragraphs()}>{(p) => <p class="scroll-para" innerHTML={p} />}</For>
             </div>
+            <For each={anchors()}>
+              {(a) => (
+                <button
+                  class="evt-margin"
+                  classList={{ 'evt-left': a.side === 'left', 'evt-right': a.side === 'right' }}
+                  style={{ top: `${a.top}px` }}
+                  data-v={a.v}
+                  title={`${a.label} (verse ${a.v})`}
+                >
+                  {a.label}
+                </button>
+              )}
+            </For>
             <div class="scroll-caption">
               <span class="he">{ch().heRef}</span>
               <ChapterFoot ch={ch()} goto={goto} />

--- a/packages/tanach/src/client/MikraotGedolot.tsx
+++ b/packages/tanach/src/client/MikraotGedolot.tsx
@@ -33,7 +33,10 @@ function wideWidth(): number {
   return Math.min(1300, Math.max(680, vw - 240));
 }
 
-const FAM = 'Frank Ruhl Libre';
+// Panim (main biblical text) gets a more formal serif; the commentaries keep
+// Frank Ruhl Libre so the central column reads distinct from the margins.
+const MAIN_FAM = 'Noto Serif Hebrew';
+const SIDE_FAM = 'Frank Ruhl Libre';
 
 /** Each verse / commentary piece is tagged with its verse number so hovering one
  *  cross-highlights the pasuk and its Rashi + Onkelos together (like the daf). */
@@ -103,7 +106,7 @@ export function MikraotGedolot(props: { book: string; chapter: number }): JSX.El
                 options={{
                   contentWidth: width(),
                   mainWidth: 0.5,
-                  fontFamily: { main: FAM, inner: FAM, outer: FAM },
+                  fontFamily: { main: MAIN_FAM, inner: SIDE_FAM, outer: SIDE_FAM },
                   fontSize: { main: 22, side: 16 },
                   lineHeight: { main: 32, side: 23 },
                 }}

--- a/packages/tanach/src/client/UsagePage.tsx
+++ b/packages/tanach/src/client/UsagePage.tsx
@@ -1,0 +1,93 @@
+import { createResource, For, Show, type JSX } from 'solid-js';
+
+interface UsageEntry {
+  ts: number;
+  ref: string;
+  producer: string;
+  model: string;
+  in: number;
+  out: number;
+  cost: number | null;
+}
+interface UsageSummary {
+  calls: number;
+  inTokens: number;
+  outTokens: number;
+  costUsd: number;
+  byProducer: Record<string, { calls: number; costUsd: number }>;
+  recent: UsageEntry[];
+}
+
+async function fetchUsage(): Promise<UsageSummary> {
+  const res = await fetch('/api/usage');
+  return (await res.json()) as UsageSummary;
+}
+
+const usd = (n: number) => `$${(n ?? 0).toFixed(4)}`;
+const num = (n: number) => (n ?? 0).toLocaleString();
+const when = (ts: number) => new Date(ts).toLocaleString();
+const model = (m: string) => m.replace(/^openrouter\//, '');
+
+/** Self-tracked LLM usage for the Tanach producers (from the KV ledger at
+ *  /api/usage). Independent of the AI Gateway. */
+export function UsagePage(): JSX.Element {
+  const [u] = createResource(fetchUsage);
+
+  return (
+    <div class="usage">
+      <header class="usage-top">
+        <a class="usage-back" href="/">‹ Tanach</a>
+        <h1>LLM Usage</h1>
+      </header>
+
+      <Show when={u.loading}>
+        <p class="status">Loading…</p>
+      </Show>
+
+      <Show when={u()}>
+        {(d) => (
+          <>
+            <div class="usage-cards">
+              <div class="usage-card"><span class="k">Cost</span><span class="v">{usd(d().costUsd)}</span></div>
+              <div class="usage-card"><span class="k">Calls</span><span class="v">{num(d().calls)}</span></div>
+              <div class="usage-card"><span class="k">Tokens in</span><span class="v">{num(d().inTokens)}</span></div>
+              <div class="usage-card"><span class="k">Tokens out</span><span class="v">{num(d().outTokens)}</span></div>
+            </div>
+
+            <h2>By producer</h2>
+            <table class="usage-table">
+              <thead><tr><th>Producer</th><th>Calls</th><th>Cost</th></tr></thead>
+              <tbody>
+                <For each={Object.entries(d().byProducer)} fallback={<tr><td colspan="3" class="muted">no calls yet</td></tr>}>
+                  {([name, p]) => (
+                    <tr><td>{name}</td><td>{num(p.calls)}</td><td>{usd(p.costUsd)}</td></tr>
+                  )}
+                </For>
+              </tbody>
+            </table>
+
+            <h2>Recent calls</h2>
+            <table class="usage-table">
+              <thead><tr><th>When</th><th>Ref</th><th>Producer</th><th>Model</th><th>In</th><th>Out</th><th>Cost</th></tr></thead>
+              <tbody>
+                <For each={d().recent} fallback={<tr><td colspan="7" class="muted">no calls yet</td></tr>}>
+                  {(e) => (
+                    <tr>
+                      <td class="muted">{when(e.ts)}</td>
+                      <td>{e.ref}</td>
+                      <td>{e.producer}</td>
+                      <td class="muted">{model(e.model)}</td>
+                      <td>{num(e.in)}</td>
+                      <td>{num(e.out)}</td>
+                      <td>{e.cost == null ? '—' : usd(e.cost)}</td>
+                    </tr>
+                  )}
+                </For>
+              </tbody>
+            </table>
+          </>
+        )}
+      </Show>
+    </div>
+  );
+}

--- a/packages/tanach/src/client/main.tsx
+++ b/packages/tanach/src/client/main.tsx
@@ -1,6 +1,8 @@
 import { render } from 'solid-js/web';
 import { App } from './App.tsx';
+import { UsagePage } from './UsagePage.tsx';
 import './styles.css';
 
 const root = document.getElementById('root');
-if (root) render(() => <App />, root);
+const isUsage = window.location.pathname.replace(/\/+$/, '') === '/usage';
+if (root) render(() => (isUsage ? <UsagePage /> : <App />), root);

--- a/packages/tanach/src/client/styles.css
+++ b/packages/tanach/src/client/styles.css
@@ -139,7 +139,8 @@ body {
 /* ---- scroll (Sefer Torah / tikun): dense justified columns, no ornament.
    Side gutters leave room for a future side panel (like the Talmud reader). */
 .scroll-main {
-  padding: 40px clamp(20px, 7vw, 150px) 48px;
+  position: relative;
+  padding: 40px clamp(20px, 11vw, 200px) 48px;
 }
 .scroll-band {
   max-width: 1000px;
@@ -262,3 +263,57 @@ body {
   background: rgba(122, 92, 46, 0.18);
   box-shadow: 0 0 0 2px rgba(122, 92, 46, 0.18);
 }
+
+/* event anchors: short section labels from the events producer, set as small
+   margin headings before the verse where each unit begins. */
+/* event anchors pinned in the outer margin, aligned to the section-start verse.
+   These are the interactive attachment points for future enrichments. */
+.evt-margin {
+  position: absolute;
+  width: clamp(78px, 9vw, 150px);
+  margin-top: -0.35em;
+  padding: 5px 7px 0;
+  font: 600 11px/1.3 'Frank Ruhl Libre', Georgia, serif;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--accent);
+  background: none;
+  border: 0;
+  border-top: 1px solid var(--accent);
+  cursor: pointer;
+  unicode-bidi: isolate;
+}
+.evt-margin.evt-right { right: clamp(8px, 1.5vw, 40px); text-align: right; }
+.evt-margin.evt-left { left: clamp(8px, 1.5vw, 40px); text-align: left; }
+.evt-margin:hover { color: var(--ink); border-top-color: var(--ink); }
+@media (max-width: 820px) {
+  .evt-margin { display: none; }
+}
+
+/* usage link + page */
+.usage-link {
+  font-size: 13px;
+  color: var(--muted);
+  text-decoration: none;
+  border-bottom: 1px dotted var(--line);
+}
+.usage-link:hover { color: var(--accent); }
+
+.usage {
+  max-width: 920px;
+  margin: 0 auto;
+  padding: 28px 28px 80px;
+}
+.usage-top { display: flex; align-items: baseline; gap: 16px; }
+.usage-back { color: var(--muted); text-decoration: none; font-size: 14px; }
+.usage-back:hover { color: var(--accent); }
+.usage h1 { font-size: 24px; margin: 0; }
+.usage h2 { font-size: 13px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted); margin-top: 34px; }
+.usage-cards { display: flex; gap: 14px; flex-wrap: wrap; margin-top: 18px; }
+.usage-card { border: 1px solid var(--line); border-radius: 8px; padding: 14px 22px; min-width: 130px; }
+.usage-card .k { display: block; font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; }
+.usage-card .v { display: block; font-size: 25px; font-weight: 600; color: var(--ink); margin-top: 4px; font-variant-numeric: tabular-nums; }
+.usage-table { width: 100%; border-collapse: collapse; font-size: 14px; margin-top: 8px; }
+.usage-table th { text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--muted); border-bottom: 2px solid var(--line); padding: 7px 10px; }
+.usage-table td { padding: 7px 10px; border-bottom: 1px solid var(--line); font-variant-numeric: tabular-nums; }
+.usage-table .muted { color: var(--muted); }

--- a/packages/tanach/src/worker/index.ts
+++ b/packages/tanach/src/worker/index.ts
@@ -10,10 +10,14 @@
 
 import { Hono } from 'hono';
 import { SefariaClient, flattenPieces } from '@corpus/core/sefaria/client';
+import type { LLMEnv } from '@corpus/core/llm/llm';
 import { isBook } from '../lib/books.ts';
+import { eventSections } from './producers/events.ts';
+import { readUsage, recordUsage } from './usage.ts';
 
-interface Env {
+interface Env extends LLMEnv {
   ASSETS: Fetcher;
+  CACHE: KVNamespace;
 }
 
 const sefaria = new SefariaClient();
@@ -133,6 +137,65 @@ app.get('/api/mikraot/:book/:chapter', async (c) => {
     prev: pasuk.prev ?? null,
   });
 });
+
+// Events anchor (first producer): short margin labels for a chapter's natural
+// narrative units ("Day One", "The Burning Bush"), pinned to the verse where
+// each begins. Cached per chapter in KV; computed once via the LLM.
+app.get('/api/events/:book/:chapter', async (c) => {
+  const book = c.req.param('book');
+  const chapter = c.req.param('chapter');
+  if (!isBook(book)) return c.json({ error: `Unknown book: ${book}` }, 400);
+  if (!/^\d+$/.test(chapter)) return c.json({ error: `Bad chapter: ${chapter}` }, 400);
+
+  const key = `events:v1:${book}:${chapter}`;
+  const cached = await c.env.CACHE.get(key);
+  if (cached) return c.json(JSON.parse(cached));
+
+  const ref = `${book} ${chapter}`;
+  let text: Awaited<ReturnType<SefariaClient['getText']>>;
+  try {
+    text = await sefaria.getText(ref);
+  } catch (e) {
+    return c.json({ error: `Sefaria fetch failed: ${(e as Error).message}` }, 502);
+  }
+  if (text.error) return c.json({ error: text.error }, 404);
+
+  const he = asVerses(text.he);
+  const en = asVerses(text.text);
+  const verses = Array.from({ length: Math.max(he.length, en.length) }, (_, i) => ({
+    n: i + 1,
+    he: he[i] ?? '',
+    en: en[i] ?? '',
+  }));
+
+  let result: Awaited<ReturnType<typeof eventSections>>;
+  try {
+    result = await eventSections(c.env, ref, verses);
+  } catch (e) {
+    return c.json({ error: `Producer failed: ${(e as Error).message}` }, 502);
+  }
+
+  const payload = { book, chapter: Number(chapter), ref, sections: result.sections };
+  // Persist the result + a usage entry (best-effort; never block the response).
+  c.executionCtx.waitUntil(
+    Promise.all([
+      c.env.CACHE.put(key, JSON.stringify(payload)),
+      recordUsage(c.env.CACHE, {
+        ts: Date.now(),
+        ref,
+        producer: 'events',
+        model: result.model,
+        in: result.inTokens,
+        out: result.outTokens,
+        cost: result.costUsd,
+      }),
+    ]).then(() => undefined),
+  );
+  return c.json(payload);
+});
+
+// Self-tracked LLM usage (totals + per-producer + recent calls).
+app.get('/api/usage', async (c) => c.json(await readUsage(c.env.CACHE)));
 
 // Everything else: serve the built SPA (static assets + index.html fallback).
 app.get('*', (c) => c.env.ASSETS.fetch(c.req.raw));

--- a/packages/tanach/src/worker/producers/events.ts
+++ b/packages/tanach/src/worker/producers/events.ts
@@ -1,0 +1,119 @@
+/**
+ * The "events" anchor producer — the first Tanach smart-note.
+ *
+ * Given a chapter, an LLM identifies its natural narrative units (a scene, a
+ * speech, a day of creation, a journey leg, a law) and returns a SHORT plain
+ * label for each, pinned to the verse where it begins. The reader renders these
+ * as small margin anchors beside the text ("Day One", "The Burning Bush", "The
+ * Spies Return"). Plain p'shat only — no interpretation, no midrash.
+ *
+ * This is a mark in the framework sense: it identifies WHERE things are. The
+ * anchor is an exact verse (Sefaria gives us that), so there is no placement
+ * risk — only the labelling is the model's job.
+ */
+
+import { runLLM, type LLMEnv } from '@corpus/core/llm/llm';
+import { costUsd } from '@corpus/core/llm/pricing';
+
+export interface EventSection {
+  /** 1-based verse number where this unit begins. */
+  verse: number;
+  /** Short plain-English label, 1-4 words. */
+  label: string;
+}
+
+export interface EventsResult {
+  sections: EventSection[];
+  model: string;
+  costUsd: number | null;
+  inTokens: number;
+  outTokens: number;
+}
+
+const SYSTEM = [
+  'You divide a chapter of the Hebrew Bible into its natural narrative units and',
+  'give each a short, plain English label.',
+  '',
+  'A unit is where a distinct thing begins: a new scene, a speech, a day of',
+  'creation, a leg of a journey, a law, a genealogy, a song. A chapter usually',
+  'has between 1 and 8 of them — do NOT label every verse.',
+  '',
+  'Rules:',
+  '- Label = 1 to 4 words, plain and concrete ("Day One", "The Burning Bush",',
+  '  "The Spies Return", "Laws of the Sabbath"). No sentences.',
+  '- Strictly p\'shat: describe what plainly happens. No interpretation, no',
+  '  midrash, no theology, no commentary.',
+  '- "verse" is the verse number where the unit begins (the first unit is',
+  '  almost always verse 1).',
+  '- Return them in order. Use English for the label.',
+].join('\n');
+
+const SCHEMA = {
+  name: 'event_sections',
+  strict: true,
+  schema: {
+    type: 'object',
+    additionalProperties: false,
+    required: ['sections'],
+    properties: {
+      sections: {
+        type: 'array',
+        items: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['verse', 'label'],
+          properties: {
+            verse: { type: 'integer', minimum: 1 },
+            label: { type: 'string' },
+          },
+        },
+      },
+    },
+  },
+};
+
+/** Render the chapter's verses as a compact numbered English+Hebrew prompt. */
+export function versesForPrompt(verses: { n: number; en: string; he: string }[]): string {
+  return verses
+    .map((v) => `${v.n}. ${(v.en || '').replace(/<[^>]+>/g, '').trim()}`)
+    .join('\n');
+}
+
+export async function eventSections(
+  env: LLMEnv,
+  ref: string,
+  verses: { n: number; en: string; he: string }[],
+): Promise<EventsResult> {
+  const maxVerse = verses.length;
+  const res = await runLLM(env, {
+    messages: [
+      { role: 'system', content: SYSTEM },
+      { role: 'user', content: `Chapter: ${ref} (${maxVerse} verses)\n\n${versesForPrompt(verses)}` },
+    ],
+    max_tokens: 700,
+    temperature: 0.2,
+    response_format: { type: 'json_schema', json_schema: SCHEMA },
+    tag: 'tanach:events',
+  });
+
+  let sections: EventSection[] = [];
+  try {
+    const parsed = JSON.parse(res.content) as { sections?: EventSection[] };
+    sections = (parsed.sections ?? [])
+      .filter((s) => Number.isInteger(s.verse) && s.verse >= 1 && s.verse <= maxVerse && s.label)
+      .map((s) => ({ verse: s.verse, label: String(s.label).trim().slice(0, 40) }))
+      .sort((a, b) => a.verse - b.verse);
+  } catch {
+    sections = [];
+  }
+
+  const inTokens = res.usage?.prompt_tokens ?? 0;
+  const outTokens = res.usage?.completion_tokens ?? 0;
+  return {
+    sections,
+    model: res.model,
+    costUsd: costUsd(res.model, res.usage),
+    inTokens,
+    outTokens,
+  };
+}

--- a/packages/tanach/src/worker/usage.ts
+++ b/packages/tanach/src/worker/usage.ts
@@ -1,0 +1,58 @@
+/**
+ * Self-tracked LLM usage ledger (KV). Every producer call appends an entry and
+ * bumps the running totals, so /api/usage can show spend broken down by
+ * producer without depending on the AI Gateway's analytics. One KV key holds a
+ * compact summary + the most recent calls.
+ */
+
+export interface UsageEntry {
+  ts: number;
+  ref: string;
+  producer: string;
+  model: string;
+  in: number;
+  out: number;
+  cost: number | null;
+}
+
+export interface UsageSummary {
+  calls: number;
+  inTokens: number;
+  outTokens: number;
+  costUsd: number;
+  byProducer: Record<string, { calls: number; costUsd: number }>;
+  recent: UsageEntry[];
+}
+
+const KEY = 'usage:v1';
+const RECENT_CAP = 100;
+
+function empty(): UsageSummary {
+  return { calls: 0, inTokens: 0, outTokens: 0, costUsd: 0, byProducer: {}, recent: [] };
+}
+
+export async function readUsage(cache: KVNamespace): Promise<UsageSummary> {
+  const raw = await cache.get(KEY);
+  if (raw) {
+    try {
+      return { ...empty(), ...(JSON.parse(raw) as UsageSummary) };
+    } catch {
+      /* fall through */
+    }
+  }
+  return empty();
+}
+
+export async function recordUsage(cache: KVNamespace, e: UsageEntry): Promise<void> {
+  const s = await readUsage(cache);
+  s.calls += 1;
+  s.inTokens += e.in;
+  s.outTokens += e.out;
+  s.costUsd += e.cost ?? 0;
+  const p = (s.byProducer[e.producer] ??= { calls: 0, costUsd: 0 });
+  p.calls += 1;
+  p.costUsd += e.cost ?? 0;
+  s.recent.unshift(e);
+  s.recent = s.recent.slice(0, RECENT_CAP);
+  await cache.put(KEY, JSON.stringify(s));
+}

--- a/packages/tanach/wrangler.toml
+++ b/packages/tanach/wrangler.toml
@@ -18,17 +18,27 @@ not_found_handling = "single-page-application"
 [observability]
 enabled = true
 
-# --- Provisioning TODO (later, when AI cards land) ---
-# The v1 reader fetches Sefaria live and uses no KV/LLM. When the producers
-# arrive, add:
-#
-# [[kv_namespaces]]            # `wrangler kv namespace create tanach-cache`
-# binding = "CACHE"
-# id = "<fill-in>"
-#
-# [vars]                       # create the `tanach` AI Gateway in the dashboard
-# AI_GATEWAY_ID = "tanach"
-# DEFAULT_LLM_MODEL = "openrouter/deepseek/deepseek-v4-pro"
-#
-# [[queues.producers]] / [[queues.consumers]]  queue = "enrichment-jobs-tanach"
-# secrets: OPENROUTER_API_KEY, STUDIO_SECRET  (`wrangler secret put …`)
+# Result cache for the producers (event labels, later synthesis/context). The
+# reader's Sefaria fetches stay un-cached for now; this is the AI-output store.
+[[kv_namespaces]]
+binding = "CACHE"
+id = "2d3ee093681441c58cf7e9f08420acc7"
+
+[vars]
+# OpenRouter calls route through a Cloudflare AI Gateway (the only path in
+# @corpus/core). We reuse the existing `talmud` gateway for now — creating a
+# dedicated `tanach` gateway needs a token with AI-Gateway scope (the MCP token
+# is KV-only). Swap to AI_GATEWAY_ID = "tanach" once it exists. Usage is tracked
+# in our own KV ledger (/api/usage), independent of the gateway.
+AI_GATEWAY_ID = "talmud"
+# Needed to build the AI Gateway URL. Not secret (it's the account id).
+CLOUDFLARE_ACCOUNT_ID = "ddf8edfc3dfd489567fe3c5b28b51aca"
+# Cheap + fast default for the producers (short structured output).
+DEFAULT_LLM_MODEL = "openrouter/deepseek/deepseek-v4-flash"
+OPENROUTER_GATEWAY_PROVIDER = "openrouter"
+# Spend caps enforced at the runLLM chokepoint (@corpus/core/llm/budget).
+DAILY_BUDGET_USD = "20"
+HOURLY_CUSTOM_BUDGET_USD = "5"
+
+# Secret (set with `wrangler secret put OPENROUTER_API_KEY`; locally via
+# packages/tanach/.dev.vars): OPENROUTER_API_KEY.


### PR DESCRIPTION
The Tanach app first AI smart-note — a **mark** that finds a chapter natural narrative units and pins a short label in the **margin** at the verse where each begins. These are real, clickable anchor points (future enrichments attach here).

- **producers/events.ts** — an LLM pass returns `{verse,label}[]` (plain p`shat units, exact-verse anchored, no placement risk). ~$0.0002/chapter on deepseek-v4-flash; cached per chapter in KV.
- **worker** — `GET /api/events/:book/:chapter` (KV-cached) + `GET /api/usage`; each call records a self-tracked usage entry (tokens + cost per producer).
- **client** — margin anchors measured from each section-start verse number, positioned in the outer margin (side chosen by column), clickable; re-measured on reflow. A `/usage` page shows totals + per-producer + recent calls.
- **infra** — KV namespace for producer output; OpenRouter via the existing `talmud` gateway (MCP token is KV-only, so a dedicated `tanach` gateway is pending — one-line swap when it exists). MG panim now Noto Serif Hebrew.

Verified live locally: Genesis 1 -> 8 sections, anchors on correct sides, /usage shows the call + cost. Prod secret uploaded.