### PR TITLE
Tanach: first test suite (19 tests) + restore the test script

### DIFF
--- a/packages/tanach/package.json
+++ b/packages/tanach/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "ship": "bash ../../scripts/ship-guard.sh && vite build && wrangler deploy",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@corpus/core": "workspace:*",

--- a/packages/tanach/tests/events-prompt.test.ts
+++ b/packages/tanach/tests/events-prompt.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { versesForPrompt } from '../src/worker/producers/events';
+
+describe('versesForPrompt', () => {
+  it('numbers verses and strips Sefaria HTML markup', () => {
+    const out = versesForPrompt([
+      { n: 1, en: 'In the <b>beginning</b>', he: 'בראשית' },
+      { n: 2, en: '  And the earth <i class="x">was</i> unformed ', he: 'והארץ' },
+    ]);
+    expect(out).toBe('1. In the beginning\n2. And the earth was unformed');
+  });
+
+  it('tolerates missing English (number still emitted)', () => {
+    expect(versesForPrompt([{ n: 3, en: '', he: 'ויאמר' }])).toBe('3. ');
+  });
+});

--- a/packages/tanach/tests/hebrew.test.ts
+++ b/packages/tanach/tests/hebrew.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { hebrewNumeral } from '../src/lib/hebrew';
+
+describe('hebrewNumeral', () => {
+  it('renders units, tens, hundreds', () => {
+    expect(hebrewNumeral(1)).toBe('א');
+    expect(hebrewNumeral(9)).toBe('ט');
+    expect(hebrewNumeral(10)).toBe('י');
+    expect(hebrewNumeral(21)).toBe('כא');
+    expect(hebrewNumeral(99)).toBe('צט');
+    expect(hebrewNumeral(100)).toBe('ק');
+    expect(hebrewNumeral(119)).toBe('קיט');
+  });
+
+  it('uses טו/טז for 15/16 (never spelling part of the divine name)', () => {
+    expect(hebrewNumeral(15)).toBe('טו');
+    expect(hebrewNumeral(16)).toBe('טז');
+    expect(hebrewNumeral(115)).toBe('קטו');
+    expect(hebrewNumeral(116)).toBe('קטז');
+    // 17 goes back to the regular tens+units form
+    expect(hebrewNumeral(17)).toBe('יז');
+  });
+
+  it('covers the longest chapter in Tanach (Psalms 119 has 176 verses)', () => {
+    expect(hebrewNumeral(176)).toBe('קעו');
+  });
+
+  it('repeats ת above 400', () => {
+    expect(hebrewNumeral(500)).toBe('תק');
+    expect(hebrewNumeral(1000)).toBe('תתר');
+  });
+});

--- a/packages/tanach/tests/registries.test.ts
+++ b/packages/tanach/tests/registries.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { BOOKS, SECTIONS, bookByName, isBook } from '../src/lib/books';
+import { COMMENTATORS } from '../src/lib/commentators';
+
+describe('BOOKS registry', () => {
+  it('has the 39 books of Tanach, uniquely named', () => {
+    expect(BOOKS.length).toBe(39);
+    expect(new Set(BOOKS.map((b) => b.name)).size).toBe(39);
+  });
+
+  it('groups them 5 Torah / 21 Neviim / 13 Ketuvim', () => {
+    const count = (s: string) => BOOKS.filter((b) => b.section === s).length;
+    expect(count('Torah')).toBe(5);
+    expect(count("Nevi'im")).toBe(21);
+    expect(count('Ketuvim')).toBe(13);
+  });
+
+  it('every book has a Hebrew name and a known section', () => {
+    for (const b of BOOKS) {
+      expect(b.he.length).toBeGreaterThan(0);
+      expect(SECTIONS).toContain(b.section);
+    }
+  });
+
+  it('bookByName / isBook resolve Sefaria English names', () => {
+    expect(bookByName('Genesis')?.he).toBe('בְּרֵאשִׁית');
+    expect(isBook('I Samuel')).toBe(true);
+    expect(isBook('1 Samuel')).toBe(false);
+    expect(bookByName('Bereshit')).toBeUndefined();
+  });
+});
+
+describe('COMMENTATORS registry', () => {
+  it('has unique keys and titles', () => {
+    expect(new Set(COMMENTATORS.map((c) => c.key)).size).toBe(COMMENTATORS.length);
+    expect(new Set(COMMENTATORS.map((c) => c.title)).size).toBe(COMMENTATORS.length);
+  });
+
+  it('keeps Rashi first (display order)', () => {
+    expect(COMMENTATORS[0]?.key).toBe('rashi');
+  });
+});

--- a/packages/tanach/tests/sources.test.ts
+++ b/packages/tanach/tests/sources.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { GEMARA_MIN, MIDRASH_MIN, verseKinds } from '../src/lib/sources';
+
+const verse = (over: Partial<Parameters<typeof verseKinds>[0]>) => ({
+  verse: 1,
+  rishonim: 0,
+  rich: false,
+  gemara: 0,
+  midrash: 0,
+  ...over,
+});
+
+describe('verseKinds', () => {
+  it('gives nothing for a bare verse', () => {
+    expect(verseKinds(verse({}))).toEqual([]);
+  });
+
+  it('flags rishonim on rich, regardless of count', () => {
+    expect(verseKinds(verse({ rich: true }))).toEqual(['rishonim']);
+    expect(verseKinds(verse({ rishonim: 7, rich: false }))).toEqual([]);
+  });
+
+  it('applies the gemara and midrash thresholds exactly', () => {
+    expect(verseKinds(verse({ gemara: GEMARA_MIN - 1 }))).toEqual([]);
+    expect(verseKinds(verse({ gemara: GEMARA_MIN }))).toEqual(['gemara']);
+    expect(verseKinds(verse({ midrash: MIDRASH_MIN - 1 }))).toEqual([]);
+    expect(verseKinds(verse({ midrash: MIDRASH_MIN }))).toEqual(['midrash']);
+  });
+
+  it('keeps display order rishonim, gemara, midrash', () => {
+    expect(verseKinds(verse({ rich: true, gemara: 9, midrash: 9 }))).toEqual([
+      'rishonim',
+      'gemara',
+      'midrash',
+    ]);
+  });
+});

--- a/packages/tanach/tests/usage.test.ts
+++ b/packages/tanach/tests/usage.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { type UsageEntry, readUsage, recordUsage } from '../src/worker/usage';
+
+/** Minimal in-memory stand-in for the KV binding (string get/put only). */
+function kvStub(initial?: Record<string, string>) {
+  const store = new Map(Object.entries(initial ?? {}));
+  return {
+    get: async (k: string) => store.get(k) ?? null,
+    put: async (k: string, v: string) => {
+      store.set(k, v);
+    },
+  } as unknown as KVNamespace;
+}
+
+const entry = (over: Partial<UsageEntry>): UsageEntry => ({
+  ts: 0,
+  ref: 'Genesis 1',
+  producer: 'translate',
+  model: 'm',
+  in: 100,
+  out: 50,
+  cost: 0.001,
+  ...over,
+});
+
+describe('usage ledger', () => {
+  it('starts empty and tolerates malformed stored JSON', async () => {
+    expect((await readUsage(kvStub())).calls).toBe(0);
+    expect((await readUsage(kvStub({ 'usage:v1': 'not json' }))).calls).toBe(0);
+  });
+
+  it('accumulates totals and per-producer buckets', async () => {
+    const kv = kvStub();
+    await recordUsage(kv, entry({}));
+    await recordUsage(kv, entry({ producer: 'events', cost: null, in: 10, out: 5 }));
+    await recordUsage(kv, entry({}));
+
+    const s = await readUsage(kv);
+    expect(s.calls).toBe(3);
+    expect(s.inTokens).toBe(210);
+    expect(s.outTokens).toBe(105);
+    expect(s.costUsd).toBeCloseTo(0.002);
+    expect(s.byProducer.translate).toEqual({ calls: 2, costUsd: expect.closeTo(0.002) });
+    expect(s.byProducer.events).toEqual({ calls: 1, costUsd: 0 });
+  });
+
+  it('keeps the most recent calls first, capped at 100', async () => {
+    const kv = kvStub();
+    for (let i = 0; i < 105; i++) {
+      await recordUsage(kv, entry({ ts: i }));
+    }
+    const s = await readUsage(kv);
+    expect(s.recent.length).toBe(100);
+    expect(s.recent[0]?.ts).toBe(104);
+    expect(s.calls).toBe(105);
+  });
+});

--- a/packages/tanach/vitest.config.ts
+++ b/packages/tanach/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+// Dedicated vitest config: vite.config.ts pulls in the Cloudflare plugin,
+// which cannot run under vitest's node environment (it rejects the
+// resolve.external vitest sets). Tests here are plain node unit tests.
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
Tanach has had zero tests since the package was created; #350 removed its broken `test` script (vitest was loading the Cloudflare vite plugin and dying at startup with no tests to run). This restores the script properly:

- Dedicated `vitest.config.ts` (plain node environment, no Cloudflare plugin) — the same pattern talmud uses.
- 19 tests over the pure logic: `hebrewNumeral` (incl. the טו/טז special case and the Psalms-119 range), the BOOKS registry (39 books, 5/21/13 split, Sefaria-name lookups), COMMENTATORS uniqueness, `verseKinds` gutter-icon thresholds, the KV usage ledger (accumulation, per-producer buckets, recent-100 cap, malformed-JSON tolerance), and `versesForPrompt` HTML stripping.

`pnpm -r test` now includes tanach, so these gate in CI from this commit on. Verified: tests, lint, typecheck all green.