### PR TITLE
Tanach: classic commentary panels (Rishonim from Sefaria)

### DIFF
--- a/packages/tanach/src/client/App.tsx
+++ b/packages/tanach/src/client/App.tsx
@@ -158,6 +158,19 @@ interface SectionNote {
   en: string;
   he: string;
 }
+interface CommentaryEntry {
+  key: string;
+  en: string;
+  heName: string;
+  he: string[];
+  enText: string[];
+}
+interface CommentaryResponse {
+  book: string;
+  chapter: number;
+  verse: number;
+  commentaries: CommentaryEntry[];
+}
 /** The event/section labels for a chapter (first producer). Best-effort: a
  *  failure just means no margin anchors — the text still renders. */
 async function fetchEvents(loc: { book: string; chapter: number }): Promise<EventSection[]> {
@@ -320,6 +333,31 @@ export function App(): JSX.Element {
     });
   });
 
+  // Classic commentary: click a verse number -> a drawer with the Rishonim on
+  // that verse (Sefaria, raw).
+  const [commentaryVerse, setCommentaryVerse] = createSignal<number | null>(null);
+  const [commentary] = createResource(
+    () => {
+      const v = commentaryVerse();
+      return v ? { book: loc().book, chapter: loc().chapter, verse: v } : null;
+    },
+    async (k) => {
+      const res = await fetch(`/api/commentary/${encodeURIComponent(k.book)}/${k.chapter}/${k.verse}`);
+      return res.ok ? ((await res.json()) as CommentaryResponse) : null;
+    },
+  );
+  const onTextClick = (e: MouseEvent) => {
+    const num = (e.target as HTMLElement).closest('.vnum');
+    if (!num) return;
+    const vt = num.closest('.vtext') as HTMLElement | null;
+    const vn = vt ? Number(vt.dataset.vn) : NaN;
+    if (vn) setCommentaryVerse(vn);
+  };
+  createEffect(() => {
+    chapterKey();
+    setCommentaryVerse(null);
+  });
+
   return (
     <div class="app" classList={{ 'view-scroll': loc().view === 'scroll', 'view-mikraot': loc().view === 'mikraot' }}>
       <header class="topbar">
@@ -395,7 +433,13 @@ export function App(): JSX.Element {
       <Show when={loc().view === 'scroll' && data()}>
         {(ch) => (
           <main class="scroll-main" ref={(el) => (scrollMain = el)}>
-            <div class="scroll-band" dir="rtl" ref={(el) => (scrollBand = el)} onMouseUp={onTextSelect}>
+            <div
+              class="scroll-band"
+              dir="rtl"
+              ref={(el) => (scrollBand = el)}
+              onMouseUp={onTextSelect}
+              onClick={onTextClick}
+            >
               <For each={paragraphs()}>{(p) => <p class="scroll-para" innerHTML={p} />}</For>
             </div>
             <For each={anchors()}>
@@ -460,6 +504,47 @@ export function App(): JSX.Element {
               <span class="xlate-en">{translation() ?? '—'}</span>
             </Show>
           </div>
+        )}
+      </Show>
+
+      {/* Classic commentary drawer (click a verse number) */}
+      <Show when={commentaryVerse()}>
+        {(v) => (
+          <aside class="comm-drawer" dir={loc().lang === 'he' ? 'rtl' : 'ltr'}>
+            <header class="comm-head">
+              <span class="comm-ref">
+                {loc().lang === 'he'
+                  ? `${heBook(loc().book)} ${hebrewNumeral(loc().chapter)}:${hebrewNumeral(v())}`
+                  : `${loc().book} ${loc().chapter}:${v()}`}
+              </span>
+              <button class="comm-close" onClick={() => setCommentaryVerse(null)} aria-label="Close">
+                ×
+              </button>
+            </header>
+            <div class="comm-body">
+              <Show when={commentary.loading}>
+                <p class="comm-muted">Loading commentary…</p>
+              </Show>
+              <Show when={commentary()}>
+                {(d) => (
+                  <For each={d().commentaries} fallback={<p class="comm-muted">No commentary on this verse.</p>}>
+                    {(cm) => {
+                      const useEn = loc().lang === 'en' && cm.enText.length > 0;
+                      const segs = useEn ? cm.enText : cm.he;
+                      return (
+                        <section class="comm-entry">
+                          <h4 class="comm-name">{loc().lang === 'he' ? cm.heName : cm.en}</h4>
+                          <For each={segs}>
+                            {(seg) => <p class="comm-text" dir={useEn ? 'ltr' : 'rtl'} innerHTML={seg} />}
+                          </For>
+                        </section>
+                      );
+                    }}
+                  </For>
+                )}
+              </Show>
+            </div>
+          </aside>
         )}
       </Show>
     </div>

--- a/packages/tanach/src/client/styles.css
+++ b/packages/tanach/src/client/styles.css
@@ -456,3 +456,59 @@ body {
   padding: 1px 2px;
   transition: background-color 0.15s ease;
 }
+
+/* verse numbers are clickable -> commentary */
+.scroll-band .vnum { cursor: pointer; transition: color 0.1s ease; }
+.scroll-band .vnum:hover { color: var(--accent); }
+
+/* classic-commentary drawer */
+.comm-drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: min(420px, 92vw);
+  background: #fbf8f1;
+  border-left: 1px solid var(--line);
+  box-shadow: -10px 0 34px rgba(60, 40, 12, 0.14);
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+}
+.comm-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--line);
+  flex: none;
+}
+.comm-ref { font-size: 17px; font-weight: 600; color: var(--ink); }
+.comm-close {
+  border: 0;
+  background: none;
+  font-size: 22px;
+  line-height: 1;
+  color: var(--muted);
+  cursor: pointer;
+}
+.comm-close:hover { color: var(--ink); }
+.comm-body { overflow-y: auto; padding: 6px 18px 32px; }
+.comm-entry { padding: 14px 0; border-bottom: 1px solid var(--line); }
+.comm-entry:last-child { border-bottom: 0; }
+.comm-name {
+  margin: 0 0 6px;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--accent);
+  font-weight: 600;
+}
+.comm-text {
+  margin: 0 0 6px;
+  font-size: 15px;
+  line-height: 1.65;
+  color: var(--ink);
+}
+.comm-text[dir='rtl'] { font-family: 'Frank Ruhl Libre', serif; font-size: 16px; }
+.comm-muted { color: var(--muted); font-style: italic; padding: 14px 0; }

--- a/packages/tanach/src/lib/commentators.ts
+++ b/packages/tanach/src/lib/commentators.ts
@@ -1,0 +1,26 @@
+/**
+ * Classic commentators fetched from Sefaria, in display order. The Sefaria index
+ * title is `${title} on ${book}` and a verse ref is `${title} on ${book}
+ * ${chapter}:${verse}`. Not every commentator covers every book (Ramban/Sforno
+ * are Torah; Radak/Metzudat lean Nevi'im-Ketuvim) — a missing one just returns
+ * nothing and is skipped.
+ */
+
+export interface Commentator {
+  key: string;
+  /** Sefaria index-title prefix, e.g. "Rashi" -> "Rashi on Genesis 1:1". */
+  title: string;
+  en: string;
+  he: string;
+}
+
+export const COMMENTATORS: Commentator[] = [
+  { key: 'rashi', title: 'Rashi', en: 'Rashi', he: 'רש״י' },
+  { key: 'rashbam', title: 'Rashbam', en: 'Rashbam', he: 'רשב״ם' },
+  { key: 'ibn-ezra', title: 'Ibn Ezra', en: 'Ibn Ezra', he: 'אבן עזרא' },
+  { key: 'ramban', title: 'Ramban', en: 'Ramban', he: 'רמב״ן' },
+  { key: 'sforno', title: 'Sforno', en: 'Sforno', he: 'ספורנו' },
+  { key: 'radak', title: 'Radak', en: 'Radak', he: 'רד״ק' },
+  { key: 'or-hachaim', title: 'Or HaChaim', en: 'Or HaChaim', he: 'אור החיים' },
+  { key: 'metzudat-david', title: 'Metzudat David', en: 'Metzudat David', he: 'מצודת דוד' },
+];

--- a/packages/tanach/src/worker/index.ts
+++ b/packages/tanach/src/worker/index.ts
@@ -9,9 +9,10 @@
  */
 
 import { Hono } from 'hono';
-import { SefariaClient, flattenPieces } from '@corpus/core/sefaria/client';
+import { SefariaClient, flattenPieces, pickV3Version } from '@corpus/core/sefaria/client';
 import type { LLMEnv } from '@corpus/core/llm/llm';
 import { isBook } from '../lib/books.ts';
+import { COMMENTATORS } from '../lib/commentators.ts';
 import { eventSections } from './producers/events.ts';
 import { sectionNote } from './producers/note.ts';
 import { translateHebrew } from './producers/translate.ts';
@@ -326,6 +327,40 @@ app.get('/api/translate', async (c) => {
     ]).then(() => undefined),
   );
   return c.json({ q, translation: result.translation });
+});
+
+// Classic commentary for a single verse: fetch each commentator's note from
+// Sefaria (Hebrew + English), skip the ones with nothing on this verse. Cached
+// per verse. No AI — raw Rishonim.
+app.get('/api/commentary/:book/:chapter/:verse', async (c) => {
+  const book = c.req.param('book');
+  const chapter = c.req.param('chapter');
+  const verse = c.req.param('verse');
+  if (!isBook(book)) return c.json({ error: `Unknown book: ${book}` }, 400);
+  if (!/^\d+$/.test(chapter) || !/^\d+$/.test(verse)) return c.json({ error: 'Bad chapter/verse' }, 400);
+
+  const key = `commentary:v1:${book}:${chapter}:${verse}`;
+  const cached = await c.env.CACHE.get(key);
+  if (cached) return c.json(JSON.parse(cached));
+
+  const results = await Promise.all(
+    COMMENTATORS.map(async (cm) => {
+      const ref = `${cm.title} on ${book} ${chapter}:${verse}`;
+      try {
+        const v3 = await sefaria.getTextV3(ref);
+        const he = flattenPieces(pickV3Version(v3.versions, 'he')).filter((s) => s.trim());
+        const en = flattenPieces(pickV3Version(v3.versions, 'en')).filter((s) => s.trim());
+        if (!he.length && !en.length) return null;
+        return { key: cm.key, en: cm.en, heName: cm.he, he, enText: en };
+      } catch {
+        return null;
+      }
+    }),
+  );
+  const commentaries = results.filter((r): r is NonNullable<typeof r> => r !== null);
+  const payload = { book, chapter: Number(chapter), verse: Number(verse), commentaries };
+  c.executionCtx.waitUntil(c.env.CACHE.put(key, JSON.stringify(payload)).then(() => undefined));
+  return c.json(payload);
 });
 
 // Self-tracked LLM usage (totals + per-producer + recent calls).


### PR DESCRIPTION
Classic commentary panels (Rishonim from Sefaria)

Click a verse number in the scroll to open a drawer with the classic
commentators on that verse, raw from Sefaria (no AI). EN/HE follows the language
toggle, falling back to Hebrew when a commentator has no English.

- lib/commentators.ts: ordered list (Rashi, Rashbam, Ibn Ezra, Ramban, Sforno,
  Radak, Or HaChaim, Metzudat David); not every one covers every book — a
  missing one returns nothing and is skipped.
- GET /api/commentary/:book/:chapter/:verse: fetches each commentator via
  Sefaria v3 (he+en), flattens, drops empties; cached per verse in KV.
- Client: verse numbers are clickable; a right-side drawer renders each
  commentator's segments.

Verified: Genesis 1:1 -> Rashi/Rashbam/Ibn Ezra/Ramban/Sforno/Radak/Or HaChaim.
