### PR TITLE
Margin anchors: separate label from text (fix crowding)

### DIFF
--- a/packages/tanach/src/client/App.tsx
+++ b/packages/tanach/src/client/App.tsx
@@ -49,7 +49,9 @@ const SETUMA = '\u0002';
 /** Margin-anchor box width + gap from the text band (used both to place the
  *  label and to decide whether it fits in the margin). */
 const ANCHOR_W = 150;
-const ANCHOR_GAP = 12;
+// Gap from the text band to the dot (the verse tick sits close to the text); the
+// label itself is pushed further into the margin by .evt-margin padding.
+const ANCHOR_GAP = 6;
 
 /**
  * Build the scroll's paragraphs from a chapter's verses, honouring the Masoretic

--- a/packages/tanach/src/client/styles.css
+++ b/packages/tanach/src/client/styles.css
@@ -280,6 +280,7 @@ body {
    These are the interactive attachment points for future enrichments. */
 .evt-margin {
   position: absolute;
+  box-sizing: border-box;
   margin-top: -0.55em;
   padding: 0;
   font-weight: 500;
@@ -304,9 +305,9 @@ body {
   background: rgba(122, 92, 46, 0.5);
   transition: background-color 0.12s ease;
 }
-.evt-margin.evt-right { text-align: left; }
+.evt-margin.evt-right { text-align: left; padding-left: 20px; }
 .evt-margin.evt-right::before { left: 0; }
-.evt-margin.evt-left { text-align: right; }
+.evt-margin.evt-left { text-align: right; padding-right: 20px; }
 .evt-margin.evt-left::before { right: 0; }
 .evt-margin:hover,
 .evt-margin.active { color: var(--accent); }


### PR DESCRIPTION
Dot stays as a verse tick near the text; the label is pushed into the margin via inner padding, so anchors no longer crowd/overlap the Hebrew on either side.