### PR TITLE
CI: deploy master automatically; opt into Node 24 actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,17 +5,22 @@ on:
     branches: [master]
   pull_request:
 
+# Actions run on the Node 24 runner default (flips 2026-06-16); opt in now so
+# a breakage surfaces in a PR, not on the flip date.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: pnpm/action-setup@v4
         with:
           version: 9.12.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm
@@ -29,3 +34,37 @@ jobs:
       - run: pnpm test
 
       - run: pnpm build
+
+  # Prod always equals master: every push to master (i.e. every merged PR)
+  # deploys both workers after checks pass. Manual `pnpm ship` from a worktree
+  # still works as a fallback (ship-guard enforces the same content==master
+  # invariant there).
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: check
+    runs-on: ubuntu-latest
+    concurrency:
+      group: deploy-prod
+      cancel-in-progress: false
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ddf8edfc3dfd489567fe3c5b28b51aca
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.1
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm --filter talmud exec vite build
+      - run: pnpm --filter talmud exec wrangler deploy
+
+      - run: pnpm --filter tanach exec vite build
+      - run: pnpm --filter tanach exec wrangler deploy

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,17 +12,20 @@ on:
         required: false
         default: https://talmud.shaunregenbaum.com
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   integration:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: pnpm/action-setup@v4
         with:
           version: 9.12.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Instead, for any code change:
 2. **Run from the worktree.** `pnpm typecheck` and `pnpm test` before any PR; `pnpm lint` too — CI gates on Biome (`biome ci .`).
 3. **PR → merge.** Commit on the branch, push, open a PR (`gh pr create`), and merge it (`gh pr merge <n> --squash --admin`). GitHub blocks self-approval, so the repo owner authorizes admin-merge.
 4. **Expect master to move.** Other agents push often. If a PR won't merge, `git merge origin/master` in the worktree, resolve, push (GitHub recomputes mergeability a few seconds later).
-5. **Deploy from the worktree** with `pnpm ship` when the change should go live.
+5. **Deploys are automatic.** Merging to master triggers the CI `deploy` job, which deploys both workers after checks pass (so prod always equals master). Manual `pnpm ship` from the worktree still works as a fallback when CI deploy is broken or you can't wait — ship-guard enforces the same content==master invariant.
 6. **Clean up.** Run `scripts/worktree-done.sh <branch>` from the main checkout — it verifies the PR merged, then deletes the remote branch, removes the worktree, and deletes the local branch (the work lives on master via the squash).
 
 ## Commit / PR text


### PR DESCRIPTION
Two CI changes:

**Deploy-on-merge.** A `deploy` job runs on every push to master (i.e. every merged PR), after the check job passes: builds and `wrangler deploy`s both workers. Prod now tracks master with no manual step, and every deploy is traceable to the commit that triggered it. Auth is the `CLOUDFLARE_API_TOKEN` repo secret — a long-lived API token created for this (Workers scripts/KV/queues/observability/email-sending/AI writes on the account + Workers Routes write on the shaunregenbaum.com and talmud.dev zones, needed for the custom domains). Manual `pnpm ship` from a worktree still works as a fallback; ship-guard enforces the same content==master invariant there.

**Node 24 opt-in.** GitHub flips actions to the Node 24 runner default on 2026-06-16. `actions/checkout` and `actions/setup-node` bumped to v5 and `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` set in both workflows so any breakage shows up in this PR rather than on the flip date.

The merge of this PR is itself the live test of the deploy job.