### PR TITLE
Tanach: subtle margin anchors, EN/HE toggle, parsha button

### DIFF
--- a/packages/tanach/src/client/App.tsx
+++ b/packages/tanach/src/client/App.tsx
@@ -91,6 +91,7 @@ interface Loc {
   chapter: number;
   view: View;
   nikud: boolean;
+  lang: 'en' | 'he';
 }
 
 function readUrl(): Loc {
@@ -99,7 +100,8 @@ function readUrl(): Loc {
   const chapter = Number(p.get('chapter') ?? '1') || 1;
   const view: View = p.get('view') === 'mikraot' ? 'mikraot' : 'scroll';
   const nikud = p.get('nikud') !== '0';
-  return { book: BOOKS.some((b) => b.name === book) ? book : 'Genesis', chapter, view, nikud };
+  const lang: 'en' | 'he' = p.get('lang') === 'he' ? 'he' : 'en';
+  return { book: BOOKS.some((b) => b.name === book) ? book : 'Genesis', chapter, view, nikud, lang };
 }
 
 async function fetchChapter(loc: { book: string; chapter: number }): Promise<Chapter> {
@@ -111,7 +113,23 @@ async function fetchChapter(loc: { book: string; chapter: number }): Promise<Cha
 
 interface EventSection {
   verse: number;
-  label: string;
+  en: string;
+  he: string;
+}
+interface Parsha {
+  name: string;
+  heName: string;
+  ref: string;
+  book: string;
+  chapter: number;
+}
+async function fetchParsha(): Promise<Parsha | null> {
+  try {
+    const res = await fetch('/api/parsha');
+    return res.ok ? ((await res.json()) as Parsha) : null;
+  } catch {
+    return null;
+  }
 }
 /** The event/section labels for a chapter (first producer). Best-effort: a
  *  failure just means no margin anchors — the text still renders. */
@@ -132,6 +150,7 @@ export function App(): JSX.Element {
     const p = new URLSearchParams({ book: l.book, chapter: String(l.chapter) });
     if (l.view === 'mikraot') p.set('view', 'mikraot');
     if (!l.nikud) p.set('nikud', '0');
+    if (l.lang === 'he') p.set('lang', 'he');
     window.history.pushState(null, '', `?${p.toString()}`);
   };
   const update = (patch: Partial<Loc>, scroll = false) => {
@@ -146,6 +165,7 @@ export function App(): JSX.Element {
   });
   const [data] = createResource(chapterKey, fetchChapter);
   const [events] = createResource(chapterKey, fetchEvents);
+  const [parsha] = createResource(fetchParsha);
 
   window.addEventListener('popstate', () => setLoc(readUrl()));
 
@@ -154,7 +174,10 @@ export function App(): JSX.Element {
   const paragraphs = createMemo(() => {
     const ch = data();
     if (!ch) return [];
-    const labels = new Map((events() ?? []).map((s) => [s.verse, s.label] as const));
+    const he = loc().lang === 'he';
+    const labels = new Map(
+      (events() ?? []).map((s) => [s.verse, (he ? s.he : s.en) || s.en || s.he] as const),
+    );
     return buildParagraphs(ch.verses, loc().nikud, labels);
   });
 
@@ -214,6 +237,18 @@ export function App(): JSX.Element {
           </For>
         </select>
 
+        <Show when={parsha()}>
+          {(p) => (
+            <button
+              class="parsha-btn"
+              onClick={() => goto(p().book, p().chapter)}
+              title={`This week's parsha — ${p().name} (${p().ref})`}
+            >
+              {loc().lang === 'he' ? p().heName || p().name : p().name}
+            </button>
+          )}
+        </Show>
+
         <div class="view-toggle" role="group" aria-label="View">
           <button classList={{ active: loc().view === 'scroll' }} onClick={() => update({ view: 'scroll' })}>
             Scroll
@@ -228,6 +263,11 @@ export function App(): JSX.Element {
             {loc().nikud ? 'נִקּוּד' : 'נקוד'}
           </button>
         </Show>
+
+        <div class="lang-toggle" role="group" aria-label="Language">
+          <button classList={{ active: loc().lang === 'en' }} onClick={() => update({ lang: 'en' })}>EN</button>
+          <button classList={{ active: loc().lang === 'he' }} onClick={() => update({ lang: 'he' })}>עב</button>
+        </div>
 
         <a class="usage-link" href="/usage" title="LLM usage">usage</a>
 

--- a/packages/tanach/src/client/styles.css
+++ b/packages/tanach/src/client/styles.css
@@ -270,22 +270,23 @@ body {
    These are the interactive attachment points for future enrichments. */
 .evt-margin {
   position: absolute;
-  width: clamp(78px, 9vw, 150px);
-  margin-top: -0.35em;
-  padding: 5px 7px 0;
-  font: 600 11px/1.3 'Frank Ruhl Libre', Georgia, serif;
+  width: clamp(74px, 8vw, 140px);
+  margin-top: -0.3em;
+  padding: 4px 6px 0;
+  font: 500 9px/1.35 'Frank Ruhl Libre', Georgia, serif;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--accent);
+  letter-spacing: 0.02em;
+  color: rgba(122, 92, 46, 0.62);
   background: none;
   border: 0;
-  border-top: 1px solid var(--accent);
+  border-top: 1px solid rgba(122, 92, 46, 0.22);
   cursor: pointer;
   unicode-bidi: isolate;
+  transition: color 0.1s ease;
 }
-.evt-margin.evt-right { right: clamp(8px, 1.5vw, 40px); text-align: right; }
-.evt-margin.evt-left { left: clamp(8px, 1.5vw, 40px); text-align: left; }
-.evt-margin:hover { color: var(--ink); border-top-color: var(--ink); }
+.evt-margin.evt-right { right: clamp(6px, 1.4vw, 36px); text-align: right; }
+.evt-margin.evt-left { left: clamp(6px, 1.4vw, 36px); text-align: left; }
+.evt-margin:hover { color: var(--accent); border-top-color: var(--accent); }
 @media (max-width: 820px) {
   .evt-margin { display: none; }
 }
@@ -317,3 +318,34 @@ body {
 .usage-table th { text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--muted); border-bottom: 2px solid var(--line); padding: 7px 10px; }
 .usage-table td { padding: 7px 10px; border-bottom: 1px solid var(--line); font-variant-numeric: tabular-nums; }
 .usage-table .muted { color: var(--muted); }
+
+
+/* this-week's-parsha button + EN/HE language toggle (like the Talmud reader) */
+.parsha-btn {
+  font-family: inherit;
+  font-size: 14px;
+  padding: 5px 12px;
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  background: none;
+  color: var(--accent);
+  cursor: pointer;
+  white-space: nowrap;
+}
+.parsha-btn:hover { background: var(--accent); color: #fff; }
+.lang-toggle {
+  display: inline-flex;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  overflow: hidden;
+}
+.lang-toggle button {
+  font-family: inherit;
+  font-size: 13px;
+  padding: 5px 10px;
+  border: 0;
+  background: #fff;
+  color: var(--muted);
+  cursor: pointer;
+}
+.lang-toggle button.active { background: var(--accent); color: #fff; }

--- a/packages/tanach/src/worker/index.ts
+++ b/packages/tanach/src/worker/index.ts
@@ -147,7 +147,7 @@ app.get('/api/events/:book/:chapter', async (c) => {
   if (!isBook(book)) return c.json({ error: `Unknown book: ${book}` }, 400);
   if (!/^\d+$/.test(chapter)) return c.json({ error: `Bad chapter: ${chapter}` }, 400);
 
-  const key = `events:v1:${book}:${chapter}`;
+  const key = `events:v2:${book}:${chapter}`;
   const cached = await c.env.CACHE.get(key);
   if (cached) return c.json(JSON.parse(cached));
 
@@ -191,6 +191,37 @@ app.get('/api/events/:book/:chapter', async (c) => {
       }),
     ]).then(() => undefined),
   );
+  return c.json(payload);
+});
+
+// This week's Torah portion (parashat hashavua), from Sefaria's calendar.
+// Returns the parsha name + the book/chapter it starts at, so the reader can
+// jump straight there. Cached ~6h (it only changes on Shabbat).
+app.get('/api/parsha', async (c) => {
+  const cacheKey = 'parsha:current';
+  const cached = await c.env.CACHE.get(cacheKey);
+  if (cached) return c.json(JSON.parse(cached));
+
+  let cal: { calendar_items?: Array<{ title?: { en?: string }; displayValue?: { en?: string; he?: string }; ref?: string }> };
+  try {
+    const r = await fetch('https://www.sefaria.org/api/calendars');
+    cal = (await r.json()) as typeof cal;
+  } catch (e) {
+    return c.json({ error: `Calendar fetch failed: ${(e as Error).message}` }, 502);
+  }
+  const parsha = (cal.calendar_items ?? []).find((it) => it?.title?.en === 'Parashat Hashavua');
+  const m = parsha?.ref?.match(/^(.+?)\s+(\d+):/);
+  if (!parsha || !m || !isBook(m[1])) {
+    return c.json({ error: `No addressable parsha (ref: ${parsha?.ref ?? 'none'})` }, 502);
+  }
+  const payload = {
+    name: parsha.displayValue?.en ?? parsha.title?.en ?? 'Parsha',
+    heName: parsha.displayValue?.he ?? '',
+    ref: parsha.ref,
+    book: m[1],
+    chapter: Number(m[2]),
+  };
+  c.executionCtx.waitUntil(c.env.CACHE.put(cacheKey, JSON.stringify(payload), { expirationTtl: 6 * 3600 }));
   return c.json(payload);
 });
 

--- a/packages/tanach/src/worker/producers/events.ts
+++ b/packages/tanach/src/worker/producers/events.ts
@@ -2,10 +2,10 @@
  * The "events" anchor producer — the first Tanach smart-note.
  *
  * Given a chapter, an LLM identifies its natural narrative units (a scene, a
- * speech, a day of creation, a journey leg, a law) and returns a SHORT plain
- * label for each, pinned to the verse where it begins. The reader renders these
- * as small margin anchors beside the text ("Day One", "The Burning Bush", "The
- * Spies Return"). Plain p'shat only — no interpretation, no midrash.
+ * speech, a day of creation, a journey leg, a law) and returns a SHORT label in
+ * both English and Hebrew, pinned to the verse where it begins. The reader
+ * renders these as small margin anchors beside the text ("Day One" / "יום
+ * ראשון", "The Burning Bush" / "הסנה הבוער"). Plain p'shat only — no midrash.
  *
  * This is a mark in the framework sense: it identifies WHERE things are. The
  * anchor is an exact verse (Sefaria gives us that), so there is no placement
@@ -18,8 +18,10 @@ import { costUsd } from '@corpus/core/llm/pricing';
 export interface EventSection {
   /** 1-based verse number where this unit begins. */
   verse: number;
-  /** Short plain-English label, 1-4 words. */
-  label: string;
+  /** Short plain English label, 1-4 words. */
+  en: string;
+  /** Short plain Hebrew label, 1-4 words. */
+  he: string;
 }
 
 export interface EventsResult {
@@ -32,20 +34,21 @@ export interface EventsResult {
 
 const SYSTEM = [
   'You divide a chapter of the Hebrew Bible into its natural narrative units and',
-  'give each a short, plain English label.',
+  'give each a short label in BOTH English and Hebrew.',
   '',
   'A unit is where a distinct thing begins: a new scene, a speech, a day of',
   'creation, a leg of a journey, a law, a genealogy, a song. A chapter usually',
   'has between 1 and 8 of them — do NOT label every verse.',
   '',
   'Rules:',
-  '- Label = 1 to 4 words, plain and concrete ("Day One", "The Burning Bush",',
-  '  "The Spies Return", "Laws of the Sabbath"). No sentences.',
-  '- Strictly p\'shat: describe what plainly happens. No interpretation, no',
+  '- "en" and "he" are each 1 to 4 words, plain and concrete ("Day One" / "יום',
+  '  ראשון", "The Burning Bush" / "הסנה הבוער"). No sentences.',
+  '- The Hebrew label is natural Hebrew, not a transliteration of the English.',
+  "- Strictly p'shat: describe what plainly happens. No interpretation, no",
   '  midrash, no theology, no commentary.',
   '- "verse" is the verse number where the unit begins (the first unit is',
   '  almost always verse 1).',
-  '- Return them in order. Use English for the label.',
+  '- Return them in order.',
 ].join('\n');
 
 const SCHEMA = {
@@ -61,10 +64,11 @@ const SCHEMA = {
         items: {
           type: 'object',
           additionalProperties: false,
-          required: ['verse', 'label'],
+          required: ['verse', 'en', 'he'],
           properties: {
             verse: { type: 'integer', minimum: 1 },
-            label: { type: 'string' },
+            en: { type: 'string' },
+            he: { type: 'string' },
           },
         },
       },
@@ -72,11 +76,9 @@ const SCHEMA = {
   },
 };
 
-/** Render the chapter's verses as a compact numbered English+Hebrew prompt. */
+/** Render the chapter's verses as a compact numbered English prompt. */
 export function versesForPrompt(verses: { n: number; en: string; he: string }[]): string {
-  return verses
-    .map((v) => `${v.n}. ${(v.en || '').replace(/<[^>]+>/g, '').trim()}`)
-    .join('\n');
+  return verses.map((v) => `${v.n}. ${(v.en || '').replace(/<[^>]+>/g, '').trim()}`).join('\n');
 }
 
 export async function eventSections(
@@ -90,7 +92,7 @@ export async function eventSections(
       { role: 'system', content: SYSTEM },
       { role: 'user', content: `Chapter: ${ref} (${maxVerse} verses)\n\n${versesForPrompt(verses)}` },
     ],
-    max_tokens: 700,
+    max_tokens: 900,
     temperature: 0.2,
     response_format: { type: 'json_schema', json_schema: SCHEMA },
     tag: 'tanach:events',
@@ -100,20 +102,24 @@ export async function eventSections(
   try {
     const parsed = JSON.parse(res.content) as { sections?: EventSection[] };
     sections = (parsed.sections ?? [])
-      .filter((s) => Number.isInteger(s.verse) && s.verse >= 1 && s.verse <= maxVerse && s.label)
-      .map((s) => ({ verse: s.verse, label: String(s.label).trim().slice(0, 40) }))
+      .filter(
+        (s) => Number.isInteger(s.verse) && s.verse >= 1 && s.verse <= maxVerse && (s.en || s.he),
+      )
+      .map((s) => ({
+        verse: s.verse,
+        en: String(s.en ?? '').trim().slice(0, 40),
+        he: String(s.he ?? '').trim().slice(0, 40),
+      }))
       .sort((a, b) => a.verse - b.verse);
   } catch {
     sections = [];
   }
 
-  const inTokens = res.usage?.prompt_tokens ?? 0;
-  const outTokens = res.usage?.completion_tokens ?? 0;
   return {
     sections,
     model: res.model,
     costUsd: costUsd(res.model, res.usage),
-    inTokens,
-    outTokens,
+    inTokens: res.usage?.prompt_tokens ?? 0,
+    outTokens: res.usage?.completion_tokens ?? 0,
   };
 }


### PR DESCRIPTION
Three reader tweaks:

- **Subtler margin anchors** — smaller, lighter; and the events producer now returns **both** an English and Hebrew label per section (cache bumped `events:v1`->`v2`).
- **EN/עב toggle** in the top bar (like the Talmud reader), URL-persisted (`?lang=he`). Switches the anchor labels and the parsha name.
- **This weeks parsha button** — `GET /api/parsha` reads Sefarias calendar (Parashat Hashavua) -> portion name + starting book/chapter (cached ~6h); the button jumps straight there.

Verified locally: Shlach -> Numbers 13; Genesis 1 anchors switch en<->he.