### PR TITLE
Tanach: anchors + source icons in Mikraot Gedolot

### DIFF
--- a/packages/tanach/src/client/App.tsx
+++ b/packages/tanach/src/client/App.tsx
@@ -11,6 +11,7 @@ import {
 } from 'solid-js';
 import { BOOKS, SECTIONS, type Section } from '../lib/books.ts';
 import { hebrewNumeral } from '../lib/hebrew.ts';
+import { KIND_GLYPH, MIDRASH_MIN, type SourceKind, type SourceVerse, verseKinds } from '../lib/sources.ts';
 import { MikraotGedolot } from './MikraotGedolot.tsx';
 
 interface Verse {
@@ -175,13 +176,6 @@ interface CommentaryResponse {
   verse: number;
   commentaries: CommentaryEntry[];
 }
-interface SourceVerse {
-  verse: number;
-  rishonim: number;
-  rich: boolean;
-  gemara: number;
-  midrash: number;
-}
 interface SourceIdx {
   verses: SourceVerse[];
 }
@@ -189,18 +183,6 @@ interface GemaraResp {
   count: number;
   passages: { ref: string; he: string; en: string }[];
 }
-type SourceKind = 'rishonim' | 'gemara' | 'midrash';
-const GEMARA_MIN = 2;
-const MIDRASH_MIN = 5;
-/** Which gutter icons a verse gets, in display order. */
-function verseKinds(v: SourceVerse): SourceKind[] {
-  const k: SourceKind[] = [];
-  if (v.rich) k.push('rishonim');
-  if (v.gemara >= GEMARA_MIN) k.push('gemara');
-  if (v.midrash >= MIDRASH_MIN) k.push('midrash');
-  return k;
-}
-const KIND_GLYPH: Record<SourceKind, string> = { rishonim: 'ר', gemara: 'ג', midrash: 'מ' };
 const SECTION_TITLE: Record<SourceKind, string> = {
   rishonim: 'Commentary',
   gemara: 'In the Talmud',
@@ -553,7 +535,16 @@ export function App(): JSX.Element {
 
       {/* Mikraot Gedolot — pasuk framed by Rashi + Onkelos (daf-renderer) */}
       <Show when={loc().view === 'mikraot'}>
-        <MikraotGedolot book={loc().book} chapter={loc().chapter} />
+        <MikraotGedolot
+          book={loc().book}
+          chapter={loc().chapter}
+          lang={loc().lang}
+          sections={events() ?? []}
+          sources={sourcesIndex()?.verses ?? []}
+          activeVerse={source()?.verse ?? null}
+          onAnchor={(verse) => openSource(verse, 'rishonim')}
+          onSource={openSource}
+        />
       </Show>
 
       {/* Scroll — Sefer Torah columns with Masoretic parsha breaks */}

--- a/packages/tanach/src/client/MikraotGedolot.tsx
+++ b/packages/tanach/src/client/MikraotGedolot.tsx
@@ -1,6 +1,7 @@
-import { createMemo, createResource, createSignal, onCleanup, Show, type JSX } from 'solid-js';
+import { createEffect, createMemo, createResource, createSignal, For, onCleanup, Show, type JSX } from 'solid-js';
 import { DafRenderer } from '../lib/daf-render/index.ts';
 import { hebrewNumeral } from '../lib/hebrew.ts';
+import { KIND_GLYPH, type SourceKind, type SourceVerse, verseKinds } from '../lib/sources.ts';
 
 interface MGVerse {
   n: number;
@@ -17,6 +18,11 @@ interface MG {
   next: string | null;
   prev: string | null;
   error?: string;
+}
+interface Section {
+  verse: number;
+  en: string;
+  he: string;
 }
 
 async function fetchMG(loc: { book: string; chapter: number }): Promise<MG> {
@@ -37,6 +43,7 @@ function wideWidth(): number {
 // Frank Ruhl Libre so the central column reads distinct from the margins.
 const MAIN_FAM = 'Noto Serif Hebrew';
 const SIDE_FAM = 'Frank Ruhl Libre';
+const ICON_SIZE = 16;
 
 /** Each verse / commentary piece is tagged with its verse number so hovering one
  *  cross-highlights the pasuk and its Rashi + Onkelos together (like the daf). */
@@ -46,11 +53,25 @@ function seg(n: number, html: string, lead = ''): string {
 
 /** The Mikraot Gedolot framed view: the pasuk (panim, with Hebrew verse numbers)
  *  in the center, wrapped by Rashi (inner) and Targum Onkelos (outer), laid out
- *  by the shared daf-renderer — the same engine the Talmud reader uses. */
-export function MikraotGedolot(props: { book: string; chapter: number }): JSX.Element {
+ *  by the shared daf-renderer. Event-section labels + source icons are pinned in
+ *  the side gutters (measured against the centered pasuk segments). */
+export function MikraotGedolot(props: {
+  book: string;
+  chapter: number;
+  lang: 'en' | 'he';
+  sections: Section[];
+  sources: SourceVerse[];
+  activeVerse: number | null;
+  onAnchor: (verse: number) => void;
+  onSource: (verse: number, kind: SourceKind) => void;
+}): JSX.Element {
   const [data] = createResource(() => ({ book: props.book, chapter: props.chapter }), fetchMG);
   const [width, setWidth] = createSignal(wideWidth());
-  const onResize = () => setWidth(wideWidth());
+  const [reflow, setReflow] = createSignal(0);
+  const onResize = () => {
+    setWidth(wideWidth());
+    setReflow((n) => n + 1);
+  };
   if (typeof window !== 'undefined') {
     window.addEventListener('resize', onResize);
     onCleanup(() => window.removeEventListener('resize', onResize));
@@ -59,9 +80,7 @@ export function MikraotGedolot(props: { book: string; chapter: number }): JSX.El
   const main = createMemo(() => {
     const d = data();
     if (!d) return ' ';
-    return d.verses
-      .map((v) => seg(v.n, v.pasuk, `<span class="vnum">${hebrewNumeral(v.n)}</span> `))
-      .join(' ');
+    return d.verses.map((v) => seg(v.n, v.pasuk, `<span class="vnum">${hebrewNumeral(v.n)}</span> `)).join(' ');
   });
   const inner = createMemo(() => {
     const d = data();
@@ -74,6 +93,7 @@ export function MikraotGedolot(props: { book: string; chapter: number }): JSX.El
     return d.verses.filter((v) => v.targum).map((v) => seg(v.n, v.targum)).join(' ') || ' ';
   });
 
+  let mainEl: HTMLElement | undefined;
   let host: HTMLDivElement | undefined;
   let curV: string | null = null;
   const highlight = (v: string | null) => {
@@ -87,8 +107,90 @@ export function MikraotGedolot(props: { book: string; chapter: number }): JSX.El
     highlight(s ? s.getAttribute('data-v') : null);
   };
 
+  // Map each verse to the top of its PASUK segment (the centered main column),
+  // relative to .mg-main; used to pin gutter anchors + icons.
+  const [anchors, setAnchors] = createSignal<{ verse: number; label: string; top: number }[]>([]);
+  const [icons, setIcons] = createSignal<{ verse: number; top: number; kinds: SourceKind[] }[]>([]);
+  const measure = () => {
+    if (!mainEl || !host) {
+      setAnchors([]);
+      setIcons([]);
+      return;
+    }
+    const mRect = mainEl.getBoundingClientRect();
+    const hRect = host.getBoundingClientRect();
+    const hostCenter = hRect.left + hRect.width / 2;
+    // gutter room: between the daf (mg-host) and the mg-main edge
+    const gutter = (mRect.width - hRect.width) / 2;
+    if (gutter < 40) {
+      setAnchors([]);
+      setIcons([]);
+      return;
+    }
+    // per verse, pick the pasuk seg (the one nearest the host centre)
+    const segTop = new Map<number, number>();
+    const best = new Map<number, number>();
+    host.querySelectorAll<HTMLElement>('.mg-seg[data-v]').forEach((el) => {
+      const v = Number(el.dataset.v);
+      if (!v) return;
+      const r = el.getBoundingClientRect();
+      if (!r.height) return;
+      const dist = Math.abs(r.left + r.width / 2 - hostCenter);
+      if (!best.has(v) || dist < (best.get(v) as number)) {
+        best.set(v, dist);
+        segTop.set(v, r.top - mRect.top);
+      }
+    });
+
+    const an: { verse: number; label: string; top: number }[] = [];
+    for (const s of props.sections) {
+      const t = segTop.get(s.verse);
+      if (t == null) continue;
+      an.push({ verse: s.verse, label: (props.lang === 'he' ? s.he : s.en) || s.en || s.he, top: t });
+    }
+    // de-collide labels (estimate height from text wrapped to the gutter width)
+    an.sort((a, b) => a.top - b.top);
+    const perLine = Math.max(8, Math.floor((Math.min(gutter, 120) - 12) / 6));
+    let prevBottom = -Infinity;
+    for (const a of an) {
+      const h = Math.max(1, Math.ceil(a.label.length / perLine)) * 14 + 8;
+      if (a.top < prevBottom + 4) a.top = prevBottom + 4;
+      prevBottom = a.top + h;
+    }
+    setAnchors(an);
+
+    const ic: { verse: number; top: number; kinds: SourceKind[] }[] = [];
+    for (const sv of props.sources) {
+      const kinds = verseKinds(sv);
+      if (!kinds.length) continue;
+      const t = segTop.get(sv.verse);
+      if (t == null) continue;
+      ic.push({ verse: sv.verse, top: t, kinds });
+    }
+    setIcons(ic);
+  };
+
+  // Re-measure after the daf lays out / inputs change. The daf renders async, so
+  // give it a couple of frames.
+  createEffect(() => {
+    data();
+    width();
+    reflow();
+    props.sections;
+    props.sources;
+    props.lang;
+    requestAnimationFrame(() =>
+      requestAnimationFrame(() => requestAnimationFrame(measure)),
+    );
+  });
+  // Persist-highlight the verse whose drawer is open.
+  createEffect(() => {
+    const v = props.activeVerse;
+    requestAnimationFrame(() => highlight(v == null ? null : String(v)));
+  });
+
   return (
-    <main class="mg-main">
+    <main class="mg-main" ref={mainEl}>
       <Show when={data.loading}>
         <p class="status">Loading commentaries…</p>
       </Show>
@@ -112,6 +214,37 @@ export function MikraotGedolot(props: { book: string; chapter: number }): JSX.El
                 }}
               />
             </div>
+            <For each={anchors()}>
+              {(a) => (
+                <button
+                  class="evt-margin evt-left mg-anchor"
+                  style={{ top: `${a.top}px` }}
+                  title={`${a.label} (verse ${a.verse})`}
+                  onClick={() => props.onAnchor(a.verse)}
+                >
+                  {a.label}
+                </button>
+              )}
+            </For>
+            <For each={icons()}>
+              {(ic) => (
+                <div class="vgutter-stack mg-icons" style={{ top: `${ic.top}px` }}>
+                  <For each={ic.kinds}>
+                    {(k) => (
+                      <button
+                        class={`vgutter vgutter-${k}`}
+                        classList={{ active: props.activeVerse === ic.verse }}
+                        style={{ width: `${ICON_SIZE}px`, height: `${ICON_SIZE}px` }}
+                        title={`${k} · verse ${ic.verse}`}
+                        onClick={() => props.onSource(ic.verse, k)}
+                      >
+                        {KIND_GLYPH[k]}
+                      </button>
+                    )}
+                  </For>
+                </div>
+              )}
+            </For>
             <p class="mg-caption">
               <span class="he">{d().heRef}</span>
               <span class="apparatus">פנים · רש״י · אונקלוס</span>

--- a/packages/tanach/src/client/styles.css
+++ b/packages/tanach/src/client/styles.css
@@ -607,3 +607,11 @@ body {
   font-weight: 600;
 }
 .comm-close { margin-inline-start: auto; }
+
+/* Mikraot Gedolot gutter anchors + icons (positioned by MikraotGedolot) */
+.mg-main { position: relative; }
+.mg-anchor { left: 6px; width: clamp(74px, 8vw, 120px); }
+.mg-icons { right: 6px; left: auto; }
+@media (max-width: 820px) {
+  .mg-anchor { display: none; }
+}

--- a/packages/tanach/src/lib/sources.ts
+++ b/packages/tanach/src/lib/sources.ts
@@ -1,0 +1,27 @@
+/** Shared verse-source model (used by the scroll reader and Mikraot Gedolot). */
+
+export type SourceKind = 'rishonim' | 'gemara' | 'midrash';
+
+export interface SourceVerse {
+  verse: number;
+  rishonim: number;
+  rich: boolean;
+  gemara: number;
+  midrash: number;
+}
+
+/** A verse gets a gemara icon at >=2 Talmud citations, a midrash icon at >=5
+ *  (a verse can have dozens; the icon flags the synthesis-worthy ones). */
+export const GEMARA_MIN = 2;
+export const MIDRASH_MIN = 5;
+
+/** Which gutter icons a verse gets, in display order (rishonim, gemara, midrash). */
+export function verseKinds(v: SourceVerse): SourceKind[] {
+  const k: SourceKind[] = [];
+  if (v.rich) k.push('rishonim');
+  if (v.gemara >= GEMARA_MIN) k.push('gemara');
+  if (v.midrash >= MIDRASH_MIN) k.push('midrash');
+  return k;
+}
+
+export const KIND_GLYPH: Record<SourceKind, string> = { rishonim: 'ר', gemara: 'ג', midrash: 'מ' };


### PR DESCRIPTION
Mikraot Gedolot: event anchors + source icons in the gutters

Ports the scroll reader's gutter to the MG (daf-renderer) view: event-section
labels in the left gutter, ר/ג/מ source icons in the right, measured against the
centered pasuk segments (.mg-seg[data-v] — the same elements the hover
cross-highlight already uses). Clicking a label opens the commentary drawer for
that verse; clicking an icon opens its source kind. The open verse is
cross-highlighted in the daf.

- Shared source model moved to lib/sources.ts (SourceKind/SourceVerse/
  verseKinds/KIND_GLYPH/thresholds) so App + MikraotGedolot share it.
- App passes events sections + the source index + lang + open callbacks to
  MikraotGedolot.
- Measurement is defensive: per verse it picks the pasuk seg nearest the daf
  centre; skips entirely when the gutter is too narrow (<40px) so it never
  overlaps the daf; labels de-collide per the scroll's logic.

NOTE: written blind — the browser/screenshot tool dropped this session, so this
is verified by typecheck + build only, NOT a live visual pass. It's isolated to
the MG view (the Default scroll reader is untouched); please eyeball the MG view
on the live site.
