### PR TITLE
Tanach: rishonim icon in the gutter, drop section-anchor dot

### DIFF
--- a/packages/tanach/src/client/App.tsx
+++ b/packages/tanach/src/client/App.tsx
@@ -48,10 +48,14 @@ const SETUMA = '\u0002';
 
 /** Margin-anchor box width + gap from the text band (used both to place the
  *  label and to decide whether it fits in the margin). */
-const ANCHOR_W = 150;
+const ANCHOR_W = 140;
 // Gap from the text band to the dot (the verse tick sits close to the text); the
 // label itself is pushed further into the margin by .evt-margin padding.
-const ANCHOR_GAP = 6;
+const ANCHOR_GAP = 24;
+// Source icons (rishonim, ...) live in a thin lane right at the band edge,
+// inside the event-anchor labels.
+const ICON_SIZE = 16;
+const ICON_GAP = 4;
 
 /**
  * Build the scroll's paragraphs from a chapter's verses, honouring the Masoretic
@@ -67,12 +71,7 @@ function escapeHtml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
-function buildParagraphs(
-  verses: Verse[],
-  nikud: boolean,
-  labels?: Map<number, string>,
-  rich?: Set<number>,
-): string[] {
+function buildParagraphs(verses: Verse[], nikud: boolean, labels?: Map<number, string>): string[] {
   let joined = verses
     .map((v) => {
       const label = labels?.get(v.n);
@@ -80,12 +79,7 @@ function buildParagraphs(
       // point (.evt-pt); the label itself is positioned in the margin by App.
       const cls = label ? 'vnum evt-pt' : 'vnum';
       const attrs = label ? ` data-v="${v.n}" data-label="${escapeHtml(label)}"` : '';
-      // a "rishonim" icon on verses where many comment (the source index marks
-      // these "rich"); clicking it opens the commentary drawer.
-      const mark = rich?.has(v.n)
-        ? `<button class="vmark vmark-rishonim" data-v="${v.n}" title="Commentary">\u05e8</button>`
-        : '';
-      return `<span class="vtext" data-vn="${v.n}"><span class="${cls}"${attrs}>${hebrewNumeral(v.n)}</span>${mark} ${v.he}</span>`;
+      return `<span class="vtext" data-vn="${v.n}"><span class="${cls}"${attrs}>${hebrewNumeral(v.n)}</span> ${v.he}</span>`;
     })
     .join(' ');
   joined = joined
@@ -242,7 +236,7 @@ export function App(): JSX.Element {
     const labels = new Map(
       (events() ?? []).map((s) => [s.verse, (he ? s.he : s.en) || s.en || s.he] as const),
     );
-    return buildParagraphs(ch.verses, loc().nikud, labels, richSet());
+    return buildParagraphs(ch.verses, loc().nikud, labels);
   });
 
   // Margin anchors: measure each section-start verse number (.evt-pt) and pin its
@@ -253,11 +247,15 @@ export function App(): JSX.Element {
   const [anchors, setAnchors] = createSignal<
     { v: string; label: string; top: number; left: number; side: 'left' | 'right' }[]
   >([]);
+  const [verseIcons, setVerseIcons] = createSignal<
+    { v: number; top: number; left: number; side: 'left' | 'right' }[]
+  >([]);
   const [reflow, setReflow] = createSignal(0);
 
   const measure = () => {
     if (loc().view !== 'scroll' || !scrollMain || !scrollBand) {
       setAnchors([]);
+      setVerseIcons([]);
       return;
     }
     const m = scrollMain.getBoundingClientRect();
@@ -276,6 +274,23 @@ export function App(): JSX.Element {
       out.push({ v: pt.dataset.v ?? '', label: pt.dataset.label ?? '', top: r.top - m.top, left, side });
     });
     setAnchors(out);
+
+    // Source icons at the band edge, for the verses the index marks "rich".
+    const rich = richSet();
+    const icons: { v: number; top: number; left: number; side: 'left' | 'right' }[] = [];
+    if (rich.size) {
+      scrollBand.querySelectorAll<HTMLElement>('.vtext').forEach((vt) => {
+        const vn = Number(vt.dataset.vn);
+        if (!rich.has(vn)) return;
+        const r = vt.getBoundingClientRect();
+        if (!r.height) return;
+        const side: 'left' | 'right' = r.left + r.width / 2 < m.left + m.width / 2 ? 'left' : 'right';
+        const left = side === 'right' ? b.right - m.left + ICON_GAP : b.left - m.left - ICON_SIZE - ICON_GAP;
+        if (left < 2 || left + ICON_SIZE > m.width - 2) return;
+        icons.push({ v: vn, top: r.top - m.top, left, side });
+      });
+    }
+    setVerseIcons(icons);
   };
 
   onMount(() => {
@@ -291,6 +306,7 @@ export function App(): JSX.Element {
     reflow();
     loc().view;
     loc().nikud;
+    richSet();
     requestAnimationFrame(() => requestAnimationFrame(measure));
   });
 
@@ -493,6 +509,19 @@ export function App(): JSX.Element {
                   onClick={() => openAnchor(a)}
                 >
                   {a.label}
+                </button>
+              )}
+            </For>
+            <For each={verseIcons()}>
+              {(ic) => (
+                <button
+                  class="vgutter vgutter-rishonim"
+                  classList={{ active: commentaryVerse() === ic.v }}
+                  style={{ top: `${ic.top}px`, left: `${ic.left}px`, width: `${ICON_SIZE}px`, height: `${ICON_SIZE}px` }}
+                  title={`Commentary (verse ${ic.v})`}
+                  onClick={() => setCommentaryVerse(ic.v)}
+                >
+                  ר
                 </button>
               )}
             </For>

--- a/packages/tanach/src/client/styles.css
+++ b/packages/tanach/src/client/styles.css
@@ -294,25 +294,10 @@ body {
   unicode-bidi: isolate;
   transition: color 0.12s ease;
 }
-/* a small dot at the verse line, on the text-facing (inner) edge */
-.evt-margin::before {
-  content: '';
-  position: absolute;
-  top: 0.55em;
-  width: 4px;
-  height: 4px;
-  border-radius: 50%;
-  background: rgba(122, 92, 46, 0.5);
-  transition: background-color 0.12s ease;
-}
-.evt-margin.evt-right { text-align: left; padding-left: 20px; }
-.evt-margin.evt-right::before { left: 0; }
-.evt-margin.evt-left { text-align: right; padding-right: 20px; }
-.evt-margin.evt-left::before { right: 0; }
+.evt-margin.evt-right { text-align: left; padding-left: 6px; }
+.evt-margin.evt-left { text-align: right; padding-right: 6px; }
 .evt-margin:hover,
 .evt-margin.active { color: var(--accent); }
-.evt-margin:hover::before,
-.evt-margin.active::before { background: var(--accent); }
 @media (max-width: 820px) {
   .evt-margin { display: none; }
 }
@@ -555,3 +540,25 @@ body {
 }
 .comm-synth-text { margin: 0; font-size: 15px; line-height: 1.6; color: var(--ink); }
 .comm-synth-text[dir='rtl'] { font-family: 'Frank Ruhl Libre', serif; font-size: 16px; }
+
+/* source icons in the band-edge gutter (positioned by App, like the anchors) */
+.vgutter {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: var(--accent);
+  color: #fff;
+  font-family: 'Frank Ruhl Libre', serif;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+  cursor: pointer;
+  z-index: 5;
+  transition: background-color 0.1s ease, transform 0.1s ease;
+}
+.vgutter:hover,
+.vgutter.active { background: var(--ink); transform: scale(1.12); }


### PR DESCRIPTION
Move the commentary icon out of the inline text into a band-edge gutter (measured like the anchors); section labels move out past the icon lane and lose the little dot — just the label text.