### PR TITLE
Tanach: reverse Gemara lookup (how a pasuk is used in the Talmud)

### DIFF
--- a/packages/tanach/src/client/App.tsx
+++ b/packages/tanach/src/client/App.tsx
@@ -178,6 +178,10 @@ interface CommentaryResponse {
 interface SourceIdx {
   verses: { verse: number; rishonim: number; rich: boolean }[];
 }
+interface GemaraResp {
+  count: number;
+  passages: { ref: string; he: string; en: string }[];
+}
 /** The event/section labels for a chapter (first producer). Best-effort: a
  *  failure just means no margin anchors — the text still renders. */
 async function fetchEvents(loc: { book: string; chapter: number }): Promise<EventSection[]> {
@@ -405,6 +409,18 @@ export function App(): JSX.Element {
       return res.ok ? ((await res.json()) as SectionNote) : null;
     },
   );
+  // Reverse Gemara: how the verse is used in the Talmud (fetched when a verse
+  // drawer opens).
+  const [gemara] = createResource(
+    () => {
+      const v = commentaryVerse();
+      return v ? { book: loc().book, chapter: loc().chapter, verse: v } : null;
+    },
+    async (k) => {
+      const res = await fetch(`/api/gemara/${encodeURIComponent(k.book)}/${k.chapter}/${k.verse}`);
+      return res.ok ? ((await res.json()) as GemaraResp) : null;
+    },
+  );
   createEffect(() => {
     chapterKey();
     setCommentaryVerse(null);
@@ -622,6 +638,41 @@ export function App(): JSX.Element {
                     }}
                   </For>
                 )}
+              </Show>
+              <Show when={gemara() && gemara()!.passages.length > 0}>
+                {(_ok) => {
+                  const g = gemara() as GemaraResp;
+                  return (
+                    <section class="comm-gemara">
+                      <h4 class="comm-name">
+                        In the Talmud{g.count > g.passages.length ? ` · ${g.count}` : ''}
+                      </h4>
+                      <For each={g.passages}>
+                        {(p) => {
+                          const text = loc().lang === 'en' ? p.en || p.he : p.he || p.en;
+                          const ltr = loc().lang === 'en' && !!p.en;
+                          return (
+                            <div class="gem-entry">
+                              <a
+                                class="gem-ref"
+                                href={`https://www.sefaria.org/${p.ref.replace(/ /g, '.').replace(/:/g, '.')}`}
+                                target="_blank"
+                                rel="noopener"
+                              >
+                                {p.ref}
+                              </a>
+                              <Show when={text}>
+                                <p class="gem-text" dir={ltr ? 'ltr' : 'rtl'}>
+                                  {text}…
+                                </p>
+                              </Show>
+                            </div>
+                          );
+                        }}
+                      </For>
+                    </section>
+                  );
+                }}
               </Show>
             </div>
           </aside>

--- a/packages/tanach/src/client/styles.css
+++ b/packages/tanach/src/client/styles.css
@@ -562,3 +562,24 @@ body {
 }
 .vgutter:hover,
 .vgutter.active { background: var(--ink); transform: scale(1.12); }
+
+/* "In the Talmud" section (reverse Gemara lookup) in the verse drawer */
+.comm-gemara { padding: 14px 0 4px; border-top: 1px solid var(--line); margin-top: 6px; }
+.gem-entry { padding: 8px 0; }
+.gem-entry + .gem-entry { border-top: 1px dashed var(--line); }
+.gem-ref {
+  display: inline-block;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--accent);
+  text-decoration: none;
+  margin-bottom: 3px;
+}
+.gem-ref:hover { text-decoration: underline; }
+.gem-text {
+  margin: 0;
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: var(--muted);
+}
+.gem-text[dir='rtl'] { font-family: 'Frank Ruhl Libre', serif; font-size: 15px; }

--- a/packages/tanach/src/worker/index.ts
+++ b/packages/tanach/src/worker/index.ts
@@ -488,6 +488,62 @@ app.get('/api/sources-index/:book/:chapter', async (c) => {
   return c.json(payload);
 });
 
+// Reverse Gemara lookup: how a verse is used in the Talmud. Sefaria's links
+// (category "Talmud" — Bavli, Yerushalmi, minor tractates) give the passages
+// that cite the verse; we fetch a snippet of each. Cached per verse.
+app.get('/api/gemara/:book/:chapter/:verse', async (c) => {
+  const book = c.req.param('book');
+  const chapter = c.req.param('chapter');
+  const verse = c.req.param('verse');
+  if (!isBook(book)) return c.json({ error: `Unknown book: ${book}` }, 400);
+  if (!/^\d+$/.test(chapter) || !/^\d+$/.test(verse)) return c.json({ error: 'Bad chapter/verse' }, 400);
+
+  const key = `gemara:v1:${book}:${chapter}:${verse}`;
+  const cached = await c.env.CACHE.get(key);
+  if (cached) return c.json(JSON.parse(cached));
+
+  type Link = { category?: string; ref?: string; sourceRef?: string; index_title?: string };
+  let links: Link[];
+  try {
+    const r = await fetch(
+      `https://www.sefaria.org/api/links/${encodeURIComponent(`${book} ${chapter}:${verse}`)}?with_text=0`,
+    );
+    links = (await r.json()) as Link[];
+  } catch (e) {
+    return c.json({ error: `Links fetch failed: ${(e as Error).message}` }, 502);
+  }
+
+  // Distinct Talmud refs, Bavli first (no "Jerusalem Talmud"/"Tractate " prefix),
+  // capped — then fetch a text snippet of each.
+  const seen = new Set<string>();
+  const picked: { ref: string; title: string }[] = [];
+  for (const l of Array.isArray(links) ? links : []) {
+    if (l.category !== 'Talmud') continue;
+    const ref = l.sourceRef || l.ref;
+    if (!ref || seen.has(ref)) continue;
+    seen.add(ref);
+    picked.push({ ref, title: l.index_title ?? '' });
+  }
+  picked.sort((a, b) => Number(/^(Jerusalem|Tractate)/.test(a.title)) - Number(/^(Jerusalem|Tractate)/.test(b.title)));
+  const top = picked.slice(0, 12);
+
+  const passages = await Promise.all(
+    top.map(async (p) => {
+      try {
+        const v3 = await sefaria.getTextV3(p.ref);
+        const he = flattenPieces(pickV3Version(v3.versions, 'he')).join(' ').replace(/<[^>]+>/g, '').trim().slice(0, 420);
+        const en = flattenPieces(pickV3Version(v3.versions, 'en')).join(' ').replace(/<[^>]+>/g, '').trim().slice(0, 420);
+        return { ref: p.ref, he, en };
+      } catch {
+        return { ref: p.ref, he: '', en: '' };
+      }
+    }),
+  );
+  const payload = { book, chapter: Number(chapter), verse: Number(verse), count: picked.length, passages };
+  c.executionCtx.waitUntil(c.env.CACHE.put(key, JSON.stringify(payload)).then(() => undefined));
+  return c.json(payload);
+});
+
 // Self-tracked LLM usage (totals + per-producer + recent calls).
 app.get('/api/usage', async (c) => c.json(await readUsage(c.env.CACHE)));
 


### PR DESCRIPTION
Reverse Gemara lookup: how a pasuk is used in the Talmud

The verse drawer now has an "In the Talmud" section listing the Gemara passages
that cite the verse (Bavli first, then Yerushalmi / minor tractates), each with
a snippet and a link to Sefaria.

- GET /api/gemara/:book/:chapter/:verse: Sefaria links (category "Talmud") for
  the verse -> distinct refs (Bavli sorted first), top 12, each passage's text
  fetched + snippeted. Cached per verse.
- Client: a gemara resource on drawer open + an "In the Talmud" section under
  the commentary, with the total count.

Verified: Leviticus 19:18 -> 27 passages incl. Shabbat 31a (Hillel "what is
hateful to you"), Pesachim 75a (dignity in execution), Nedarim 65b (vengeance).

Next: midrashim (its own layer); a known nit — consecutive section labels can
overlap vertically in the gutter.
