### PR TITLE
LLM cost: cheapest-flash routing + trim redundant prompt context

### DIFF
--- a/packages/core/src/llm/llm.ts
+++ b/packages/core/src/llm/llm.ts
@@ -78,12 +78,18 @@ export interface LLMCallOptions {
   thinking?: boolean;
   stream?: boolean;
   /**
-   * OpenRouter provider routing. Default for `openrouter/deepseek/*` models is
-   * `{ order: ['DeepSeek'], allow_fallbacks: false }` so we always hit
-   * DeepSeek's own promo-priced endpoint. Pass `null` to opt out.
-   * Ignored for `@cf/*` models.
+   * OpenRouter provider routing. When unset, `openrouter/deepseek/*` models
+   * default to `{ sort: 'price', allow_fallbacks: true, require_parameters: true }`
+   * — cheapest qualifying endpoint first (see the routing block in
+   * callOpenRouterGateway). Pass an explicit object to override, or `null` to
+   * opt out and take OpenRouter's default load-balancer. Ignored for `@cf/*`.
    */
-  provider?: { order?: string[]; allow_fallbacks?: boolean } | null;
+  provider?: {
+    order?: string[];
+    allow_fallbacks?: boolean;
+    sort?: 'price' | 'throughput' | 'latency';
+    require_parameters?: boolean;
+  } | null;
   /**
    * Skip the Cloudflare AI Gateway's prompt cache for this request. Sends
    * `cf-aig-skip-cache: true` on the OpenRouter Universal Endpoint call. Use
@@ -434,14 +440,25 @@ async function callOpenRouterGateway(env: LLMEnv, model: LLMModelId, opts: LLMCa
     body.stream = true;
     body.stream_options = { include_usage: true };
   }
-  // Auto provider-pinning was removed: pinning DeepSeek's own endpoint is
-  // cheap when it's healthy, but during congestion the cascade lands on
-  // rate-limited providers and worsens latency. OpenRouter's default routing
-  // picks the lowest-latency healthy provider. Re-enable on a per-call basis
-  // via opts.provider when explicitly choosing cost-over-speed.
+  // Provider routing. An explicit opts.provider always wins; pass `null` to
+  // opt out and take OpenRouter's default load-balancer. Otherwise, for any
+  // DeepSeek slug we route cheapest-endpoint-first:
+  //   - V4 Pro: DeepSeek's own endpoint is the cheapest ($0.435/$0.87), so
+  //     price-sorting keeps Pro on first-party.
+  //   - V4 Flash: third-party providers (Baidu / DeepInfra / Cloudflare,
+  //     ~$0.10/$0.20) undercut DeepSeek's own Flash ($0.14/$0.28) by ~30-40%,
+  //     so price-sorting moves Flash to the cheaper endpoint.
+  // `require_parameters` keeps routing to providers that honor everything we
+  // send (response_format / json_schema / reasoning) so structured-output
+  // marks never land on an endpoint that silently drops the schema — if no
+  // cheaper provider qualifies it just falls back to DeepSeek, costing nothing.
+  // `allow_fallbacks` preserves availability under congestion (the reason
+  // hard-pinning was originally removed).
   const explicitProvider = (opts as { provider?: unknown }).provider;
-  if (explicitProvider) {
-    body.provider = explicitProvider;
+  if (explicitProvider !== undefined) {
+    if (explicitProvider !== null) body.provider = explicitProvider;
+  } else if (orSlug.startsWith('deepseek/')) {
+    body.provider = { sort: 'price', allow_fallbacks: true, require_parameters: true };
   }
 
   const url = openRouterGatewayUrl(env);

--- a/packages/talmud/src/worker/code-marks.ts
+++ b/packages/talmud/src/worker/code-marks.ts
@@ -127,9 +127,6 @@ const RABBI_USER_TEMPLATE = `Tractate: {{tractate}}, page {{page}}.
 Hebrew/Aramaic source (copy excerpt VERBATIM from here):
 {{hebrew}}
 
-English translation (for rabbi identification, do not copy):
-{{english}}
-
 Identify every distinct rabbi named. Return JSON per the schema.`;
 
 const NOW = '2026-05-04T00:00:00.000Z';
@@ -150,7 +147,7 @@ const NOW = '2026-05-04T00:00:00.000Z';
 // instance — V4 doesn't reliably produce deep nested JSON in one shot, so we
 // split structural extraction from rabbi enrichment the same way the legacy
 // pipeline did.
-const ARGUMENT_SYSTEM_PROMPT = `You are a scholar of Talmud. Given a focal amud's Hebrew/Aramaic source split into NUMBERED segments and its English translation (same numbering), identify the argument structure as discrete sections.
+const ARGUMENT_SYSTEM_PROMPT = `You are a scholar of Talmud. Given a focal amud's Hebrew/Aramaic source split into NUMBERED segments, identify the argument structure as discrete sections.
 
 Output STRICT JSON only — no markdown, no prose:
 
@@ -226,7 +223,7 @@ const ARGUMENT_USER_TEMPLATE_HE = `מסכת: {{tractate}}, דף {{page}}.
 // Halacha mark — topics + start/end segment indices.
 // ---------------------------------------------------------------------------
 
-const HALACHA_SYSTEM_PROMPT = `You are a scholar of Jewish law (halacha). Given a focal amud's Hebrew/Aramaic source split into NUMBERED segments and its English translation (same numbering), identify the main PRACTICAL halachic topics discussed on the page.
+const HALACHA_SYSTEM_PROMPT = `You are a scholar of Jewish law (halacha). Given a focal amud's Hebrew/Aramaic source split into NUMBERED segments, identify the main PRACTICAL halachic topics discussed on the page.
 
 Output STRICT JSON only:
 
@@ -381,7 +378,7 @@ Build comparison tables ONLY for regions that genuinely warrant a grid. Return J
 // Aggadata mark — narrative units (stories, parables, ethical maxims).
 // ---------------------------------------------------------------------------
 
-const AGGADATA_SYSTEM_PROMPT = `You are a Talmud scholar. Given a focal amud's Hebrew/Aramaic source (NUMBERED segments) and its English translation (same numbering), identify every aggadic unit — narrative stories, biographical anecdotes, parables (mashalim), dream/miracle reports, and ethical maxims embedded in narrative. Skip purely halachic exposition.
+const AGGADATA_SYSTEM_PROMPT = `You are a Talmud scholar. Given a focal amud's Hebrew/Aramaic source (NUMBERED segments), identify every aggadic unit — narrative stories, biographical anecdotes, parables (mashalim), dream/miracle reports, and ethical maxims embedded in narrative. Skip purely halachic exposition.
 
 Output STRICT JSON only:
 
@@ -458,7 +455,7 @@ const AGGADATA_USER_TEMPLATE_HE = `מסכת: {{tractate}}, דף {{page}}.
 // Pesukim mark — biblical citations / allusions.
 // ---------------------------------------------------------------------------
 
-const PESUKIM_SYSTEM_PROMPT = `You are a scholar of Tanach and Talmud. Given a focal amud's Hebrew/Aramaic source (NUMBERED segments) and its English translation (same numbering), identify every reference to a Tanach verse on the page — explicit citations, allusions, and paraphrases.
+const PESUKIM_SYSTEM_PROMPT = `You are a scholar of Tanach and Talmud. Given a focal amud's Hebrew/Aramaic source (NUMBERED segments), identify every reference to a Tanach verse on the page — explicit citations, allusions, and paraphrases.
 
 Output STRICT JSON only:
 
@@ -1343,15 +1340,16 @@ Rules:
 
 ${HEBREW_GLOSS_STYLE}`;
 
-// Shared user prompt template for the four leaf rabbi enrichments. The
+// Shared user prompt template for the five leaf rabbi enrichments. The
 // synthesis has its own template that consumes depends.
+// Daf-agnostic leaves (bio / philosophy / relationships / classification /
+// geography). The output is biographical and does NOT depend on the focal
+// daf, so the daf's Hebrew is deliberately NOT injected — it would be ~daf-
+// worth of input tokens per leaf per rabbi for zero effect on the answer.
+// (The per-daf .evidence enrichments, which DO need the daf, use their own
+// templates.)
 const RABBI_LEAF_USER_TEMPLATE = `Rabbi:
 {{mark_input}}
-
-Tractate: {{tractate}}, page {{page}}.
-
-Focal Hebrew of the daf:
-{{hebrew}}
 
 Return JSON per the schema.`;
 
@@ -1614,11 +1612,6 @@ ${HEBREW_NATIVE_STYLE}`;
 // Hebrew user templates — same template variables as the English versions.
 const RABBI_LEAF_USER_TEMPLATE_HE = `החכם:
 {{mark_input}}
-
-מסכת: {{tractate}}, דף {{page}}.
-
-עברית מוקד של הדף:
-{{hebrew}}
 
 החזר JSON לפי הסכימה.`;
 
@@ -3921,9 +3914,6 @@ const PLACES_USER_TEMPLATE = `Tractate: {{tractate}}, page {{page}}.
 
 Hebrew/Aramaic source (copy excerpts VERBATIM from here):
 {{hebrew}}
-
-English translation (for context only):
-{{english}}
 
 Identify every geographic reference. Return JSON per the schema.`;
 

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -2429,8 +2429,27 @@ async function runExtractorFannedOut(
     ? dedupeByRange(rawInstances as Array<Partial<{ startSegIdx: number; endSegIdx: number }>>)
     : rawInstances;
 
-  const renderAndCall = async (anchorsOverride: Record<string, unknown>, maxTokens: number) => {
-    const callVars = { ...baseVars, anchors: anchorsOverride };
+  const renderAndCall = async (
+    anchorsOverride: Record<string, unknown>,
+    maxTokens: number,
+    segRange?: { start: number; end: number },
+  ) => {
+    const callVars: Record<string, unknown> = { ...baseVars, anchors: anchorsOverride };
+    // Fan-out scoping: when this call covers a single section, send only that
+    // section's Hebrew segments instead of the whole amud. Pre-number the lines
+    // with their GLOBAL segment index (the exact [N] labels renderTemplate emits
+    // for the full array) so excerpt anchoring and the section-range move ids
+    // stay valid; passing a string makes renderTemplate skip its array path and
+    // emit it verbatim. Cuts (sections-1)x the amud's Hebrew per daf — the
+    // section text is the only large payload that was duplicated across calls.
+    if (segRange && Array.isArray(baseVars.segments_he)) {
+      const full = baseVars.segments_he as string[];
+      const sliced = full.map((s, i) => `[${i}] ${s}`).slice(segRange.start, segRange.end + 1);
+      // Only narrow when the range actually selects segments. An out-of-range
+      // section (data drift between the parent mark and the slice) falls back
+      // to the full amud rather than sending an empty source.
+      if (sliced.length > 0) callVars.segments_he = sliced.join('\n');
+    }
     const systemPrompt = renderTemplate(ext.system_prompt, callVars);
     const userPrompt = renderTemplate(ext.user_prompt_template, callVars);
     const r = await runLLM(rc.env, {
@@ -2464,7 +2483,23 @@ async function runExtractorFannedOut(
   for (let i = 0; i < instances.length; i += FAN_OUT_CONCURRENCY) {
     const wave = instances.slice(i, i + FAN_OUT_CONCURRENCY);
     const settled = await Promise.all(
-      wave.map((inst) => renderAndCall({ ...anchors, [fanOutMarkId]: [inst] }, 8000)),
+      wave.map((inst) => {
+        // Type-check BEFORE any coercion: Number(null) / Number('') === 0, which
+        // would turn a malformed section into a bogus 0-0 range and silently
+        // send only segment 0. A non-number index falls back to full-daf text.
+        const rawStart = (inst as { startSegIdx?: unknown }).startSegIdx;
+        const rawEnd = (inst as { endSegIdx?: unknown }).endSegIdx;
+        const segRange =
+          typeof rawStart === 'number' &&
+          Number.isInteger(rawStart) &&
+          typeof rawEnd === 'number' &&
+          Number.isInteger(rawEnd) &&
+          rawStart >= 0 &&
+          rawEnd >= rawStart
+            ? { start: rawStart, end: rawEnd }
+            : undefined;
+        return renderAndCall({ ...anchors, [fanOutMarkId]: [inst] }, 8000, segRange);
+      }),
     );
     for (const { r, systemPrompt, userPrompt } of settled) {
       if (!sysSample) { sysSample = systemPrompt; userSample = userPrompt; }


### PR DESCRIPTION
## Why
Audit of OpenRouter spend (account lifetime ~\$1,509) found two recoverable levers: Flash calls weren't routed to the cheapest provider, and several producers send input tokens that can't affect the answer.

## Changes
**Provider routing** (`packages/core/src/llm/llm.ts`, shared by talmud + tanach)
- DeepSeek calls now default to `{ sort: 'price', allow_fallbacks: true, require_parameters: true }` (cheapest qualifying endpoint first) instead of OpenRouter's default load-balancer.
- V4 **Pro** stays on DeepSeek first-party (cheapest at \$0.435/\$0.87). V4 **Flash** moves to Baidu/DeepInfra/Cloudflare (~\$0.10/\$0.20 vs DeepSeek's own \$0.14/\$0.28) — **~30-40% off all Flash spend, input AND output**.
- `require_parameters` keeps structured-output marks on endpoints that honor the schema (falls back to DeepSeek otherwise — costs nothing). Explicit `opts.provider` still wins; `null` opts out.

**Context trims** (`packages/talmud`) — remove input tokens that don't change the output
- **argument-move fan-out** sends only each section's Hebrew segments instead of re-sending the whole amud on every section call (the largest pure duplication; ~(sections−1)× the amud per daf). Global `[N]` indices preserved so excerpt anchoring + section-range move ids stay valid; out-of-range/malformed sections fall back to full-daf text.
- **rabbi + places** drop the verbose English translation (Hebrew-only verbatim extraction; English was ~3-4× the Hebrew in tokens).
- the five **daf-agnostic rabbi leaves** (bio/philosophy/relationships/classification/geography) no longer inject focal daf Hebrew.
- remove the phantom "and its English translation" claim from argument/halacha/aggadata/pesukim prompts (those marks only ever received Hebrew).

## Savings (input trims)
~10-12k input tokens/cold daf → ~\$6-8 per full-Shas re-warm (+ ~\$1 one-time for the rabbi leaves); negligible per-day in steady state. The recurring win is the Flash routing change. argument-move scoping also cuts latency and the timeout risk on 40+-move dapim.

## Safety
- No `cache_version` bumps — prompt text is not in the cache key, so existing entries stay valid; only cold/re-warm computations take the cheaper path. No forced re-warm.
- `pnpm typecheck` + `pnpm test` (1938 tests) green. Codex read-only review applied (hardened the section-index guard against `Number(null)===0`).

## Follow-up
If `require_parameters` turns out too restrictive (cheap providers not advertising json_schema support), dropping it or curating a provider allowlist is the next lever. Worth confirming the May-31 DeepSeek V4 Pro price change on the OpenRouter Activity dashboard.