### PR TITLE
Tanach: word/phrase translation on selection

### DIFF
--- a/packages/tanach/src/client/App.tsx
+++ b/packages/tanach/src/client/App.tsx
@@ -278,6 +278,31 @@ export function App(): JSX.Element {
     setSelected(null);
   });
 
+  // Word / phrase translation: select Hebrew in the text (double-click a word or
+  // drag a phrase) -> an English gloss popup at the selection.
+  const [wordSel, setWordSel] = createSignal<{ he: string; ctx: string; x: number; y: number } | null>(null);
+  const [translation] = createResource(wordSel, async (w) => {
+    const res = await fetch(`/api/translate?q=${encodeURIComponent(w.he)}&ctx=${encodeURIComponent(w.ctx)}`);
+    return res.ok ? (((await res.json()) as { translation?: string }).translation ?? null) : null;
+  });
+  const onTextSelect = () => {
+    const g = window.getSelection();
+    const text = g?.toString().trim() ?? '';
+    if (!g || g.rangeCount === 0 || !text || text.length > 80 || !/[א-ת]/.test(text)) return;
+    const r = g.getRangeAt(0).getBoundingClientRect();
+    const ctx = (g.anchorNode?.parentElement?.textContent ?? '').replace(/\s+/g, ' ').trim();
+    setWordSel({ he: text, ctx, x: r.left + r.width / 2, y: r.bottom });
+  };
+  onMount(() => {
+    const clear = () => setWordSel(null);
+    window.addEventListener('scroll', clear, { passive: true });
+    onCleanup(() => window.removeEventListener('scroll', clear));
+  });
+  createEffect(() => {
+    chapterKey();
+    setWordSel(null);
+  });
+
   return (
     <div class="app" classList={{ 'view-scroll': loc().view === 'scroll', 'view-mikraot': loc().view === 'mikraot' }}>
       <header class="topbar">
@@ -353,7 +378,7 @@ export function App(): JSX.Element {
       <Show when={loc().view === 'scroll' && data()}>
         {(ch) => (
           <main class="scroll-main" ref={(el) => (scrollMain = el)}>
-            <div class="scroll-band" dir="rtl" ref={(el) => (scrollBand = el)}>
+            <div class="scroll-band" dir="rtl" ref={(el) => (scrollBand = el)} onMouseUp={onTextSelect}>
               <For each={paragraphs()}>{(p) => <p class="scroll-para" innerHTML={p} />}</For>
             </div>
             <For each={anchors()}>
@@ -403,6 +428,21 @@ export function App(): JSX.Element {
               <ChapterFoot ch={ch()} goto={goto} lang={loc().lang} />
             </div>
           </main>
+        )}
+      </Show>
+
+      {/* Word/phrase translation gloss, pinned at the selection */}
+      <Show when={wordSel()}>
+        {(w) => (
+          <div class="xlate-pop" style={{ left: `${w().x}px`, top: `${w().y + 8}px` }}>
+            <span class="xlate-he" dir="rtl">{w().he}</span>
+            <Show when={translation.loading}>
+              <span class="xlate-en muted">…</span>
+            </Show>
+            <Show when={!translation.loading}>
+              <span class="xlate-en">{translation() ?? '—'}</span>
+            </Show>
+          </div>
         )}
       </Show>
     </div>

--- a/packages/tanach/src/client/styles.css
+++ b/packages/tanach/src/client/styles.css
@@ -417,3 +417,31 @@ body {
   color: var(--ink);
 }
 .note-pop-body.muted { color: var(--muted); font-style: italic; }
+
+/* word/phrase translation gloss (text selection) */
+.xlate-pop {
+  position: fixed;
+  transform: translateX(-50%);
+  z-index: 40;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  max-width: 360px;
+  padding: 7px 13px;
+  background: #2c2418;
+  color: #fdf8ee;
+  border-radius: 8px;
+  box-shadow: 0 6px 22px rgba(0, 0, 0, 0.28);
+  pointer-events: none;
+}
+.xlate-pop .xlate-he {
+  font-family: 'Frank Ruhl Libre', serif;
+  font-size: 15px;
+  color: #e9d9b8;
+  white-space: nowrap;
+}
+.xlate-pop .xlate-en {
+  font-size: 14px;
+  line-height: 1.35;
+}
+.xlate-pop .xlate-en.muted { opacity: 0.6; }

--- a/packages/tanach/src/worker/index.ts
+++ b/packages/tanach/src/worker/index.ts
@@ -14,6 +14,7 @@ import type { LLMEnv } from '@corpus/core/llm/llm';
 import { isBook } from '../lib/books.ts';
 import { eventSections } from './producers/events.ts';
 import { sectionNote } from './producers/note.ts';
+import { translateHebrew } from './producers/translate.ts';
 import { readUsage, recordUsage } from './usage.ts';
 
 interface Env extends LLMEnv {
@@ -285,6 +286,46 @@ app.get('/api/note/:book/:chapter/:start', async (c) => {
     ]).then(() => undefined),
   );
   return c.json(payload);
+});
+
+// Word / phrase translation: the reader selects Hebrew and gets an English
+// gloss (in the sense it carries in the given verse context). Cached per
+// normalized selection.
+app.get('/api/translate', async (c) => {
+  const q = (c.req.query('q') ?? '').trim();
+  const ctx = (c.req.query('ctx') ?? '').trim().slice(0, 400);
+  if (!q) return c.json({ error: 'Missing q' }, 400);
+  if (q.length > 120) return c.json({ error: 'Selection too long' }, 400);
+
+  // Cache key ignores niqqud/cantillation so vocalized + bare forms share a hit.
+  const norm = q.replace(/[֑-ׇ]/g, '').replace(/\s+/g, ' ').trim();
+  const key = `translate:v1:${norm}`;
+  const cached = await c.env.CACHE.get(key);
+  if (cached !== null) return c.json({ q, translation: cached, cached: true });
+
+  let result: Awaited<ReturnType<typeof translateHebrew>>;
+  try {
+    result = await translateHebrew(c.env, q, ctx);
+  } catch (e) {
+    return c.json({ error: `Translate failed: ${(e as Error).message}` }, 502);
+  }
+  if (!result.translation) return c.json({ error: 'No translation' }, 502);
+
+  c.executionCtx.waitUntil(
+    Promise.all([
+      c.env.CACHE.put(key, result.translation, { expirationTtl: 60 * 60 * 24 * 30 }),
+      recordUsage(c.env.CACHE, {
+        ts: Date.now(),
+        ref: norm.slice(0, 40),
+        producer: 'translate',
+        model: result.model,
+        in: result.inTokens,
+        out: result.outTokens,
+        cost: result.costUsd,
+      }),
+    ]).then(() => undefined),
+  );
+  return c.json({ q, translation: result.translation });
 });
 
 // Self-tracked LLM usage (totals + per-producer + recent calls).

--- a/packages/tanach/src/worker/producers/translate.ts
+++ b/packages/tanach/src/worker/producers/translate.ts
@@ -1,0 +1,65 @@
+/**
+ * Word / phrase translation. The reader selects Hebrew in the text (double-click
+ * a word, or drag across a phrase) and gets a concise English gloss. Context
+ * (the surrounding verse) is passed so a word is translated in the sense it has
+ * here. Cached per normalized selection.
+ */
+
+import { runLLM, type LLMEnv } from '@corpus/core/llm/llm';
+import { costUsd } from '@corpus/core/llm/pricing';
+
+export interface TranslateResult {
+  translation: string;
+  model: string;
+  costUsd: number | null;
+  inTokens: number;
+  outTokens: number;
+}
+
+const SYSTEM = [
+  'You translate Biblical Hebrew into concise, plain English.',
+  '',
+  'You are given a word or short phrase (it may carry niqqud and cantillation)',
+  'and, when available, the verse it comes from for context. Return ONLY the',
+  'English translation — a word or short phrase, in the sense it carries in this',
+  'context. No explanation, no transliteration, no notes.',
+].join('\n');
+
+const SCHEMA = {
+  name: 'translation',
+  strict: true,
+  schema: {
+    type: 'object',
+    additionalProperties: false,
+    required: ['translation'],
+    properties: { translation: { type: 'string' } },
+  },
+};
+
+export async function translateHebrew(env: LLMEnv, q: string, context: string): Promise<TranslateResult> {
+  const res = await runLLM(env, {
+    messages: [
+      { role: 'system', content: SYSTEM },
+      { role: 'user', content: `Hebrew: ${q}${context ? `\n\nFrom this verse: ${context}` : ''}` },
+    ],
+    max_tokens: 120,
+    temperature: 0.2,
+    response_format: { type: 'json_schema', json_schema: SCHEMA },
+    tag: 'tanach:translate',
+  });
+
+  let translation = '';
+  try {
+    translation = String((JSON.parse(res.content) as { translation?: string }).translation ?? '').trim();
+  } catch {
+    /* leave empty */
+  }
+
+  return {
+    translation,
+    model: res.model,
+    costUsd: costUsd(res.model, res.usage),
+    inTokens: res.usage?.prompt_tokens ?? 0,
+    outTokens: res.usage?.completion_tokens ?? 0,
+  };
+}


### PR DESCRIPTION
Word/phrase translation on text selection

Select Hebrew in the scroll (double-click a word or drag a phrase) and get a
concise English gloss in a popup at the selection. Covers single word and
multi-word with one mechanism (native selection), mirroring the Talmud reader.

- producers/translate.ts: Biblical-Hebrew -> concise English, context-aware
  (the surrounding verse is passed so a word is glossed in its sense here).
- GET /api/translate?q=&ctx= — cached per niqqud-stripped selection (30d),
  usage-tracked under the "translate" producer.
- Client: a mouseup handler on the scroll band reads the selection, fetches,
  and shows a small gloss popup; cleared on scroll / chapter change.

Verified: בְּרֵאשִׁית -> "In the beginning"; תֹהוּ וָבֹהוּ -> "formless and empty";
popup renders at the selected word.
