### PR TITLE
Clicking a section anchor highlights its verses

### DIFF
--- a/packages/tanach/src/client/App.tsx
+++ b/packages/tanach/src/client/App.tsx
@@ -75,7 +75,7 @@ function buildParagraphs(verses: Verse[], nikud: boolean, labels?: Map<number, s
       // point (.evt-pt); the label itself is positioned in the margin by App.
       const cls = label ? 'vnum evt-pt' : 'vnum';
       const attrs = label ? ` data-v="${v.n}" data-label="${escapeHtml(label)}"` : '';
-      return `<span class="${cls}"${attrs}>${hebrewNumeral(v.n)}</span> ${v.he}`;
+      return `<span class="vtext" data-vn="${v.n}"><span class="${cls}"${attrs}>${hebrewNumeral(v.n)}</span> ${v.he}</span>`;
     })
     .join(' ');
   joined = joined
@@ -303,6 +303,21 @@ export function App(): JSX.Element {
   createEffect(() => {
     chapterKey();
     setWordSel(null);
+  });
+
+  // Highlight the selected section's verses in the text (clicking an anchor).
+  createEffect(() => {
+    const sel = selected();
+    paragraphs();
+    requestAnimationFrame(() => {
+      if (!scrollBand) return;
+      scrollBand.querySelectorAll('.vtext.hl').forEach((e) => e.classList.remove('hl'));
+      if (!sel) return;
+      scrollBand.querySelectorAll<HTMLElement>('.vtext').forEach((e) => {
+        const vn = Number(e.dataset.vn);
+        if (vn >= sel.start && vn <= sel.end) e.classList.add('hl');
+      });
+    });
   });
 
   return (

--- a/packages/tanach/src/client/styles.css
+++ b/packages/tanach/src/client/styles.css
@@ -446,3 +446,13 @@ body {
   line-height: 1.35;
 }
 .xlate-pop .xlate-en.muted { opacity: 0.6; }
+
+/* highlight the verses of a clicked section anchor */
+.vtext.hl {
+  background: rgba(122, 92, 46, 0.13);
+  border-radius: 3px;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+  padding: 1px 2px;
+  transition: background-color 0.15s ease;
+}


### PR DESCRIPTION
Each verse is wrapped in a .vtext span; clicking a margin anchor tints that section's verse range while its note is open.