### PR TITLE
Tanach: collapsed-deck gutter icons that fan out on hover

### DIFF
--- a/packages/tanach/src/client/App.tsx
+++ b/packages/tanach/src/client/App.tsx
@@ -52,10 +52,10 @@ const SETUMA = '\u0002';
 const ANCHOR_W = 140;
 // Gap from the text band to the dot (the verse tick sits close to the text); the
 // label itself is pushed further into the margin by .evt-margin padding.
-const ANCHOR_GAP = 64;
+const ANCHOR_GAP = 26;
 // Source icons (rishonim, ...) live in a thin lane right at the band edge,
 // inside the event-anchor labels.
-const ICON_SIZE = 16;
+const ICON_SIZE = 14;
 const ICON_GAP = 4;
 
 /**
@@ -313,10 +313,11 @@ export function App(): JSX.Element {
         if (!kinds) return;
         const r = vt.getBoundingClientRect();
         if (!r.height) return;
-        const rowW = kinds.length * ICON_SIZE + (kinds.length - 1) * 3;
+        // One-icon-wide lane: the stack is a collapsed vertical deck (icons
+        // overlap, a sliver of each shows) that fans out on hover.
         const side: 'left' | 'right' = r.left + r.width / 2 < m.left + m.width / 2 ? 'left' : 'right';
-        const left = side === 'right' ? b.right - m.left + ICON_GAP : b.left - m.left - rowW - ICON_GAP;
-        if (left < 2 || left + rowW > m.width - 2) return;
+        const left = side === 'right' ? b.right - m.left + ICON_GAP : b.left - m.left - ICON_SIZE - ICON_GAP;
+        if (left < 2 || left + ICON_SIZE > m.width - 2) return;
         icons.push({ v: vn, top: r.top - m.top, left, side, kinds });
       });
     }

--- a/packages/tanach/src/client/styles.css
+++ b/packages/tanach/src/client/styles.css
@@ -542,35 +542,47 @@ body {
 .comm-synth-text[dir='rtl'] { font-family: 'Frank Ruhl Libre', serif; font-size: 16px; }
 
 /* source icons in the band-edge gutter (positioned by App, like the anchors) */
+/* Collapsed vertical "deck" of source icons: they overlap so a sliver of each
+   shows (signalling how many), and fan out on hover / focus / tap so each is
+   clickable — the Talmud gutter-cluster behaviour. */
 .vgutter-stack {
   position: absolute;
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   align-items: center;
-  gap: 3px;
-  margin-top: -0.1em;
+  margin-top: -0.2em;
   z-index: 5;
 }
+.vgutter-stack:hover,
+.vgutter-stack:focus-within { z-index: 20; }
 .vgutter {
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 0;
-  border: 0;
+  border: 1px solid #fbf8f1;
   border-radius: 50%;
   color: #fff;
   font-family: 'Frank Ruhl Libre', serif;
-  font-size: 10px;
+  font-size: 9px;
   font-weight: 700;
   line-height: 1;
   cursor: pointer;
-  transition: transform 0.1s ease, filter 0.1s ease;
+  position: relative;
+  box-sizing: border-box;
+  margin-top: -10px;
+  transition: margin-top 140ms ease, transform 80ms ease;
 }
+.vgutter-stack .vgutter:first-child { margin-top: 0; }
+.vgutter-stack:hover .vgutter,
+.vgutter-stack:focus-within .vgutter { margin-top: 4px; }
+.vgutter-stack:hover .vgutter:first-child,
+.vgutter-stack:focus-within .vgutter:first-child { margin-top: 0; }
 .vgutter-rishonim { background: var(--accent); }
 .vgutter-gemara { background: #5d6b7d; }
 .vgutter-midrash { background: #9a7b3e; }
 .vgutter:hover,
-.vgutter.active { transform: scale(1.14); filter: brightness(0.86); }
+.vgutter.active { transform: scale(1.16); z-index: 1; }
 
 /* "In the Talmud" section (reverse Gemara lookup) in the verse drawer */
 .comm-gemara { padding: 14px 0 4px; border-top: 1px solid var(--line); margin-top: 6px; }


### PR DESCRIPTION
Match Talmud's .gutter-cluster: overlapping deck (sliver of each shows the count) that fans out on hover/focus/tap so each icon is clickable. Collapsed deck ~22px regardless of count, so no overflow.