### PR TITLE
Tanach: midrash synthesis + Gemara/Midrash gutter icons

### DIFF
--- a/packages/tanach/src/client/App.tsx
+++ b/packages/tanach/src/client/App.tsx
@@ -175,13 +175,32 @@ interface CommentaryResponse {
   verse: number;
   commentaries: CommentaryEntry[];
 }
+interface SourceVerse {
+  verse: number;
+  rishonim: number;
+  rich: boolean;
+  gemara: number;
+  midrash: number;
+}
 interface SourceIdx {
-  verses: { verse: number; rishonim: number; rich: boolean }[];
+  verses: SourceVerse[];
 }
 interface GemaraResp {
   count: number;
   passages: { ref: string; he: string; en: string }[];
 }
+type SourceKind = 'rishonim' | 'gemara' | 'midrash';
+const GEMARA_MIN = 2;
+const MIDRASH_MIN = 5;
+/** Which gutter icons a verse gets, in display order. */
+function verseKinds(v: SourceVerse): SourceKind[] {
+  const k: SourceKind[] = [];
+  if (v.rich) k.push('rishonim');
+  if (v.gemara >= GEMARA_MIN) k.push('gemara');
+  if (v.midrash >= MIDRASH_MIN) k.push('midrash');
+  return k;
+}
+const KIND_GLYPH: Record<SourceKind, string> = { rishonim: 'ר', gemara: 'ג', midrash: 'מ' };
 /** The event/section labels for a chapter (first producer). Best-effort: a
  *  failure just means no margin anchors — the text still renders. */
 async function fetchEvents(loc: { book: string; chapter: number }): Promise<EventSection[]> {
@@ -252,7 +271,7 @@ export function App(): JSX.Element {
     { v: string; label: string; top: number; left: number; side: 'left' | 'right' }[]
   >([]);
   const [verseIcons, setVerseIcons] = createSignal<
-    { v: number; top: number; left: number; side: 'left' | 'right' }[]
+    { v: number; top: number; left: number; side: 'left' | 'right'; kinds: SourceKind[] }[]
   >([]);
   const [reflow, setReflow] = createSignal(0);
 
@@ -279,19 +298,25 @@ export function App(): JSX.Element {
     });
     setAnchors(out);
 
-    // Source icons at the band edge, for the verses the index marks "rich".
-    const rich = richSet();
-    const icons: { v: number; top: number; left: number; side: 'left' | 'right' }[] = [];
-    if (rich.size) {
+    // Source icons (ר/ג/מ) stacked at the band edge, for verses the index flags.
+    const kindsByVerse = new Map<number, SourceKind[]>();
+    for (const v of sourcesIndex()?.verses ?? []) {
+      const k = verseKinds(v);
+      if (k.length) kindsByVerse.set(v.verse, k);
+    }
+    const icons: { v: number; top: number; left: number; side: 'left' | 'right'; kinds: SourceKind[] }[] = [];
+    if (kindsByVerse.size) {
       scrollBand.querySelectorAll<HTMLElement>('.vtext').forEach((vt) => {
         const vn = Number(vt.dataset.vn);
-        if (!rich.has(vn)) return;
+        const kinds = kindsByVerse.get(vn);
+        if (!kinds) return;
         const r = vt.getBoundingClientRect();
         if (!r.height) return;
+        // icons stack vertically -> the lane stays one icon wide
         const side: 'left' | 'right' = r.left + r.width / 2 < m.left + m.width / 2 ? 'left' : 'right';
         const left = side === 'right' ? b.right - m.left + ICON_GAP : b.left - m.left - ICON_SIZE - ICON_GAP;
         if (left < 2 || left + ICON_SIZE > m.width - 2) return;
-        icons.push({ v: vn, top: r.top - m.top, left, side });
+        icons.push({ v: vn, top: r.top - m.top, left, side, kinds });
       });
     }
     setVerseIcons(icons);
@@ -311,6 +336,7 @@ export function App(): JSX.Element {
     loc().view;
     loc().nikud;
     richSet();
+    sourcesIndex();
     requestAnimationFrame(() => requestAnimationFrame(measure));
   });
 
@@ -421,6 +447,54 @@ export function App(): JSX.Element {
       return res.ok ? ((await res.json()) as GemaraResp) : null;
     },
   );
+  // Midrash: the source list + an AI synthesis (only where there's substantial
+  // midrash, since a verse can have dozens).
+  const idxByVerse = createMemo(() => {
+    const map = new Map<number, SourceVerse>();
+    for (const v of sourcesIndex()?.verses ?? []) map.set(v.verse, v);
+    return map;
+  });
+  const [midrash] = createResource(
+    () => {
+      const v = commentaryVerse();
+      return v && (idxByVerse().get(v)?.midrash ?? 1) > 0 ? { book: loc().book, chapter: loc().chapter, verse: v } : null;
+    },
+    async (k) => {
+      const res = await fetch(`/api/midrash/${encodeURIComponent(k.book)}/${k.chapter}/${k.verse}`);
+      return res.ok ? ((await res.json()) as GemaraResp) : null;
+    },
+  );
+  const [midrashSynth] = createResource(
+    () => {
+      const v = commentaryVerse();
+      return v && (idxByVerse().get(v)?.midrash ?? 0) >= MIDRASH_MIN
+        ? { book: loc().book, chapter: loc().chapter, verse: v }
+        : null;
+    },
+    async (k) => {
+      const res = await fetch(`/api/midrash-synthesis/${encodeURIComponent(k.book)}/${k.chapter}/${k.verse}`);
+      return res.ok ? ((await res.json()) as SectionNote) : null;
+    },
+  );
+  // Scroll the drawer to the section whose icon was clicked.
+  const [focusSection, setFocusSection] = createSignal<SourceKind | null>(null);
+  const openSource = (v: number, kind: SourceKind) => {
+    setFocusSection(kind);
+    setCommentaryVerse(v);
+  };
+  createEffect(() => {
+    const fs = focusSection();
+    commentaryVerse();
+    if (fs === 'gemara') gemara();
+    if (fs === 'midrash') midrash();
+    if (!fs || fs === 'rishonim') return;
+    requestAnimationFrame(() =>
+      requestAnimationFrame(() => {
+        const sel = fs === 'gemara' ? '.comm-gemara' : '.comm-midrash';
+        document.querySelector(sel)?.scrollIntoView({ block: 'start', behavior: 'smooth' });
+      }),
+    );
+  });
   createEffect(() => {
     chapterKey();
     setCommentaryVerse(null);
@@ -530,15 +604,21 @@ export function App(): JSX.Element {
             </For>
             <For each={verseIcons()}>
               {(ic) => (
-                <button
-                  class="vgutter vgutter-rishonim"
-                  classList={{ active: commentaryVerse() === ic.v }}
-                  style={{ top: `${ic.top}px`, left: `${ic.left}px`, width: `${ICON_SIZE}px`, height: `${ICON_SIZE}px` }}
-                  title={`Commentary (verse ${ic.v})`}
-                  onClick={() => setCommentaryVerse(ic.v)}
-                >
-                  ר
-                </button>
+                <div class="vgutter-stack" style={{ top: `${ic.top}px`, left: `${ic.left}px` }}>
+                  <For each={ic.kinds}>
+                    {(k) => (
+                      <button
+                        class={`vgutter vgutter-${k}`}
+                        classList={{ active: commentaryVerse() === ic.v }}
+                        style={{ width: `${ICON_SIZE}px`, height: `${ICON_SIZE}px` }}
+                        title={`${k} · verse ${ic.v}`}
+                        onClick={() => openSource(ic.v, k)}
+                      >
+                        {KIND_GLYPH[k]}
+                      </button>
+                    )}
+                  </For>
+                </div>
               )}
             </For>
             <Show when={selected()}>
@@ -648,6 +728,49 @@ export function App(): JSX.Element {
                         In the Talmud{g.count > g.passages.length ? ` · ${g.count}` : ''}
                       </h4>
                       <For each={g.passages}>
+                        {(p) => {
+                          const text = loc().lang === 'en' ? p.en || p.he : p.he || p.en;
+                          const ltr = loc().lang === 'en' && !!p.en;
+                          return (
+                            <div class="gem-entry">
+                              <a
+                                class="gem-ref"
+                                href={`https://www.sefaria.org/${p.ref.replace(/ /g, '.').replace(/:/g, '.')}`}
+                                target="_blank"
+                                rel="noopener"
+                              >
+                                {p.ref}
+                              </a>
+                              <Show when={text}>
+                                <p class="gem-text" dir={ltr ? 'ltr' : 'rtl'}>
+                                  {text}…
+                                </p>
+                              </Show>
+                            </div>
+                          );
+                        }}
+                      </For>
+                    </section>
+                  );
+                }}
+              </Show>
+              <Show when={midrash() && midrash()!.passages.length > 0}>
+                {(_ok) => {
+                  const md = midrash() as GemaraResp;
+                  return (
+                    <section class="comm-midrash">
+                      <h4 class="comm-name">Midrash{md.count > md.passages.length ? ` · ${md.count}` : ''}</h4>
+                      <Show when={midrashSynth.loading}>
+                        <p class="comm-muted">Synthesizing the midrashim…</p>
+                      </Show>
+                      <Show when={midrashSynth()}>
+                        {(sy) => (
+                          <p class="comm-synth-text" dir={loc().lang === 'he' ? 'rtl' : 'ltr'}>
+                            {loc().lang === 'he' ? sy().he || sy().en : sy().en || sy().he}
+                          </p>
+                        )}
+                      </Show>
+                      <For each={md.passages}>
                         {(p) => {
                           const text = loc().lang === 'en' ? p.en || p.he : p.he || p.en;
                           const ltr = loc().lang === 'en' && !!p.en;

--- a/packages/tanach/src/client/styles.css
+++ b/packages/tanach/src/client/styles.css
@@ -542,26 +542,35 @@ body {
 .comm-synth-text[dir='rtl'] { font-family: 'Frank Ruhl Libre', serif; font-size: 16px; }
 
 /* source icons in the band-edge gutter (positioned by App, like the anchors) */
-.vgutter {
+.vgutter-stack {
   position: absolute;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  margin-top: -0.15em;
+  z-index: 5;
+}
+.vgutter {
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 0;
   border: 0;
   border-radius: 50%;
-  background: var(--accent);
   color: #fff;
   font-family: 'Frank Ruhl Libre', serif;
   font-size: 10px;
   font-weight: 700;
   line-height: 1;
   cursor: pointer;
-  z-index: 5;
-  transition: background-color 0.1s ease, transform 0.1s ease;
+  transition: transform 0.1s ease, filter 0.1s ease;
 }
+.vgutter-rishonim { background: var(--accent); }
+.vgutter-gemara { background: #5d6b7d; }
+.vgutter-midrash { background: #9a7b3e; }
 .vgutter:hover,
-.vgutter.active { background: var(--ink); transform: scale(1.12); }
+.vgutter.active { transform: scale(1.14); filter: brightness(0.86); }
 
 /* "In the Talmud" section (reverse Gemara lookup) in the verse drawer */
 .comm-gemara { padding: 14px 0 4px; border-top: 1px solid var(--line); margin-top: 6px; }
@@ -583,3 +592,7 @@ body {
   color: var(--muted);
 }
 .gem-text[dir='rtl'] { font-family: 'Frank Ruhl Libre', serif; font-size: 15px; }
+
+
+/* midrash section in the verse drawer (synthesis + capped sources) */
+.comm-midrash { padding: 14px 0 4px; border-top: 1px solid var(--line); margin-top: 6px; }

--- a/packages/tanach/src/worker/index.ts
+++ b/packages/tanach/src/worker/index.ts
@@ -14,6 +14,7 @@ import type { LLMEnv } from '@corpus/core/llm/llm';
 import { isBook } from '../lib/books.ts';
 import { COMMENTATORS } from '../lib/commentators.ts';
 import { eventSections } from './producers/events.ts';
+import { midrashSynthesis } from './producers/midrash.ts';
 import { sectionNote } from './producers/note.ts';
 import { synthesize } from './producers/synthesis.ts';
 import { translateHebrew } from './producers/translate.ts';
@@ -444,7 +445,7 @@ app.get('/api/sources-index/:book/:chapter', async (c) => {
   if (!isBook(book)) return c.json({ error: `Unknown book: ${book}` }, 400);
   if (!/^\d+$/.test(chapter)) return c.json({ error: 'Bad chapter' }, 400);
 
-  const key = `srcidx:v3:${book}:${chapter}`;
+  const key = `srcidx:v4:${book}:${chapter}`;
   const cached = await c.env.CACHE.get(key);
   if (cached) return c.json(JSON.parse(cached));
 
@@ -474,23 +475,110 @@ app.get('/api/sources-index/:book/:chapter', async (c) => {
       }
     }),
   );
+  // Talmud + Midrash citation counts per verse, from one chapter-wide links
+  // fetch (Sefaria's link graph). Heavy for the busiest chapters (~6MB) —
+  // best-effort: on failure the icons just don't show, the drawers still work.
+  const gem = new Map<number, number>();
+  const mid = new Map<number, number>();
+  try {
+    const r = await fetch(
+      `https://www.sefaria.org/api/links/${encodeURIComponent(`${book} ${chapter}`)}?with_text=0`,
+    );
+    type Link = { category?: string; anchorVerse?: number; sourceRef?: string; ref?: string };
+    const links = (await r.json()) as Link[];
+    const gemSeen = new Map<number, Set<string>>();
+    const midSeen = new Map<number, Set<string>>();
+    for (const l of Array.isArray(links) ? links : []) {
+      const v = l.anchorVerse;
+      if (!v) continue;
+      const ref = l.sourceRef || l.ref;
+      if (!ref) continue;
+      if (l.category === 'Talmud') {
+        const s = gemSeen.get(v) ?? new Set<string>();
+        s.add(ref);
+        gemSeen.set(v, s);
+      } else if (l.category === 'Midrash') {
+        const s = midSeen.get(v) ?? new Set<string>();
+        s.add(ref);
+        midSeen.set(v, s);
+      }
+    }
+    gemSeen.forEach((s, v) => gem.set(v, s.size));
+    midSeen.forEach((s, v) => mid.set(v, s.size));
+  } catch {
+    /* links too heavy / unavailable — skip gemara+midrash counts */
+  }
+
   const entries = [...acc.entries()].sort((a, b) => a[0] - b[0]);
   // "rich" = many commentators AND in the top fraction of this chapter by volume.
   const weights = entries.map(([, e]) => e.w).sort((a, b) => a - b);
   const cutoff = weights.length ? weights[Math.floor(weights.length * 0.6)] : 0;
-  const verses = entries.map(([verse, e]) => ({
-    verse,
-    rishonim: e.n,
-    rich: e.n >= 3 && e.w >= cutoff,
-  }));
+  // union of verses that have any source so gemara/midrash-only verses still appear
+  const allVerses = new Set<number>([...acc.keys(), ...gem.keys(), ...mid.keys()]);
+  const verses = [...allVerses]
+    .sort((a, b) => a - b)
+    .map((verse) => {
+      const e = acc.get(verse) ?? { n: 0, w: 0 };
+      return {
+        verse,
+        rishonim: e.n,
+        rich: e.n >= 3 && e.w >= cutoff,
+        gemara: gem.get(verse) ?? 0,
+        midrash: mid.get(verse) ?? 0,
+      };
+    });
   const payload = { book, chapter: Number(chapter), verses };
   c.executionCtx.waitUntil(c.env.CACHE.put(key, JSON.stringify(payload)).then(() => undefined));
   return c.json(payload);
 });
 
-// Reverse Gemara lookup: how a verse is used in the Talmud. Sefaria's links
-// (category "Talmud" — Bavli, Yerushalmi, minor tractates) give the passages
-// that cite the verse; we fetch a snippet of each. Cached per verse.
+interface SourcePassage {
+  ref: string;
+  he: string;
+  en: string;
+}
+
+/** Distinct citing passages of one Sefaria category for a verse (Talmud /
+ *  Midrash), capped, each with a fetched text snippet. `bavliFirst` floats the
+ *  Bavli ahead of Yerushalmi / minor tractates. */
+async function fetchPassages(
+  ref: string,
+  category: string,
+  cap: number,
+  bavliFirst = false,
+): Promise<{ count: number; passages: SourcePassage[] }> {
+  type Link = { category?: string; ref?: string; sourceRef?: string; index_title?: string };
+  const r = await fetch(`https://www.sefaria.org/api/links/${encodeURIComponent(ref)}?with_text=0`);
+  const links = (await r.json()) as Link[];
+  const seen = new Set<string>();
+  const picked: { ref: string; title: string }[] = [];
+  for (const l of Array.isArray(links) ? links : []) {
+    if (l.category !== category) continue;
+    const sref = l.sourceRef || l.ref;
+    if (!sref || seen.has(sref)) continue;
+    seen.add(sref);
+    picked.push({ ref: sref, title: l.index_title ?? '' });
+  }
+  if (bavliFirst) {
+    picked.sort((a, b) => Number(/^(Jerusalem|Tractate)/.test(a.title)) - Number(/^(Jerusalem|Tractate)/.test(b.title)));
+  }
+  const passages = await Promise.all(
+    picked.slice(0, cap).map(async (p) => {
+      try {
+        const v3 = await sefaria.getTextV3(p.ref);
+        const he = flattenPieces(pickV3Version(v3.versions, 'he')).join(' ').replace(/<[^>]+>/g, '').trim().slice(0, 420);
+        const en = flattenPieces(pickV3Version(v3.versions, 'en')).join(' ').replace(/<[^>]+>/g, '').trim().slice(0, 420);
+        return { ref: p.ref, he, en };
+      } catch {
+        return { ref: p.ref, he: '', en: '' };
+      }
+    }),
+  );
+  return { count: picked.length, passages };
+}
+
+// Reverse Gemara lookup: how a verse is used in the Talmud (Sefaria's link
+// graph, category "Talmud"). Cached per verse.
 app.get('/api/gemara/:book/:chapter/:verse', async (c) => {
   const book = c.req.param('book');
   const chapter = c.req.param('chapter');
@@ -502,45 +590,97 @@ app.get('/api/gemara/:book/:chapter/:verse', async (c) => {
   const cached = await c.env.CACHE.get(key);
   if (cached) return c.json(JSON.parse(cached));
 
-  type Link = { category?: string; ref?: string; sourceRef?: string; index_title?: string };
-  let links: Link[];
+  let res: Awaited<ReturnType<typeof fetchPassages>>;
   try {
-    const r = await fetch(
-      `https://www.sefaria.org/api/links/${encodeURIComponent(`${book} ${chapter}:${verse}`)}?with_text=0`,
-    );
-    links = (await r.json()) as Link[];
+    res = await fetchPassages(`${book} ${chapter}:${verse}`, 'Talmud', 12, true);
   } catch (e) {
     return c.json({ error: `Links fetch failed: ${(e as Error).message}` }, 502);
   }
-
-  // Distinct Talmud refs, Bavli first (no "Jerusalem Talmud"/"Tractate " prefix),
-  // capped — then fetch a text snippet of each.
-  const seen = new Set<string>();
-  const picked: { ref: string; title: string }[] = [];
-  for (const l of Array.isArray(links) ? links : []) {
-    if (l.category !== 'Talmud') continue;
-    const ref = l.sourceRef || l.ref;
-    if (!ref || seen.has(ref)) continue;
-    seen.add(ref);
-    picked.push({ ref, title: l.index_title ?? '' });
-  }
-  picked.sort((a, b) => Number(/^(Jerusalem|Tractate)/.test(a.title)) - Number(/^(Jerusalem|Tractate)/.test(b.title)));
-  const top = picked.slice(0, 12);
-
-  const passages = await Promise.all(
-    top.map(async (p) => {
-      try {
-        const v3 = await sefaria.getTextV3(p.ref);
-        const he = flattenPieces(pickV3Version(v3.versions, 'he')).join(' ').replace(/<[^>]+>/g, '').trim().slice(0, 420);
-        const en = flattenPieces(pickV3Version(v3.versions, 'en')).join(' ').replace(/<[^>]+>/g, '').trim().slice(0, 420);
-        return { ref: p.ref, he, en };
-      } catch {
-        return { ref: p.ref, he: '', en: '' };
-      }
-    }),
-  );
-  const payload = { book, chapter: Number(chapter), verse: Number(verse), count: picked.length, passages };
+  const payload = { book, chapter: Number(chapter), verse: Number(verse), count: res.count, passages: res.passages };
   c.executionCtx.waitUntil(c.env.CACHE.put(key, JSON.stringify(payload)).then(() => undefined));
+  return c.json(payload);
+});
+
+// Midrash on a verse (Sefaria's link graph, category "Midrash"). Capped list of
+// sources; the synthesis (next endpoint) distills the volume. Cached per verse.
+app.get('/api/midrash/:book/:chapter/:verse', async (c) => {
+  const book = c.req.param('book');
+  const chapter = c.req.param('chapter');
+  const verse = c.req.param('verse');
+  if (!isBook(book)) return c.json({ error: `Unknown book: ${book}` }, 400);
+  if (!/^\d+$/.test(chapter) || !/^\d+$/.test(verse)) return c.json({ error: 'Bad chapter/verse' }, 400);
+
+  const key = `midrash:v1:${book}:${chapter}:${verse}`;
+  const cached = await c.env.CACHE.get(key);
+  if (cached) return c.json(JSON.parse(cached));
+
+  let res: Awaited<ReturnType<typeof fetchPassages>>;
+  try {
+    res = await fetchPassages(`${book} ${chapter}:${verse}`, 'Midrash', 14);
+  } catch (e) {
+    return c.json({ error: `Links fetch failed: ${(e as Error).message}` }, 502);
+  }
+  const payload = { book, chapter: Number(chapter), verse: Number(verse), count: res.count, passages: res.passages };
+  c.executionCtx.waitUntil(c.env.CACHE.put(key, JSON.stringify(payload)).then(() => undefined));
+  return c.json(payload);
+});
+
+// Midrash synthesis (AI): distills the verse's midrashim into a thematic
+// overview. Requested for verses with substantial midrash. Cached + tracked.
+app.get('/api/midrash-synthesis/:book/:chapter/:verse', async (c) => {
+  const book = c.req.param('book');
+  const chapter = c.req.param('chapter');
+  const verse = c.req.param('verse');
+  if (!isBook(book)) return c.json({ error: `Unknown book: ${book}` }, 400);
+  if (!/^\d+$/.test(chapter) || !/^\d+$/.test(verse)) return c.json({ error: 'Bad chapter/verse' }, 400);
+
+  const key = `midrash-synth:v1:${book}:${chapter}:${verse}`;
+  const cached = await c.env.CACHE.get(key);
+  if (cached) return c.json(JSON.parse(cached));
+
+  let passages: SourcePassage[];
+  const cm = await c.env.CACHE.get(`midrash:v1:${book}:${chapter}:${verse}`);
+  if (cm) {
+    passages = JSON.parse(cm).passages as SourcePassage[];
+  } else {
+    try {
+      passages = (await fetchPassages(`${book} ${chapter}:${verse}`, 'Midrash', 14)).passages;
+    } catch (e) {
+      return c.json({ error: `Links fetch failed: ${(e as Error).message}` }, 502);
+    }
+  }
+  if (passages.length < 2) return c.json({ error: 'Not enough midrash to synthesize' }, 404);
+
+  let verseText = '';
+  try {
+    const t = await sefaria.getText(`${book} ${chapter}:${verse}`);
+    verseText = (asVerses(t.text)[0] || asVerses(t.he)[0] || '').replace(/<[^>]+>/g, '').trim();
+  } catch {
+    /* optional */
+  }
+  const mtext = passages.map((p) => p.he || p.en).filter(Boolean).join('\n\n');
+
+  let result: Awaited<ReturnType<typeof midrashSynthesis>>;
+  try {
+    result = await midrashSynthesis(c.env, `${book} ${chapter}:${verse}`, verseText, mtext);
+  } catch (e) {
+    return c.json({ error: `Producer failed: ${(e as Error).message}` }, 502);
+  }
+  const payload = { book, chapter: Number(chapter), verse: Number(verse), en: result.en, he: result.he };
+  c.executionCtx.waitUntil(
+    Promise.all([
+      c.env.CACHE.put(key, JSON.stringify(payload)),
+      recordUsage(c.env.CACHE, {
+        ts: Date.now(),
+        ref: `${book} ${chapter}:${verse}`,
+        producer: 'midrash-synthesis',
+        model: result.model,
+        in: result.inTokens,
+        out: result.outTokens,
+        cost: result.costUsd,
+      }),
+    ]).then(() => undefined),
+  );
   return c.json(payload);
 });
 

--- a/packages/tanach/src/worker/producers/midrash.ts
+++ b/packages/tanach/src/worker/producers/midrash.ts
@@ -1,0 +1,79 @@
+/**
+ * Midrash synthesis — a verse can have dozens of midrashim (Genesis 1:1 has
+ * ~140), so dumping them is useless. This distills the midrashic material on a
+ * verse into a short thematic overview (what the midrashim draw out, the main
+ * directions), bilingual, so the reader gets the gist before the source list.
+ *
+ * Composes on the midrash fetch (the Midrash-category links for the verse).
+ */
+
+import { runLLM, type LLMEnv } from '@corpus/core/llm/llm';
+import { costUsd } from '@corpus/core/llm/pricing';
+
+export interface MidrashSynthResult {
+  en: string;
+  he: string;
+  model: string;
+  costUsd: number | null;
+  inTokens: number;
+  outTokens: number;
+}
+
+const SYSTEM = [
+  'You summarize the midrashic material on a verse of the Hebrew Bible for a',
+  'reader — what the midrashim draw out of it.',
+  '',
+  'You are given the verse and excerpts from several midrashim (aggadic /',
+  'homiletic traditions). Write a short thematic overview: the main directions',
+  'the midrashim take, recurring motifs, notable readings.',
+  '',
+  'Rules:',
+  '- 2 to 4 sentences. Group by theme rather than listing each midrash.',
+  '- Only summarize what the given excerpts say; invent nothing.',
+  '- This is aggada — narrative/homiletic. Do not present it as plain p\'shat or',
+  '  as halacha.',
+  '- Give it in BOTH English ("en") and natural, fluent Hebrew ("he").',
+].join('\n');
+
+const SCHEMA = {
+  name: 'midrash_synthesis',
+  strict: true,
+  schema: {
+    type: 'object',
+    additionalProperties: false,
+    required: ['en', 'he'],
+    properties: { en: { type: 'string' }, he: { type: 'string' } },
+  },
+};
+
+export async function midrashSynthesis(env: LLMEnv, ref: string, verseText: string, midrashText: string): Promise<MidrashSynthResult> {
+  const res = await runLLM(env, {
+    messages: [
+      { role: 'system', content: SYSTEM },
+      { role: 'user', content: `Verse ${ref}: ${verseText}\n\nMidrashim:\n${midrashText}` },
+    ],
+    max_tokens: 800,
+    temperature: 0.35,
+    response_format: { type: 'json_schema', json_schema: SCHEMA },
+    tag: 'tanach:midrash-synthesis',
+  });
+
+  let en = '';
+  let he = '';
+  try {
+    const p = JSON.parse(res.content) as { en?: string; he?: string };
+    en = String(p.en ?? '').trim();
+    he = String(p.he ?? '').trim();
+  } catch {
+    /* leave empty */
+  }
+
+  return {
+    en,
+    he,
+    model: res.model,
+    costUsd: costUsd(res.model, res.usage),
+    inTokens: res.usage?.prompt_tokens ?? 0,
+    outTokens: res.usage?.completion_tokens ?? 0,
+  };
+}


### PR DESCRIPTION
Midrash layer + Gemara/Midrash gutter icons + source index

Answers the "what's the icon / how do we do midrash" gap: stacked source icons
in the gutter and a synthesis-led midrash drawer.

- Source index extended: one chapter-wide Sefaria links fetch (best-effort,
  ~6MB worst case, cached) counts Talmud + Midrash citations per verse alongside
  the curated-rishonim counts. Cache bumped srcidx v3 -> v4.
- Gutter icons now stack vertically: ר (rishonim, rich verses), ג (gemara,
  >=2 citations), מ (midrash, >=5), each colour-coded. Clicking one opens the
  verse drawer and scrolls to that section.
- Midrash: a verse can have dozens (Genesis 1:1 has ~143), so it leads with an
  AI SYNTHESIS (producers/midrash.ts) that distills the themes, then a capped,
  Sefaria-linked source list. New /api/midrash + /api/midrash-synthesis.
- Gemara endpoint refactored onto a shared fetchPassages() helper (also used by
  midrash); the reverse-Gemara list is unchanged.

Verified: Genesis 1:1 midrash synthesis distills the Bereshit Rabbah corpus
(created for Israel/Torah, bereshit letter-plays -> 613/ברית, Elohim=justice
+mercy); Leviticus 19:18 gemara -> Shabbat 31a (Hillel).
