### PR TITLE
Core model: the four primitives (Spine, Anchor, Artifact, Producer)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "//": "Corpus-agnostic engine shared by the talmud and tanach apps: LLM/budget plumbing (./llm), and incrementally the coordinate/anchor model, KV cache key builders + freshness, producer-registry grammar, dependency graph, and recipe-based sidebar DSL. Ships raw .ts sources (no build step) — consumers bundle via Vite with moduleResolution: bundler, and tsc resolves the @corpus/core/* path alias from tsconfig.base.json. Subpaths are populated as modules are extracted out of packages/talmud (see plan PR-3..6).",
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "exports": {
     "./context/*": "./src/context/*.ts",
@@ -14,10 +15,14 @@
     "./llm/*": "./src/llm/*.ts",
     "./studio/*": "./src/studio/*.ts",
     "./cache/*": "./src/cache/*.ts",
-    "./sefaria/*": "./src/sefaria/*.ts"
+    "./sefaria/*": "./src/sefaria/*.ts",
+    "./model/*": "./src/model/*.ts",
+    "./store/*": "./src/store/*.ts",
+    "./run/*": "./src/run/*.ts"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260511.1",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vitest": "^4.1.5"
   }
 }

--- a/packages/core/src/model/anchor.ts
+++ b/packages/core/src/model/anchor.ts
@@ -1,0 +1,145 @@
+/**
+ * Anchor — THE one shape for "where a piece sits". Every legacy placement
+ * vocabulary (AnchorCoord, ContextItem.segs/amud, SegMatch, the seven studio
+ * AnchorOutput variants) maps into it — see model/compat.ts.
+ *
+ * Precision notes:
+ * - 'cross-daf' is NOT a precision. Whether a span is cross-daf is DERIVED at
+ *   render time by comparing the span's unit path (e.g. [tractate, page]) to
+ *   the unit currently in view; the anchor itself just says where it sits.
+ * - Whole-daf is a TRUNCATED path ([tractate, page], precision 'unit') — this
+ *   retires the DAF_SEG=-1 sentinel in the new model.
+ */
+
+import type { RefPart } from './spine.ts';
+
+export interface AnchorPoint {
+  /** Reference path into the spine, outermost level first. May be truncated
+   *  (a division/unit/work address) — see spine.ts. */
+  path: RefPart[];
+  /** Token window [start, end] within the leaf segment, when known. */
+  tokens?: [number, number];
+  /** Verbatim excerpt at this point (display / fallback matching only — not
+   *  part of the anchor's identity, see {@link anchorKey}). */
+  excerpt?: string;
+}
+
+export interface AnchorRange {
+  start: AnchorPoint;
+  end: AnchorPoint;
+}
+
+export type Span = (AnchorPoint | AnchorRange)[];
+
+export type AnchorPrecision = 'token' | 'segment' | 'division' | 'unit' | 'work' | 'external';
+
+export interface Anchor {
+  /** Spine id this anchor addresses (see model/spine.ts). */
+  spine: string;
+  span: Span;
+  precision: AnchorPrecision;
+  /** How the anchor was earned: 'tosfos-dh' | 'ai' | 'extractor' | 'human' | … */
+  via?: string;
+  /** 0..1 (AI-earned anchors carry this). */
+  confidence?: number;
+}
+
+export function isRange(p: AnchorPoint | AnchorRange): p is AnchorRange {
+  return 'start' in p;
+}
+
+const PRECISION_RANK: Record<AnchorPrecision, number> = {
+  token: 5,
+  segment: 4,
+  division: 3,
+  unit: 2,
+  work: 1,
+  external: 0,
+};
+
+/** Finer precision = higher rank. */
+export function precisionRank(p: AnchorPrecision): number {
+  return PRECISION_RANK[p];
+}
+
+/** > 0 when `a` is finer than `b`, < 0 when coarser, 0 when equal. */
+export function comparePrecision(a: AnchorPrecision, b: AnchorPrecision): number {
+  return precisionRank(a) - precisionRank(b);
+}
+
+/** Identity key of one span element. Excerpt is deliberately excluded — it is
+ *  display data, not location; two anchors at the same place with different
+ *  excerpts are the same anchor. JSON keeps '2' and 2 distinct. */
+function elementKey(p: AnchorPoint | AnchorRange): string {
+  if (isRange(p)) return `R${pointKey(p.start)}|${pointKey(p.end)}`;
+  return `P${pointKey(p)}`;
+}
+
+function pointKey(p: AnchorPoint): string {
+  return JSON.stringify([p.path, p.tokens ?? null]);
+}
+
+/** Dedupe + sort a span deterministically (same span always serializes the
+ *  same way, regardless of producer emission order). */
+export function normalizeAnchor(a: Anchor): Anchor {
+  const seen = new Set<string>();
+  const out: Span = [];
+  for (const el of a.span) {
+    const k = elementKey(el);
+    if (!seen.has(k)) {
+      seen.add(k);
+      out.push(el);
+    }
+  }
+  out.sort((x, y) => (elementKey(x) < elementKey(y) ? -1 : elementKey(x) > elementKey(y) ? 1 : 0));
+  return { ...a, span: out };
+}
+
+/** Stable string id for an anchor's LOCATION (spine + precision + normalized
+ *  span). via/confidence/excerpts are provenance/display, not identity. */
+export function anchorKey(a: Anchor): string {
+  const n = normalizeAnchor(a);
+  return `${n.spine}|${n.precision}|${n.span.map(elementKey).join(';')}`;
+}
+
+/** Safety bound for numeric range expansion (a daf has tens of segments; a
+ *  range wider than this is a malformed anchor, not a real span). */
+const MAX_RANGE_EXPANSION = 10_000;
+
+/**
+ * Expand a span to points. A range expands to one point per index ONLY when
+ * both endpoints' leaf path components are numbers on the SAME parent path
+ * (e.g. [t, p, 3]..[t, p, 6] → 3,4,5,6) and the width is bounded; otherwise
+ * the range contributes its two endpoints as-is.
+ */
+export function pointsOf(span: Span): AnchorPoint[] {
+  const out: AnchorPoint[] = [];
+  for (const el of span) {
+    if (!isRange(el)) {
+      out.push(el);
+      continue;
+    }
+    const s = el.start.path;
+    const e = el.end.path;
+    const sLeaf = s[s.length - 1];
+    const eLeaf = e[e.length - 1];
+    const sameParent = s.length === e.length && s.slice(0, -1).every((part, i) => part === e[i]);
+    // Endpoints carrying token windows must survive verbatim — synthesized
+    // intermediate points would silently drop the token metadata.
+    const hasTokens = el.start.tokens !== undefined || el.end.tokens !== undefined;
+    if (
+      !hasTokens &&
+      sameParent &&
+      typeof sLeaf === 'number' &&
+      typeof eLeaf === 'number' &&
+      eLeaf >= sLeaf &&
+      eLeaf - sLeaf + 1 <= MAX_RANGE_EXPANSION
+    ) {
+      const parent = s.slice(0, -1);
+      for (let i = sLeaf; i <= eLeaf; i++) out.push({ path: [...parent, i] });
+    } else {
+      out.push(el.start, el.end);
+    }
+  }
+  return out;
+}

--- a/packages/core/src/model/artifact.ts
+++ b/packages/core/src/model/artifact.ts
@@ -1,0 +1,28 @@
+/**
+ * Artifact — one produced piece: a typed body pinned to anchors, with full
+ * provenance. Marks' instances, enrichment outputs, context items, links, and
+ * anchor refinements are all artifacts; `kind` is an open string so apps can
+ * define their own without touching core.
+ */
+
+import type { Anchor } from './anchor.ts';
+import type { Provenance } from './provenance.ts';
+
+export interface Artifact<Body = unknown> {
+  id: string;
+  /** 'mark-instance' | 'enrichment' | 'context-item' | 'link' |
+   *  'anchor-refinement' | app-defined. */
+  kind: string;
+  anchors: Anchor[];
+  body: Body;
+  provenance: Provenance;
+}
+
+/** Body of a kind='link' artifact: the artifact's anchors[0] is the source,
+ *  the rest are targets, related under `relation` (see ../context/link.ts for
+ *  the modelled relation set). */
+export interface LinkBody {
+  relation: string;
+}
+
+export type { LinkRelation } from '../context/link.ts';

--- a/packages/core/src/model/compat.ts
+++ b/packages/core/src/model/compat.ts
@@ -1,0 +1,618 @@
+/**
+ * Compat bridges — bidirectional projections between the legacy vocabularies
+ * (AnchorCoord / ContextItem / SegMatch / the studio AnchorOutput shapes /
+ * MarkDefinition + EnrichmentDefinition) and the four-primitive model
+ * (Spine / Anchor / Artifact / Producer).
+ *
+ * The legacy STUDIO shapes are copied here structurally (field-for-field from
+ * packages/talmud/src/worker/studio-schema.ts) because core must not import
+ * from the apps; the app's real defs satisfy these structural types and the
+ * talmud-side projection test feeds the live registry through.
+ *
+ * Losslessness contract: every legacy field with no first-class Producer home
+ * rides VERBATIM in `Producer.legacy`, and the inverse projections rebuild the
+ * original def from it — `markFromProducer(producerFromMark(def))` and
+ * `enrichmentFromProducer(producerFromEnrichment(def))` deep-equal the input
+ * for every entry in the real registry.
+ */
+
+import type { AnchorCoord, AnchorSpan, DafRef } from '../context/coord.ts';
+import { normalizeSpan } from '../context/coord.ts';
+import type { SegMatch } from '../context/match.ts';
+import type { ContextItem } from '../context/types.ts';
+import type { RawDependency } from '../registry/depGraph.ts';
+import type { Anchor, AnchorPoint, AnchorPrecision } from './anchor.ts';
+import type { Artifact } from './artifact.ts';
+import type { RefinementBody } from './placement.ts';
+import type { Producer, ProducerInput } from './producer.ts';
+
+/** The Gemara spine id in the talmud binding. A spine-less AnchorCoord (the
+ *  pre-commentary default) addresses it. */
+export const BAVLI_SPINE = 'bavli';
+
+// ===========================================================================
+// 1. Coord bridges
+// ===========================================================================
+
+/** The spine id an AnchorCoord addresses: its own `spine` (a commentary work
+ *  like 'Rashi'), else the Gemara spine. */
+export function spineIdOfCoord(c: AnchorCoord): string {
+  return c.spine ?? BAVLI_SPINE;
+}
+
+/** AnchorCoord → Anchor. A real segment becomes a segment-precision point
+ *  [tractate, page, seg]; the DAF_SEG sentinel becomes the truncated unit path
+ *  [tractate, page] (the new model's whole-daf encoding). */
+export function anchorFromCoord(c: AnchorCoord): Anchor {
+  const spine = spineIdOfCoord(c);
+  return c.seg >= 0
+    ? { spine, span: [{ path: [c.tractate, c.page, c.seg] }], precision: 'segment' }
+    : { spine, span: [{ path: [c.tractate, c.page] }], precision: 'unit' };
+}
+
+/** Anchor → AnchorCoord, for single-point spans whose path is a daf address
+ *  ([tractate, page] or [tractate, page, seg]). Null when not representable
+ *  (multi-point spans, ranges, token windows below coord granularity, external
+ *  spines). The exact inverse of {@link anchorFromCoord}. */
+export function coordFromAnchor(a: Anchor): AnchorCoord | null {
+  if (a.span.length !== 1) return null;
+  const el = a.span[0];
+  if ('start' in el) return null;
+  const { path } = el;
+  const [tractate, page, seg] = path;
+  if (typeof tractate !== 'string' || typeof page !== 'string') return null;
+  const spinePart = a.spine === BAVLI_SPINE ? {} : { spine: a.spine };
+  if (path.length === 2) return { tractate, page, seg: -1, ...spinePart };
+  if (path.length === 3 && typeof seg === 'number') return { tractate, page, seg, ...spinePart };
+  return null;
+}
+
+/** AnchorSpan → one Anchor (normalized + deduped via normalizeSpan). Precision
+ *  is 'unit' when any coordinate is daf-level (DAF_SEG), else 'segment'. Spans
+ *  are single-spine in practice; the first coordinate's spine wins. */
+export function anchorFromSpan(span: AnchorSpan): Anchor {
+  const coords = normalizeSpan(span);
+  const spine = coords.length ? spineIdOfCoord(coords[0]) : BAVLI_SPINE;
+  const anyDafLevel = coords.some((c) => c.seg < 0);
+  return {
+    spine,
+    span: coords.map((c) =>
+      c.seg >= 0 ? { path: [c.tractate, c.page, c.seg] } : { path: [c.tractate, c.page] },
+    ),
+    precision: anyDafLevel ? 'unit' : 'segment',
+  };
+}
+
+// ===========================================================================
+// 2. ContextItem bridge
+// ===========================================================================
+
+function viaConfidence(it: { via?: string; confidence?: number }): Partial<Anchor> {
+  return {
+    ...(it.via !== undefined ? { via: it.via } : {}),
+    ...(it.confidence !== undefined ? { confidence: it.confidence } : {}),
+  };
+}
+
+/**
+ * A ContextItem's in-daf placement as an Anchor:
+ *  - segs        → one segment-precision point per seg;
+ *  - amud only   → the truncated daf path at 'division' precision. LOSSY on
+ *                  purpose: WHICH amud is not encoded in the path (the daf is
+ *                  the page unit); the letter stays recoverable from item.amud.
+ *  - neither     → the whole daf at 'unit' precision when something placed the
+ *                  item there (`via` is set — e.g. the AI placer's deliberate
+ *                  whole-daf verdict); null when the item is simply unplaced.
+ * via/confidence carry onto the anchor. The cross-daf `coord` is a SECOND
+ * anchor — see {@link anchorsFromContextItem}.
+ */
+export function anchorFromContextItem(it: ContextItem, daf: DafRef): Anchor | null {
+  if (it.segs.length > 0) {
+    return {
+      spine: BAVLI_SPINE,
+      span: it.segs.map((seg) => ({ path: [daf.tractate, daf.page, seg] })),
+      precision: 'segment',
+      ...viaConfidence(it),
+    };
+  }
+  if (it.amud) {
+    return {
+      spine: BAVLI_SPINE,
+      span: [{ path: [daf.tractate, daf.page] }],
+      precision: 'division',
+      ...viaConfidence(it),
+    };
+  }
+  if (it.via !== undefined) {
+    return {
+      spine: BAVLI_SPINE,
+      span: [{ path: [daf.tractate, daf.page] }],
+      precision: 'unit',
+      ...viaConfidence(it),
+    };
+  }
+  return null;
+}
+
+/** All anchors a ContextItem carries: the in-daf placement anchor (when any)
+ *  plus the cross-daf `coord` as its own anchor (when present). */
+export function anchorsFromContextItem(it: ContextItem, daf: DafRef): Anchor[] {
+  const out: Anchor[] = [];
+  const placement = anchorFromContextItem(it, daf);
+  if (placement) out.push(placement);
+  if (it.coord) out.push({ ...anchorFromCoord(it.coord), ...viaConfidence(it) });
+  return out;
+}
+
+// ===========================================================================
+// 3. SegMatch bridge
+// ===========================================================================
+
+/**
+ * A matcher's SegMatch as an anchor-refinement artifact targeting
+ * `targetArtifactId`. Placement precedence mirrors applyMatches: a deliberate
+ * wholeDaf verdict wins (unit), then segs (segment points), then a coord-only
+ * match (the cross-daf home). Throws on an unplaced match (segs empty, no
+ * wholeDaf, no coord — applyMatches treats those as no-ops; there is no
+ * refinement to express). `createdAt` is left '' — timestamps are the caller's
+ * job.
+ */
+export function refinementFromSegMatch(
+  m: SegMatch,
+  daf: DafRef,
+  targetArtifactId: string,
+): Artifact<RefinementBody> {
+  let anchor: Anchor;
+  if (m.wholeDaf) {
+    anchor = { spine: BAVLI_SPINE, span: [{ path: [daf.tractate, daf.page] }], precision: 'unit' };
+  } else if (m.segs.length > 0) {
+    const segs = Array.from(new Set(m.segs)).sort((a, b) => a - b);
+    anchor = {
+      spine: BAVLI_SPINE,
+      span: segs.map((seg) => ({ path: [daf.tractate, daf.page, seg] })),
+      precision: 'segment',
+    };
+  } else if (m.coord) {
+    anchor = anchorFromCoord(m.coord);
+  } else {
+    throw new Error(`SegMatch for ${m.key} carries no placement (a no-op, not a refinement)`);
+  }
+  anchor = {
+    ...anchor,
+    via: m.via,
+    ...(m.confidence !== undefined ? { confidence: m.confidence } : {}),
+  };
+  return {
+    id: `refinement:${m.via}:${m.key}`,
+    kind: 'anchor-refinement',
+    anchors: [anchor],
+    body: { targetArtifactId, anchor },
+    provenance: {
+      authority: m.via === 'ai' ? 'ai' : 'rule',
+      producerId: `matcher:${m.via}`,
+      inputs: [],
+      createdAt: '',
+    },
+  };
+}
+
+// ===========================================================================
+// 4. AnchorOutput bridge — the 7 studio anchor shapes, lifted structurally.
+// ===========================================================================
+
+export interface LegacySegmentAnchor {
+  segIdx: number;
+}
+export interface LegacySegmentRangeAnchor {
+  startSegIdx: number;
+  endSegIdx: number;
+}
+export interface LegacyPhraseAnchor {
+  excerpt: string;
+  segIdx?: number;
+  tokenStart?: number;
+  tokenEnd?: number;
+}
+export interface LegacyMultiAnchor {
+  anchors: LegacyPhraseAnchor[];
+  relation?: string;
+}
+export interface LegacyCrossDafAnchor {
+  source: LegacyPhraseAnchor | LegacySegmentRangeAnchor;
+  target: { tractate: string; page: string; segIdx?: number };
+}
+export interface LegacyExternalAnchor {
+  source: LegacyPhraseAnchor;
+  url: string;
+  resource_kind?: string;
+}
+export interface LegacyWholeDafAnchor {
+  _: 'whole-daf';
+}
+export type LegacyAnchorOutput =
+  | LegacySegmentAnchor
+  | LegacySegmentRangeAnchor
+  | LegacyPhraseAnchor
+  | LegacyMultiAnchor
+  | LegacyCrossDafAnchor
+  | LegacyExternalAnchor
+  | LegacyWholeDafAnchor;
+
+function phrasePoint(a: LegacyPhraseAnchor, daf: DafRef): AnchorPoint {
+  const tokens =
+    a.tokenStart !== undefined && a.tokenEnd !== undefined
+      ? ([a.tokenStart, a.tokenEnd] as [number, number])
+      : undefined;
+  return a.segIdx !== undefined
+    ? {
+        path: [daf.tractate, daf.page, a.segIdx],
+        ...(tokens ? { tokens } : {}),
+        excerpt: a.excerpt,
+      }
+    : { path: [daf.tractate, daf.page], excerpt: a.excerpt };
+}
+
+function anchorFromPhrase(a: LegacyPhraseAnchor, daf: DafRef, spine: string): Anchor {
+  // Precision claims only what the anchor actually locates: a token window
+  // when both token bounds exist, the segment when only segIdx does (most
+  // runtime phrase instances — token positions resolve client-side), and the
+  // whole daf when the phrase floated free of any segment.
+  const hasTokens = a.tokenStart !== undefined && a.tokenEnd !== undefined;
+  return {
+    spine,
+    span: [phrasePoint(a, daf)],
+    precision: a.segIdx === undefined ? 'unit' : hasTokens ? 'token' : 'segment',
+  };
+}
+
+function anchorFromRange(a: LegacySegmentRangeAnchor, daf: DafRef, spine: string): Anchor {
+  return {
+    spine,
+    span: [
+      {
+        start: { path: [daf.tractate, daf.page, a.startSegIdx] },
+        end: { path: [daf.tractate, daf.page, a.endSegIdx] },
+      },
+    ],
+    precision: 'segment',
+  };
+}
+
+function wholeDafAnchor(daf: DafRef, spine: string): Anchor {
+  return { spine, span: [{ path: [daf.tractate, daf.page] }], precision: 'unit' };
+}
+
+/** Every studio AnchorOutput variant as Anchor[]. Cross-daf and external
+ *  outputs produce TWO anchors (the source here + the target there / the
+ *  external resource); multi-anchor produces one per sub-anchor. */
+export function anchorsFromAnchorOutput(
+  out: LegacyAnchorOutput,
+  daf: DafRef,
+  spine: string = BAVLI_SPINE,
+): Anchor[] {
+  if ('_' in out) return [wholeDafAnchor(daf, spine)];
+  if ('url' in out) {
+    return [
+      anchorFromPhrase(out.source, daf, spine),
+      {
+        spine: `external:${out.resource_kind ?? 'url'}`,
+        span: [{ path: [out.url] }],
+        precision: 'external',
+      },
+    ];
+  }
+  if ('target' in out) {
+    const source =
+      'excerpt' in out.source
+        ? anchorFromPhrase(out.source, daf, spine)
+        : anchorFromRange(out.source, daf, spine);
+    const t = out.target;
+    const target: Anchor =
+      t.segIdx !== undefined
+        ? { spine, span: [{ path: [t.tractate, t.page, t.segIdx] }], precision: 'segment' }
+        : { spine, span: [{ path: [t.tractate, t.page] }], precision: 'unit' };
+    return [source, target];
+  }
+  if ('anchors' in out) return out.anchors.map((a) => anchorFromPhrase(a, daf, spine));
+  if ('excerpt' in out) return [anchorFromPhrase(out, daf, spine)];
+  if ('startSegIdx' in out) return [anchorFromRange(out, daf, spine)];
+  return [{ spine, span: [{ path: [daf.tractate, daf.page, out.segIdx] }], precision: 'segment' }];
+}
+
+// ===========================================================================
+// 5. Producer projections — MarkDefinition / EnrichmentDefinition ↔ Producer.
+// ===========================================================================
+
+export type LegacyAnchorKind =
+  | 'segment'
+  | 'segment-range'
+  | 'phrase'
+  | 'multi-anchor'
+  | 'cross-daf'
+  | 'external'
+  | 'whole-daf';
+
+export type LegacyMarkDependency = string | { mark: string };
+export type LegacyEnrichmentDependency =
+  | string
+  | { enrichment: string; fanOut?: boolean }
+  | { mark: string };
+
+/** Structural copy of studio-schema's MarkDefinition. The app's real defs are
+ *  assignment-compatible (their narrower unions widen into these fields). */
+export interface LegacyMarkDef {
+  id: string;
+  label: string;
+  description?: string;
+  category?: string;
+  anchor: LegacyAnchorKind;
+  render: unknown;
+  recipe?: unknown;
+  extractor: unknown;
+  dependencies?: LegacyMarkDependency[];
+  passes?: string[];
+  parent_mark?: string;
+  experimental?: boolean;
+  status: 'draft' | 'promoted';
+  def_hash: string;
+  cache_version: string;
+  source: 'kv' | 'code';
+  updated_at: string;
+}
+
+/** Structural copy of studio-schema's EnrichmentDefinition. */
+export interface LegacyEnrichmentDef {
+  id: string;
+  label: string;
+  description?: string;
+  category?: string;
+  target_mark: string;
+  mode: 'augment-content' | 'refine-anchors' | 'aggregate';
+  scope: 'global' | 'local' | 'spine';
+  dependencies?: LegacyEnrichmentDependency[];
+  passes?: string[];
+  extractor: unknown;
+  status: 'draft' | 'promoted';
+  def_hash: string;
+  cache_version: string;
+  source: 'kv' | 'code';
+  updated_at: string;
+}
+
+/** The anchor PRECISION a legacy anchor kind discovers. Verbatim kind is kept
+ *  in `legacy.anchorKind` so nothing is lost (e.g. cross-daf vs segment). */
+export function mapAnchorKindToPrecision(kind: LegacyAnchorKind): AnchorPrecision {
+  switch (kind) {
+    case 'phrase':
+      return 'token';
+    case 'whole-daf':
+      return 'unit';
+    default:
+      // segment, segment-range, multi-anchor, cross-daf, external all discover
+      // segment-level source anchors.
+      return 'segment';
+  }
+}
+
+/** Legacy dependency vocabulary → ProducerInput. The mark-vs-enrichment flavor
+ *  of `{ producer }` references is NOT encoded here — it round-trips through
+ *  the verbatim `legacy.dependencies` bag instead. */
+function inputsFromDependencies(
+  deps: ReadonlyArray<LegacyMarkDependency | LegacyEnrichmentDependency> | undefined,
+): ProducerInput[] {
+  return (deps ?? []).map((d) => {
+    if (typeof d === 'string') return { source: d };
+    if ('enrichment' in d) {
+      return d.fanOut !== undefined
+        ? { producer: d.enrichment, fanOut: d.fanOut }
+        : { producer: d.enrichment };
+    }
+    return { producer: d.mark };
+  });
+}
+
+/** Own-key-conditional spread: carries `key: undefined` as an own key when the
+ *  source object had one, and omits it entirely when it didn't — so strict
+ *  (own-key) round-trips hold for explicit-undefined optionals. */
+function ownKey<T extends object, K extends keyof T>(obj: T, key: K): Partial<Pick<T, K>> {
+  return key in obj ? ({ [key]: obj[key] } as Partial<Pick<T, K>>) : {};
+}
+
+/** Fields producerFromMark maps first-class or into named legacy slots. Any
+ *  OTHER own field on a def (future shapes, KV-authored extras) is preserved
+ *  verbatim in legacy.rest instead of being silently dropped. */
+const MARK_KNOWN_FIELDS = new Set([
+  'id',
+  'label',
+  'description',
+  'category',
+  'anchor',
+  'render',
+  'recipe',
+  'extractor',
+  'dependencies',
+  'passes',
+  'parent_mark',
+  'experimental',
+  'status',
+  'def_hash',
+  'cache_version',
+  'source',
+  'updated_at',
+]);
+
+function restOf(def: object, known: ReadonlySet<string>): Record<string, unknown> | undefined {
+  const rest: Record<string, unknown> = {};
+  let any = false;
+  for (const k of Object.keys(def)) {
+    if (!known.has(k)) {
+      rest[k] = (def as Record<string, unknown>)[k];
+      any = true;
+    }
+  }
+  return any ? rest : undefined;
+}
+
+export function producerFromMark(def: LegacyMarkDef): Producer {
+  const rest = restOf(def, MARK_KNOWN_FIELDS);
+  return {
+    id: def.id,
+    label: def.label,
+    ...ownKey(def, 'description'),
+    ...ownKey(def, 'category'),
+    kind: 'mark-instance',
+    inputs: inputsFromDependencies(def.dependencies),
+    recipe: { extractor: def.extractor, render: def.render },
+    anchoring: { behavior: 'discovers', precision: mapAnchorKindToPrecision(def.anchor) },
+    cardinality: 'many',
+    scope: 'local',
+    key_shape: 'mark',
+    cacheVersion: def.cache_version,
+    ...ownKey(def, 'passes'),
+    status: def.status,
+    ...ownKey(def, 'experimental'),
+    source: def.source,
+    updatedAt: def.updated_at,
+    legacy: {
+      anchorKind: def.anchor,
+      def_hash: def.def_hash,
+      ...('recipe' in def ? { sidebarRecipe: def.recipe } : {}),
+      ...('parent_mark' in def ? { parent_mark: def.parent_mark } : {}),
+      ...('dependencies' in def ? { dependencies: def.dependencies } : {}),
+      ...(rest !== undefined ? { rest } : {}),
+    },
+  };
+}
+
+export function markFromProducer(p: Producer): LegacyMarkDef {
+  const legacy = p.legacy ?? {};
+  return {
+    ...((legacy.rest as Record<string, unknown> | undefined) ?? {}),
+    id: p.id,
+    label: p.label,
+    ...ownKey(p, 'description'),
+    ...ownKey(p, 'category'),
+    anchor: legacy.anchorKind as LegacyAnchorKind,
+    render: p.recipe.render,
+    ...('sidebarRecipe' in legacy ? { recipe: legacy.sidebarRecipe } : {}),
+    extractor: p.recipe.extractor,
+    ...('dependencies' in legacy
+      ? { dependencies: legacy.dependencies as LegacyMarkDependency[] }
+      : {}),
+    ...ownKey(p, 'passes'),
+    ...('parent_mark' in legacy ? { parent_mark: legacy.parent_mark as string } : {}),
+    ...ownKey(p, 'experimental'),
+    status: p.status ?? 'promoted',
+    def_hash: legacy.def_hash as string,
+    cache_version: p.cacheVersion,
+    source: p.source ?? 'code',
+    updated_at: p.updatedAt ?? '',
+  } as LegacyMarkDef;
+}
+
+const MODE_TO_BEHAVIOR = {
+  'augment-content': 'inherits',
+  'refine-anchors': 'discovers',
+  aggregate: 'aggregates',
+} as const;
+
+/** Fields producerFromEnrichment maps first-class or into named legacy slots;
+ *  everything else rides verbatim in legacy.rest. */
+const ENRICHMENT_KNOWN_FIELDS = new Set([
+  'id',
+  'label',
+  'description',
+  'category',
+  'target_mark',
+  'mode',
+  'scope',
+  'dependencies',
+  'passes',
+  'extractor',
+  'status',
+  'def_hash',
+  'cache_version',
+  'source',
+  'updated_at',
+]);
+
+export function producerFromEnrichment(def: LegacyEnrichmentDef): Producer {
+  const fanOut = (def.dependencies ?? []).some(
+    (d) => typeof d === 'object' && 'fanOut' in d && d.fanOut === true,
+  );
+  const rest = restOf(def, ENRICHMENT_KNOWN_FIELDS);
+  return {
+    id: def.id,
+    label: def.label,
+    ...ownKey(def, 'description'),
+    ...ownKey(def, 'category'),
+    kind: def.mode === 'refine-anchors' ? 'anchor-refinement' : 'enrichment',
+    inputs: inputsFromDependencies(def.dependencies),
+    recipe: { extractor: def.extractor },
+    anchoring: { behavior: MODE_TO_BEHAVIOR[def.mode], target: def.target_mark },
+    cardinality: fanOut ? 'per-input' : 'one',
+    scope: def.scope,
+    key_shape: 'enrich',
+    cacheVersion: def.cache_version,
+    ...ownKey(def, 'passes'),
+    status: def.status,
+    source: def.source,
+    updatedAt: def.updated_at,
+    legacy: {
+      def_hash: def.def_hash,
+      ...('dependencies' in def ? { dependencies: def.dependencies } : {}),
+      ...(rest !== undefined ? { rest } : {}),
+    },
+  };
+}
+
+export function enrichmentFromProducer(p: Producer): LegacyEnrichmentDef {
+  const legacy = p.legacy ?? {};
+  const mode =
+    p.kind === 'anchor-refinement'
+      ? 'refine-anchors'
+      : p.anchoring.behavior === 'aggregates'
+        ? 'aggregate'
+        : 'augment-content';
+  return {
+    ...((legacy.rest as Record<string, unknown> | undefined) ?? {}),
+    id: p.id,
+    label: p.label,
+    ...ownKey(p, 'description'),
+    ...ownKey(p, 'category'),
+    target_mark: p.anchoring.target ?? '',
+    mode,
+    scope: p.scope,
+    ...('dependencies' in legacy
+      ? { dependencies: legacy.dependencies as LegacyEnrichmentDependency[] }
+      : {}),
+    ...ownKey(p, 'passes'),
+    extractor: p.recipe.extractor,
+    status: p.status ?? 'promoted',
+    def_hash: legacy.def_hash as string,
+    cache_version: p.cacheVersion,
+    source: p.source ?? 'code',
+    updated_at: p.updatedAt ?? '',
+  } as LegacyEnrichmentDef;
+}
+
+/** Back to the legacy 'gemara' | { mark } | { enrichment } dependency
+ *  vocabulary — byte-identical to the original def's `dependencies` (it rides
+ *  verbatim in the legacy bag), so registry/depGraph's producerNodesFrom is fed
+ *  exactly what it gets today. Producers born WITHOUT a legacy bag get a
+ *  best-effort reconstruction from `inputs` (mark producers reference marks;
+ *  enrich producers reference enrichments; spine inputs read as source leaves). */
+export function rawDependenciesOf(p: Producer): RawDependency[] {
+  const legacy = p.legacy?.dependencies;
+  if (Array.isArray(legacy)) return legacy as RawDependency[];
+  return p.inputs.map((input): RawDependency => {
+    if ('source' in input) return input.source;
+    if ('producer' in input) {
+      if (p.key_shape === 'mark') return { mark: input.producer };
+      return input.fanOut !== undefined
+        ? { enrichment: input.producer, fanOut: input.fanOut }
+        : { enrichment: input.producer };
+    }
+    return input.spine;
+  });
+}

--- a/packages/core/src/model/placement.ts
+++ b/packages/core/src/model/placement.ts
@@ -1,0 +1,74 @@
+/**
+ * Placement — the LIFECYCLE by which an anchor is earned, not a fifth
+ * primitive. A piece may start coarse (unit), get refined to a segment by a
+ * deterministic matcher, then to tokens by AI, then corrected by a human; each
+ * step is an anchor-refinement artifact, and {@link applyRefinements} is the
+ * one writer that folds refinements onto their targets (mirroring the legacy
+ * applyMatches semantics in ../context/match.ts).
+ *
+ * Rules, in order of authority:
+ *  - a human-earned anchor (via 'human') is NEVER replaced;
+ *  - a refinement applies only when the target has no anchor on that spine, or
+ *    the refinement is STRICTLY finer than what's there (precision over
+ *    recall: never silently downgrade).
+ */
+
+import type { Anchor } from './anchor.ts';
+import { comparePrecision, precisionRank } from './anchor.ts';
+import type { Artifact } from './artifact.ts';
+
+export { comparePrecision, precisionRank };
+
+/** Anchored to an actual span of the text (tokens or segments) — "located". */
+export function isLocated(a: Anchor): boolean {
+  return a.precision === 'token' || a.precision === 'segment';
+}
+
+/** Earned by the AI placer ('ai', or a qualified 'ai-*' via like 'ai-phrase'). */
+export function isAiEarned(a: Anchor): boolean {
+  return a.via === 'ai' || (a.via?.startsWith('ai-') ?? false);
+}
+
+export function isHumanEarned(a: Anchor): boolean {
+  return a.via === 'human';
+}
+
+/** Body of a kind='anchor-refinement' artifact: a better anchor for another
+ *  artifact. */
+export interface RefinementBody {
+  targetArtifactId: string;
+  anchor: Anchor;
+}
+
+/**
+ * Fold refinements onto their target artifacts in place (mirrors applyMatches:
+ * pure logic, mutates the passed array's members). Per refinement: find the
+ * target by id; on the refinement anchor's spine, add the anchor if none is
+ * there, or replace the existing one(s) only when the refinement is strictly
+ * finer than ALL of them; never touch a spine that carries a human-earned
+ * anchor. Returns the number of refinements applied.
+ */
+export function applyRefinements(
+  artifacts: Artifact[],
+  refinements: Artifact<RefinementBody>[],
+): number {
+  const byId = new Map(artifacts.map((a) => [a.id, a]));
+  let applied = 0;
+  for (const r of refinements) {
+    const target = byId.get(r.body.targetArtifactId);
+    if (!target) continue;
+    const next = r.body.anchor;
+    const onSpine = target.anchors.filter((a) => a.spine === next.spine);
+    if (onSpine.length === 0) {
+      target.anchors.push(next);
+      applied++;
+      continue;
+    }
+    if (onSpine.some(isHumanEarned)) continue;
+    const finest = Math.max(...onSpine.map((a) => precisionRank(a.precision)));
+    if (precisionRank(next.precision) <= finest) continue;
+    target.anchors = [...target.anchors.filter((a) => a.spine !== next.spine), next];
+    applied++;
+  }
+  return applied;
+}

--- a/packages/core/src/model/producer.ts
+++ b/packages/core/src/model/producer.ts
@@ -1,0 +1,62 @@
+/**
+ * Producer — the unified registry-entry shape behind both legacy definition
+ * families (MarkDefinition / EnrichmentDefinition). A producer declares what it
+ * makes (kind), from what (inputs), how (recipe), where its outputs sit
+ * (anchoring), how many it makes (cardinality), and how its outputs cache
+ * (scope + key_shape + cacheVersion). model/compat.ts projects the legacy defs
+ * into this shape LOSSLESSLY (anything without a first-class field rides in
+ * `legacy`).
+ */
+
+import type { AnchorPrecision } from './anchor.ts';
+
+/** How a producer's outputs get their anchors:
+ *  - 'discovers'  — the extractor finds them (mark extraction, anchor refiners)
+ *  - 'inherits'   — outputs sit where their input instance sits (per-instance
+ *                   enrichments)
+ *  - 'aggregates' — one output over many inputs (daf-level synthesis) */
+export type AnchorBehavior = 'discovers' | 'inherits' | 'aggregates';
+
+export type Cardinality = 'one' | 'many' | 'per-input';
+
+export type ProducerInput =
+  | { source: string }
+  | { producer: string; fanOut?: boolean }
+  | { spine: string; select?: 'unit' | 'work' };
+
+export interface Recipe {
+  extractor: unknown;
+  render?: unknown;
+}
+
+export interface Producer {
+  id: string;
+  label: string;
+  description?: string;
+  category?: string;
+  /** 'mark-instance' | 'enrichment' | 'anchor-refinement' | app-defined. */
+  kind: string;
+  inputs: ProducerInput[];
+  recipe: Recipe;
+  anchoring: {
+    behavior: AnchorBehavior;
+    precision?: AnchorPrecision;
+    spine?: string;
+    /** The producer whose outputs this one operates on (legacy target_mark). */
+    target?: string;
+  };
+  cardinality: Cardinality;
+  scope: 'global' | 'local' | 'spine';
+  /** FROZEN legacy key family ('mark:…' vs 'enrich:…' cache keys) — kept so
+   *  every already-warmed KV entry stays reachable. */
+  key_shape: 'mark' | 'enrich';
+  cacheVersion: string;
+  passes?: string[];
+  status?: 'draft' | 'promoted';
+  experimental?: boolean;
+  source?: 'kv' | 'code';
+  updatedAt?: string;
+  /** Lossless round-trip bag: legacy fields with no first-class home
+   *  (anchorKind, def_hash, sidebar recipe, verbatim dependencies, …). */
+  legacy?: Record<string, unknown>;
+}

--- a/packages/core/src/model/provenance.ts
+++ b/packages/core/src/model/provenance.ts
@@ -1,0 +1,89 @@
+/**
+ * Provenance — how an artifact was made: who decided (human / rule / ai), by
+ * which producer + recipe, from which inputs, at what cost. The model-side
+ * superset of the fields legacy RunResult cache entries already carry;
+ * {@link provenanceOf} synthesizes a Provenance from a stored legacy entry so
+ * nothing needs re-generation to enter the new model.
+ */
+
+export type Authority = 'human' | 'rule' | 'ai';
+
+/** One input an artifact was built from. Legacy entries only know the resolved
+ *  dependency KEY (sourceKey); real artifact ids + content hashes arrive when
+ *  producers write artifacts natively. */
+export interface InputRef {
+  artifactId?: string;
+  sourceKey?: string;
+  contentHash?: string;
+}
+
+/** Generation cost stamped onto a cache entry — the permanent per-entry
+ *  ledger. VERBATIM copy of the talmud worker's CostStamp (index.ts) so stored
+ *  stamps parse unchanged. */
+export interface CostStamp {
+  /** OpenRouter billed USD (net of prompt-cache); null on Workers AI / unpriced. */
+  billedUsd: number | null;
+  /** List-price estimate total; null when the model has no known rate. */
+  estimatedUsd: number | null;
+  /** Estimate split so input-vs-output dollars are answerable per entry. */
+  costInUsd: number | null;
+  costOutUsd: number | null;
+  tokensIn: number;
+  tokensOut: number;
+  lang: 'en' | 'he';
+  cacheVersion: string;
+  computedAt: number;
+}
+
+export interface Provenance {
+  authority: Authority;
+  producerId: string;
+  recipeHash?: string;
+  inputs: InputRef[];
+  confidence?: number;
+  model?: string;
+  transport?: string;
+  usage?: unknown;
+  cost?: CostStamp | null;
+  /** ISO timestamp; '' when the legacy entry recorded no time. */
+  createdAt: string;
+  updatedAt?: string;
+}
+
+/** The fields of a stored legacy RunResult that provenance synthesis reads.
+ *  Structural on purpose: core must not import from the apps; any stored
+ *  RunResult-shaped object satisfies this. */
+export interface LegacyRunFields {
+  model: string;
+  transport: string;
+  recipe_hash?: string;
+  usage?: unknown;
+  cost?: CostStamp | null;
+  deps_resolved?: Record<string, unknown>;
+  anchors_resolved?: Record<string, unknown>;
+}
+
+/** Transports that mean a real LLM produced the content. Everything else
+ *  ('computed', 'graph', 'lookup', …) is a deterministic rule. */
+const AI_TRANSPORTS = new Set(['workers-ai', 'openrouter-gateway']);
+
+/** Synthesize a Provenance from a legacy stored RunResult-shaped object.
+ *  Inputs are the resolved dependency + anchor keys (legacy entries don't
+ *  record real artifact ids or content hashes, so each becomes a sourceKey). */
+export function provenanceOf(stored: LegacyRunFields, producerId: string): Provenance {
+  const inputs: InputRef[] = [
+    ...Object.keys(stored.deps_resolved ?? {}),
+    ...Object.keys(stored.anchors_resolved ?? {}),
+  ].map((k) => ({ sourceKey: k }));
+  return {
+    authority: AI_TRANSPORTS.has(stored.transport) ? 'ai' : 'rule',
+    producerId,
+    recipeHash: stored.recipe_hash,
+    inputs,
+    model: stored.model,
+    transport: stored.transport,
+    usage: stored.usage,
+    cost: stored.cost,
+    createdAt: stored.cost?.computedAt ? new Date(stored.cost.computedAt).toISOString() : '',
+  };
+}

--- a/packages/core/src/model/spine.ts
+++ b/packages/core/src/model/spine.ts
@@ -1,0 +1,66 @@
+/**
+ * Spine — one of the four primitives (Spine / Anchor / Artifact / Producer).
+ *
+ * A spine is an addressable text or entity space artifacts pin to: the Bavli
+ * ('bavli', levels tractate/page/seg), Tanach ('tanach', book/chapter/verse), a
+ * commentary work ('rashi'), or an entity registry ('entity:rabbi', one level —
+ * the entity id). Text spines are ordered (reading order); entity spines are
+ * not. A reference INTO a spine is a path of components, one per level, and may
+ * stop early: a truncated path names the containing division (e.g.
+ * ['Berakhot', '2a'] = the whole daf — this is what retires the DAF_SEG=-1
+ * sentinel in the new model).
+ */
+
+export type RefPart = string | number;
+
+export interface SpineDef {
+  /** 'bavli', 'tanach', 'rashi', 'entity:rabbi'. */
+  id: string;
+  kind: 'text' | 'entity';
+  label?: string;
+  /** Address levels, outermost first. bavli: ['tractate','page','seg'];
+   *  tanach: ['book','chapter','verse']; entity:rabbi: ['id']. */
+  levels: string[];
+  /** Whether positions on this spine have a reading order. Defaults to true
+   *  for kind='text', false for kind='entity' (see {@link isOrderedSpine}). */
+  ordered?: boolean;
+  /** Pure normalization hook (slugging, alias folding). Applied by
+   *  {@link SpineRegistry.ref} after depth validation. */
+  normalizePath?: (path: RefPart[]) => RefPart[];
+}
+
+/** The effective `ordered` flag with its kind-based default applied. */
+export function isOrderedSpine(def: SpineDef): boolean {
+  return def.ordered ?? def.kind === 'text';
+}
+
+export interface SpineRegistry {
+  get(id: string): SpineDef | undefined;
+  list(): SpineDef[];
+  /** Validate + normalize a reference path into a spine: depth must be
+   *  1..levels.length (truncated paths name divisions), then the spine's
+   *  normalizePath hook applies. Throws on an unknown spine or bad depth. */
+  ref(spineId: string, path: RefPart[]): RefPart[];
+}
+
+export function createSpineRegistry(defs: SpineDef[]): SpineRegistry {
+  const byId = new Map<string, SpineDef>();
+  for (const def of defs) {
+    if (byId.has(def.id)) throw new Error(`duplicate spine id: ${def.id}`);
+    byId.set(def.id, def);
+  }
+  return {
+    get: (id) => byId.get(id),
+    list: () => [...byId.values()],
+    ref(spineId, path) {
+      const def = byId.get(spineId);
+      if (!def) throw new Error(`unknown spine: ${spineId}`);
+      if (path.length < 1 || path.length > def.levels.length) {
+        throw new Error(
+          `spine ${spineId} expects a path of depth 1..${def.levels.length}, got ${path.length}`,
+        );
+      }
+      return def.normalizePath ? def.normalizePath(path) : path;
+    },
+  };
+}

--- a/packages/core/tests/anchor-compat.test.ts
+++ b/packages/core/tests/anchor-compat.test.ts
@@ -1,0 +1,360 @@
+import { describe, expect, it } from 'vitest';
+import { type AnchorCoord, DAF_SEG, type DafRef } from '../src/context/coord.ts';
+import type { SegMatch } from '../src/context/match.ts';
+import { placementOf } from '../src/context/placement.ts';
+import type { ContextItem } from '../src/context/types.ts';
+import {
+  anchorFromContextItem,
+  anchorFromCoord,
+  anchorFromSpan,
+  anchorsFromAnchorOutput,
+  anchorsFromContextItem,
+  coordFromAnchor,
+  type LegacyAnchorOutput,
+  refinementFromSegMatch,
+  spineIdOfCoord,
+} from '../src/model/compat.ts';
+
+const daf: DafRef = { tractate: 'Berakhot', page: '2a' };
+
+function item(over: Partial<ContextItem>): ContextItem {
+  return {
+    source: 'dafyomi-insights',
+    sourceLabel: 'Insights',
+    kind: 'note',
+    key: 'k1',
+    segs: [],
+    ...over,
+  };
+}
+
+describe('AnchorCoord <-> Anchor', () => {
+  it('segment coord round-trips', () => {
+    const c: AnchorCoord = { tractate: 'Gittin', page: '67b', seg: 4 };
+    const a = anchorFromCoord(c);
+    expect(a).toEqual({
+      spine: 'bavli',
+      span: [{ path: ['Gittin', '67b', 4] }],
+      precision: 'segment',
+    });
+    expect(coordFromAnchor(a)).toEqual(c);
+  });
+
+  it('DAF_SEG coord becomes a truncated unit path and round-trips', () => {
+    const c: AnchorCoord = { tractate: 'Pesachim', page: '50a', seg: DAF_SEG };
+    const a = anchorFromCoord(c);
+    expect(a).toEqual({
+      spine: 'bavli',
+      span: [{ path: ['Pesachim', '50a'] }],
+      precision: 'unit',
+    });
+    expect(coordFromAnchor(a)).toEqual(c);
+  });
+
+  it('commentary-spine coord round-trips with its spine', () => {
+    const c: AnchorCoord = { tractate: 'Berakhot', page: '2a', seg: DAF_SEG, spine: 'Rashi' };
+    expect(spineIdOfCoord(c)).toBe('Rashi');
+    const a = anchorFromCoord(c);
+    expect(a.spine).toBe('Rashi');
+    expect(a.precision).toBe('unit');
+    expect(coordFromAnchor(a)).toEqual(c);
+  });
+
+  it('coordFromAnchor is null for non-representable anchors', () => {
+    expect(
+      coordFromAnchor({
+        spine: 'bavli',
+        span: [{ path: ['Berakhot', '2a', 1] }, { path: ['Berakhot', '2a', 2] }],
+        precision: 'segment',
+      }),
+    ).toBeNull();
+    expect(
+      coordFromAnchor({
+        spine: 'bavli',
+        span: [{ start: { path: ['Berakhot', '2a', 1] }, end: { path: ['Berakhot', '2a', 2] } }],
+        precision: 'segment',
+      }),
+    ).toBeNull();
+    expect(
+      coordFromAnchor({
+        spine: 'external:url',
+        span: [{ path: ['https://example.com'] }],
+        precision: 'external',
+      }),
+    ).toBeNull();
+  });
+
+  it('anchorFromSpan normalizes and derives precision from DAF_SEG presence', () => {
+    const segSpan = anchorFromSpan([
+      { tractate: 'Berakhot', page: '2a', seg: 3 },
+      { tractate: 'Berakhot', page: '2a', seg: 1 },
+      { tractate: 'Berakhot', page: '2a', seg: 3 },
+    ]);
+    expect(segSpan.precision).toBe('segment');
+    expect(segSpan.span).toEqual([
+      { path: ['Berakhot', '2a', 1] },
+      { path: ['Berakhot', '2a', 3] },
+    ]);
+
+    const mixed = anchorFromSpan([
+      { tractate: 'Berakhot', page: '2a', seg: 1 },
+      { tractate: 'Pesachim', page: '50a', seg: DAF_SEG },
+    ]);
+    expect(mixed.precision).toBe('unit');
+    expect(mixed.span).toContainEqual({ path: ['Pesachim', '50a'] });
+  });
+});
+
+describe('ContextItem -> Anchor (placementOf parity)', () => {
+  it('segment placement: level segment -> precision segment, via/confidence carried', () => {
+    const it_ = item({ segs: [2, 5], via: 'tosfos-dh', confidence: 0.9 });
+    expect(placementOf(it_, daf)?.level).toBe('segment');
+    const a = anchorFromContextItem(it_, daf);
+    expect(a).toEqual({
+      spine: 'bavli',
+      span: [{ path: ['Berakhot', '2a', 2] }, { path: ['Berakhot', '2a', 5] }],
+      precision: 'segment',
+      via: 'tosfos-dh',
+      confidence: 0.9,
+    });
+  });
+
+  it('amud-only placement: level amud -> precision division (amud letter lossy, recoverable from item.amud)', () => {
+    const it_ = item({ amud: 'b', via: 'mishnah' });
+    expect(placementOf(it_, daf)?.level).toBe('amud');
+    const a = anchorFromContextItem(it_, daf);
+    expect(a).toEqual({
+      spine: 'bavli',
+      span: [{ path: ['Berakhot', '2a'] }],
+      precision: 'division',
+      via: 'mishnah',
+    });
+    // The accepted loss: the anchor path does not encode WHICH amud.
+    expect(JSON.stringify(a)).not.toContain('"b"');
+    expect(it_.amud).toBe('b');
+  });
+
+  it('deliberate whole-daf placement: level daf -> precision unit', () => {
+    const it_ = item({ via: 'ai', confidence: 0.6 });
+    expect(placementOf(it_, daf)?.level).toBe('daf');
+    const a = anchorFromContextItem(it_, daf);
+    expect(a).toEqual({
+      spine: 'bavli',
+      span: [{ path: ['Berakhot', '2a'] }],
+      precision: 'unit',
+      via: 'ai',
+      confidence: 0.6,
+    });
+  });
+
+  it('an unplaced item (no segs, no amud, no via) bridges to null, like placementOf', () => {
+    const it_ = item({});
+    expect(placementOf(it_, daf)).toBeNull();
+    expect(anchorFromContextItem(it_, daf)).toBeNull();
+  });
+
+  it('cross-daf: the coord becomes a SECOND anchor whose unit path differs from the daf in view', () => {
+    const it_ = item({
+      segs: [1],
+      via: 'ai',
+      coord: { tractate: 'Gittin', page: '68a', seg: 2 },
+    });
+    expect(placementOf(it_, daf)?.level).toBe('cross-daf');
+    const anchors = anchorsFromContextItem(it_, daf);
+    expect(anchors).toHaveLength(2);
+    expect(anchors[0].span[0]).toEqual({ path: ['Berakhot', '2a', 1] });
+    const coordAnchor = anchors[1];
+    expect(coordAnchor.precision).toBe('segment');
+    const [t, p] = (coordAnchor.span[0] as { path: (string | number)[] }).path;
+    expect([t, p]).not.toEqual([daf.tractate, daf.page]);
+  });
+
+  it('anchorsFromContextItem with no coord is just the placement anchor', () => {
+    const anchors = anchorsFromContextItem(item({ segs: [0], via: 'pieceKeys' }), daf);
+    expect(anchors).toHaveLength(1);
+    expect(anchors[0].precision).toBe('segment');
+  });
+});
+
+describe('SegMatch -> refinement artifact', () => {
+  it('segs match -> segment anchor with via/confidence', () => {
+    const m: SegMatch = { key: 'k1', segs: [4, 2, 4], via: 'ai', confidence: 0.8 };
+    const r = refinementFromSegMatch(m, daf, 'art-1');
+    expect(r.kind).toBe('anchor-refinement');
+    expect(r.body.targetArtifactId).toBe('art-1');
+    expect(r.body.anchor).toEqual({
+      spine: 'bavli',
+      span: [{ path: ['Berakhot', '2a', 2] }, { path: ['Berakhot', '2a', 4] }],
+      precision: 'segment',
+      via: 'ai',
+      confidence: 0.8,
+    });
+    expect(r.provenance).toEqual({
+      authority: 'ai',
+      producerId: 'matcher:ai',
+      inputs: [],
+      createdAt: '',
+    });
+  });
+
+  it('wholeDaf match -> unit anchor; deterministic via -> rule authority', () => {
+    const m: SegMatch = { key: 'k2', segs: [], via: 'tosfos-dh', wholeDaf: true };
+    const r = refinementFromSegMatch(m, daf, 'art-2');
+    expect(r.body.anchor.precision).toBe('unit');
+    expect(r.body.anchor.span).toEqual([{ path: ['Berakhot', '2a'] }]);
+    expect(r.provenance.authority).toBe('rule');
+    expect(r.provenance.producerId).toBe('matcher:tosfos-dh');
+  });
+
+  it('coord-only match -> the cross-daf anchor', () => {
+    const m: SegMatch = {
+      key: 'k3',
+      segs: [],
+      via: 'ai',
+      coord: { tractate: 'Gittin', page: '67b', seg: 4 },
+    };
+    const r = refinementFromSegMatch(m, daf, 'art-3');
+    expect(r.body.anchor.span).toEqual([{ path: ['Gittin', '67b', 4] }]);
+    expect(r.body.anchor.precision).toBe('segment');
+    expect(r.body.anchor.via).toBe('ai');
+  });
+
+  it('throws on an unplaced (no-op) match', () => {
+    const m: SegMatch = { key: 'k4', segs: [], via: 'ai' };
+    expect(() => refinementFromSegMatch(m, daf, 'art-4')).toThrow(/no placement/);
+  });
+});
+
+describe('AnchorOutput -> Anchor[] (all 7 variants)', () => {
+  it('segment', () => {
+    expect(anchorsFromAnchorOutput({ segIdx: 3 }, daf)).toEqual([
+      { spine: 'bavli', span: [{ path: ['Berakhot', '2a', 3] }], precision: 'segment' },
+    ]);
+  });
+
+  it('segment-range', () => {
+    expect(anchorsFromAnchorOutput({ startSegIdx: 2, endSegIdx: 6 }, daf)).toEqual([
+      {
+        spine: 'bavli',
+        span: [{ start: { path: ['Berakhot', '2a', 2] }, end: { path: ['Berakhot', '2a', 6] } }],
+        precision: 'segment',
+      },
+    ]);
+  });
+
+  it('phrase with indices -> token precision with tokens + excerpt', () => {
+    expect(
+      anchorsFromAnchorOutput({ excerpt: 'אביי', segIdx: 1, tokenStart: 4, tokenEnd: 5 }, daf),
+    ).toEqual([
+      {
+        spine: 'bavli',
+        span: [{ path: ['Berakhot', '2a', 1], tokens: [4, 5], excerpt: 'אביי' }],
+        precision: 'token',
+      },
+    ]);
+  });
+
+  it('phrase without segIdx -> unit precision (the excerpt floats on the daf)', () => {
+    expect(anchorsFromAnchorOutput({ excerpt: 'אביי' }, daf)).toEqual([
+      {
+        spine: 'bavli',
+        span: [{ path: ['Berakhot', '2a'], excerpt: 'אביי' }],
+        precision: 'unit',
+      },
+    ]);
+  });
+
+  it('phrase with segIdx but NO token bounds -> segment precision (claims only what it locates)', () => {
+    // Most runtime phrase instances carry excerpt + segIdx only; token
+    // positions resolve client-side. The anchor must not claim 'token'
+    // precision it cannot back with a token window.
+    expect(anchorsFromAnchorOutput({ excerpt: 'אביי', segIdx: 1 }, daf)).toEqual([
+      {
+        spine: 'bavli',
+        span: [{ path: ['Berakhot', '2a', 1], excerpt: 'אביי' }],
+        precision: 'segment',
+      },
+    ]);
+  });
+
+  it('multi-anchor -> one anchor per sub-anchor', () => {
+    const anchors = anchorsFromAnchorOutput(
+      {
+        anchors: [
+          { excerpt: 'A', segIdx: 0, tokenStart: 0, tokenEnd: 1 },
+          { excerpt: 'A', segIdx: 8, tokenStart: 3, tokenEnd: 4 },
+        ],
+        relation: 'inclusio',
+      },
+      daf,
+    );
+    expect(anchors).toHaveLength(2);
+    expect(anchors.every((a) => a.precision === 'token')).toBe(true);
+  });
+
+  it('cross-daf -> source anchor + target anchor (segment when segIdx present)', () => {
+    const out: LegacyAnchorOutput = {
+      source: { startSegIdx: 1, endSegIdx: 2 },
+      target: { tractate: 'Pesachim', page: '50a', segIdx: 7 },
+    };
+    const anchors = anchorsFromAnchorOutput(out, daf);
+    expect(anchors).toHaveLength(2);
+    expect(anchors[0].precision).toBe('segment');
+    expect(anchors[1]).toEqual({
+      spine: 'bavli',
+      span: [{ path: ['Pesachim', '50a', 7] }],
+      precision: 'segment',
+    });
+  });
+
+  it('cross-daf target without segIdx -> unit target', () => {
+    const anchors = anchorsFromAnchorOutput(
+      {
+        source: { excerpt: 'תניא', segIdx: 0 },
+        target: { tractate: 'Pesachim', page: '50a' },
+      },
+      daf,
+    );
+    expect(anchors[1]).toEqual({
+      spine: 'bavli',
+      span: [{ path: ['Pesachim', '50a'] }],
+      precision: 'unit',
+    });
+  });
+
+  it('external -> source anchor + external-spine anchor', () => {
+    const anchors = anchorsFromAnchorOutput(
+      {
+        source: { excerpt: 'חרובא', segIdx: 5 },
+        url: 'https://en.wikipedia.org/wiki/Carob',
+        resource_kind: 'article',
+      },
+      daf,
+    );
+    expect(anchors).toHaveLength(2);
+    expect(anchors[1]).toEqual({
+      spine: 'external:article',
+      span: [{ path: ['https://en.wikipedia.org/wiki/Carob'] }],
+      precision: 'external',
+    });
+  });
+
+  it('external without resource_kind defaults the spine to external:url', () => {
+    const anchors = anchorsFromAnchorOutput(
+      { source: { excerpt: 'x', segIdx: 0 }, url: 'https://example.com' },
+      daf,
+    );
+    expect(anchors[1].spine).toBe('external:url');
+  });
+
+  it('whole-daf -> the truncated unit path', () => {
+    expect(anchorsFromAnchorOutput({ _: 'whole-daf' }, daf)).toEqual([
+      { spine: 'bavli', span: [{ path: ['Berakhot', '2a'] }], precision: 'unit' },
+    ]);
+  });
+
+  it('a commentary spine flows through', () => {
+    const anchors = anchorsFromAnchorOutput({ segIdx: 2 }, daf, 'rashi');
+    expect(anchors[0].spine).toBe('rashi');
+  });
+});

--- a/packages/core/tests/anchor.test.ts
+++ b/packages/core/tests/anchor.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type Anchor,
+  anchorKey,
+  comparePrecision,
+  isRange,
+  normalizeAnchor,
+  pointsOf,
+  precisionRank,
+} from '../src/model/anchor.ts';
+
+const seg = (n: number) => ({ path: ['Berakhot', '2a', n] });
+
+describe('anchorKey', () => {
+  it('is stable across span emission order', () => {
+    const a: Anchor = { spine: 'bavli', span: [seg(3), seg(1)], precision: 'segment' };
+    const b: Anchor = { spine: 'bavli', span: [seg(1), seg(3)], precision: 'segment' };
+    expect(anchorKey(a)).toBe(anchorKey(b));
+  });
+
+  it('ignores excerpt (display data) but not tokens (location)', () => {
+    const base: Anchor = {
+      spine: 'bavli',
+      span: [{ path: ['Berakhot', '2a', 0], tokens: [2, 5] }],
+      precision: 'token',
+    };
+    const withExcerpt: Anchor = {
+      ...base,
+      span: [{ path: ['Berakhot', '2a', 0], tokens: [2, 5], excerpt: 'מאימתי' }],
+    };
+    const otherTokens: Anchor = {
+      ...base,
+      span: [{ path: ['Berakhot', '2a', 0], tokens: [6, 9] }],
+    };
+    expect(anchorKey(withExcerpt)).toBe(anchorKey(base));
+    expect(anchorKey(otherTokens)).not.toBe(anchorKey(base));
+  });
+
+  it('distinguishes spine, precision, and stringy-vs-numeric path parts', () => {
+    const a: Anchor = { spine: 'bavli', span: [seg(2)], precision: 'segment' };
+    expect(anchorKey({ ...a, spine: 'rashi' })).not.toBe(anchorKey(a));
+    expect(anchorKey({ ...a, precision: 'unit' })).not.toBe(anchorKey(a));
+    const stringy: Anchor = {
+      spine: 'bavli',
+      span: [{ path: ['Berakhot', '2a', '2'] }],
+      precision: 'segment',
+    };
+    expect(anchorKey(stringy)).not.toBe(anchorKey(a));
+  });
+});
+
+describe('normalizeAnchor', () => {
+  it('dedupes and sorts deterministically', () => {
+    const a: Anchor = {
+      spine: 'bavli',
+      span: [seg(4), seg(1), seg(4), { start: seg(2), end: seg(3) }],
+      precision: 'segment',
+    };
+    const n1 = normalizeAnchor(a);
+    const n2 = normalizeAnchor({ ...a, span: [...a.span].reverse() });
+    expect(n1.span).toEqual(n2.span);
+    expect(n1.span).toHaveLength(3);
+    expect(normalizeAnchor(n1)).toEqual(n1);
+  });
+
+  it('does not mutate the input', () => {
+    const span = [seg(2), seg(1)];
+    const a: Anchor = { spine: 'bavli', span, precision: 'segment' };
+    normalizeAnchor(a);
+    expect(a.span).toBe(span);
+    expect(span[0]).toEqual(seg(2));
+  });
+});
+
+describe('precisionRank / comparePrecision', () => {
+  it('orders token > segment > division > unit > work > external', () => {
+    expect(precisionRank('token')).toBe(5);
+    expect(precisionRank('segment')).toBe(4);
+    expect(precisionRank('division')).toBe(3);
+    expect(precisionRank('unit')).toBe(2);
+    expect(precisionRank('work')).toBe(1);
+    expect(precisionRank('external')).toBe(0);
+    expect(comparePrecision('token', 'segment')).toBeGreaterThan(0);
+    expect(comparePrecision('unit', 'segment')).toBeLessThan(0);
+    expect(comparePrecision('division', 'division')).toBe(0);
+  });
+});
+
+describe('isRange / pointsOf', () => {
+  it('isRange discriminates points from ranges', () => {
+    expect(isRange(seg(1))).toBe(false);
+    expect(isRange({ start: seg(1), end: seg(2) })).toBe(true);
+  });
+
+  it('expands numeric same-parent ranges', () => {
+    expect(pointsOf([{ start: seg(2), end: seg(5) }])).toEqual([seg(2), seg(3), seg(4), seg(5)]);
+  });
+
+  it('passes points through and keeps endpoints for non-expandable ranges', () => {
+    const crossDaf = {
+      start: { path: ['Berakhot', '2a', 9] },
+      end: { path: ['Berakhot', '2b', 1] },
+    };
+    expect(pointsOf([seg(0), crossDaf])).toEqual([seg(0), crossDaf.start, crossDaf.end]);
+    const stringLeaf = {
+      start: { path: ['Genesis', '1'] },
+      end: { path: ['Genesis', '3'] },
+    };
+    expect(pointsOf([stringLeaf])).toEqual([stringLeaf.start, stringLeaf.end]);
+  });
+
+  it('is bounded: a pathologically wide range yields its endpoints', () => {
+    const wide = {
+      start: { path: ['Berakhot', '2a', 0] },
+      end: { path: ['Berakhot', '2a', 1_000_000] },
+    };
+    expect(pointsOf([wide])).toEqual([wide.start, wide.end]);
+  });
+
+  it('the bound counts points inclusively (0..9999 expands; 0..10000 does not)', () => {
+    const atCap = {
+      start: { path: ['Berakhot', '2a', 0] },
+      end: { path: ['Berakhot', '2a', 9_999] },
+    };
+    expect(pointsOf([atCap])).toHaveLength(10_000);
+    const overCap = {
+      start: { path: ['Berakhot', '2a', 0] },
+      end: { path: ['Berakhot', '2a', 10_000] },
+    };
+    expect(pointsOf([overCap])).toEqual([overCap.start, overCap.end]);
+  });
+
+  it('never expands token-bearing ranges (synthesized points would drop the tokens)', () => {
+    const tokened = {
+      start: { path: ['Berakhot', '2a', 2], tokens: [0, 3] as [number, number] },
+      end: { path: ['Berakhot', '2a', 4] },
+    };
+    expect(pointsOf([tokened])).toEqual([tokened.start, tokened.end]);
+  });
+});

--- a/packages/core/tests/placement.test.ts
+++ b/packages/core/tests/placement.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import type { Anchor } from '../src/model/anchor.ts';
+import type { Artifact } from '../src/model/artifact.ts';
+import {
+  applyRefinements,
+  isAiEarned,
+  isHumanEarned,
+  isLocated,
+  type RefinementBody,
+} from '../src/model/placement.ts';
+import type { Provenance } from '../src/model/provenance.ts';
+
+const prov: Provenance = {
+  authority: 'rule',
+  producerId: 'test',
+  inputs: [],
+  createdAt: '',
+};
+
+function artifact(id: string, anchors: Anchor[]): Artifact {
+  return { id, kind: 'context-item', anchors, body: {}, provenance: prov };
+}
+
+function refinement(targetArtifactId: string, anchor: Anchor): Artifact<RefinementBody> {
+  return {
+    id: `r:${targetArtifactId}`,
+    kind: 'anchor-refinement',
+    anchors: [anchor],
+    body: { targetArtifactId, anchor },
+    provenance: prov,
+  };
+}
+
+const unit: Anchor = { spine: 'bavli', span: [{ path: ['Berakhot', '2a'] }], precision: 'unit' };
+const segment: Anchor = {
+  spine: 'bavli',
+  span: [{ path: ['Berakhot', '2a', 3] }],
+  precision: 'segment',
+  via: 'ai',
+  confidence: 0.8,
+};
+const token: Anchor = {
+  spine: 'bavli',
+  span: [{ path: ['Berakhot', '2a', 3], tokens: [1, 2] }],
+  precision: 'token',
+  via: 'ai-phrase',
+};
+
+describe('anchor predicates', () => {
+  it('isLocated = token or segment precision', () => {
+    expect(isLocated(token)).toBe(true);
+    expect(isLocated(segment)).toBe(true);
+    expect(isLocated(unit)).toBe(false);
+    expect(isLocated({ ...unit, precision: 'division' })).toBe(false);
+  });
+
+  it('isAiEarned matches ai and ai-* vias', () => {
+    expect(isAiEarned(segment)).toBe(true);
+    expect(isAiEarned(token)).toBe(true);
+    expect(isAiEarned({ ...segment, via: 'tosfos-dh' })).toBe(false);
+    expect(isAiEarned(unit)).toBe(false);
+  });
+
+  it('isHumanEarned', () => {
+    expect(isHumanEarned({ ...segment, via: 'human' })).toBe(true);
+    expect(isHumanEarned(segment)).toBe(false);
+  });
+});
+
+describe('applyRefinements', () => {
+  it('applies to an artifact with no anchor on that spine', () => {
+    const a = artifact('a1', []);
+    const n = applyRefinements([a], [refinement('a1', segment)]);
+    expect(n).toBe(1);
+    expect(a.anchors).toEqual([segment]);
+  });
+
+  it('adds rather than replaces when the spines differ', () => {
+    const rashi: Anchor = { ...segment, spine: 'rashi' };
+    const a = artifact('a1', [segment]);
+    expect(applyRefinements([a], [refinement('a1', rashi)])).toBe(1);
+    expect(a.anchors).toHaveLength(2);
+  });
+
+  it('upgrades a coarser anchor on the same spine', () => {
+    const a = artifact('a1', [unit]);
+    expect(applyRefinements([a], [refinement('a1', segment)])).toBe(1);
+    expect(a.anchors).toEqual([segment]);
+    expect(applyRefinements([a], [refinement('a1', token)])).toBe(1);
+    expect(a.anchors).toEqual([token]);
+  });
+
+  it('refuses to downgrade or sidestep at equal precision', () => {
+    const a = artifact('a1', [segment]);
+    expect(applyRefinements([a], [refinement('a1', unit)])).toBe(0);
+    const otherSegment: Anchor = {
+      ...segment,
+      span: [{ path: ['Berakhot', '2a', 9] }],
+    };
+    expect(applyRefinements([a], [refinement('a1', otherSegment)])).toBe(0);
+    expect(a.anchors).toEqual([segment]);
+  });
+
+  it('never overwrites a human-earned anchor, even with finer precision', () => {
+    const human: Anchor = { ...segment, via: 'human' };
+    const a = artifact('a1', [human]);
+    expect(applyRefinements([a], [refinement('a1', token)])).toBe(0);
+    expect(a.anchors).toEqual([human]);
+  });
+
+  it('skips refinements whose target is missing and returns the applied count', () => {
+    const a = artifact('a1', []);
+    const b = artifact('b1', [unit]);
+    const n = applyRefinements(
+      [a, b],
+      [refinement('a1', segment), refinement('b1', token), refinement('ghost', token)],
+    );
+    expect(n).toBe(2);
+  });
+});

--- a/packages/core/tests/provenance.test.ts
+++ b/packages/core/tests/provenance.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { type CostStamp, type LegacyRunFields, provenanceOf } from '../src/model/provenance.ts';
+
+const cost: CostStamp = {
+  billedUsd: 0.0012,
+  estimatedUsd: 0.0015,
+  costInUsd: 0.0005,
+  costOutUsd: 0.001,
+  tokensIn: 1200,
+  tokensOut: 400,
+  lang: 'en',
+  cacheVersion: '4',
+  computedAt: 1750000000000,
+};
+
+describe('provenanceOf', () => {
+  it('a modern openrouter entry: ai authority, recipeHash + cost + inputs', () => {
+    const stored: LegacyRunFields = {
+      model: 'openrouter/deepseek/deepseek-v4-flash',
+      transport: 'openrouter-gateway',
+      recipe_hash: 'abc123def456',
+      usage: { prompt_tokens: 1200, completion_tokens: 400 },
+      cost,
+      deps_resolved: { 'argument.background': '...', gemara: '...' },
+      anchors_resolved: { rabbi: [] },
+    };
+    const p = provenanceOf(stored, 'argument.synthesis');
+    expect(p).toEqual({
+      authority: 'ai',
+      producerId: 'argument.synthesis',
+      recipeHash: 'abc123def456',
+      inputs: [
+        { sourceKey: 'argument.background' },
+        { sourceKey: 'gemara' },
+        { sourceKey: 'rabbi' },
+      ],
+      model: 'openrouter/deepseek/deepseek-v4-flash',
+      transport: 'openrouter-gateway',
+      usage: { prompt_tokens: 1200, completion_tokens: 400 },
+      cost,
+      createdAt: new Date(cost.computedAt).toISOString(),
+    });
+  });
+
+  it('workers-ai transport is ai authority', () => {
+    const p = provenanceOf({ model: '@cf/some/model', transport: 'workers-ai' }, 'rabbi');
+    expect(p.authority).toBe('ai');
+  });
+
+  it.each(['computed', 'graph', 'lookup'])('%s transport is rule authority', (transport) => {
+    const p = provenanceOf({ model: transport, transport }, 'rabbi.observations');
+    expect(p.authority).toBe('rule');
+    expect(p.model).toBe(transport);
+  });
+
+  it('an old vintage (no recipe_hash, no cost, no deps) degrades gracefully', () => {
+    const p = provenanceOf(
+      { model: 'openrouter/deepseek/deepseek-v3', transport: 'openrouter-gateway' },
+      'argument',
+    );
+    expect(p.recipeHash).toBeUndefined();
+    expect(p.cost).toBeUndefined();
+    expect(p.inputs).toEqual([]);
+    expect(p.createdAt).toBe('');
+  });
+
+  it('null cost (explicitly unpriced) keeps createdAt empty and passes cost through', () => {
+    const p = provenanceOf({ model: 'x', transport: 'openrouter-gateway', cost: null }, 'argument');
+    expect(p.cost).toBeNull();
+    expect(p.createdAt).toBe('');
+  });
+});

--- a/packages/core/tests/spine-registry.test.ts
+++ b/packages/core/tests/spine-registry.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createSpineRegistry,
+  isOrderedSpine,
+  type RefPart,
+  type SpineDef,
+} from '../src/model/spine.ts';
+
+const bavli: SpineDef = {
+  id: 'bavli',
+  kind: 'text',
+  label: 'Talmud Bavli',
+  levels: ['tractate', 'page', 'seg'],
+};
+
+const tanach: SpineDef = {
+  id: 'tanach',
+  kind: 'text',
+  levels: ['book', 'chapter', 'verse'],
+  normalizePath: (path: RefPart[]) =>
+    path.map((part) => (typeof part === 'string' ? part.toLowerCase() : part)),
+};
+
+const rabbiEntity: SpineDef = {
+  id: 'entity:rabbi',
+  kind: 'entity',
+  levels: ['id'],
+};
+
+describe('createSpineRegistry', () => {
+  it('registers and lists spines', () => {
+    const reg = createSpineRegistry([bavli, tanach, rabbiEntity]);
+    expect(reg.get('bavli')).toBe(bavli);
+    expect(reg.get('nope')).toBeUndefined();
+    expect(reg.list().map((d) => d.id)).toEqual(['bavli', 'tanach', 'entity:rabbi']);
+  });
+
+  it('throws on duplicate ids', () => {
+    expect(() => createSpineRegistry([bavli, { ...tanach, id: 'bavli' }])).toThrow(
+      /duplicate spine id: bavli/,
+    );
+  });
+
+  it('ref validates depth: 1..levels.length', () => {
+    const reg = createSpineRegistry([bavli]);
+    expect(reg.ref('bavli', ['Berakhot'])).toEqual(['Berakhot']);
+    expect(reg.ref('bavli', ['Berakhot', '2a'])).toEqual(['Berakhot', '2a']);
+    expect(reg.ref('bavli', ['Berakhot', '2a', 3])).toEqual(['Berakhot', '2a', 3]);
+    expect(() => reg.ref('bavli', [])).toThrow(/depth/);
+    expect(() => reg.ref('bavli', ['Berakhot', '2a', 3, 9])).toThrow(/depth/);
+  });
+
+  it('ref throws on an unknown spine', () => {
+    const reg = createSpineRegistry([bavli]);
+    expect(() => reg.ref('tanach', ['Genesis'])).toThrow(/unknown spine: tanach/);
+  });
+
+  it('ref applies the normalizePath hook', () => {
+    const reg = createSpineRegistry([tanach]);
+    expect(reg.ref('tanach', ['Genesis', 1, 1])).toEqual(['genesis', 1, 1]);
+  });
+
+  it('entity spines: single-level refs, unordered by default', () => {
+    const reg = createSpineRegistry([rabbiEntity]);
+    expect(reg.ref('entity:rabbi', ['abaye'])).toEqual(['abaye']);
+    expect(() => reg.ref('entity:rabbi', ['abaye', 'extra'])).toThrow(/depth/);
+    expect(isOrderedSpine(rabbiEntity)).toBe(false);
+    expect(isOrderedSpine(bavli)).toBe(true);
+    expect(isOrderedSpine({ ...rabbiEntity, ordered: true })).toBe(true);
+  });
+});

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "types": ["@cloudflare/workers-types"]
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "tests/**/*.ts", "vitest.config.ts"]
 }

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+  },
+});

--- a/packages/talmud/tests/producer-projection.test.ts
+++ b/packages/talmud/tests/producer-projection.test.ts
@@ -1,0 +1,153 @@
+/**
+ * The Producer projections must be LOSSLESS over the real registry: every
+ * code-defined mark and enrichment survives the round trip through the
+ * four-primitive Producer shape byte-for-byte, and the dependency vocabulary
+ * fed to the dep graph is identical either way. This is the gate that lets the
+ * new model adopt the existing registry without regenerating anything.
+ */
+
+import {
+  enrichmentFromProducer,
+  markFromProducer,
+  producerFromEnrichment,
+  producerFromMark,
+  rawDependenciesOf,
+} from '@corpus/core/model/compat';
+import { producerNodesFrom } from '@corpus/core/registry/depGraph';
+import { describe, expect, it } from 'vitest';
+import { CODE_ENRICHMENTS, CODE_MARKS } from '../src/worker/code-marks';
+
+describe('mark round-trip', () => {
+  for (const def of CODE_MARKS) {
+    it(`markFromProducer(producerFromMark(${def.id})) strict-equals the def`, () => {
+      // toStrictEqual: own-key preservation matters — a round-trip that
+      // materializes absent optionals as own `undefined` keys (or vice versa)
+      // is lossy in a way toEqual cannot see.
+      expect(markFromProducer(producerFromMark(def))).toStrictEqual(def);
+    });
+  }
+});
+
+describe('enrichment round-trip', () => {
+  for (const def of CODE_ENRICHMENTS) {
+    it(`enrichmentFromProducer(producerFromEnrichment(${def.id})) strict-equals the def`, () => {
+      expect(enrichmentFromProducer(producerFromEnrichment(def))).toStrictEqual(def);
+    });
+  }
+});
+
+describe('round-trip beyond the current registry (future/KV-authored shapes)', () => {
+  const baseMark = CODE_MARKS[0];
+  const baseEnrichment = CODE_ENRICHMENTS[0];
+
+  it('UNKNOWN own fields on a mark def survive the round trip via legacy.rest', () => {
+    const futureDef = {
+      ...baseMark,
+      some_future_field: { nested: true },
+      model_hint: 'pro',
+    } as unknown as typeof baseMark;
+    const p = producerFromMark(futureDef);
+    expect((p.legacy?.rest as Record<string, unknown>).some_future_field).toEqual({
+      nested: true,
+    });
+    expect(markFromProducer(p)).toStrictEqual(futureDef);
+  });
+
+  it('UNKNOWN own fields on an enrichment def survive the round trip via legacy.rest', () => {
+    const futureDef = {
+      ...baseEnrichment,
+      system_prompt: 'a flat KV-style field',
+      output_schema: { type: 'object' },
+    } as unknown as typeof baseEnrichment;
+    expect(enrichmentFromProducer(producerFromEnrichment(futureDef))).toStrictEqual(futureDef);
+  });
+
+  it('explicit-undefined optionals round-trip as own keys (and absence as absence)', () => {
+    const withOwnUndefined = {
+      ...baseMark,
+      description: undefined,
+    } as unknown as typeof baseMark;
+    const back = markFromProducer(producerFromMark(withOwnUndefined));
+    expect('description' in back).toBe(true);
+    expect(back.description).toBeUndefined();
+    expect(back).toStrictEqual(withOwnUndefined);
+
+    const withoutKey = { ...baseMark } as Record<string, unknown>;
+    delete withoutKey.description;
+    const back2 = markFromProducer(producerFromMark(withoutKey as typeof baseMark));
+    expect('description' in back2).toBe(false);
+  });
+});
+
+describe('dependency vocabulary round-trip', () => {
+  it('rawDependenciesOf returns the verbatim dependencies for every def', () => {
+    for (const def of CODE_MARKS) {
+      expect(rawDependenciesOf(producerFromMark(def))).toEqual(def.dependencies ?? []);
+    }
+    for (const def of CODE_ENRICHMENTS) {
+      expect(rawDependenciesOf(producerFromEnrichment(def))).toEqual(def.dependencies ?? []);
+    }
+  });
+
+  it('producerNodesFrom over projected defs equals producerNodesFrom over the originals', () => {
+    const originals = producerNodesFrom([...CODE_MARKS, ...CODE_ENRICHMENTS]);
+    const projected = producerNodesFrom(
+      [...CODE_MARKS.map(producerFromMark), ...CODE_ENRICHMENTS.map(producerFromEnrichment)].map(
+        (p) => ({ id: p.id, dependencies: rawDependenciesOf(p) }),
+      ),
+    );
+    expect(projected).toEqual(originals);
+  });
+});
+
+describe('projection semantics spot-checks', () => {
+  const markById = new Map(CODE_MARKS.map((d) => [d.id, d]));
+  const enrichmentById = new Map(CODE_ENRICHMENTS.map((d) => [d.id, d]));
+
+  it('rabbi mark: discovers, cardinality many, key_shape mark, token precision', () => {
+    const def = markById.get('rabbi');
+    expect(def).toBeDefined();
+    const p = producerFromMark(def!);
+    expect(p.kind).toBe('mark-instance');
+    expect(p.anchoring.behavior).toBe('discovers');
+    expect(p.anchoring.precision).toBe('token'); // phrase anchor
+    expect(p.cardinality).toBe('many');
+    expect(p.key_shape).toBe('mark');
+    expect(p.scope).toBe('local');
+    expect(p.legacy?.anchorKind).toBe('phrase');
+    expect(p.inputs).toEqual([{ source: 'gemara' }]);
+  });
+
+  it('argument.synthesis: an aggregate enrichment projects to behavior aggregates', () => {
+    const def = enrichmentById.get('argument.synthesis');
+    expect(def).toBeDefined();
+    expect(def!.mode).toBe('aggregate');
+    const p = producerFromEnrichment(def!);
+    expect(p.kind).toBe('enrichment');
+    expect(p.anchoring.behavior).toBe('aggregates');
+    expect(p.anchoring.target).toBe(def!.target_mark);
+    expect(p.key_shape).toBe('enrich');
+  });
+
+  it('biyun.essay: fanOut dependencies project to cardinality per-input', () => {
+    const def = enrichmentById.get('biyun.essay');
+    expect(def).toBeDefined();
+    expect(def!.dependencies?.some((d) => typeof d === 'object' && 'fanOut' in d && d.fanOut)).toBe(
+      true,
+    );
+    const p = producerFromEnrichment(def!);
+    expect(p.cardinality).toBe('per-input');
+    expect(p.inputs.some((i) => 'producer' in i && i.fanOut === true)).toBe(true);
+  });
+
+  it('a non-fanOut enrichment projects to cardinality one', () => {
+    const def = enrichmentById.get('argument.synthesis');
+    expect(producerFromEnrichment(def!).cardinality).toBe('one');
+  });
+
+  it('an augment-content enrichment projects to behavior inherits', () => {
+    const def = CODE_ENRICHMENTS.find((d) => d.mode === 'augment-content');
+    expect(def).toBeDefined();
+    expect(producerFromEnrichment(def!).anchoring.behavior).toBe('inherits');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(jsdom@29.1.1)(vite@6.4.2)
 
   packages/talmud:
     dependencies:


### PR DESCRIPTION
Stage 2 of the four-primitive consolidation (after the characterization baseline in #356). Ships the pure shared vocabulary at `@corpus/core/model` — additive only, nothing consumes it yet.

## The four primitives

- **Spine** (`spine.ts`) — any addressable corpus: bavli/tanach/commentary works as text spines, plus degenerate **entity spines** (rabbi/place registries) whose referents have no linear order. Depth-checked `ref()` against declared levels.
- **Anchor** (`anchor.ts`) — the ONE placement shape `{spine, span, precision, via, confidence}` replacing today's three vocabularies (AnchorCoord / ContextItem segs / SegMatch). `precision: token|segment|division|unit|work|external`; cross-daf is *derived* at render time; whole-daf is a truncated path (retires `DAF_SEG=-1` in the new model).
- **Artifact** (`artifact.ts` + `provenance.ts`) — `{id, kind, anchors[], body, provenance}`. The provenance envelope is the per-artifact **build manifest**: authority `human|rule|ai`, producerId, recipeHash, `inputs[]` with content hashes, model/transport/usage/cost (`CostStamp` copied verbatim so stored entries parse unchanged). `provenanceOf()` synthesizes it from legacy stored RunResult fields.
- **Producer** (`producer.ts`) — one shape replacing MarkDefinition + EnrichmentDefinition: anchoring behavior `discovers|inherits|aggregates`, cardinality, frozen `key_shape: 'mark'|'enrich'` (cache-key compatibility), `legacy` bag for lossless round-trips.

**Placement is not a fifth primitive** (`placement.ts`): it's the lifecycle by which an anchor is earned — `RefinementBody` + `applyRefinements` (fills absent anchors, upgrades strictly-finer precision, **never overwrites `via:'human'`**).

## The bridges (`compat.ts`)

Bidirectional, tested over the live registry: AnchorCoord/ContextItem/SegMatch/all 7 studio AnchorOutput variants ↔ Anchor (with `placementOf`-parity), and **lossless producer projections** — every `CODE_MARKS`/`CODE_ENRICHMENTS` def round-trips `toStrictEqual`; unknown future/KV fields ride verbatim in `legacy.rest`; explicit-undefined optionals round-trip as own keys; `rawDependenciesOf` feeds `producerNodesFrom` byte-identically to today.

## Review notes

Codex review found three issues, all fixed before this PR: allowlist projections that would have dropped unknown fields on future defs (now rest-preserved + toStrictEqual), phrase anchors claiming `token` precision without token bounds (now `segment`), and an off-by-one + token-dropping branch in bounded range expansion.

Tests: 61 new core tests (core now has its own vitest suite under `pnpm -r test`) + 73 talmud projection tests. Full suite: core 61, talmud 2043, tanach 19; typecheck + biome clean.