### PR TITLE
Tanach: commentary icon + AI synthesis on rich verses

### DIFF
--- a/packages/tanach/src/client/App.tsx
+++ b/packages/tanach/src/client/App.tsx
@@ -67,7 +67,12 @@ function escapeHtml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
-function buildParagraphs(verses: Verse[], nikud: boolean, labels?: Map<number, string>): string[] {
+function buildParagraphs(
+  verses: Verse[],
+  nikud: boolean,
+  labels?: Map<number, string>,
+  rich?: Set<number>,
+): string[] {
   let joined = verses
     .map((v) => {
       const label = labels?.get(v.n);
@@ -75,7 +80,12 @@ function buildParagraphs(verses: Verse[], nikud: boolean, labels?: Map<number, s
       // point (.evt-pt); the label itself is positioned in the margin by App.
       const cls = label ? 'vnum evt-pt' : 'vnum';
       const attrs = label ? ` data-v="${v.n}" data-label="${escapeHtml(label)}"` : '';
-      return `<span class="vtext" data-vn="${v.n}"><span class="${cls}"${attrs}>${hebrewNumeral(v.n)}</span> ${v.he}</span>`;
+      // a "rishonim" icon on verses where many comment (the source index marks
+      // these "rich"); clicking it opens the commentary drawer.
+      const mark = rich?.has(v.n)
+        ? `<button class="vmark vmark-rishonim" data-v="${v.n}" title="Commentary">\u05e8</button>`
+        : '';
+      return `<span class="vtext" data-vn="${v.n}"><span class="${cls}"${attrs}>${hebrewNumeral(v.n)}</span>${mark} ${v.he}</span>`;
     })
     .join(' ');
   joined = joined
@@ -171,6 +181,9 @@ interface CommentaryResponse {
   verse: number;
   commentaries: CommentaryEntry[];
 }
+interface SourceIdx {
+  verses: { verse: number; rishonim: number; rich: boolean }[];
+}
 /** The event/section labels for a chapter (first producer). Best-effort: a
  *  failure just means no margin anchors — the text still renders. */
 async function fetchEvents(loc: { book: string; chapter: number }): Promise<EventSection[]> {
@@ -206,6 +219,17 @@ export function App(): JSX.Element {
   const [data] = createResource(chapterKey, fetchChapter);
   const [events] = createResource(chapterKey, fetchEvents);
   const [parsha] = createResource(fetchParsha);
+  const [sourcesIndex] = createResource(chapterKey, async (k) => {
+    try {
+      const res = await fetch(`/api/sources-index/${encodeURIComponent(k.book)}/${k.chapter}`);
+      return res.ok ? ((await res.json()) as SourceIdx) : null;
+    } catch {
+      return null;
+    }
+  });
+  const richSet = createMemo(
+    () => new Set((sourcesIndex()?.verses ?? []).filter((v) => v.rich).map((v) => v.verse)),
+  );
 
   window.addEventListener('popstate', () => setLoc(readUrl()));
 
@@ -218,7 +242,7 @@ export function App(): JSX.Element {
     const labels = new Map(
       (events() ?? []).map((s) => [s.verse, (he ? s.he : s.en) || s.en || s.he] as const),
     );
-    return buildParagraphs(ch.verses, loc().nikud, labels);
+    return buildParagraphs(ch.verses, loc().nikud, labels, richSet());
   });
 
   // Margin anchors: measure each section-start verse number (.evt-pt) and pin its
@@ -347,12 +371,24 @@ export function App(): JSX.Element {
     },
   );
   const onTextClick = (e: MouseEvent) => {
-    const num = (e.target as HTMLElement).closest('.vnum');
-    if (!num) return;
-    const vt = num.closest('.vtext') as HTMLElement | null;
+    const hit = (e.target as HTMLElement).closest('.vmark-rishonim, .vnum');
+    if (!hit) return;
+    const vt = hit.closest('.vtext') as HTMLElement | null;
     const vn = vt ? Number(vt.dataset.vn) : NaN;
     if (vn) setCommentaryVerse(vn);
   };
+  // Synthesis: only fetched for "rich" verses (where many comment), so it isn't
+  // generated for every pasuk.
+  const [synthesis] = createResource(
+    () => {
+      const v = commentaryVerse();
+      return v && richSet().has(v) ? { book: loc().book, chapter: loc().chapter, verse: v } : null;
+    },
+    async (k) => {
+      const res = await fetch(`/api/synthesis/${encodeURIComponent(k.book)}/${k.chapter}/${k.verse}`);
+      return res.ok ? ((await res.json()) as SectionNote) : null;
+    },
+  );
   createEffect(() => {
     chapterKey();
     setCommentaryVerse(null);
@@ -522,6 +558,21 @@ export function App(): JSX.Element {
               </button>
             </header>
             <div class="comm-body">
+              <Show when={richSet().has(v())}>
+                <section class="comm-synth">
+                  <h4 class="comm-synth-name">Synthesis</h4>
+                  <Show when={synthesis.loading}>
+                    <p class="comm-muted">Synthesizing the commentators…</p>
+                  </Show>
+                  <Show when={synthesis()}>
+                    {(sy) => (
+                      <p class="comm-synth-text" dir={loc().lang === 'he' ? 'rtl' : 'ltr'}>
+                        {loc().lang === 'he' ? sy().he || sy().en : sy().en || sy().he}
+                      </p>
+                    )}
+                  </Show>
+                </section>
+              </Show>
               <Show when={commentary.loading}>
                 <p class="comm-muted">Loading commentary…</p>
               </Show>

--- a/packages/tanach/src/client/styles.css
+++ b/packages/tanach/src/client/styles.css
@@ -512,3 +512,46 @@ body {
 }
 .comm-text[dir='rtl'] { font-family: 'Frank Ruhl Libre', serif; font-size: 16px; }
 .comm-muted { color: var(--muted); font-style: italic; padding: 14px 0; }
+
+/* rishonim icon (verses where many comment) */
+.vmark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 15px;
+  height: 15px;
+  margin: 0 1px 0 3px;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: var(--accent);
+  color: #fff;
+  font-family: 'Frank Ruhl Libre', serif;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+  cursor: pointer;
+  vertical-align: middle;
+  transition: background-color 0.1s ease;
+  unicode-bidi: isolate;
+}
+.vmark:hover { background: var(--ink); }
+
+/* synthesis block at the top of the commentary drawer */
+.comm-synth {
+  background: rgba(122, 92, 46, 0.08);
+  border: 1px solid rgba(122, 92, 46, 0.18);
+  border-radius: 8px;
+  padding: 12px 14px;
+  margin: 8px 0 6px;
+}
+.comm-synth-name {
+  margin: 0 0 6px;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--accent);
+  font-weight: 700;
+}
+.comm-synth-text { margin: 0; font-size: 15px; line-height: 1.6; color: var(--ink); }
+.comm-synth-text[dir='rtl'] { font-family: 'Frank Ruhl Libre', serif; font-size: 16px; }

--- a/packages/tanach/src/worker/index.ts
+++ b/packages/tanach/src/worker/index.ts
@@ -15,6 +15,7 @@ import { isBook } from '../lib/books.ts';
 import { COMMENTATORS } from '../lib/commentators.ts';
 import { eventSections } from './producers/events.ts';
 import { sectionNote } from './producers/note.ts';
+import { synthesize } from './producers/synthesis.ts';
 import { translateHebrew } from './producers/translate.ts';
 import { readUsage, recordUsage } from './usage.ts';
 
@@ -329,20 +330,17 @@ app.get('/api/translate', async (c) => {
   return c.json({ q, translation: result.translation });
 });
 
-// Classic commentary for a single verse: fetch each commentator's note from
-// Sefaria (Hebrew + English), skip the ones with nothing on this verse. Cached
-// per verse. No AI — raw Rishonim.
-app.get('/api/commentary/:book/:chapter/:verse', async (c) => {
-  const book = c.req.param('book');
-  const chapter = c.req.param('chapter');
-  const verse = c.req.param('verse');
-  if (!isBook(book)) return c.json({ error: `Unknown book: ${book}` }, 400);
-  if (!/^\d+$/.test(chapter) || !/^\d+$/.test(verse)) return c.json({ error: 'Bad chapter/verse' }, 400);
+interface VerseCommentary {
+  key: string;
+  en: string;
+  heName: string;
+  he: string[];
+  enText: string[];
+}
 
-  const key = `commentary:v1:${book}:${chapter}:${verse}`;
-  const cached = await c.env.CACHE.get(key);
-  if (cached) return c.json(JSON.parse(cached));
-
+/** Fetch each curated commentator's note on a verse from Sefaria (he+en), drop
+ *  the empties. Shared by the commentary drawer and the synthesis producer. */
+async function fetchVerseCommentaries(book: string, chapter: string, verse: string): Promise<VerseCommentary[]> {
   const results = await Promise.all(
     COMMENTATORS.map(async (cm) => {
       const ref = `${cm.title} on ${book} ${chapter}:${verse}`;
@@ -357,8 +355,135 @@ app.get('/api/commentary/:book/:chapter/:verse', async (c) => {
       }
     }),
   );
-  const commentaries = results.filter((r): r is NonNullable<typeof r> => r !== null);
+  return results.filter((r): r is VerseCommentary => r !== null);
+}
+
+// Classic commentary for a single verse: each commentator's note from Sefaria
+// (Hebrew + English), the empties skipped. Cached per verse. No AI — raw Rishonim.
+app.get('/api/commentary/:book/:chapter/:verse', async (c) => {
+  const book = c.req.param('book');
+  const chapter = c.req.param('chapter');
+  const verse = c.req.param('verse');
+  if (!isBook(book)) return c.json({ error: `Unknown book: ${book}` }, 400);
+  if (!/^\d+$/.test(chapter) || !/^\d+$/.test(verse)) return c.json({ error: 'Bad chapter/verse' }, 400);
+
+  const key = `commentary:v1:${book}:${chapter}:${verse}`;
+  const cached = await c.env.CACHE.get(key);
+  if (cached) return c.json(JSON.parse(cached));
+
+  const commentaries = await fetchVerseCommentaries(book, chapter, verse);
   const payload = { book, chapter: Number(chapter), verse: Number(verse), commentaries };
+  c.executionCtx.waitUntil(c.env.CACHE.put(key, JSON.stringify(payload)).then(() => undefined));
+  return c.json(payload);
+});
+
+// Commentary synthesis (AI): a short balanced overview of how the Rishonim read
+// the verse. The reader only requests it on "rich" verses (per the source
+// index), so it isn't generated for every pasuk. Cached + usage-tracked.
+app.get('/api/synthesis/:book/:chapter/:verse', async (c) => {
+  const book = c.req.param('book');
+  const chapter = c.req.param('chapter');
+  const verse = c.req.param('verse');
+  if (!isBook(book)) return c.json({ error: `Unknown book: ${book}` }, 400);
+  if (!/^\d+$/.test(chapter) || !/^\d+$/.test(verse)) return c.json({ error: 'Bad chapter/verse' }, 400);
+
+  const key = `synthesis:v1:${book}:${chapter}:${verse}`;
+  const cached = await c.env.CACHE.get(key);
+  if (cached) return c.json(JSON.parse(cached));
+
+  // Reuse the cached commentary if the drawer already fetched it.
+  let commentaries: VerseCommentary[];
+  const cc = await c.env.CACHE.get(`commentary:v1:${book}:${chapter}:${verse}`);
+  commentaries = cc
+    ? (JSON.parse(cc).commentaries as VerseCommentary[])
+    : await fetchVerseCommentaries(book, chapter, verse);
+  if (commentaries.length < 2) return c.json({ error: 'Not enough commentary to synthesize' }, 404);
+
+  let verseText = '';
+  try {
+    const t = await sefaria.getText(`${book} ${chapter}:${verse}`);
+    verseText = (asVerses(t.text)[0] || asVerses(t.he)[0] || '').replace(/<[^>]+>/g, '').trim();
+  } catch {
+    /* verse text is optional context */
+  }
+  const ctext = commentaries
+    .map((cm) => `${cm.en}: ${cm.he.join(' ').replace(/<[^>]+>/g, '').slice(0, 600)}`)
+    .join('\n\n');
+
+  let result: Awaited<ReturnType<typeof synthesize>>;
+  try {
+    result = await synthesize(c.env, `${book} ${chapter}:${verse}`, verseText, ctext);
+  } catch (e) {
+    return c.json({ error: `Producer failed: ${(e as Error).message}` }, 502);
+  }
+
+  const payload = { book, chapter: Number(chapter), verse: Number(verse), en: result.en, he: result.he };
+  c.executionCtx.waitUntil(
+    Promise.all([
+      c.env.CACHE.put(key, JSON.stringify(payload)),
+      recordUsage(c.env.CACHE, {
+        ts: Date.now(),
+        ref: `${book} ${chapter}:${verse}`,
+        producer: 'synthesis',
+        model: result.model,
+        in: result.inTokens,
+        out: result.outTokens,
+        cost: result.costUsd,
+      }),
+    ]).then(() => undefined),
+  );
+  return c.json(payload);
+});
+
+// Per-chapter rishonim index: how many of the curated commentators comment on
+// each verse. ~8 light per-chapter fetches (matches what the drawer shows). The
+// reader uses this to show the commentary icon only where many comment.
+app.get('/api/sources-index/:book/:chapter', async (c) => {
+  const book = c.req.param('book');
+  const chapter = c.req.param('chapter');
+  if (!isBook(book)) return c.json({ error: `Unknown book: ${book}` }, 400);
+  if (!/^\d+$/.test(chapter)) return c.json({ error: 'Bad chapter' }, 400);
+
+  const key = `srcidx:v3:${book}:${chapter}`;
+  const cached = await c.env.CACHE.get(key);
+  if (cached) return c.json(JSON.parse(cached));
+
+  // Per verse: how many commentators, and the total weight (chars of Hebrew
+  // commentary) — volume is a better "richness" signal than count, since in the
+  // Torah almost every verse has several commentators.
+  const acc = new Map<number, { n: number; w: number }>();
+  await Promise.all(
+    COMMENTATORS.map(async (cm) => {
+      try {
+        const v3 = await sefaria.getTextV3(`${cm.title} on ${book} ${chapter}`);
+        const heArr = (() => {
+          const he = pickV3Version(v3.versions, 'he');
+          return Array.isArray(he) ? (he as unknown[]) : [];
+        })();
+        for (let i = 0; i < heArr.length; i++) {
+          const segs = flattenPieces(heArr[i]).map((x) => x.replace(/<[^>]+>/g, '').trim());
+          const chars = segs.join('').length;
+          if (!chars) continue;
+          const e = acc.get(i + 1) ?? { n: 0, w: 0 };
+          e.n += 1;
+          e.w += chars;
+          acc.set(i + 1, e);
+        }
+      } catch {
+        /* commentator absent on this book */
+      }
+    }),
+  );
+  const entries = [...acc.entries()].sort((a, b) => a[0] - b[0]);
+  // "rich" = many commentators AND in the top fraction of this chapter by volume.
+  const weights = entries.map(([, e]) => e.w).sort((a, b) => a - b);
+  const cutoff = weights.length ? weights[Math.floor(weights.length * 0.6)] : 0;
+  const verses = entries.map(([verse, e]) => ({
+    verse,
+    rishonim: e.n,
+    rich: e.n >= 3 && e.w >= cutoff,
+  }));
+  const payload = { book, chapter: Number(chapter), verses };
   c.executionCtx.waitUntil(c.env.CACHE.put(key, JSON.stringify(payload)).then(() => undefined));
   return c.json(payload);
 });

--- a/packages/tanach/src/worker/producers/synthesis.ts
+++ b/packages/tanach/src/worker/producers/synthesis.ts
@@ -1,0 +1,79 @@
+/**
+ * Commentary synthesis — distills the several classic commentators on a verse
+ * into one short, balanced overview ("Rashi reads X; Ramban counters Y; Ibn
+ * Ezra stays with the plain sense Z"). Shown only on verses where many comment
+ * (the reader gates this by the source index), so it isn't generated per pasuk.
+ *
+ * Composes on the commentary fetch: its input is the per-verse Rishonim.
+ */
+
+import { runLLM, type LLMEnv } from '@corpus/core/llm/llm';
+import { costUsd } from '@corpus/core/llm/pricing';
+
+export interface SynthesisResult {
+  en: string;
+  he: string;
+  model: string;
+  costUsd: number | null;
+  inTokens: number;
+  outTokens: number;
+}
+
+const SYSTEM = [
+  'You summarize how the classic Jewish commentators read a verse of the Hebrew',
+  'Bible, for a reader deciding what to dig into.',
+  '',
+  'You are given the verse and several commentators\' notes. Write a short',
+  'overview of the MAIN lines of interpretation: what they broadly agree on, and',
+  'where — and how — they differ.',
+  '',
+  'Rules:',
+  '- 2 to 4 sentences. Name the commentators you refer to (Rashi, Ramban, ...).',
+  '- Only summarize what the given commentators say; add no interpretation of',
+  '  your own and nothing not present in the notes.',
+  '- If they mostly agree, say so plainly rather than inventing a dispute.',
+  '- Give it in BOTH English ("en") and natural, fluent Hebrew ("he").',
+].join('\n');
+
+const SCHEMA = {
+  name: 'commentary_synthesis',
+  strict: true,
+  schema: {
+    type: 'object',
+    additionalProperties: false,
+    required: ['en', 'he'],
+    properties: { en: { type: 'string' }, he: { type: 'string' } },
+  },
+};
+
+export async function synthesize(env: LLMEnv, ref: string, verseText: string, commentatorsText: string): Promise<SynthesisResult> {
+  const res = await runLLM(env, {
+    messages: [
+      { role: 'system', content: SYSTEM },
+      { role: 'user', content: `Verse ${ref}: ${verseText}\n\nCommentators:\n${commentatorsText}` },
+    ],
+    max_tokens: 800,
+    temperature: 0.3,
+    response_format: { type: 'json_schema', json_schema: SCHEMA },
+    tag: 'tanach:synthesis',
+  });
+
+  let en = '';
+  let he = '';
+  try {
+    const p = JSON.parse(res.content) as { en?: string; he?: string };
+    en = String(p.en ?? '').trim();
+    he = String(p.he ?? '').trim();
+  } catch {
+    /* leave empty */
+  }
+
+  return {
+    en,
+    he,
+    model: res.model,
+    costUsd: costUsd(res.model, res.usage),
+    inTokens: res.usage?.prompt_tokens ?? 0,
+    outTokens: res.usage?.completion_tokens ?? 0,
+  };
+}


### PR DESCRIPTION
Commentary icon + AI synthesis on the verses where many comment

Adds a rishonim icon (Talmud-style Hebrew letter) and an AI synthesis, shown
only on "rich" verses — not every pasuk.

- /api/sources-index/:book/:chapter: per-verse commentator count + total volume,
  from the curated commentators' chapter fetches (matches the drawer). Marks a
  verse "rich" when several comment AND it's in the top fraction of the chapter
  by commentary volume — so the icon is selective.
- producers/synthesis.ts + /api/synthesis/:book/:chapter/:verse: a short
  bilingual overview of how the Rishonim read the verse (names them, agreements
  + differences; only summarizes the given notes). Composes on the commentary
  fetch (shared fetchVerseCommentaries helper). Cached + usage-tracked.
- Client: a "ר" icon after the verse number on rich verses opens the commentary
  drawer, which now leads with the synthesis (fetched only for rich verses),
  then the raw commentators.

Verified: Genesis 1 -> 12/28 verses rich; synthesis on 1:1 correctly distills
Rashi/Ramban (Rabbi Yitzchak), Rashbam vs Ibn Ezra (grammar), Sforno, Radak.

Next: a midrash layer (its own icon) — deferred because the per-verse midrash
links are very heavy (Genesis 1:1 alone has 147), the natural synthesis case.
