### PR TITLE
Keyboard accessibility for every interactive element; Biome to zero warnings

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -8,7 +8,8 @@
       "!**/node_modules",
       "!**/static",
       "!Sandbox",
-      "!**/scripts/out"
+      "!**/scripts/out",
+      "!**/src/lib/data"
     ]
   },
   "formatter": {
@@ -28,7 +29,6 @@
     "enabled": true,
     "rules": {
       "recommended": true,
-      "a11y": "warn",
       "style": {
         "noNonNullAssertion": "off"
       },

--- a/packages/talmud/src/client/AIActivityPanel.tsx
+++ b/packages/talmud/src/client/AIActivityPanel.tsx
@@ -247,7 +247,8 @@ export default function AIActivityPanel(): JSX.Element {
           {(entry) => renderEntry(entry)}
         </For>
         <Show when={groups().loading.length > MAX_RUNNING}>
-          <div
+          <button
+            type="button"
             onClick={() => setShowRunning((v) => !v)}
             title={showRunning() ? 'Show fewer running' : 'Show all running'}
             style={{
@@ -257,6 +258,11 @@ export default function AIActivityPanel(): JSX.Element {
               padding: '0.15rem 0',
               cursor: 'pointer',
               color: '#8a2a2b',
+              width: '100%',
+              font: 'inherit',
+              'text-align': 'left',
+              border: 'none',
+              background: 'transparent',
             }}
           >
             <span
@@ -280,12 +286,13 @@ export default function AIActivityPanel(): JSX.Element {
                 {showRunning() ? '▾' : '▸'}
               </span>
             </span>
-          </div>
+          </button>
         </Show>
 
         {/* Queued — collapsed to a single count by default. */}
         <Show when={groups().queued.length > 0}>
-          <div
+          <button
+            type="button"
             onClick={() => setShowQueued((v) => !v)}
             title={showQueued() ? 'Hide queued' : 'Show queued'}
             style={{
@@ -295,6 +302,11 @@ export default function AIActivityPanel(): JSX.Element {
               padding: '0.15rem 0',
               cursor: 'pointer',
               color: '#9a8b6f',
+              width: '100%',
+              font: 'inherit',
+              'text-align': 'left',
+              border: 'none',
+              background: 'transparent',
             }}
           >
             <span
@@ -325,7 +337,7 @@ export default function AIActivityPanel(): JSX.Element {
             >
               {fmtMs(oldestQueuedWait())}
             </span>
-          </div>
+          </button>
           <Show when={showQueued()}>
             <For each={groups().queued}>{(entry) => renderEntry(entry)}</For>
           </Show>
@@ -333,7 +345,8 @@ export default function AIActivityPanel(): JSX.Element {
 
         {/* Recently finished — collapsed to a single count by default. */}
         <Show when={groups().terminal.length > 0}>
-          <div
+          <button
+            type="button"
             onClick={() => setShowDone((v) => !v)}
             title={showDone() ? 'Hide finished' : 'Show finished'}
             style={{
@@ -343,6 +356,11 @@ export default function AIActivityPanel(): JSX.Element {
               padding: '0.15rem 0',
               cursor: 'pointer',
               color: '#15803d',
+              width: '100%',
+              font: 'inherit',
+              'text-align': 'left',
+              border: 'none',
+              background: 'transparent',
             }}
           >
             <span style={{ 'flex-shrink': 0 }}>✓</span>
@@ -353,7 +371,7 @@ export default function AIActivityPanel(): JSX.Element {
                 {showDone() ? '▾' : '▸'}
               </span>
             </span>
-          </div>
+          </button>
           <Show when={showDone()}>
             <For each={groups().terminal}>{(entry) => renderEntry(entry)}</For>
           </Show>

--- a/packages/talmud/src/client/AlignPage.tsx
+++ b/packages/talmud/src/client/AlignPage.tsx
@@ -178,6 +178,8 @@ export function AlignPage(): JSX.Element {
   const [hlAdj, setHlAdj] = createSignal<'prev' | 'next' | null>(null);
   const [prevOpen, setPrevOpen] = createSignal(false);
   const [nextOpen, setNextOpen] = createSignal(false);
+  const togglePrevOpen = () => setPrevOpen((o) => !o);
+  const toggleNextOpen = () => setNextOpen((o) => !o);
   const [detail, setDetail] = createSignal<Detail>(null);
 
   const ref = createMemo(() => ({ t: tractate(), p: page() }));
@@ -789,10 +791,19 @@ export function AlignPage(): JSX.Element {
           </div>
           <div class="aw-spinebox" ref={spineBox}>
             <Show when={adjPreview(prevDaf(), 'last', prevOpen())}>
+              {/* biome-ignore lint/a11y/useSemanticElements: holds block-level children (.aw-adjlab/.aw-adjtext divs) styled by the .aw-adj class rules; a native button's content model and UA styles would break it */}
               <div
                 class={`aw-adj${hlAdj() === 'prev' ? ' hot' : ''}`}
                 data-adj="prev"
-                onClick={() => setPrevOpen((o) => !o)}
+                role="button"
+                tabIndex={0}
+                onClick={togglePrevOpen}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    togglePrevOpen();
+                  }
+                }}
               >
                 <div class="aw-adjlab">
                   ‹ prev · {adjPage(page(), 'prev')} ·{' '}
@@ -805,6 +816,8 @@ export function AlignPage(): JSX.Element {
                 />
               </div>
             </Show>
+            {/* biome-ignore lint/a11y/noStaticElementInteractions: hover-to-locate highlight over per-word spans in injected HTML; mouse-position-driven, not an activatable control */}
+            {/* biome-ignore lint/a11y/useKeyWithMouseEvents: focusing the whole amud container has no meaningful keyboard equivalent of per-word hover */}
             <div
               class="aw-daf"
               dir="rtl"
@@ -818,10 +831,19 @@ export function AlignPage(): JSX.Element {
               onMouseLeave={() => setHl([])}
             />
             <Show when={adjPreview(nextDaf(), 'first', nextOpen())}>
+              {/* biome-ignore lint/a11y/useSemanticElements: holds block-level children (.aw-adjlab/.aw-adjtext divs) styled by the .aw-adj class rules; a native button's content model and UA styles would break it */}
               <div
                 class={`aw-adj${hlAdj() === 'next' ? ' hot' : ''}`}
                 data-adj="next"
-                onClick={() => setNextOpen((o) => !o)}
+                role="button"
+                tabIndex={0}
+                onClick={toggleNextOpen}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    toggleNextOpen();
+                  }
+                }}
               >
                 <div class="aw-adjlab">
                   › next · {adjPage(page(), 'next')} ·{' '}

--- a/packages/talmud/src/client/ArgumentFlowGraph.tsx
+++ b/packages/talmud/src/client/ArgumentFlowGraph.tsx
@@ -318,8 +318,21 @@ export default function ArgumentFlowGraph(props: Props): JSX.Element {
               const active = () => props.activeIndex === n.index;
               const cy = () => nodeY(i()) + NODE_H / 2;
               const lines = () => wrapTitle(n.title, TITLE_CHARS, TITLE_LINES);
+              const select = () => props.onSelect(n.index);
               return (
-                <g style={{ cursor: 'pointer' }} onClick={() => props.onSelect(n.index)}>
+                // biome-ignore lint/a11y/useSemanticElements: native <button> cannot be used inside an SVG diagram
+                <g
+                  role="button"
+                  tabindex={0}
+                  style={{ cursor: 'pointer' }}
+                  onClick={select}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      select();
+                    }
+                  }}
+                >
                   <title>{`${n.index + 1}. ${n.title} — click for voices`}</title>
                   <rect
                     x={LEFT_PAD}

--- a/packages/talmud/src/client/ArgumentFlowSidebar.tsx
+++ b/packages/talmud/src/client/ArgumentFlowSidebar.tsx
@@ -115,10 +115,20 @@ function ArgumentSection(props: {
 
   return (
     <section class="flow-section">
+      {/* biome-ignore lint/a11y/useSemanticElements: section heading that doubles as a daf-anchor target; a button element would break the flow-section-head heading layout */}
       <h3
         class="flow-section-head"
         classList={{ 'flow-section-head-linked': !!props.onAnchorClick }}
         onClick={clickHead}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            clickHead();
+          }
+        }}
+        // biome-ignore lint/a11y/noNoninteractiveElementToInteractiveRole: the heading stays an h3 in the DOM for the flow-section-head styling; restructuring to a nested button would change the reader layout
+        role="button"
+        tabIndex={0}
       >
         <span class="flow-section-num">§{props.idx + 1}</span>
         <span class="flow-section-title">{sec().title}</span>

--- a/packages/talmud/src/client/ArgumentNarrative.tsx
+++ b/packages/talmud/src/client/ArgumentNarrative.tsx
@@ -228,8 +228,18 @@ export default function ArgumentNarrative(props: {
                       );
                     };
                     return (
+                      // biome-ignore lint/a11y/useSemanticElements: a beat is a list item in the ordered beat list; converting it to a button would break the ol>li structure and layout
                       <li
                         onClick={toggle}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                            toggle();
+                          }
+                        }}
+                        // biome-ignore lint/a11y/noNoninteractiveElementToInteractiveRole: the beat stays an li in the DOM so the ol keeps valid children; a nested button would change the reader layout
+                        role="button"
+                        tabIndex={0}
                         title={anchored() ? 'Highlight this beat on the daf' : undefined}
                         style={{
                           'font-size': '0.82rem',

--- a/packages/talmud/src/client/ArgumentSidebar.tsx
+++ b/packages/talmud/src/client/ArgumentSidebar.tsx
@@ -552,8 +552,20 @@ function ArgumentMoveCard(props: {
           card's click-to-highlight target to the synthesis body — clicks
           on rabbi-link buttons + chips stopPropagation so they don't toggle
           the highlight. */}
+      {/* biome-ignore lint/a11y/useSemanticElements: wraps the synthesis prose block, which nests rabbi-link buttons and chips; a native button cannot contain them */}
       <div
         onClick={toggleHighlight}
+        onKeyDown={(e) => {
+          // Only the wrapper itself toggles — a keydown bubbled up from a
+          // focused rabbi-link button or chip inside must not also toggle.
+          if (e.currentTarget !== e.target) return;
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            toggleHighlight();
+          }
+        }}
+        role="button"
+        tabIndex={0}
         title={isActive() ? t('move.highlight.clear') : t('move.highlight.set')}
         style={{ cursor: 'pointer' }}
       >
@@ -626,9 +638,19 @@ function ArgumentMoveFlow(props: {
             const f = m.fields;
             const color = ROLE_COLORS[f.role] ?? '#64748b';
             const isActive = () => props.highlightedMoveId === f.id;
+            const toggleMove = () => props.onHighlightMove(isActive() ? null : m);
             return (
+              // biome-ignore lint/a11y/useSemanticElements: inline-styled flex row with a baseline-aligned Hebrew excerpt; a native button's UA styles (border, font, centering) would alter the reader layout
               <div
-                onClick={() => props.onHighlightMove(isActive() ? null : m)}
+                onClick={toggleMove}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    toggleMove();
+                  }
+                }}
+                role="button"
+                tabIndex={0}
                 title="Highlight this move on the daf"
                 style={{
                   display: 'flex',

--- a/packages/talmud/src/client/ArgumentVoiceMap.tsx
+++ b/packages/talmud/src/client/ArgumentVoiceMap.tsx
@@ -461,12 +461,26 @@ export default function ArgumentVoiceMap(props: Props): JSX.Element {
             <For each={layout().nodes}>
               {(n) => {
                 const clickable = props.onClickVoice && isClickableVoiceName(n.name);
+                const openVoice = clickable ? () => props.onClickVoice!(n.name) : undefined;
                 const titleText = n.stance
                   ? `${n.name} (${n.role})\n${n.stance}`
                   : `${n.name} (${n.role})`;
                 return (
+                  // biome-ignore lint/a11y/noStaticElementInteractions: role="button"/tabindex ARE set when this voice is clickable; Biome cannot resolve the conditional role expression
                   <g
-                    onClick={clickable ? () => props.onClickVoice!(n.name) : undefined}
+                    role={clickable ? 'button' : undefined}
+                    tabindex={clickable ? 0 : undefined}
+                    onClick={openVoice}
+                    onKeyDown={
+                      openVoice
+                        ? (e) => {
+                            if (e.key === 'Enter' || e.key === ' ') {
+                              e.preventDefault();
+                              openVoice();
+                            }
+                          }
+                        : undefined
+                    }
                     style={clickable ? { cursor: 'pointer' } : undefined}
                   >
                     <title>{clickable ? `${titleText}\n— click to open` : titleText}</title>

--- a/packages/talmud/src/client/DafViewer.tsx
+++ b/packages/talmud/src/client/DafViewer.tsx
@@ -3495,6 +3495,7 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
           </Show>
           {/* EN/HE language toggle, folded inline here on the daf page; the
               floating TopBar overlay covers the other routes (see App.tsx). */}
+          {/* biome-ignore lint/a11y/useSemanticElements: .tb-seg is an inline-flex pill; a fieldset cannot reliably be a flex container and carries UA border/padding/min-inline-size */}
           <div class="tb-seg" role="group" aria-label="Language" data-tour="lang">
             <button
               type="button"
@@ -3634,6 +3635,7 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
               </div>
             </Show>
 
+            {/* biome-ignore lint/a11y/noStaticElementInteractions: mouseup here delegates pointer text-selection + tap handling for the daf words, not a click action of its own; keyboard access lives on the focusable controls inside */}
             <div
               ref={surfaceEl}
               class="daf-surface"
@@ -3998,6 +4000,8 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
           <Show>. */}
       <Show when={isMobile()}>
         <Show when={layersOpen()}>
+          {/* biome-ignore lint/a11y/noStaticElementInteractions: backdrop click-to-close; the sheet's ✕ close button is the keyboard path */}
+          {/* biome-ignore lint/a11y/useKeyWithClickEvents: backdrop click-to-close; the sheet's ✕ close button is the keyboard path */}
           <div
             onClick={() => setLayersOpen(false)}
             style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.25)', 'z-index': 200 }}

--- a/packages/talmud/src/client/DevModeShelf.tsx
+++ b/packages/talmud/src/client/DevModeShelf.tsx
@@ -132,6 +132,7 @@ export default function DevModeShelf(props: Props) {
       }}
     >
       {/* Drag handle on the right edge */}
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: pointer-drag resize handle for the dev-only shelf; resizing has no keyboard equivalent */}
       <div
         onMouseDown={onDragStart}
         style={{

--- a/packages/talmud/src/client/GeographyMap.tsx
+++ b/packages/talmud/src/client/GeographyMap.tsx
@@ -513,7 +513,12 @@ export function GeographyMap(props: GeographyMapProps): JSX.Element {
             const gen = props.generationByName?.get(name);
             const genColor = gen ? GENERATION_BY_ID[gen]?.color : undefined;
             const fill = genColor ?? GEN_FALLBACK_COLOR;
+            const activate = () => {
+              if (props.onHighlightSingleRabbi) props.onHighlightSingleRabbi(name);
+              else onDotClick(d);
+            };
             return (
+              // biome-ignore lint/a11y/useSemanticElements: native <button> cannot be used inside an SVG map
               <circle
                 cx={off.x}
                 cy={off.y}
@@ -522,10 +527,17 @@ export function GeographyMap(props: GeographyMapProps): JSX.Element {
                 stroke={activeCity() ? '#000' : 'rgba(0,0,0,0.25)'}
                 stroke-width={activeCity() ? 0.6 : 0.3}
                 style={{ cursor: 'pointer' }}
+                role="button"
+                tabindex={0}
                 onClick={(e) => {
                   e.stopPropagation();
-                  if (props.onHighlightSingleRabbi) props.onHighlightSingleRabbi(name);
-                  else onDotClick(d);
+                  activate();
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    activate();
+                  }
                 }}
               >
                 <title>{`${name} · ${d.city.name} (${d.city.nameHe})${gen ? ` · ${GENERATION_BY_ID[gen]?.label ?? ''}` : ''}`}</title>
@@ -552,7 +564,12 @@ export function GeographyMap(props: GeographyMapProps): JSX.Element {
 
   const renderPlaceDot = (city: KnownCity): JSX.Element => {
     const active = () => props.activePlace === city.name;
+    const activate = () => {
+      if (!props.onHighlightPlace) return;
+      props.onHighlightPlace(active() ? null : city.name);
+    };
     return (
+      // biome-ignore lint/a11y/useSemanticElements: native <button> cannot be used inside an SVG map
       <circle
         cx={city.x}
         cy={city.y}
@@ -561,10 +578,17 @@ export function GeographyMap(props: GeographyMapProps): JSX.Element {
         stroke={active() ? '#000' : 'rgba(0,0,0,0.25)'}
         stroke-width={active() ? 0.6 : 0.3}
         style={{ cursor: 'pointer' }}
+        role="button"
+        tabindex={0}
         onClick={(e) => {
           e.stopPropagation();
-          if (!props.onHighlightPlace) return;
-          props.onHighlightPlace(active() ? null : city.name);
+          activate();
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            activate();
+          }
         }}
       >
         <title>{`${city.name} (${city.nameHe}) · ${t('geography.mentionedInDaf')}`}</title>
@@ -663,6 +687,7 @@ export function GeographyMap(props: GeographyMapProps): JSX.Element {
               role="img"
               aria-label={t('geography.eretzYisrael.aria')}
             >
+              {/* biome-ignore lint/a11y/useSemanticElements: native <button> cannot be used inside an SVG map */}
               <path
                 d={ISRAEL_SHAPE.d}
                 fill="none"
@@ -671,7 +696,16 @@ export function GeographyMap(props: GeographyMapProps): JSX.Element {
                 stroke-linejoin="round"
                 opacity="0.85"
                 style={{ cursor: 'pointer' }}
+                role="button"
+                tabindex={0}
+                aria-label={t('geography.eretzYisrael')}
                 onClick={() => onRegionClick('israel')}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    onRegionClick('israel');
+                  }
+                }}
               />
               <For each={data().placeDots.filter((c) => c.region === 'israel')}>
                 {(c) => renderPlaceDot(c)}
@@ -713,6 +747,7 @@ export function GeographyMap(props: GeographyMapProps): JSX.Element {
               aria-label={t('geography.bavel.aria')}
             >
               {/* Invisible hit-box so clicks anywhere inside the region fire onRegionClick */}
+              {/* biome-ignore lint/a11y/useSemanticElements: native <button> cannot be used inside an SVG map */}
               <rect
                 x="30"
                 y="-10"
@@ -720,7 +755,16 @@ export function GeographyMap(props: GeographyMapProps): JSX.Element {
                 height="195"
                 fill="transparent"
                 style={{ cursor: 'pointer' }}
+                role="button"
+                tabindex={0}
+                aria-label={t('geography.bavel')}
                 onClick={() => onRegionClick('bavel')}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    onRegionClick('bavel');
+                  }
+                }}
               />
               {/* Euphrates — Pumbedita → Nehardea → Sura → Naresh */}
               <path
@@ -851,7 +895,9 @@ export function GeographyMap(props: GeographyMapProps): JSX.Element {
                 const toFull = fromB ? t('geography.eretzYisrael') : t('geography.bavel');
                 const arrow = row.direction === 'both' ? '↔' : '→';
                 return (
+                  // biome-ignore lint/a11y/useSemanticElements: a native <button> would inject UA layout/typography into this tightly inline-styled row; role+tabIndex+keydown give the same semantics
                   <div
+                    role="button"
                     onMouseEnter={onEnter}
                     onMouseLeave={onLeave}
                     onFocus={onEnter}

--- a/packages/talmud/src/client/RabbiLineageTree.tsx
+++ b/packages/talmud/src/client/RabbiLineageTree.tsx
@@ -614,10 +614,20 @@ export default function RabbiLineageTree(props: Props): JSX.Element {
               const labelColor = n.role === 'subject' ? PRIMARY_COLOR : '#222';
               const borderWidth = n.role === 'subject' ? 2 : n.primary ? 1.75 : 1.25;
 
+              const activate = () => hasEv && clickNode(n);
               return (
+                // biome-ignore lint/a11y/noStaticElementInteractions: role="button"/tabindex ARE set when the node has on-daf evidence; Biome cannot resolve the conditional role expression
                 <g
+                  role={hasEv ? 'button' : undefined}
+                  tabindex={hasEv ? 0 : undefined}
                   style={{ cursor: hasEv ? 'pointer' : 'default' }}
-                  onClick={() => hasEv && clickNode(n)}
+                  onClick={activate}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      activate();
+                    }
+                  }}
                 >
                   <title>
                     {ev

--- a/packages/talmud/src/client/RunTreeDag.tsx
+++ b/packages/talmud/src/client/RunTreeDag.tsx
@@ -239,11 +239,21 @@ export function RunTreeDag(props: {
                   const exp = () => expanded().has(id);
                   const slow = () => (n().cold_ms ?? 0) > 10_000;
                   const dim = () => !!selected() && !connected().has(id);
+                  const activate = () => {
+                    setSelected(id);
+                    if (hasKids(id)) toggleExpand(id);
+                  };
                   return (
+                    // biome-ignore lint/a11y/useSemanticElements: node card contains a nested expand <button>; a native button cannot contain another button
                     <div
-                      onClick={() => {
-                        setSelected(id);
-                        if (hasKids(id)) toggleExpand(id);
+                      role="button"
+                      tabIndex={0}
+                      onClick={activate}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          activate();
+                        }
                       }}
                       style={{
                         position: 'absolute',

--- a/packages/talmud/src/client/RunTreeDock.tsx
+++ b/packages/talmud/src/client/RunTreeDock.tsx
@@ -86,8 +86,17 @@ function RunRow(props: {
   const color = () => (isLLM() ? (r().model?.includes('pro') ? BADGE_PRO : BADGE_LLM) : BADGE_SRC);
   const pct = () => Math.max(2, Math.round(((r().cold_ms ?? 0) / props.maxMs) * 100));
   return (
+    // biome-ignore lint/a11y/useSemanticElements: row contains a nested inspect <button>; a native button cannot contain another button
     <div
+      role="button"
+      tabIndex={0}
       onClick={props.onClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          props.onClick?.();
+        }
+      }}
       title={r().id}
       style={{
         display: 'flex',
@@ -491,6 +500,7 @@ export default function RunTreeDock(props: {
       }}
     >
       {/* resize handle (left edge) */}
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: drag-to-resize handle; the interaction is pointer-position-driven (mousemove), there is no keyboard equivalent */}
       <div
         onMouseDown={onResizeStart}
         title="drag to resize"
@@ -758,11 +768,21 @@ export default function RunTreeDock(props: {
                       const exp = () => expanded().has(id);
                       const slow = () => (n().cold_ms ?? 0) > 10_000;
                       const dim = () => !!selected() && !connected().has(id);
+                      const activate = () => {
+                        setSelected(id);
+                        if (hasKids(id)) toggleExpand(id);
+                      };
                       return (
+                        // biome-ignore lint/a11y/useSemanticElements: node card contains a nested expand <button>; a native button cannot contain another button
                         <div
-                          onClick={() => {
-                            setSelected(id);
-                            if (hasKids(id)) toggleExpand(id);
+                          role="button"
+                          tabIndex={0}
+                          onClick={activate}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter' || e.key === ' ') {
+                              e.preventDefault();
+                              activate();
+                            }
                           }}
                           style={{
                             position: 'absolute',
@@ -880,6 +900,7 @@ export default function RunTreeDock(props: {
               position: 'relative',
             }}
           >
+            {/* biome-ignore lint/a11y/noStaticElementInteractions: drag-to-resize handle; the interaction is pointer-position-driven (mousemove), there is no keyboard equivalent */}
             <div
               onMouseDown={onDetailResizeStart}
               title="drag to resize"

--- a/packages/talmud/src/client/SpineCoveragePage.tsx
+++ b/packages/talmud/src/client/SpineCoveragePage.tsx
@@ -687,10 +687,20 @@ export function SpineCoveragePage(): JSX.Element {
                     const filledCount = createMemo(
                       () => r().columns.filter((c) => row.cells[c.id]).length,
                     );
+                    const toggleRow = () => setExpanded(isOpen() ? null : row.page);
                     return (
                       <>
+                        {/* biome-ignore lint/a11y/useSemanticElements: a native <button> would inject UA layout/typography into this tightly inline-styled grid row; role+tabIndex+keydown give the same semantics */}
                         <div
-                          onClick={() => setExpanded(isOpen() ? null : row.page)}
+                          role="button"
+                          tabIndex={0}
+                          onClick={toggleRow}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter' || e.key === ' ') {
+                              e.preventDefault();
+                              toggleRow();
+                            }
+                          }}
                           style={{
                             display: 'flex',
                             'align-items': 'center',

--- a/packages/talmud/src/client/SpineFlowGraph.tsx
+++ b/packages/talmud/src/client/SpineFlowGraph.tsx
@@ -484,7 +484,9 @@ export default function SpineFlowGraph(props: {
                           <For each={chips}>
                             {(c) => {
                               const on = () => hl() === c.slug;
+                              const trace = () => props.onRabbi?.(c.slug);
                               return (
+                                // biome-ignore lint/a11y/useSemanticElements: native <button> cannot be used inside an SVG diagram
                                 <text
                                   x={c.x}
                                   y={yTop + h - 8}
@@ -493,7 +495,15 @@ export default function SpineFlowGraph(props: {
                                   font-family="system-ui, sans-serif"
                                   fill={on() ? HILITE : '#8a7a55'}
                                   style={{ cursor: 'pointer' }}
-                                  onClick={() => props.onRabbi?.(c.slug)}
+                                  role="button"
+                                  tabindex={0}
+                                  onClick={trace}
+                                  onKeyDown={(e) => {
+                                    if (e.key === 'Enter' || e.key === ' ') {
+                                      e.preventDefault();
+                                      trace();
+                                    }
+                                  }}
                                 >
                                   <title>{`trace ${c.name} across the tractate`}</title>
                                   {c.name}
@@ -558,10 +568,20 @@ export default function SpineFlowGraph(props: {
                   {(page) => {
                     const yTop = o.nodeY.get(page)!;
                     const meta = o.meta.get(page)!;
+                    const pick = () => props.onPickDaf?.(page);
                     return (
+                      // biome-ignore lint/a11y/useSemanticElements: native <button> cannot be used inside an SVG diagram
                       <g
+                        role="button"
+                        tabindex={0}
                         style={{ cursor: props.onPickDaf ? 'pointer' : 'default' }}
-                        onClick={() => props.onPickDaf?.(page)}
+                        onClick={pick}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                            pick();
+                          }
+                        }}
                       >
                         <title>{`${page} — ${meta.sections} sections${meta.hasCross ? ' · cross-daf links' : ''}`}</title>
                         <rect

--- a/packages/talmud/src/client/TopBar.tsx
+++ b/packages/talmud/src/client/TopBar.tsx
@@ -48,6 +48,7 @@ export function TopBar(): JSX.Element {
       >
         {t('tutorial.help')}
       </button>
+      {/* biome-ignore lint/a11y/useSemanticElements: .tb-seg is an inline-flex pill; a fieldset cannot reliably be a flex container and carries UA border/padding/min-inline-size */}
       <div
         class="tb-seg"
         role="group"

--- a/packages/talmud/src/client/TypeProfilePanel.tsx
+++ b/packages/talmud/src/client/TypeProfilePanel.tsx
@@ -114,13 +114,22 @@ export default function TypeProfilePanel(props: {
           {(p) => {
             const isActive = () =>
               props.active?.start === p.unit.startSegIdx && props.active?.end === p.unit.endSegIdx;
+            const toggleHighlight = () =>
+              props.onHighlight?.(
+                isActive() ? null : { start: p.unit.startSegIdx, end: p.unit.endSegIdx },
+              );
             return (
+              // biome-ignore lint/a11y/useSemanticElements: a native <button> would inject UA layout/typography into this tightly inline-styled flex row; role+tabIndex+keydown give the same semantics
               <div
-                onClick={() =>
-                  props.onHighlight?.(
-                    isActive() ? null : { start: p.unit.startSegIdx, end: p.unit.endSegIdx },
-                  )
-                }
+                role="button"
+                tabIndex={0}
+                onClick={toggleHighlight}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    toggleHighlight();
+                  }
+                }}
                 title="Click to highlight this section on the daf"
                 style={{
                   display: 'flex',

--- a/packages/talmud/src/client/UsagePage.tsx
+++ b/packages/talmud/src/client/UsagePage.tsx
@@ -515,8 +515,19 @@ function Collapsible(props: {
   };
   return (
     <div style={{ 'margin-top': '0.7rem' }}>
+      {/* biome-ignore lint/a11y/useSemanticElements: collapsible section heading; converting the h3 to a button would change the heading's layout and typography */}
       <h3
         onClick={toggle}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            toggle();
+          }
+        }}
+        // biome-ignore lint/a11y/noNoninteractiveElementToInteractiveRole: the heading stays an h3 in the DOM for its layout/typography; restructuring to a nested button would change the click target
+        role="button"
+        tabIndex={0}
+        aria-expanded={open()}
         style={{
           'font-size': '0.8rem',
           color: '#777',

--- a/packages/talmud/src/client/UserHighlightUI.tsx
+++ b/packages/talmud/src/client/UserHighlightUI.tsx
@@ -199,7 +199,10 @@ export function NotesPanel(props: {
       >
         <For each={props.highlights}>
           {(h) => (
+            // biome-ignore lint/a11y/useSemanticElements: the row nests a delete button; a native button cannot contain another button
             <div
+              role="button"
+              tabIndex={0}
               style={{
                 padding: '0.55rem 0.8rem',
                 'border-bottom': '1px solid #f3f3f3',
@@ -208,6 +211,15 @@ export function NotesPanel(props: {
                 gap: '0.5rem',
               }}
               onClick={() => props.onJump(h)}
+              onKeyDown={(e) => {
+                // Only the row itself jumps — a keydown bubbled up from the
+                // focused delete button must not also jump.
+                if (e.currentTarget !== e.target) return;
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  props.onJump(h);
+                }
+              }}
             >
               <span
                 style={{

--- a/packages/talmud/src/client/conceptLinks.tsx
+++ b/packages/talmud/src/client/conceptLinks.tsx
@@ -324,10 +324,11 @@ function ConceptMention(props: { value: string; term: Term }): JSX.Element {
   };
 
   return (
+    // biome-ignore lint/a11y/useSemanticElements: inline span inside flowing prose; a button element would break text layout and selection/copy
     <span
       ref={termRef}
       style={termStyle}
-      tabindex={0}
+      tabIndex={0}
       role="button"
       aria-label={`${termLabel(props.term)}: ${props.term.gloss}`}
       onMouseEnter={openTip}
@@ -338,6 +339,8 @@ function ConceptMention(props: { value: string; term: Term }): JSX.Element {
       {props.value}
       <Show when={open()}>
         <Portal>
+          {/* biome-ignore lint/a11y/noStaticElementInteractions: tooltip body; onClick only stops propagation so a click on the tooltip doesn't trigger the surrounding card's click action */}
+          {/* biome-ignore lint/a11y/useKeyWithClickEvents: tooltip body; onClick only stops propagation — there is no activation behavior to mirror on the keyboard */}
           <span
             ref={place}
             style={{ ...tooltipStyle, left: `${pos().left}px`, top: `${pos().top}px` }}

--- a/packages/talmud/src/client/rabbiLinks.tsx
+++ b/packages/talmud/src/client/rabbiLinks.tsx
@@ -177,9 +177,10 @@ export function RabbiText(props: {
         // name in the document text flow (copyable) while staying clickable +
         // keyboard-accessible.
         return (
+          // biome-ignore lint/a11y/useSemanticElements: inline span inside flowing prose; <a>/<button> drop the name from text selection/copy (see comment above)
           <span
             role="link"
-            tabindex={0}
+            tabIndex={0}
             onClick={(e) => {
               e.stopPropagation();
               props.onPushRabbi(targetName);

--- a/packages/talmud/src/client/sidebar/primitives.tsx
+++ b/packages/talmud/src/client/sidebar/primitives.tsx
@@ -223,10 +223,11 @@ export function SectionCard(props: {
         }
       >
         {/* clickable label toggles; the inspect 'i' inside stops propagation */}
+        {/* biome-ignore lint/a11y/useSemanticElements: the label row nests the inspect 'i' button; a native button cannot contain another button */}
         <div
           onClick={() => setOpen((v) => !v)}
           role="button"
-          tabindex={0}
+          tabIndex={0}
           aria-expanded={open()}
           onKeyDown={(e) => {
             // Only the wrapper itself toggles — a keydown bubbled up from the

--- a/packages/talmud/src/client/styles.css
+++ b/packages/talmud/src/client/styles.css
@@ -581,9 +581,13 @@ body.dev-panel-open .daf-page {
     width: 100%;
   }
   .daf-aside {
+    /* biome-ignore lint/complexity/noImportantStyles: must beat the inline position:sticky set in DafViewer.tsx JSX */
     position: static !important;
+    /* biome-ignore lint/complexity/noImportantStyles: must beat the inline width:420px set in DafViewer.tsx JSX */
     width: 100% !important;
+    /* biome-ignore lint/complexity/noImportantStyles: must beat the inline max-height:calc(100vh - 2rem) set in DafViewer.tsx JSX */
     max-height: none !important;
+    /* biome-ignore lint/complexity/noImportantStyles: must beat the inline overflow:auto set in DafViewer.tsx JSX */
     overflow: visible !important;
   }
   .daf-cluster > section {
@@ -592,11 +596,15 @@ body.dev-panel-open .daf-page {
   /* Strips stack full-width below the daf on mobile; desktop stickiness is
      irrelevant here. Override the narrow-desktop hide. */
   .daf-strip {
-    display: flex !important;
-    position: static !important;
-    width: 100% !important;
-    max-height: none !important;
-    overflow: visible !important;
+    /* No !important needed: the narrow-desktop hide (display:none @1279px) and
+       the 220px/240px base widths are equal-specificity (0,1,0) rules EARLIER
+       in this file, so this later block wins by source order; nothing else
+       (no inline styles) sets position/max-height/overflow on .daf-strip. */
+    display: flex;
+    position: static;
+    width: 100%;
+    max-height: none;
+    overflow: visible;
   }
   /* Native pan + pinch-zoom on the daf container regardless of mode. The
      traditional Tzurat HaDaf renders at full 520px width on phones (the
@@ -612,6 +620,7 @@ body.dev-panel-open .daf-page {
     /* Override the desktop inline style: when content overflows, flex
        centering hides the leading edge out of reach. Anchor to start so
        users can pan both directions. */
+    /* biome-ignore lint/complexity/noImportantStyles: must beat the inline justify-content:center set in DafViewer.tsx JSX */
     justify-content: flex-start !important;
   }
   /* The body column wraps the surface — keep its overflow visible so
@@ -789,7 +798,10 @@ body.dev-panel-open .daf-page {
   z-index: 1;
 }
 /* Single-item clusters: no stack to expand. Neutralize the negative
-   margin so the lone icon sits flush at its anchor. */
+   margin so the lone icon sits flush at its anchor. No !important needed:
+   the lone icon is always :first-child, so every equal-or-higher-specificity
+   margin-top rule above already resolves to 0, and this (0,3,0) rule is last
+   in source. GutterOverlay.tsx sets no inline margins. */
 .gutter-cluster[data-count="1"] .gutter-icon {
-  margin: 0 !important;
+  margin: 0;
 }

--- a/packages/talmud/src/lib/daf-render/styles.css
+++ b/packages/talmud/src/lib/daf-render/styles.css
@@ -62,6 +62,7 @@
 }
 
 /* Spacer heights driven by the layout engine */
+/* biome-ignore lint/style/noDescendingSpecificity: disjoint properties — this sets height; the earlier higher-specificity .daf-main .daf-start rule sets width/margins */
 .daf-root .daf-start {
   height: var(--daf-start);
 }
@@ -87,6 +88,7 @@
   margin-right: calc(0.5 * var(--daf-padding-horizontal));
 }
 
+/* biome-ignore lint/style/noDescendingSpecificity: disjoint properties — this sets margins; the earlier higher-specificity .daf-inner/.daf-outer .daf-end rules set height */
 .daf-root .daf-end {
   margin-left: calc(0.5 * var(--daf-padding-horizontal));
   margin-right: calc(0.5 * var(--daf-padding-horizontal));
@@ -117,11 +119,13 @@
 }
 
 /* Vertical padding */
+/* biome-ignore lint/style/noDescendingSpecificity: disjoint properties — this sets margin-top; the earlier higher-specificity .daf-inner/.daf-outer .daf-mid rule sets width/clear */
 .daf-root .daf-mid,
 .daf-root .daf-main .daf-text {
   margin-top: var(--daf-padding-vertical);
 }
 
+/* biome-ignore lint/style/noDescendingSpecificity: disjoint properties — this sets margin-bottom; the earlier higher-specificity .daf-inner/.daf-outer .daf-mid rule sets width/clear */
 .daf-root .daf-mid,
 .daf-root .daf-main .daf-inner-mid,
 .daf-root .daf-main .daf-outer-mid {
@@ -129,6 +133,7 @@
 }
 
 /* Text */
+/* biome-ignore lint/style/noDescendingSpecificity: disjoint properties — this sets direction/text-align; the earlier higher-specificity .daf-main .daf-text rule sets margin-top */
 .daf-root .daf-text {
   direction: var(--daf-direction);
   text-align: justify;
@@ -346,6 +351,7 @@
    generation spectrum (see injectRabbiUnderlines.ts); this rule only switches
    the stroke to dashed. */
 .daf-root .daf-text .rabbi-underline-anonymous {
+  /* biome-ignore lint/complexity/noImportantStyles: must beat the LATER equal-specificity .rabbi-underline rule whose border-bottom shorthand resets the style to solid */
   border-bottom-style: dashed !important;
 }
 
@@ -383,6 +389,7 @@
 }
 
 /* Per-word click target. Tokenized by src/client/tokenize.ts. */
+/* biome-ignore lint/style/noDescendingSpecificity: disjoint properties — this sets cursor/padding/radius/transition; the earlier higher-specificity .city-marker > .daf-word rule sets color */
 .daf-root .daf-text .daf-word {
   cursor: pointer;
   padding: 0 1px;

--- a/packages/talmud/src/lib/sefref/sefaria/client.ts
+++ b/packages/talmud/src/lib/sefref/sefaria/client.ts
@@ -21,10 +21,11 @@ export interface SefariaTextResponse {
     versionTitle: string;
     versionSource?: string;
   }>;
-  commentary?: any[];
-  sheets?: any[];
-  notes?: any[];
-  links?: any[];
+  /** Present on the v1 response but never read here — shapes left opaque. */
+  commentary?: unknown[];
+  sheets?: unknown[];
+  notes?: unknown[];
+  links?: unknown[];
 }
 
 export interface SefariaRelatedResponse {
@@ -41,8 +42,9 @@ export interface SefariaRelatedResponse {
     sourceHasEn: boolean;
     commentaryNum?: number;
   }>;
-  sheets: any[];
-  notes: any[];
+  /** Present on the /related response but never read here — shapes left opaque. */
+  sheets: unknown[];
+  notes: unknown[];
 }
 
 export interface TalmudPageData {

--- a/packages/talmud/src/lib/sefref/sefaria/links.ts
+++ b/packages/talmud/src/lib/sefref/sefaria/links.ts
@@ -33,7 +33,15 @@ const commentaryIncludes = {
   Tosafot: 'tosafot',
 } as const;
 
-function parseLink(daf: string, linkObj: any): SefariaLink | null {
+/** The raw link object Sefaria's /api/related returns — only the fields we read. */
+interface RawSefariaLink {
+  ref: string;
+  category: string;
+  anchorRef?: string;
+  collectiveTitle?: { en: string; he: string };
+}
+
+function parseLink(daf: string, linkObj: RawSefariaLink): SefariaLink | null {
   try {
     const anchorRef = linkObj.anchorRef;
     if (!anchorRef?.includes(':')) return null;
@@ -102,7 +110,7 @@ export async function getSefariaLinks(tractate: string, daf: string): Promise<Se
       throw new Error(`HTTP ${response.status}: ${response.statusText}`);
     }
 
-    const data = (await response.json()) as { links?: unknown };
+    const data = (await response.json()) as { links?: RawSefariaLink[] };
 
     if (!data.links || !Array.isArray(data.links)) {
       console.warn('No links data found in Sefaria response');
@@ -110,7 +118,7 @@ export async function getSefariaLinks(tractate: string, daf: string): Promise<Se
     }
 
     const links = data.links
-      .map((linkObj: any) => parseLink(ref, linkObj))
+      .map((linkObj) => parseLink(ref, linkObj))
       .filter((link: SefariaLink | null): link is SefariaLink => link !== null)
       .filter(includeLink);
 

--- a/packages/talmud/tests/enrichment-cache.test.ts
+++ b/packages/talmud/tests/enrichment-cache.test.ts
@@ -8,8 +8,8 @@ import type { LruMap } from '../src/lib/lruMap';
 // module is imported (below, in beforeAll) — node provides EventTarget + Event
 // globally, so no jsdom dependency is needed just to exercise the wiring.
 class FakeWindow extends EventTarget {}
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-(globalThis as any).window = new FakeWindow();
+const fakeWindow = new FakeWindow();
+(globalThis as unknown as { window: FakeWindow }).window = fakeWindow;
 
 let runResultCache: LruMap<string, RunResult>;
 let runCacheKey: (e: string, t: string, p: string, i: string, lang: string) => string;
@@ -91,8 +91,7 @@ describe('cache invalidation', () => {
       fakeResult('bio'),
     );
     expect(runResultCache.size).toBe(1);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (globalThis as any).window.dispatchEvent(new Event('marks-runs-invalidate'));
+    fakeWindow.dispatchEvent(new Event('marks-runs-invalidate'));
     expect(runResultCache.size).toBe(0);
   });
 });

--- a/packages/tanach/src/client/App.tsx
+++ b/packages/tanach/src/client/App.tsx
@@ -578,6 +578,7 @@ export function App(): JSX.Element {
           </button>
         </Show>
 
+        {/* biome-ignore lint/a11y/useSemanticElements: a fieldset would bring UA margin/padding/min-inline-size and change the toggle's layout; div+role="group" carries the same semantics */}
         <div class="lang-toggle" role="group" aria-label="Language">
           <button
             type="button"
@@ -641,6 +642,8 @@ export function App(): JSX.Element {
       <Show when={loc().view === 'scroll' && data()}>
         {(ch) => (
           <main class="scroll-main" ref={(el) => (scrollMain = el)}>
+            {/* biome-ignore lint/a11y/noStaticElementInteractions: scripture prose surface; onMouseUp is text-selection word lookup and onClick is a pointer convenience delegated to verse-number spans inside innerHTML — a role would mis-announce running text */}
+            {/* biome-ignore lint/a11y/useKeyWithClickEvents: the click target (.vnum spans inside innerHTML) is not focusable; the same verse drawers are keyboard-reachable via the gutter <button>s (evt-margin / vgutter) */}
             <div
               class="scroll-band"
               dir="rtl"

--- a/packages/tanach/src/client/MikraotGedolot.tsx
+++ b/packages/tanach/src/client/MikraotGedolot.tsx
@@ -128,7 +128,8 @@ export function MikraotGedolot(props: {
         el.classList.add('hl');
       });
   };
-  const onOver = (e: MouseEvent) => {
+  // Shared by mouse-over and focus so keyboard focus mirrors the hover highlight.
+  const onOver = (e: Event) => {
     const s = (e.target as HTMLElement).closest('.mg-seg');
     highlight(s ? s.getAttribute('data-v') : null);
   };
@@ -228,11 +229,14 @@ export function MikraotGedolot(props: {
       <Show when={data()}>
         {(d) => (
           <>
+            {/* biome-ignore lint/a11y/noStaticElementInteractions: hover-only cross-highlighting of pasuk/Rashi/Onkelos segments is decorative; activation lives on the gutter <button>s — a role would mis-announce the rendered daf text */}
             <div
               class="mg-host"
               ref={host}
               onMouseOver={onOver}
+              onFocus={onOver}
               onMouseLeave={() => highlight(null)}
+              onBlur={() => highlight(null)}
             >
               <DafRenderer
                 main={main()}

--- a/packages/tanach/src/lib/daf-render/styles.css
+++ b/packages/tanach/src/lib/daf-render/styles.css
@@ -62,6 +62,7 @@
 }
 
 /* Spacer heights driven by the layout engine */
+/* biome-ignore lint/style/noDescendingSpecificity: disjoint properties — this sets height; the earlier higher-specificity .daf-main .daf-start rule sets width/margins */
 .daf-root .daf-start {
   height: var(--daf-start);
 }
@@ -87,6 +88,7 @@
   margin-right: calc(0.5 * var(--daf-padding-horizontal));
 }
 
+/* biome-ignore lint/style/noDescendingSpecificity: disjoint properties — this sets margins; the earlier higher-specificity .daf-inner/.daf-outer .daf-end rules set height */
 .daf-root .daf-end {
   margin-left: calc(0.5 * var(--daf-padding-horizontal));
   margin-right: calc(0.5 * var(--daf-padding-horizontal));
@@ -117,11 +119,13 @@
 }
 
 /* Vertical padding */
+/* biome-ignore lint/style/noDescendingSpecificity: disjoint properties — this sets margin-top; the earlier higher-specificity .daf-inner/.daf-outer .daf-mid rule sets width/clear */
 .daf-root .daf-mid,
 .daf-root .daf-main .daf-text {
   margin-top: var(--daf-padding-vertical);
 }
 
+/* biome-ignore lint/style/noDescendingSpecificity: disjoint properties — this sets margin-bottom; the earlier higher-specificity .daf-inner/.daf-outer .daf-mid rule sets width/clear */
 .daf-root .daf-mid,
 .daf-root .daf-main .daf-inner-mid,
 .daf-root .daf-main .daf-outer-mid {
@@ -129,6 +133,7 @@
 }
 
 /* Text */
+/* biome-ignore lint/style/noDescendingSpecificity: disjoint properties — this sets direction/text-align; the earlier higher-specificity .daf-main .daf-text rule sets margin-top */
 .daf-root .daf-text {
   direction: var(--daf-direction);
   text-align: justify;
@@ -346,6 +351,7 @@
    generation spectrum (see injectRabbiUnderlines.ts); this rule only switches
    the stroke to dashed. */
 .daf-root .daf-text .rabbi-underline-anonymous {
+  /* biome-ignore lint/complexity/noImportantStyles: must beat the LATER equal-specificity .rabbi-underline rule whose border-bottom shorthand resets the style to solid */
   border-bottom-style: dashed !important;
 }
 
@@ -383,6 +389,7 @@
 }
 
 /* Per-word click target. Tokenized by src/client/tokenize.ts. */
+/* biome-ignore lint/style/noDescendingSpecificity: disjoint properties — this sets cursor/padding/radius/transition; the earlier higher-specificity .city-marker > .daf-word rule sets color */
 .daf-root .daf-text .daf-word {
   cursor: pointer;
   padding: 0 1px;


### PR DESCRIPTION
Finishes the lint ratchet started in #350/#352: **`biome ci` now reports zero diagnostics — no errors, no warnings.**

**Keyboard accessibility (88 warnings → 0).** Every clickable element in both apps is now keyboard-operable: `role="button"`/`role="link"`, `tabIndex={0}`, and Enter/Space activation that calls the *same* handler as the mouse path (extracted to shared consts where inline, so the two can't drift). That covers the argument sidebar rows, dialectic narrative beats, flow-graph/voice-map/lineage-tree/spine-graph nodes, geography map dots and region toggles, run-tree rows and DAG nodes, usage collapsibles, user highlights, concept/rabbi term links, and the align-page previews. Hover-only interactions gained focus/blur mirrors. Nodes that are only sometimes clickable announce button semantics conditionally. The AIActivityPanel toggles became real buttons (pixel-identical resets).

Suppressions were used only where button semantics would be a lie, each with its reason inline: reading surfaces (the daf, the scroll band), click-to-close backdrops (the dialog ✕ is the keyboard path), pointer-drag resize handles, hover-positioned tooltips, and role-on-div cases where a native `<button>` can't nest inner buttons or would break flowing Hebrew/English prose or SVG layout.

**CSS (25 → 0).** Each `!important` was traced to what it fights: kept (with the proof in the suppression) where it beats an inline style set from JS or a later shorthand reset; removed where source order already wins. Descending-specificity pairs were proven property-disjoint and suppressed with one-line proofs. The talmud and tanach daf-render stylesheets remain byte-identical.

**Types (10 → 0).** Sefaria response fields nobody reads became `unknown[]`; the links parser got a `RawSefariaLink` interface matching exactly the fields it reads; test mocks properly typed.

**Config:** a11y group restored to error severity (instances are at zero, so the gate holds it there); the generated `src/lib/data` dir excluded from linting (the 1.1 MiB rabbi-places.json tripped Biome's file-size cap).

Mouse behavior is byte-identical at every site. Verified: zero Biome diagnostics, typecheck green ×3 packages, 1962 tests pass (incl. the client component suites covering the edited components), build passes.