### PR TITLE
Fix import-name order in the new tanach tests

### DIFF
--- a/packages/tanach/tests/registries.test.ts
+++ b/packages/tanach/tests/registries.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { BOOKS, SECTIONS, bookByName, isBook } from '../src/lib/books';
+import { BOOKS, bookByName, isBook, SECTIONS } from '../src/lib/books';
 import { COMMENTATORS } from '../src/lib/commentators';
 
 describe('BOOKS registry', () => {

--- a/packages/tanach/tests/usage.test.ts
+++ b/packages/tanach/tests/usage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { type UsageEntry, readUsage, recordUsage } from '../src/worker/usage';
+import { readUsage, recordUsage, type UsageEntry } from '../src/worker/usage';
 
 /** Minimal in-memory stand-in for the KV binding (string get/put only). */
 function kvStub(initial?: Record<string, string>) {


### PR DESCRIPTION
Two of the test files added in #353 had unsorted import specifiers, which fails `biome ci` (errors, not warnings) — master is red on it. This is the one-line organizeImports fix. (Process note: #353 was admin-merged over the red check by mistake; the chained merge command did not gate on the CI conclusion.)