### PR TITLE
Experimental cards never lazy-warm (biyun, chart)

### DIFF
--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -3404,6 +3404,29 @@ async function recordRecentJobError(
 }
 
 /**
+ * Experimental cards (biyun, chart) must never lazy-warm. A cold-miss /api/run
+ * for an experimental, LLM-backed producer is skipped unless the caller
+ * explicitly opts in to a warm — so a reader, or a dev merely viewing the card,
+ * never triggers its paid Pro-tier generation. Free (computed) producers — the
+ * biyun whole-daf chip instance, deterministic enrichments — are never gated;
+ * only paid LLM warms are. The experimental cards are code-defined, so the code
+ * registry is the source of truth for the flag.
+ */
+export function isExperimentalLlmWarm(job: { mark_id?: string; enrichment_id?: string }): boolean {
+  if (job.mark_id) {
+    const m = findCodeMark(job.mark_id);
+    return !!m && m.experimental === true && m.extractor.kind === 'llm';
+  }
+  if (job.enrichment_id) {
+    const e = findCodeEnrichment(job.enrichment_id);
+    if (!e || e.extractor.kind !== 'llm' || !e.target_mark) return false;
+    const m = findCodeMark(e.target_mark);
+    return !!m && m.experimental === true;
+  }
+  return false;
+}
+
+/**
  * POST /api/run — async producer.
  *
  * 1. Validate body.
@@ -3486,6 +3509,16 @@ app.post('/api/run', async (c) => {
     }
   }
 
+  // Experimental cards (biyun, chart) never lazy-warm: only an explicit, trusted
+  // warm enqueues their paid Pro-tier LLM job. A reader — or a dev merely
+  // viewing the card — gets cache-only. Cache hits above still serve, so already-
+  // warmed experimental content keeps rendering; this gates only the WARM.
+  // Explicit warm = a trusted bypass_cache (e.g. the studio re-run) or a trusted
+  // warm_experimental flag.
+  const rawWarmExperimental = (raw as { warm_experimental?: unknown }).warm_experimental === true;
+  const explicitWarm = job.bypass_cache || (trusted && rawWarmExperimental);
+  const skipExperimentalWarm = !explicitWarm && isExperimentalLlmWarm(job);
+
   // Stale-while-revalidate: on a version-bump miss, serve the PREVIOUS version's
   // cached value (tagged refreshing) while the new one recomputes in the
   // background — so bumping a cache_version never makes readers wait. (No
@@ -3505,18 +3538,32 @@ app.post('/api/run', async (c) => {
           const sectionRange = sectionRangeOf(def, job.mark_input);
           if (!sectionRange || result.section_range === sectionRange) {
             // Enqueue the recompute only when budget allows (else just serve
-            // stale; the warm path will fill the new version when budget frees).
+            // stale; the warm path will fill the new version when budget frees)
+            // and only when not gated as an experimental warm. `refreshing`
+            // reflects whether a recompute was ACTUALLY queued — otherwise the
+            // client polls a run that will never start and keeps the updating
+            // marker up (experimental cards stay stale until explicitly warmed;
+            // budget-paused stays stale until budget frees).
             const customRun = !!(job.enrichment_id.endsWith('.qa') && job.user_question);
-            if ((await checkBudget(c.env, { custom: customRun })).ok) {
+            let refreshing = false;
+            if (!skipExperimentalWarm && (await checkBudget(c.env, { custom: customRun })).ok) {
               job.runId = await makeRunId(job);
               await c.env.ENRICHMENT_QUEUE.send(job);
+              refreshing = true;
             }
             recordTelemetry(c, runTelemetryRec(job, { ...result, cache_hit: true }, 0));
-            return c.json({ status: 'ok', result: { ...result, cache_hit: true, total_ms: 0, stale: true, refreshing: true } });
+            return c.json({ status: 'ok', result: { ...result, cache_hit: true, total_ms: 0, stale: true, refreshing } });
           }
         } catch { /* corrupt prev value; fall through to a normal enqueue */ }
       }
     }
+  }
+
+  // Cold miss on an experimental card without an explicit warm: do NOT enqueue
+  // the paid job. Return a clear, non-pending signal so the client shows
+  // "not generated" rather than polling a run that will never start.
+  if (skipExperimentalWarm) {
+    return c.json({ status: 'skipped', reason: 'experimental', experimental: true, warmed: false });
   }
 
   if (!c.env.ENRICHMENT_QUEUE) {

--- a/packages/talmud/tests/experimental-no-lazy-warm.test.ts
+++ b/packages/talmud/tests/experimental-no-lazy-warm.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { isExperimentalLlmWarm } from '../src/worker/index';
+
+// The /api/run gate: experimental, LLM-backed cards must never lazy-warm. Only
+// an explicit trusted warm (bypass_cache / warm_experimental) enqueues their
+// paid Pro-tier job. This test pins WHICH producers the gate catches, so adding
+// or promoting an experimental card can't silently start auto-warming it.
+describe('isExperimentalLlmWarm — experimental cards do not lazy-warm', () => {
+  it('gates the experimental LLM mark (chart)', () => {
+    expect(isExperimentalLlmWarm({ mark_id: 'chart' })).toBe(true);
+  });
+
+  it('gates an enrichment whose target mark is experimental (biyun.essay)', () => {
+    expect(isExperimentalLlmWarm({ enrichment_id: 'biyun.essay' })).toBe(true);
+  });
+
+  it('does NOT gate the free computed biyun chip mark (no LLM cost)', () => {
+    // The biyun mark is experimental but `computed` (the whole-daf instance),
+    // so it is free and must stay reachable — only its paid essay is gated.
+    expect(isExperimentalLlmWarm({ mark_id: 'biyun' })).toBe(false);
+  });
+
+  it('does NOT gate canonical (non-experimental) producers', () => {
+    expect(isExperimentalLlmWarm({ mark_id: 'argument' })).toBe(false);
+    expect(isExperimentalLlmWarm({ mark_id: 'rabbi' })).toBe(false);
+    expect(isExperimentalLlmWarm({ enrichment_id: 'rabbi.synthesis' })).toBe(false);
+    expect(isExperimentalLlmWarm({ enrichment_id: 'argument.synthesis' })).toBe(false);
+  });
+
+  it('does NOT gate unknown / empty producers', () => {
+    expect(isExperimentalLlmWarm({})).toBe(false);
+    expect(isExperimentalLlmWarm({ mark_id: 'does-not-exist' })).toBe(false);
+    expect(isExperimentalLlmWarm({ enrichment_id: 'does-not-exist' })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why
biyun and chart are experimental/dev-only and now run on Pro + a reasoning pass (#341). Merely viewing them — or a reader opening a cold daf — should not trigger their paid generation. They should warm **only when explicitly turned on**.

## What
Gate the `/api/run` warm path so experimental, LLM-backed producers don't lazy-warm.

- **`isExperimentalLlmWarm(job)`**: true for the **chart** mark (experimental + LLM) and **biyun.essay** (enrichment whose target mark `biyun` is experimental). The free **computed biyun chip** instance and all canonical producers are never gated — only paid LLM warms are.
- **`/api/run`**: on a cold miss for a gated producer, returns `{status:'skipped', experimental:true}` instead of enqueuing the job. **Cache hits and stale-while-revalidate still serve** existing content; the SWR recompute enqueue is gated too.
- **Explicit warm** = a trusted `bypass_cache` (the studio re-run) or a trusted `warm_experimental` flag. Public callers can never warm experimental cards.
- SWR `refreshing` now reflects whether a recompute was actually queued, so the client doesn't poll a run that never starts (also fixes the pre-existing budget-paused case — Codex find).

The warm crons (yomi `WARM_MARKS`, `DEEP_WARM_PLAN`) already exclude biyun/chart, so `/api/run` was the only lazy-warm vector.

## Verification
- `pnpm typecheck` + `pnpm test` (1943, incl. a new unit test pinning which producers the gate catches) green.
- Codex read-only review: confirmed cache hits pass through, SWR still serves stale, no canonical/computed producer wrongly gated; flagged the `refreshing` semantics, now fixed.

## Note
This is a server-side enforcement, independent of the client. With no client changes, experimental cards simply stop auto-warming (the intended default). A future "generate this card" dev control can opt in by sending `warm_experimental: true` with studio auth.