### PR TITLE
Tanach: section-note popover, responsive columns, Spectral font, Hebrew nav, IL/diaspora parsha

### DIFF
--- a/packages/tanach/index.html
+++ b/packages/tanach/index.html
@@ -7,7 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Frank+Ruhl+Libre:wght@400;500;700&family=Noto+Serif+Hebrew:wght@400;500;600&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Frank+Ruhl+Libre:wght@400;500;700&family=Noto+Serif+Hebrew:wght@400;500;600&family=Spectral:ital,wght@0,400;0,500;0,600;1,400&display=swap"
       rel="stylesheet"
     />
   </head>

--- a/packages/tanach/src/client/App.tsx
+++ b/packages/tanach/src/client/App.tsx
@@ -46,6 +46,11 @@ function stripNikud(html: string): string {
 const PETUCHA = '\u0001';
 const SETUMA = '\u0002';
 
+/** Margin-anchor box width + gap from the text band (used both to place the
+ *  label and to decide whether it fits in the margin). */
+const ANCHOR_W = 150;
+const ANCHOR_GAP = 12;
+
 /**
  * Build the scroll's paragraphs from a chapter's verses, honouring the Masoretic
  * parsha breaks exactly as a Torah scroll lays them out (Sefaria marks them with
@@ -123,13 +128,33 @@ interface Parsha {
   book: string;
   chapter: number;
 }
+/** The Hebrew name of a book, for the Hebrew-mode chapter refs. */
+function heBook(name: string): string {
+  return BOOKS.find((b) => b.name === name)?.he ?? name;
+}
+
+/** Israel and the Diaspora occasionally read different weekly portions; pick by
+ *  the browser's time zone (Asia/Jerusalem => Israel). */
+function inIsrael(): boolean {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone === 'Asia/Jerusalem';
+  } catch {
+    return false;
+  }
+}
+
 async function fetchParsha(): Promise<Parsha | null> {
   try {
-    const res = await fetch('/api/parsha');
+    const res = await fetch(`/api/parsha?loc=${inIsrael() ? 'israel' : 'diaspora'}`);
     return res.ok ? ((await res.json()) as Parsha) : null;
   } catch {
     return null;
   }
+}
+
+interface SectionNote {
+  en: string;
+  he: string;
 }
 /** The event/section labels for a chapter (first producer). Best-effort: a
  *  failure just means no margin anchors — the text still renders. */
@@ -186,7 +211,9 @@ export function App(): JSX.Element {
   // its column faces. Re-measured on reflow (resize / font load / nikud toggle).
   let scrollMain: HTMLElement | undefined;
   let scrollBand: HTMLElement | undefined;
-  const [anchors, setAnchors] = createSignal<{ v: string; label: string; top: number; side: 'left' | 'right' }[]>([]);
+  const [anchors, setAnchors] = createSignal<
+    { v: string; label: string; top: number; left: number; side: 'left' | 'right' }[]
+  >([]);
   const [reflow, setReflow] = createSignal(0);
 
   const measure = () => {
@@ -195,12 +222,19 @@ export function App(): JSX.Element {
       return;
     }
     const m = scrollMain.getBoundingClientRect();
-    const out: { v: string; label: string; top: number; side: 'left' | 'right' }[] = [];
+    const b = scrollBand.getBoundingClientRect();
+    const out: { v: string; label: string; top: number; left: number; side: 'left' | 'right' }[] = [];
     scrollBand.querySelectorAll<HTMLElement>('.evt-pt').forEach((pt) => {
       const r = pt.getBoundingClientRect();
       if (!r.height) return;
-      const side: 'left' | 'right' = r.left + r.width / 2 - m.left < m.width / 2 ? 'left' : 'right';
-      out.push({ v: pt.dataset.v ?? '', label: pt.dataset.label ?? '', top: r.top - m.top, side });
+      // Side = which half of the band the verse sits in. Position the label just
+      // OUTSIDE the band on that side; skip it when the margin can't hold it (so
+      // it never overlaps the text — at narrow widths the layout drops to one
+      // column, which widens the margins and brings the anchors back).
+      const side: 'left' | 'right' = r.left + r.width / 2 < m.left + m.width / 2 ? 'left' : 'right';
+      const left = side === 'right' ? b.right - m.left + ANCHOR_GAP : b.left - m.left - ANCHOR_W - ANCHOR_GAP;
+      if (left < 4 || left + ANCHOR_W > m.width - 4) return;
+      out.push({ v: pt.dataset.v ?? '', label: pt.dataset.label ?? '', top: r.top - m.top, left, side });
     });
     setAnchors(out);
   };
@@ -219,6 +253,29 @@ export function App(): JSX.Element {
     loc().view;
     loc().nikud;
     requestAnimationFrame(() => requestAnimationFrame(measure));
+  });
+
+  // Section note popover: clicking a margin anchor opens a short p'shat note for
+  // that section's verse range (start..next section - 1).
+  const [selected, setSelected] = createSignal<
+    { start: number; end: number; label: string; top: number; side: 'left' | 'right' } | null
+  >(null);
+  const openAnchor = (a: { v: string; label: string; top: number; side: 'left' | 'right' }) => {
+    const start = Number(a.v);
+    const secs = (events() ?? []).slice().sort((x, y) => x.verse - y.verse);
+    const idx = secs.findIndex((s) => s.verse === start);
+    const end = idx >= 0 && idx + 1 < secs.length ? secs[idx + 1].verse - 1 : (data()?.verses.length ?? start);
+    setSelected({ start, end, label: a.label, top: a.top, side: a.side });
+  };
+  const [note] = createResource(selected, async (sel) => {
+    const l = loc();
+    const url = `/api/note/${encodeURIComponent(l.book)}/${l.chapter}/${sel.start}?end=${sel.end}&label=${encodeURIComponent(sel.label)}`;
+    const res = await fetch(url);
+    return res.ok ? ((await res.json()) as SectionNote) : null;
+  });
+  createEffect(() => {
+    chapterKey();
+    setSelected(null);
   });
 
   return (
@@ -273,7 +330,9 @@ export function App(): JSX.Element {
 
         <div class="chapter-nav">
           <button disabled={loc().chapter <= 1} onClick={() => goto(loc().book, loc().chapter - 1)}>‹</button>
-          <span class="chapter-label">ch. {loc().chapter}</span>
+          <span class="chapter-label">
+            {loc().lang === 'he' ? hebrewNumeral(loc().chapter) : `ch. ${loc().chapter}`}
+          </span>
           <button onClick={() => goto(loc().book, loc().chapter + 1)}>›</button>
         </div>
       </header>
@@ -301,18 +360,47 @@ export function App(): JSX.Element {
               {(a) => (
                 <button
                   class="evt-margin"
-                  classList={{ 'evt-left': a.side === 'left', 'evt-right': a.side === 'right' }}
-                  style={{ top: `${a.top}px` }}
+                  classList={{
+                    'evt-left': a.side === 'left',
+                    'evt-right': a.side === 'right',
+                    active: selected()?.start === Number(a.v),
+                  }}
+                  style={{ top: `${a.top}px`, left: `${a.left}px`, width: `${ANCHOR_W}px` }}
                   data-v={a.v}
                   title={`${a.label} (verse ${a.v})`}
+                  onClick={() => openAnchor(a)}
                 >
                   {a.label}
                 </button>
               )}
             </For>
+            <Show when={selected()}>
+              {(sel) => (
+                <div
+                  class="note-pop"
+                  classList={{ 'note-left': sel().side === 'left', 'note-right': sel().side === 'right' }}
+                  style={{ top: `${sel().top}px` }}
+                >
+                  <button class="note-close" onClick={() => setSelected(null)} aria-label="Close">
+                    ×
+                  </button>
+                  <div class="note-pop-label">{sel().label}</div>
+                  <Show when={note.loading}>
+                    <p class="note-pop-body muted">Reading the section…</p>
+                  </Show>
+                  <Show when={note()}>
+                    {(n) => (
+                      <p class="note-pop-body" dir={loc().lang === 'he' ? 'rtl' : 'ltr'}>
+                        {loc().lang === 'he' ? n().he || n().en : n().en || n().he}
+                      </p>
+                    )}
+                  </Show>
+                </div>
+              )}
+            </Show>
             <div class="scroll-caption">
               <span class="he">{ch().heRef}</span>
-              <ChapterFoot ch={ch()} goto={goto} />
+              <ChapterFoot ch={ch()} goto={goto} lang={loc().lang} />
             </div>
           </main>
         )}
@@ -321,19 +409,27 @@ export function App(): JSX.Element {
   );
 }
 
-function ChapterFoot(props: { ch: Chapter; goto: (b: string, c: number) => void }): JSX.Element {
-  const nav = (ref: string | null, label: (r: string) => string) => (
+function ChapterFoot(props: { ch: Chapter; goto: (b: string, c: number) => void; lang: 'en' | 'he' }): JSX.Element {
+  const fmt = (book: string, chapter: number) =>
+    props.lang === 'he' ? `${heBook(book)} ${hebrewNumeral(chapter)}` : `${book} ${chapter}`;
+  const nav = (ref: string | null, dir: 'prev' | 'next') => (
     <Show when={ref} fallback={<span />}>
       {(r) => {
         const p = parseRef(r());
-        return p ? <button onClick={() => props.goto(p.book, p.chapter)}>{label(r())}</button> : <span />;
+        if (!p) return <span />;
+        const txt = fmt(p.book, p.chapter);
+        return (
+          <button onClick={() => props.goto(p.book, p.chapter)}>
+            {dir === 'prev' ? `‹ ${txt}` : `${txt} ›`}
+          </button>
+        );
       }}
     </Show>
   );
   return (
     <nav class="chapter-foot">
-      {nav(props.ch.prev, (r) => `‹ ${r}`)}
-      {nav(props.ch.next, (r) => `${r} ›`)}
+      {nav(props.ch.prev, 'prev')}
+      {nav(props.ch.next, 'next')}
     </nav>
   );
 }

--- a/packages/tanach/src/client/styles.css
+++ b/packages/tanach/src/client/styles.css
@@ -17,7 +17,7 @@ body {
   margin: 0;
   background: var(--bg);
   color: var(--ink);
-  font-family: 'Frank Ruhl Libre', Georgia, 'Times New Roman', serif;
+  font-family: 'Spectral', 'Frank Ruhl Libre', Georgia, serif;
   line-height: 1.6;
 }
 
@@ -140,17 +140,27 @@ body {
    Side gutters leave room for a future side panel (like the Talmud reader). */
 .scroll-main {
   position: relative;
-  padding: 40px clamp(20px, 11vw, 200px) 48px;
+  padding: 40px 28px 48px;
 }
 .scroll-band {
-  max-width: 1000px;
+  max-width: 900px;
   margin: 0 auto;
   color: var(--ink);
+  font-family: 'Frank Ruhl Libre', serif;
   font-size: 16px;
   line-height: 1.6;
   column-count: 2;
   column-gap: 3.2rem;
   column-rule: 1px solid var(--line);
+}
+/* If two columns + their anchor margins can't fit, drop to one column (which
+   widens the margins, so the anchors reappear). */
+@media (max-width: 1240px) {
+  .scroll-band {
+    column-count: 1;
+    max-width: 620px;
+    column-rule: none;
+  }
 }
 /* Each petucha-delimited portion is its own justified paragraph: the last line
    ends naturally (start-aligned), like the blank line-remainder in a scroll. */
@@ -270,10 +280,11 @@ body {
    These are the interactive attachment points for future enrichments. */
 .evt-margin {
   position: absolute;
-  width: clamp(96px, 13vw, 180px);
   margin-top: -0.55em;
   padding: 0;
-  font: 500 10px/1.4 'Frank Ruhl Libre', Georgia, serif;
+  font-weight: 500;
+  font-size: 10.5px;
+  line-height: 1.4;
   letter-spacing: 0.01em;
   color: rgba(122, 92, 46, 0.7);
   background: none;
@@ -293,12 +304,14 @@ body {
   background: rgba(122, 92, 46, 0.5);
   transition: background-color 0.12s ease;
 }
-.evt-margin.evt-right { right: clamp(10px, 2vw, 48px); text-align: right; }
+.evt-margin.evt-right { text-align: left; }
 .evt-margin.evt-right::before { left: 0; }
-.evt-margin.evt-left { left: clamp(10px, 2vw, 48px); text-align: left; }
+.evt-margin.evt-left { text-align: right; }
 .evt-margin.evt-left::before { right: 0; }
-.evt-margin:hover { color: var(--accent); }
-.evt-margin:hover::before { background: var(--accent); }
+.evt-margin:hover,
+.evt-margin.active { color: var(--accent); }
+.evt-margin:hover::before,
+.evt-margin.active::before { background: var(--accent); }
 @media (max-width: 820px) {
   .evt-margin { display: none; }
 }
@@ -361,3 +374,46 @@ body {
   cursor: pointer;
 }
 .lang-toggle button.active { background: var(--accent); color: #fff; }
+
+
+/* section-note popover (clicking a margin anchor) */
+.note-pop {
+  position: absolute;
+  width: clamp(240px, 26vw, 350px);
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  box-shadow: 0 10px 34px rgba(60, 40, 12, 0.18);
+  padding: 15px 18px 17px;
+  z-index: 20;
+}
+.note-pop.note-right { right: clamp(10px, 2vw, 48px); }
+.note-pop.note-left { left: clamp(10px, 2vw, 48px); }
+.note-close {
+  position: absolute;
+  top: 6px;
+  right: 9px;
+  border: 0;
+  background: none;
+  font-size: 19px;
+  line-height: 1;
+  color: var(--muted);
+  cursor: pointer;
+}
+.note-close:hover { color: var(--ink); }
+.note-pop-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--accent);
+  font-weight: 600;
+  margin-bottom: 8px;
+  padding-right: 16px;
+}
+.note-pop-body {
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--ink);
+}
+.note-pop-body.muted { color: var(--muted); font-style: italic; }

--- a/packages/tanach/src/worker/index.ts
+++ b/packages/tanach/src/worker/index.ts
@@ -13,6 +13,7 @@ import { SefariaClient, flattenPieces } from '@corpus/core/sefaria/client';
 import type { LLMEnv } from '@corpus/core/llm/llm';
 import { isBook } from '../lib/books.ts';
 import { eventSections } from './producers/events.ts';
+import { sectionNote } from './producers/note.ts';
 import { readUsage, recordUsage } from './usage.ts';
 
 interface Env extends LLMEnv {
@@ -198,13 +199,17 @@ app.get('/api/events/:book/:chapter', async (c) => {
 // Returns the parsha name + the book/chapter it starts at, so the reader can
 // jump straight there. Cached ~6h (it only changes on Shabbat).
 app.get('/api/parsha', async (c) => {
-  const cacheKey = 'parsha:current';
+  // The weekly reading desyncs between Israel and the Diaspora for a few weeks a
+  // year (when a yom tov falls on Shabbat outside Israel). Sefaria's calendar
+  // takes diaspora=1 (default) / diaspora=0 (Israel).
+  const israel = c.req.query('loc') === 'israel';
+  const cacheKey = `parsha:current:${israel ? 'il' : 'gola'}`;
   const cached = await c.env.CACHE.get(cacheKey);
   if (cached) return c.json(JSON.parse(cached));
 
   let cal: { calendar_items?: Array<{ title?: { en?: string }; displayValue?: { en?: string; he?: string }; ref?: string }> };
   try {
-    const r = await fetch('https://www.sefaria.org/api/calendars');
+    const r = await fetch(`https://www.sefaria.org/api/calendars?diaspora=${israel ? 0 : 1}`);
     cal = (await r.json()) as typeof cal;
   } catch (e) {
     return c.json({ error: `Calendar fetch failed: ${(e as Error).message}` }, 502);
@@ -222,6 +227,63 @@ app.get('/api/parsha', async (c) => {
     chapter: Number(m[2]),
   };
   c.executionCtx.waitUntil(c.env.CACHE.put(cacheKey, JSON.stringify(payload), { expirationTtl: 6 * 3600 }));
+  return c.json(payload);
+});
+
+// Section note (second producer, composes on events): a short bilingual p'shat
+// note for the verse range [start..end] of a chapter. Triggered when the reader
+// clicks a margin anchor. Cached per range.
+app.get('/api/note/:book/:chapter/:start', async (c) => {
+  const book = c.req.param('book');
+  const chapter = c.req.param('chapter');
+  const start = Number(c.req.param('start'));
+  const end = Number(c.req.query('end')) || start;
+  const label = c.req.query('label') ?? '';
+  if (!isBook(book)) return c.json({ error: `Unknown book: ${book}` }, 400);
+  if (!/^\d+$/.test(chapter) || !start) return c.json({ error: 'Bad chapter/verse' }, 400);
+
+  const key = `note:v1:${book}:${chapter}:${start}-${end}`;
+  const cached = await c.env.CACHE.get(key);
+  if (cached) return c.json(JSON.parse(cached));
+
+  let text: Awaited<ReturnType<SefariaClient['getText']>>;
+  try {
+    text = await sefaria.getText(`${book} ${chapter}`);
+  } catch (e) {
+    return c.json({ error: `Sefaria fetch failed: ${(e as Error).message}` }, 502);
+  }
+  if (text.error) return c.json({ error: text.error }, 404);
+
+  const en = asVerses(text.text);
+  const last = Math.min(end, en.length);
+  const slice: string[] = [];
+  for (let n = start; n <= last; n++) {
+    slice.push(`${n}. ${(en[n - 1] ?? '').replace(/<[^>]+>/g, '').trim()}`);
+  }
+  const ref = end > start ? `${book} ${chapter}:${start}-${end}` : `${book} ${chapter}:${start}`;
+
+  let result: Awaited<ReturnType<typeof sectionNote>>;
+  try {
+    result = await sectionNote(c.env, ref, label, slice.join('\n'));
+  } catch (e) {
+    return c.json({ error: `Producer failed: ${(e as Error).message}` }, 502);
+  }
+
+  const payload = { book, chapter: Number(chapter), start, end, en: result.en, he: result.he };
+  c.executionCtx.waitUntil(
+    Promise.all([
+      c.env.CACHE.put(key, JSON.stringify(payload)),
+      recordUsage(c.env.CACHE, {
+        ts: Date.now(),
+        ref,
+        producer: 'note',
+        model: result.model,
+        in: result.inTokens,
+        out: result.outTokens,
+        cost: result.costUsd,
+      }),
+    ]).then(() => undefined),
+  );
   return c.json(payload);
 });
 

--- a/packages/tanach/src/worker/producers/note.ts
+++ b/packages/tanach/src/worker/producers/note.ts
@@ -1,0 +1,82 @@
+/**
+ * The "section note" enrichment — the second Tanach smart-note.
+ *
+ * Composes on the events mark: given a section (a verse range the events
+ * producer delimited) it writes a short plain-language p'shat note about what
+ * happens there, in both English and Hebrew. Rendered when the reader clicks a
+ * margin anchor. Strictly plain sense — no midrash, no homily.
+ */
+
+import { runLLM, type LLMEnv } from '@corpus/core/llm/llm';
+import { costUsd } from '@corpus/core/llm/pricing';
+
+export interface NoteResult {
+  en: string;
+  he: string;
+  model: string;
+  costUsd: number | null;
+  inTokens: number;
+  outTokens: number;
+}
+
+const SYSTEM = [
+  'You write a short note explaining what happens in a passage of the Hebrew',
+  'Bible, on the p\'shat (plain, contextual) level — for a reader who just',
+  'arrived at this section.',
+  '',
+  'Rules:',
+  '- 2 to 3 sentences. Plain and concrete: what plainly happens, and what the',
+  '  text means in its own context.',
+  '- Strictly p\'shat. No midrash, no homily, no theology, no commentary debates,',
+  '  no quoting commentators.',
+  '- Do not just restate the verses — orient and explain plainly.',
+  '- Give the note in BOTH English ("en") and natural, fluent Hebrew ("he").',
+].join('\n');
+
+const SCHEMA = {
+  name: 'section_note',
+  strict: true,
+  schema: {
+    type: 'object',
+    additionalProperties: false,
+    required: ['en', 'he'],
+    properties: { en: { type: 'string' }, he: { type: 'string' } },
+  },
+};
+
+export async function sectionNote(
+  env: LLMEnv,
+  ref: string,
+  label: string,
+  versesText: string,
+): Promise<NoteResult> {
+  const res = await runLLM(env, {
+    messages: [
+      { role: 'system', content: SYSTEM },
+      { role: 'user', content: `Passage: ${ref}${label ? ` — "${label}"` : ''}\n\n${versesText}` },
+    ],
+    max_tokens: 700,
+    temperature: 0.3,
+    response_format: { type: 'json_schema', json_schema: SCHEMA },
+    tag: 'tanach:note',
+  });
+
+  let en = '';
+  let he = '';
+  try {
+    const p = JSON.parse(res.content) as { en?: string; he?: string };
+    en = String(p.en ?? '').trim();
+    he = String(p.he ?? '').trim();
+  } catch {
+    /* leave empty */
+  }
+
+  return {
+    en,
+    he,
+    model: res.model,
+    costUsd: costUsd(res.model, res.usage),
+    inTokens: res.usage?.prompt_tokens ?? 0,
+    outTokens: res.usage?.completion_tokens ?? 0,
+  };
+}


### PR DESCRIPTION
Section-note popover, responsive columns, Spectral English, Hebrew nav, IL/diaspora parsha

Second producer + a batch of reader polish:

- Section note (producers/note.ts): clicking a margin anchor opens a short
  bilingual p'shat note for that section's verse range. GET /api/note/:book/
  :chapter/:start?end=&label= (KV-cached, usage-tracked). Composes on the events
  mark (the anchor delimits the range).
- Margin anchors rebuilt: positioned just OUTSIDE the text band (measured), so
  they hug the text on each side; auto-skipped when the margin cannot hold them.
- Responsive: if two columns + their anchor margins do not fit, drop to one
  column (<=1240px), which widens the margins and brings the anchors back.
- English font is now Spectral (Hebrew stays Frank Ruhl Libre).
- Chapter nav (prev/next + foot) shows Hebrew book name + numeral in HE mode.
- Parsha is chosen by location: Israel vs Diaspora differ some weeks; the client
  detects the time zone (Asia/Jerusalem => Israel) and /api/parsha passes
  diaspora=0/1 to Sefaria.

Verified locally: 2-col @1440 / 1-col @1100 with no overlap; note popover for
Genesis 1 sections; parsha resolves per locale.
