### PR TITLE
ArtifactStore: the KV store layer for the four primitives

### DIFF
--- a/packages/core/src/store/artifact-store.ts
+++ b/packages/core/src/store/artifact-store.ts
@@ -1,0 +1,194 @@
+/**
+ * ArtifactStore — the one KV surface for producer outputs. Wraps a minimal
+ * structural KV (a Cloudflare KVNamespace satisfies it) with:
+ *
+ *  - key derivation via a pluggable {@link KeyScheme} (talmud delegates to the
+ *    frozen cache/keys.ts contract; tanach uses literal templates);
+ *  - the legacy read/write envelope semantics (plain JSON, null on parse
+ *    error, NO TTL ever — mirrors the worker's readCachedResult /
+ *    writeCachedResult exactly);
+ *  - the HUMAN-EDIT GUARD: a human-authored entry is never silently
+ *    overwritten by rule/AI output;
+ *  - stale-while-revalidate reads across a cache_version bump (getSWR);
+ *  - generalized staleness (recipe hash + input content hashes).
+ */
+
+import { recipeHash } from '../cache/keys.ts';
+import type { Recipe } from '../model/producer.ts';
+import type { InputRef } from '../model/provenance.ts';
+import type { StoredArtifact } from './envelope.ts';
+import type { ArtifactAddress, KeyScheme, ProducerKeyInfo } from './key-schemes.ts';
+import { producerKeyInfo } from './key-schemes.ts';
+
+/** Minimal structural KV — the subset of KVNamespace the store uses, kept as
+ *  its own interface so core's public surface doesn't depend on workers-types
+ *  (a real KVNamespace is assignment-compatible). */
+export interface KVStore {
+  get(key: string): Promise<string | null>;
+  put(key: string, value: string): Promise<void>;
+  delete(key: string): Promise<void>;
+}
+
+export type PutResult = { ok: true } | { ok: false; reason: 'human-locked' };
+
+export type Staleness = 'fresh' | 'stale-recipe' | 'stale-inputs' | 'unknown';
+
+/** Accepts bare ProducerKeyInfo or any Producer-shaped object (with a recipe).
+ *  Routes through producerKeyInfo so hasHePrompt is DERIVED from the recipe's
+ *  extractor when not explicitly set — a full Producer passed structurally
+ *  would otherwise default to "no Hebrew prompt" and mis-key he-prompted
+ *  marks. */
+type ProducerLike = ProducerKeyInfo & { recipe?: { extractor?: unknown } };
+function keyInfoOf(p: ProducerLike): ProducerKeyInfo {
+  return producerKeyInfo(p);
+}
+
+export class ArtifactStore {
+  constructor(
+    private readonly kv: KVStore,
+    private readonly scheme: KeyScheme,
+  ) {}
+
+  /** The canonical KV key for (producer, address). Accepts a full Producer
+   *  (hasHePrompt derives from its recipe) or the bare key info. */
+  keyFor(p: ProducerLike, addr: ArtifactAddress): string {
+    return this.scheme.key(keyInfoOf(p), addr);
+  }
+
+  /** Read one entry. Mirrors the worker's readCachedResult byte-for-byte:
+   *  null on miss, null on unparseable JSON (a corrupted entry reads as a
+   *  miss and regenerates rather than throwing). */
+  async get(key: string): Promise<StoredArtifact | null> {
+    const raw = await this.kv.get(key);
+    if (!raw) return null;
+    try {
+      return JSON.parse(raw) as StoredArtifact;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Read by (producer, address): the canonical key first, then any
+   *  scheme-declared legacy alias keys. The returned `key` is ALWAYS the
+   *  canonical one — writes never target an alias, so a hit served from an
+   *  alias migrates to the canonical key on its next write. */
+  async getWithAliases(
+    p: ProducerLike,
+    addr: ArtifactAddress,
+  ): Promise<{ key: string; value: StoredArtifact | null }> {
+    const info = keyInfoOf(p);
+    const key = this.scheme.key(info, addr);
+    const hit = await this.get(key);
+    if (hit) return { key, value: hit };
+    for (const alias of this.scheme.legacyKeys?.(info, addr) ?? []) {
+      const aliasHit = await this.get(alias);
+      if (aliasHit) return { key, value: aliasHit };
+    }
+    return { key, value: null };
+  }
+
+  /** Stale-while-revalidate read: the canonical key first; on miss, the
+   *  previous-cache_version key. `stale: true` means the value was served
+   *  from the previous version — the CALLER decides whether to enqueue a
+   *  refresh (this store never marks `refreshing` or enqueues anything).
+   *
+   *  `canonicalKey` is ALWAYS the current-version key (what a refresh job
+   *  targets, what write-through writes); `servedKey` is where the value
+   *  actually came from. The optional `accept` predicate guards BOTH reads —
+   *  a value failing it is treated as a miss (production's section_range
+   *  guard: a cached section enrichment whose range no longer matches the
+   *  requested instance must not be served, fresh OR stale). */
+  async getSWR(
+    p: ProducerLike,
+    addr: ArtifactAddress,
+    opts?: { accept?: (value: StoredArtifact) => boolean },
+  ): Promise<{
+    canonicalKey: string;
+    servedKey: string;
+    value: StoredArtifact | null;
+    stale: boolean;
+  }> {
+    const info = keyInfoOf(p);
+    const canonicalKey = this.scheme.key(info, addr);
+    const accept = opts?.accept ?? (() => true);
+    const hit = await this.get(canonicalKey);
+    if (hit && accept(hit)) {
+      return { canonicalKey, servedKey: canonicalKey, value: hit, stale: false };
+    }
+    const prevKey = this.scheme.previousKey(canonicalKey, info);
+    if (prevKey) {
+      const prev = await this.get(prevKey);
+      if (prev && accept(prev)) {
+        return { canonicalKey, servedKey: prevKey, value: prev, stale: true };
+      }
+    }
+    return { canonicalKey, servedKey: canonicalKey, value: null, stale: false };
+  }
+
+  /**
+   * Write one entry — plain JSON, NO TTL ever (outputs are deterministic per
+   * key; expiry would silently rot warmed pages — see writeCachedResult).
+   *
+   * HUMAN-EDIT GUARD: if the existing entry is human-authored
+   * (provenance.authority === 'human') and the incoming value is not, the
+   * write is refused ({ok:false, reason:'human-locked'}). Human-over-human
+   * always writes. `force` cannot launder a non-human value over a human one —
+   * it is reserved for future, stricter lock modes and only ever applies when
+   * the incoming authority IS 'human'.
+   *
+   * Known race (accepted): the guard is read-check-write, not atomic. Two
+   * concurrent writers can interleave between the read and the put; KV offers
+   * no CAS, and the guard's job is preventing the SYSTEMATIC clobber (a
+   * re-warm overwriting an edit), not winning a same-millisecond race.
+   */
+  async put(key: string, value: StoredArtifact, _opts?: { force?: boolean }): Promise<PutResult> {
+    const existing = await this.get(key);
+    const existingHuman = existing?.provenance?.authority === 'human';
+    const incomingHuman = value.provenance?.authority === 'human';
+    if (existingHuman && !incomingHuman) return { ok: false, reason: 'human-locked' };
+    await this.kv.put(key, JSON.stringify(value));
+    return { ok: true };
+  }
+
+  async evict(key: string): Promise<void> {
+    await this.kv.delete(key);
+  }
+
+  /**
+   * Generalized staleness for a stored entry against the producer's CURRENT
+   * recipe (and optionally its current inputs). The recipe leg mirrors the
+   * /api/stale tri-state exactly (fresh / stale / unknown), extended with a
+   * second input-hash leg:
+   *
+   *  - no stored recipe hash (pre-stamp entry)        → 'unknown'
+   *  - stored hash ≠ current recipe hash              → 'stale-recipe'
+   *  - currentInputs given + stored provenance inputs: any pair (matched by
+   *    artifactId, else sourceKey) whose contentHashes both exist and differ  → 'stale-inputs'
+   *  - otherwise                                       → 'fresh'
+   */
+  async staleness(
+    stored: StoredArtifact,
+    p: { recipe: Recipe } | { recipeHash: string },
+    currentInputs?: InputRef[],
+  ): Promise<Staleness> {
+    const storedHash = stored.recipe_hash ?? stored.provenance?.recipeHash;
+    if (!storedHash) return 'unknown';
+    const currentHash = 'recipeHash' in p ? p.recipeHash : await recipeHash(p.recipe);
+    if (storedHash !== currentHash) return 'stale-recipe';
+    const storedInputs = stored.provenance?.inputs;
+    if (currentInputs && storedInputs) {
+      for (const cur of currentInputs) {
+        if (cur.contentHash === undefined) continue;
+        const match = storedInputs.find((s) =>
+          cur.artifactId !== undefined
+            ? s.artifactId === cur.artifactId
+            : cur.sourceKey !== undefined && s.sourceKey === cur.sourceKey,
+        );
+        if (match?.contentHash !== undefined && match.contentHash !== cur.contentHash) {
+          return 'stale-inputs';
+        }
+      }
+    }
+    return 'fresh';
+  }
+}

--- a/packages/core/src/store/envelope.ts
+++ b/packages/core/src/store/envelope.ts
@@ -1,0 +1,64 @@
+/**
+ * StoredArtifact — the KV value envelope. Byte-compatible with the talmud
+ * worker's stored RunResult / RunResultEnrichment (every legacy field stays at
+ * TOP level so existing entries parse unchanged); the model-shaped additions
+ * (`provenance`, `anchors`) are two optional fields old readers ignore.
+ *
+ * Deliberately EXCLUDED: `total_ms`, `stale`, `refreshing` — those are
+ * RESPONSE-time injections the /api/run cache-hit path spreads on top
+ * (`{ ...result, cache_hit: true, total_ms: 0, stale, refreshing }`); they are
+ * never written to KV (verified against every writeCachedResult call site).
+ */
+
+import type { Anchor } from '../model/anchor.ts';
+import type { Authority, CostStamp, Provenance } from '../model/provenance.ts';
+import { provenanceOf } from '../model/provenance.ts';
+
+export interface StoredArtifact {
+  content: string;
+  reasoning?: string;
+  parsed: unknown;
+  parse_error: string | null;
+  model: string;
+  transport: string;
+  attempts: number;
+  usage: unknown;
+  elapsed_ms: number;
+  prompt_chars: number;
+  resolved: { system_prompt: string; user_prompt: string };
+  cache_hit: boolean;
+  /** Deterministic post-generation lint issues (hard issues that gated the
+   *  cache write). Empty array means clean; absent on older entries. */
+  lint_issues?: unknown[];
+  /** Full standardized check-layer output (all severities). Observe-only. */
+  check_issues?: unknown[];
+  /** Content hash of the producer's recipe at generation time (recipeHash in
+   *  cache/keys.ts). Absent on entries written before the stamp existed. */
+  recipe_hash?: string;
+  /** Generation cost stamped at write time — the permanent per-entry ledger.
+   *  Absent on computed (no-LLM) marks and on pre-stamp entries. */
+  cost?: CostStamp | null;
+  // --- RunResultEnrichment extras (absent on mark entries) ---
+  deps_resolved?: Record<string, unknown>;
+  anchors_resolved?: Record<string, unknown>;
+  /** Segment range (`${startSegIdx}-${endSegIdx}`) a section enrichment was
+   *  computed for; the hot path refuses a hit whose stamp mismatches. */
+  section_range?: string;
+  // --- NEW (additive; old readers ignore) ---
+  provenance?: Provenance;
+  anchors?: Anchor[];
+}
+
+/**
+ * Who decided this artifact's content. Native model-era entries carry it
+ * first-class on `provenance.authority`; legacy entries derive it from the
+ * transport exactly the way {@link provenanceOf} does (LLM transports → 'ai',
+ * everything else — 'computed', 'graph', 'lookup', … — → 'rule'). Delegating
+ * to provenanceOf keeps the transport classification in ONE place.
+ */
+export function authorityOf(stored: StoredArtifact): Authority {
+  return (
+    stored.provenance?.authority ??
+    provenanceOf(stored, stored.provenance?.producerId ?? '').authority
+  );
+}

--- a/packages/core/src/store/key-schemes.ts
+++ b/packages/core/src/store/key-schemes.ts
@@ -1,0 +1,176 @@
+/**
+ * KeyScheme — how an ArtifactStore turns (producer, address) into a KV key.
+ *
+ * Two schemes exist:
+ *  - {@link talmudLegacyKeyScheme} DELEGATES to the frozen byte-exact contract
+ *    in cache/keys.ts (`keyForMark` / `keyForEnrichment` / `previousVersionKey`)
+ *    — it never re-implements the key shape, so the production KV cache can
+ *    never cold-miss from a drift here.
+ *  - {@link templateKeyScheme} carries per-producer-id literal key templates
+ *    (the tanach app's `events:v2:{book}:{chapter}` family), copied EXACTLY
+ *    from the app's hand-built keys.
+ *
+ * Addresses arrive PRE-DERIVED: `instanceId` is already the instanceIdOf()
+ * output and `qualifier` already the qualifierHash() output (both async hash
+ * derivations), which is what keeps `KeyScheme.key` synchronous — the key
+ * functions in cache/keys.ts are themselves sync.
+ */
+
+import type { EnrichmentScope } from '../cache/keys.ts';
+import { keyForEnrichment, keyForMark, previousVersionKey } from '../cache/keys.ts';
+
+/** The producer fields key derivation needs. */
+export interface ProducerKeyInfo {
+  id: string;
+  cacheVersion: string;
+  scope: EnrichmentScope;
+  key_shape: 'mark' | 'enrich';
+  /** Whether the producer's extractor declares a Hebrew system prompt.
+   *  Production rule (cacheKeyForRunBody): a lang='he' MARK request keys onto
+   *  the ':he' namespace ONLY when the def has a Hebrew prompt — otherwise it
+   *  collapses to the English key (computed marks, he-less marks). Enrichments
+   *  always key by the requested lang. Getting this wrong cold-misses or
+   *  orphans entries, so derive it via {@link producerKeyInfo} rather than
+   *  hand-setting. */
+  hasHePrompt?: boolean;
+}
+
+/** Derive ProducerKeyInfo from any Producer-shaped object, including the
+ *  hasHePrompt flag off the recipe's extractor. Use this instead of passing a
+ *  full Producer structurally — a Producer lacks hasHePrompt as an own field,
+ *  and defaulting it to false would mis-key Hebrew-prompted marks. */
+export function producerKeyInfo(p: {
+  id: string;
+  cacheVersion: string;
+  scope: EnrichmentScope;
+  key_shape: 'mark' | 'enrich';
+  hasHePrompt?: boolean;
+  recipe?: { extractor?: unknown };
+}): ProducerKeyInfo {
+  const ext = (p.recipe?.extractor ?? {}) as { system_prompt_he?: unknown };
+  return {
+    id: p.id,
+    cacheVersion: p.cacheVersion,
+    scope: p.scope,
+    key_shape: p.key_shape,
+    hasHePrompt:
+      p.hasHePrompt ??
+      (typeof ext.system_prompt_he === 'string' && ext.system_prompt_he.length > 0),
+  };
+}
+
+/** Where an artifact sits, key-wise. */
+export interface ArtifactAddress {
+  /** ALREADY instanceIdOf-derived (e.g. 'abaye', 'f35cd02cd97b'). */
+  instanceId?: string;
+  /** Spine locator: talmud `{work: tractate, unit: page}`; tanach
+   *  `{work: book, unit: chapter}`. `unit` may be omitted where the key
+   *  doesn't need it (global enrichments, work-level templates). */
+  unit?: { work: string; unit?: string };
+  /** ALREADY qualifierHash-derived (e.g. the hashed user question). */
+  qualifier?: string;
+  lang?: 'en' | 'he';
+}
+
+export interface KeyScheme {
+  key(p: ProducerKeyInfo, addr: ArtifactAddress): string;
+  /** The previous-cache_version key (stale-while-revalidate source), or null
+   *  when there is no decrementable previous version. */
+  previousKey(key: string, p: ProducerKeyInfo): string | null;
+  /** Optional alias keys to try on read when the canonical key misses.
+   *  Reads-only — writes always go to the canonical key. */
+  legacyKeys?(p: ProducerKeyInfo, addr: ArtifactAddress): string[];
+}
+
+/**
+ * The talmud (and any registry-keyed) scheme: pure delegation to cache/keys.ts.
+ *
+ *  - key_shape 'mark'   → keyForMark, requires `unit.work` + `unit.unit`
+ *                         (tractate + page).
+ *  - key_shape 'enrich' → keyForEnrichment; the daf argument is passed for
+ *                         scope='local' (uses tractate+page) and scope='spine'
+ *                         (uses the tractate only — keyForEnrichment slugs just
+ *                         `daf.tractate`; a missing page is tolerated there
+ *                         because the page never reaches the key), and omitted
+ *                         for scope='global'. Missing-daf errors surface from
+ *                         keyForEnrichment itself, byte-identical to production.
+ */
+export function talmudLegacyKeyScheme(): KeyScheme {
+  return {
+    key(p, addr) {
+      if (p.key_shape === 'mark') {
+        if (!addr.unit?.work || addr.unit.unit === undefined) {
+          throw new Error(`mark producer ${p.id} needs unit {work, unit} (tractate, page)`);
+        }
+        // Production lang rule (cacheKeyForRunBody): ':he' only when the mark
+        // declares a Hebrew prompt; otherwise a he request keys onto the
+        // English entry. Enrichments below key by the requested lang always.
+        const lang = addr.lang === 'he' && p.hasHePrompt ? 'he' : 'en';
+        return keyForMark(
+          { id: p.id, cache_version: p.cacheVersion },
+          addr.unit.work,
+          addr.unit.unit,
+          lang,
+        );
+      }
+      if (addr.instanceId === undefined) {
+        throw new Error(`enrich producer ${p.id} needs an instanceId (instanceIdOf-derived)`);
+      }
+      // scope='local' keys on tractate+page — a missing page must FAIL, not
+      // silently derive a ':berakhot:' key. scope='spine' only reads
+      // daf.tractate inside keyForEnrichment, so a page-less unit is fine
+      // there ('' never reaches the key bytes).
+      if (p.scope === 'local' && (!addr.unit?.work || addr.unit.unit === undefined)) {
+        throw new Error(`local enrich producer ${p.id} needs unit {work, unit} (tractate, page)`);
+      }
+      const daf =
+        p.scope === 'global' || !addr.unit
+          ? undefined
+          : { tractate: addr.unit.work, page: addr.unit.unit ?? '' };
+      return keyForEnrichment(
+        { id: p.id, cache_version: p.cacheVersion, scope: p.scope },
+        addr.instanceId,
+        daf,
+        addr.qualifier,
+        addr.lang ?? 'en',
+      );
+    },
+    previousKey(key, p) {
+      return previousVersionKey(key, p.id, p.cacheVersion);
+    },
+  };
+}
+
+/** One literal key template: `key` builds the canonical key from the address
+ *  (extra app-specific fields — verse, start/end, norm — ride along on the
+ *  open record); `previous` and `legacy` are optional per-template hooks. */
+export interface KeyTemplate {
+  key(addr: ArtifactAddress & Record<string, unknown>): string;
+  previous?(key: string, p: ProducerKeyInfo): string | null;
+  /** Alias keys to try on read when the canonical key misses. */
+  legacy?(addr: ArtifactAddress & Record<string, unknown>): string[];
+}
+
+/**
+ * Per-producer-id literal key templates — for apps (tanach) whose cache keys
+ * are hand-built strings rather than registry-derived. The templates must be
+ * copied byte-exactly from the app's code; this scheme only routes by id.
+ */
+export function templateKeyScheme(templates: Record<string, KeyTemplate>): KeyScheme {
+  const templateOf = (id: string): KeyTemplate => {
+    const t = templates[id];
+    if (!t) throw new Error(`no key template registered for producer ${id}`);
+    return t;
+  };
+  return {
+    key(p, addr) {
+      return templateOf(p.id).key(addr as ArtifactAddress & Record<string, unknown>);
+    },
+    previousKey(key, p) {
+      return templateOf(p.id).previous?.(key, p) ?? null;
+    },
+    legacyKeys(p, addr) {
+      return templateOf(p.id).legacy?.(addr as ArtifactAddress & Record<string, unknown>) ?? [];
+    },
+  };
+}

--- a/packages/core/tests/artifact-store.test.ts
+++ b/packages/core/tests/artifact-store.test.ts
@@ -1,0 +1,411 @@
+/**
+ * ArtifactStore behavior over an in-memory KV: envelope round-trip (legacy and
+ * model-era), the human-edit guard matrix, SWR reads across a version bump,
+ * alias reads, generalized staleness, and the corrupted-JSON read contract
+ * (null, mirroring the worker's readCachedResult).
+ */
+
+import { describe, expect, it } from 'vitest';
+import { recipeHash } from '../src/cache/keys.ts';
+import type { Authority, Provenance } from '../src/model/provenance.ts';
+import { ArtifactStore, type KVStore } from '../src/store/artifact-store.ts';
+import { authorityOf, type StoredArtifact } from '../src/store/envelope.ts';
+import type { ArtifactAddress } from '../src/store/key-schemes.ts';
+import { talmudLegacyKeyScheme, templateKeyScheme } from '../src/store/key-schemes.ts';
+
+function memoryKV(initial: Record<string, string> = {}): { kv: KVStore; raw: Map<string, string> } {
+  const raw = new Map(Object.entries(initial));
+  return {
+    raw,
+    kv: {
+      get: async (k) => raw.get(k) ?? null,
+      put: async (k, v) => {
+        raw.set(k, v);
+      },
+      delete: async (k) => {
+        raw.delete(k);
+      },
+    },
+  };
+}
+
+/** A legacy envelope — exactly the fields every stored vintage carries. */
+const LEGACY: StoredArtifact = {
+  content: '{"instances":[]}',
+  parsed: { instances: [] },
+  parse_error: null,
+  model: '@cf/meta/llama-3.3-70b-instruct-fp8-fast',
+  transport: 'workers-ai',
+  attempts: 2,
+  usage: { input_tokens: 11, output_tokens: 7, total_tokens: 18 },
+  elapsed_ms: 999,
+  prompt_chars: 222,
+  resolved: { system_prompt: 'legacy sys', user_prompt: 'legacy usr' },
+  cache_hit: false,
+};
+
+function provenance(authority: Authority, extra: Partial<Provenance> = {}): Provenance {
+  return { authority, producerId: 'test.producer', inputs: [], createdAt: '', ...extra };
+}
+
+/** A model-era envelope: every optional field populated, incl. the additive ones. */
+const MODERN: StoredArtifact = {
+  ...LEGACY,
+  reasoning: 'thought about it',
+  transport: 'openrouter-gateway',
+  lint_issues: [],
+  check_issues: [{ check: 'anchor-verbatim', severity: 'soft' }],
+  recipe_hash: 'abc123def456',
+  cost: {
+    billedUsd: 0.0042,
+    estimatedUsd: 0.005,
+    costInUsd: 0.003,
+    costOutUsd: 0.002,
+    tokensIn: 1500,
+    tokensOut: 600,
+    lang: 'en',
+    cacheVersion: '5',
+    computedAt: 1750000000000,
+  },
+  deps_resolved: { 'argument.voices': { voices: [] } },
+  anchors_resolved: { rabbi: [{ fields: { name: 'Abaye' } }] },
+  section_range: '2-5',
+  provenance: provenance('ai', { recipeHash: 'abc123def456', model: 'deepseek' }),
+  anchors: [{ spine: 'bavli', span: [{ path: ['Berakhot', '5a', 3] }], precision: 'segment' }],
+};
+
+function store(initial: Record<string, string> = {}) {
+  const { kv, raw } = memoryKV(initial);
+  return { store: new ArtifactStore(kv, talmudLegacyKeyScheme()), raw };
+}
+
+describe('put/get round-trip', () => {
+  it('a modern envelope (provenance + anchors included) survives intact', async () => {
+    const { store: s } = store();
+    expect(await s.put('k', MODERN)).toEqual({ ok: true });
+    expect(await s.get('k')).toEqual(MODERN);
+  });
+
+  it('a legacy envelope (no provenance) reads fine and derives authority', async () => {
+    const { store: s } = store({ legacy: JSON.stringify(LEGACY) });
+    const hit = await s.get('legacy');
+    expect(hit).toEqual(LEGACY);
+    // workers-ai is an LLM transport → 'ai'; a computed transport → 'rule'.
+    expect(authorityOf(hit as StoredArtifact)).toBe('ai');
+    expect(authorityOf({ ...LEGACY, transport: 'computed' })).toBe('rule');
+    expect(authorityOf(MODERN)).toBe('ai');
+    expect(authorityOf({ ...LEGACY, provenance: provenance('human') })).toBe('human');
+  });
+
+  it('get on a miss returns null', async () => {
+    const { store: s } = store();
+    expect(await s.get('nope')).toBeNull();
+  });
+
+  it('get on corrupted JSON returns null (mirrors readCachedResult)', async () => {
+    const { store: s } = store({ bad: '{not json' });
+    expect(await s.get('bad')).toBeNull();
+  });
+});
+
+describe('human-edit guard', () => {
+  const HUMAN = { ...LEGACY, provenance: provenance('human') };
+  const RULE = { ...LEGACY, provenance: provenance('rule') };
+  const AI = { ...LEGACY, provenance: provenance('ai') };
+
+  async function attempt(
+    existing: StoredArtifact | null,
+    incoming: StoredArtifact,
+    opts?: { force?: boolean },
+  ) {
+    const { store: s, raw } = store(existing ? { k: JSON.stringify(existing) } : {});
+    const result = await s.put('k', incoming, opts);
+    return { result, stored: raw.get('k') ?? null };
+  }
+
+  it('AI over human is refused (entry untouched)', async () => {
+    const { result, stored } = await attempt(HUMAN, AI);
+    expect(result).toEqual({ ok: false, reason: 'human-locked' });
+    expect(stored).toBe(JSON.stringify(HUMAN));
+  });
+
+  it('rule over human is refused', async () => {
+    const { result } = await attempt(HUMAN, RULE);
+    expect(result).toEqual({ ok: false, reason: 'human-locked' });
+  });
+
+  it('legacy (no provenance) over human is refused', async () => {
+    const { result } = await attempt(HUMAN, LEGACY);
+    expect(result).toEqual({ ok: false, reason: 'human-locked' });
+  });
+
+  it('human over human writes', async () => {
+    const edited = { ...HUMAN, content: 'edited again' };
+    const { result, stored } = await attempt(HUMAN, edited);
+    expect(result).toEqual({ ok: true });
+    expect(stored).toBe(JSON.stringify(edited));
+  });
+
+  it('force + human writes', async () => {
+    const { result } = await attempt(HUMAN, { ...HUMAN, content: 'forced' }, { force: true });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('force + AI is STILL refused (force cannot launder authority)', async () => {
+    const { result, stored } = await attempt(HUMAN, AI, { force: true });
+    expect(result).toEqual({ ok: false, reason: 'human-locked' });
+    expect(stored).toBe(JSON.stringify(HUMAN));
+  });
+
+  it('AI over AI writes', async () => {
+    const next = { ...AI, content: 'regenerated' };
+    const { result, stored } = await attempt(AI, next);
+    expect(result).toEqual({ ok: true });
+    expect(stored).toBe(JSON.stringify(next));
+  });
+
+  it('write to empty writes', async () => {
+    const { result, stored } = await attempt(null, AI);
+    expect(result).toEqual({ ok: true });
+    expect(stored).toBe(JSON.stringify(AI));
+  });
+
+  it('AI over human even when the existing entry is human BUT the new one carries no provenance', async () => {
+    // (Same as the legacy case above, kept explicit: absence of provenance is
+    // not-human, so it cannot replace a human edit.)
+    const { result } = await attempt(HUMAN, { ...LEGACY, provenance: undefined });
+    expect(result).toEqual({ ok: false, reason: 'human-locked' });
+  });
+});
+
+describe('getSWR', () => {
+  const BIO = { id: 'rabbi.bio', cacheVersion: '5', scope: 'global', key_shape: 'enrich' } as const;
+  const ADDR = { instanceId: 'abaye' };
+  const CANONICAL = 'enrich:rabbi.bio:5:abaye';
+  const PREVIOUS = 'enrich:rabbi.bio:4:abaye';
+
+  it('canonical hit → stale:false, served from the canonical key', async () => {
+    const { store: s } = store({ [CANONICAL]: JSON.stringify(MODERN) });
+    expect(await s.getSWR(BIO, ADDR)).toEqual({
+      canonicalKey: CANONICAL,
+      servedKey: CANONICAL,
+      value: MODERN,
+      stale: false,
+    });
+  });
+
+  it('canonical miss, previous-version hit → stale:true, canonicalKey still the refresh target', async () => {
+    // canonicalKey is what a refresh job/write-through targets; servedKey is
+    // only where the bytes came from. Returning the previous key as THE key
+    // would point the refresh at the dying version.
+    const { store: s } = store({ [PREVIOUS]: JSON.stringify(LEGACY) });
+    expect(await s.getSWR(BIO, ADDR)).toEqual({
+      canonicalKey: CANONICAL,
+      servedKey: PREVIOUS,
+      value: LEGACY,
+      stale: true,
+    });
+  });
+
+  it('both miss → null, canonical keys, stale:false', async () => {
+    const { store: s } = store();
+    expect(await s.getSWR(BIO, ADDR)).toEqual({
+      canonicalKey: CANONICAL,
+      servedKey: CANONICAL,
+      value: null,
+      stale: false,
+    });
+  });
+
+  it('version 1 has no previous key → plain miss', async () => {
+    const { store: s } = store();
+    const v1 = { ...BIO, cacheVersion: '1' };
+    expect(await s.getSWR(v1, ADDR)).toEqual({
+      canonicalKey: 'enrich:rabbi.bio:1:abaye',
+      servedKey: 'enrich:rabbi.bio:1:abaye',
+      value: null,
+      stale: false,
+    });
+  });
+
+  it('accept guards the CANONICAL read (section_range-style mismatch falls through)', async () => {
+    // Production's section_range guard: a cached section enrichment whose
+    // stored range no longer matches the requested instance must not be
+    // served. With the canonical entry rejected and no previous entry, the
+    // read is a miss.
+    const mismatched = { ...MODERN, section_range: '0-3' };
+    const { store: s } = store({ [CANONICAL]: JSON.stringify(mismatched) });
+    const result = await s.getSWR(BIO, ADDR, {
+      accept: (v) => v.section_range === '4-7',
+    });
+    expect(result).toEqual({
+      canonicalKey: CANONICAL,
+      servedKey: CANONICAL,
+      value: null,
+      stale: false,
+    });
+  });
+
+  it('accept guards the PREVIOUS read too (no wrong-section stale serves)', async () => {
+    const mismatchedPrev = { ...LEGACY, section_range: '0-3' };
+    const matchingPrev = { ...LEGACY, section_range: '4-7' };
+    const { store: s } = store({ [PREVIOUS]: JSON.stringify(mismatchedPrev) });
+    expect(
+      (await s.getSWR(BIO, ADDR, { accept: (v) => v.section_range === '4-7' })).value,
+    ).toBeNull();
+    const { store: s2 } = store({ [PREVIOUS]: JSON.stringify(matchingPrev) });
+    expect(await s2.getSWR(BIO, ADDR, { accept: (v) => v.section_range === '4-7' })).toEqual({
+      canonicalKey: CANONICAL,
+      servedKey: PREVIOUS,
+      value: matchingPrev,
+      stale: true,
+    });
+  });
+});
+
+describe('getWithAliases', () => {
+  type A = ArtifactAddress & Record<string, unknown>;
+  const scheme = templateKeyScheme({
+    events: {
+      key: (a: A) => `events:v2:${a.unit?.work}:${a.unit?.unit}`,
+      legacy: (a: A) => [`events:v1:${a.unit?.work}:${a.unit?.unit}`],
+    },
+  });
+  const EVENTS = { id: 'events', cacheVersion: '2', scope: 'local', key_shape: 'enrich' } as const;
+  const ADDR = { unit: { work: 'Genesis', unit: '1' } };
+
+  it('canonical hit wins (aliases never read)', async () => {
+    const { kv, raw } = memoryKV({
+      'events:v2:Genesis:1': JSON.stringify(MODERN),
+      'events:v1:Genesis:1': JSON.stringify(LEGACY),
+    });
+    const s = new ArtifactStore(kv, scheme);
+    expect(await s.getWithAliases(EVENTS, ADDR)).toEqual({
+      key: 'events:v2:Genesis:1',
+      value: MODERN,
+    });
+    expect(raw.size).toBe(2);
+  });
+
+  it('canonical miss → alias hit, but the returned key stays CANONICAL', async () => {
+    const { kv } = memoryKV({ 'events:v1:Genesis:1': JSON.stringify(LEGACY) });
+    const s = new ArtifactStore(kv, scheme);
+    expect(await s.getWithAliases(EVENTS, ADDR)).toEqual({
+      key: 'events:v2:Genesis:1',
+      value: LEGACY,
+    });
+  });
+
+  it('writes go to the canonical key only — no store-side alias writes', async () => {
+    const { kv, raw } = memoryKV();
+    const s = new ArtifactStore(kv, scheme);
+    const key = s.keyFor(EVENTS, ADDR);
+    expect(key).toBe('events:v2:Genesis:1');
+    await s.put(key, LEGACY);
+    expect([...raw.keys()]).toEqual(['events:v2:Genesis:1']);
+  });
+
+  it('both miss → null under the canonical key', async () => {
+    const { kv } = memoryKV();
+    const s = new ArtifactStore(kv, scheme);
+    expect(await s.getWithAliases(EVENTS, ADDR)).toEqual({
+      key: 'events:v2:Genesis:1',
+      value: null,
+    });
+  });
+});
+
+describe('staleness', () => {
+  const RECIPE = { extractor: { kind: 'llm', system_prompt: 'do the thing' } };
+
+  it('fresh: stored hash equals the current recipe hash', async () => {
+    const { store: s } = store();
+    const hash = await recipeHash(RECIPE);
+    expect(await s.staleness({ ...LEGACY, recipe_hash: hash }, { recipe: RECIPE })).toBe('fresh');
+    expect(await s.staleness({ ...LEGACY, recipe_hash: hash }, { recipeHash: hash })).toBe('fresh');
+  });
+
+  it('stale-recipe: stored hash differs from the current one', async () => {
+    const { store: s } = store();
+    expect(await s.staleness({ ...LEGACY, recipe_hash: 'older0hash00' }, { recipe: RECIPE })).toBe(
+      'stale-recipe',
+    );
+  });
+
+  it('unknown: no stored hash anywhere (pre-stamp entry)', async () => {
+    const { store: s } = store();
+    expect(await s.staleness(LEGACY, { recipe: RECIPE })).toBe('unknown');
+  });
+
+  it('falls back to provenance.recipeHash when the top-level stamp is absent', async () => {
+    const { store: s } = store();
+    const hash = await recipeHash(RECIPE);
+    const stored = { ...LEGACY, provenance: provenance('ai', { recipeHash: hash }) };
+    expect(await s.staleness(stored, { recipe: RECIPE })).toBe('fresh');
+  });
+
+  it('stale-inputs: a matched input contentHash differs', async () => {
+    const { store: s } = store();
+    const stored: StoredArtifact = {
+      ...LEGACY,
+      recipe_hash: 'samehash0000',
+      provenance: provenance('ai', {
+        inputs: [
+          { sourceKey: 'ctx:gemara:v1:berakhot:5a', contentHash: 'aaa' },
+          { artifactId: 'mark:argument:4:berakhot:5a', contentHash: 'bbb' },
+        ],
+      }),
+    };
+    expect(
+      await s.staleness(stored, { recipeHash: 'samehash0000' }, [
+        { artifactId: 'mark:argument:4:berakhot:5a', contentHash: 'CHANGED' },
+      ]),
+    ).toBe('stale-inputs');
+    expect(
+      await s.staleness(stored, { recipeHash: 'samehash0000' }, [
+        { sourceKey: 'ctx:gemara:v1:berakhot:5a', contentHash: 'CHANGED' },
+      ]),
+    ).toBe('stale-inputs');
+  });
+
+  it('fresh with matching inputs (and tolerant of hash-less / unmatched ones)', async () => {
+    const { store: s } = store();
+    const stored: StoredArtifact = {
+      ...LEGACY,
+      recipe_hash: 'samehash0000',
+      provenance: provenance('ai', {
+        inputs: [{ sourceKey: 'ctx:gemara:v1:berakhot:5a', contentHash: 'aaa' }],
+      }),
+    };
+    expect(
+      await s.staleness(stored, { recipeHash: 'samehash0000' }, [
+        { sourceKey: 'ctx:gemara:v1:berakhot:5a', contentHash: 'aaa' },
+        { sourceKey: 'ctx:gemara:v1:berakhot:5a' }, // no current hash → not comparable
+        { sourceKey: 'never-stored', contentHash: 'zzz' }, // no stored counterpart
+      ]),
+    ).toBe('fresh');
+  });
+
+  it('recipe mismatch wins over input comparison (checked first)', async () => {
+    const { store: s } = store();
+    const stored: StoredArtifact = {
+      ...LEGACY,
+      recipe_hash: 'old0hash0000',
+      provenance: provenance('ai', { inputs: [{ sourceKey: 'k', contentHash: 'aaa' }] }),
+    };
+    expect(
+      await s.staleness(stored, { recipeHash: 'new0hash0000' }, [
+        { sourceKey: 'k', contentHash: 'CHANGED' },
+      ]),
+    ).toBe('stale-recipe');
+  });
+});
+
+describe('evict', () => {
+  it('deletes the entry', async () => {
+    const { store: s, raw } = store({ k: JSON.stringify(LEGACY) });
+    await s.evict('k');
+    expect(raw.has('k')).toBe(false);
+    expect(await s.get('k')).toBeNull();
+  });
+});

--- a/packages/core/tests/key-schemes.test.ts
+++ b/packages/core/tests/key-schemes.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Key-scheme parity — the load-bearing guarantee that the store layer can
+ * never cold-miss the production KV cache:
+ *
+ *  - talmudLegacyKeyScheme is byte-equal to keyForMark / keyForEnrichment,
+ *    asserted against LITERAL key strings copied from the PR #356 golden
+ *    snapshot (packages/talmud/tests/__snapshots__/producer-key-golden.test.ts.snap);
+ *  - previousKey is byte-equal to previousVersionKey;
+ *  - templateKeyScheme reproduces the tanach app's hand-built keys
+ *    byte-exactly (templates copied from packages/tanach/src/worker/index.ts).
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  instanceIdOf,
+  keyForEnrichment,
+  keyForMark,
+  previousVersionKey,
+  qualifierHash,
+} from '../src/cache/keys.ts';
+import type { ArtifactAddress, ProducerKeyInfo } from '../src/store/key-schemes.ts';
+import { talmudLegacyKeyScheme, templateKeyScheme } from '../src/store/key-schemes.ts';
+
+const DAF_UNIT = { work: 'Berakhot', unit: '5a' };
+
+function producer(
+  id: string,
+  cacheVersion: string,
+  scope: ProducerKeyInfo['scope'],
+  key_shape: ProducerKeyInfo['key_shape'],
+): ProducerKeyInfo {
+  return { id, cacheVersion, scope, key_shape };
+}
+
+describe('talmudLegacyKeyScheme — byte-equal to the frozen cache/keys contract', () => {
+  const scheme = talmudLegacyKeyScheme();
+
+  it('mark keys match the golden snapshot literals (Berakhot 5a)', () => {
+    // Literals copied from producer-key-golden.test.ts.snap:
+    //   "rabbi@4 mark lang=en  mark:rabbi:4:berakhot:5a"
+    //   "aggadata@4 mark lang=he->he mark:aggadata:4:he:berakhot:5a"
+    const rabbi = producer('rabbi', '4', 'local', 'mark');
+    expect(scheme.key(rabbi, { unit: DAF_UNIT, lang: 'en' })).toBe('mark:rabbi:4:berakhot:5a');
+    expect(scheme.key(rabbi, { unit: DAF_UNIT })).toBe('mark:rabbi:4:berakhot:5a'); // lang defaults en
+    const aggadata = { ...producer('aggadata', '4', 'local', 'mark'), hasHePrompt: true };
+    expect(scheme.key(aggadata, { unit: DAF_UNIT, lang: 'he' })).toBe(
+      'mark:aggadata:4:he:berakhot:5a',
+    );
+  });
+
+  it("mark ':he' namespace requires a Hebrew prompt — production's lang-collapse rule", () => {
+    // cacheKeyForRunBody: a lang='he' mark request keys onto the ':he'
+    // namespace ONLY when the def declares system_prompt_he; computed and
+    // he-less marks collapse to the English key. Deriving ':he' here for a
+    // he-less mark would orphan writes and cold-miss the production entries.
+    const heLess = producer('rabbi', '4', 'local', 'mark'); // hasHePrompt absent → false
+    expect(scheme.key(heLess, { unit: DAF_UNIT, lang: 'he' })).toBe(
+      keyForMark({ id: 'rabbi', cache_version: '4' }, 'Berakhot', '5a', 'en'),
+    );
+    const hePrompted = { ...producer('aggadata', '4', 'local', 'mark'), hasHePrompt: true };
+    expect(scheme.key(hePrompted, { unit: DAF_UNIT, lang: 'he' })).toBe(
+      keyForMark({ id: 'aggadata', cache_version: '4' }, 'Berakhot', '5a', 'he'),
+    );
+    // en requests never touch the ':he' namespace either way.
+    expect(scheme.key(hePrompted, { unit: DAF_UNIT, lang: 'en' })).toBe(
+      keyForMark({ id: 'aggadata', cache_version: '4' }, 'Berakhot', '5a', 'en'),
+    );
+  });
+
+  it('global enrichment keys match the golden snapshot literals', async () => {
+    // Literals copied from producer-key-golden.test.ts.snap:
+    //   "rabbi.bio@5 enrich inst=named lang=en enrich:rabbi.bio:5:abaye"
+    //   "rabbi.bio@5 enrich inst=named lang=he enrich:rabbi.bio:5:he:abaye"
+    //   "rabbi.bio@5 enrich inst=daf lang=en enrich:rabbi.bio:5:f35cd02cd97b"
+    const bio = producer('rabbi.bio', '5', 'global', 'enrich');
+    const named = await instanceIdOf({ fields: { name: 'Abaye' } });
+    const wholeDaf = await instanceIdOf({ fields: {} });
+    expect(named).toBe('abaye');
+    expect(wholeDaf).toBe('f35cd02cd97b');
+    expect(scheme.key(bio, { instanceId: named, lang: 'en' })).toBe('enrich:rabbi.bio:5:abaye');
+    expect(scheme.key(bio, { instanceId: named, lang: 'he' })).toBe('enrich:rabbi.bio:5:he:abaye');
+    expect(scheme.key(bio, { instanceId: wholeDaf })).toBe('enrich:rabbi.bio:5:f35cd02cd97b');
+    // A supplied unit must NOT leak into a global key (production omits daf).
+    expect(scheme.key(bio, { instanceId: named, unit: DAF_UNIT })).toBe('enrich:rabbi.bio:5:abaye');
+  });
+
+  it('local enrichment keys match the golden snapshot literals', async () => {
+    // Literals copied from producer-key-golden.test.ts.snap:
+    //   "aggadata.synthesis@3 enrich inst=named lang=en enrich:aggadata.synthesis:3:abaye:berakhot:5a"
+    //   "aggadata.synthesis@3 enrich inst=named lang=he enrich:aggadata.synthesis:3:he:abaye:berakhot:5a"
+    const synthesis = producer('aggadata.synthesis', '3', 'local', 'enrich');
+    const named = await instanceIdOf({ fields: { name: 'Abaye' } });
+    expect(scheme.key(synthesis, { instanceId: named, unit: DAF_UNIT, lang: 'en' })).toBe(
+      'enrich:aggadata.synthesis:3:abaye:berakhot:5a',
+    );
+    expect(scheme.key(synthesis, { instanceId: named, unit: DAF_UNIT, lang: 'he' })).toBe(
+      'enrich:aggadata.synthesis:3:he:abaye:berakhot:5a',
+    );
+  });
+
+  it('the qualified (.qa) key matches the golden snapshot literal', async () => {
+    // Literal copied from producer-key-golden.test.ts.snap:
+    //   "argument-move.qa@5 enrich inst=named lang=en q="What is the halacha?"
+    //    enrich:argument-move.qa:5:abaye:berakhot:5a:q_311ab477fd15"
+    const qa = producer('argument-move.qa', '5', 'local', 'enrich');
+    const named = await instanceIdOf({ fields: { name: 'Abaye' } });
+    const qHash = await qualifierHash('What is the halacha?');
+    expect(qHash).toBe('311ab477fd15');
+    expect(scheme.key(qa, { instanceId: named, unit: DAF_UNIT, qualifier: qHash })).toBe(
+      'enrich:argument-move.qa:5:abaye:berakhot:5a:q_311ab477fd15',
+    );
+  });
+
+  it('spine-scope keys mirror keyForEnrichment exactly (tractate-only tail)', async () => {
+    // No spine-scope def exists in the code registry yet, so there is no golden
+    // line to copy — parity against the delegate IS the contract here.
+    const spineDef = { id: 'test.spine', cache_version: '1', scope: 'spine' as const };
+    const spineProducer = producer('test.spine', '1', 'spine', 'enrich');
+    const named = await instanceIdOf({ fields: { name: 'Abaye' } });
+    const key = scheme.key(spineProducer, { instanceId: named, unit: DAF_UNIT });
+    expect(key).toBe(
+      keyForEnrichment(spineDef, named, { tractate: 'Berakhot', page: '5a' }, undefined, 'en'),
+    );
+    expect(key).toBe('enrich:test.spine:1:abaye:berakhot'); // tractate only, no page
+    // The page never reaches a spine key, so a page-less unit derives the same bytes.
+    expect(scheme.key(spineProducer, { instanceId: named, unit: { work: 'Berakhot' } })).toBe(key);
+  });
+
+  it('local scope REQUIRES a full unit — page-less addresses fail, never derive', async () => {
+    const synthesis = producer('aggadata.synthesis', '3', 'local', 'enrich');
+    const named = await instanceIdOf({ fields: { name: 'Abaye' } });
+    expect(() => scheme.key(synthesis, { instanceId: named })).toThrow(/needs unit/);
+    // A work-only unit must not silently derive an ':berakhot:' key with an
+    // empty page segment — that would be a new, wrong key namespace.
+    expect(() => scheme.key(synthesis, { instanceId: named, unit: { work: 'Berakhot' } })).toThrow(
+      /needs unit/,
+    );
+  });
+
+  it('previousKey is byte-equal to previousVersionKey', () => {
+    const cases: Array<[string, ProducerKeyInfo]> = [
+      ['enrich:rabbi.bio:5:abaye', producer('rabbi.bio', '5', 'global', 'enrich')],
+      ['enrich:rabbi.bio:5:he:abaye', producer('rabbi.bio', '5', 'global', 'enrich')],
+      [
+        'enrich:aggadata.synthesis:3:abaye:berakhot:5a',
+        producer('aggadata.synthesis', '3', 'local', 'enrich'),
+      ],
+      ['mark:rabbi:4:berakhot:5a', producer('rabbi', '4', 'local', 'mark')],
+      ['enrich:tidbit:1:f35cd02cd97b', producer('tidbit', '1', 'global', 'enrich')], // v1 → null
+      ['enrich:thing:v2:abc', producer('thing', 'v2', 'global', 'enrich')], // non-numeric → null
+    ];
+    for (const [key, p] of cases) {
+      expect(scheme.previousKey(key, p), key).toBe(previousVersionKey(key, p.id, p.cacheVersion));
+    }
+    // And the literal decrement, so the SWR shape is visible in the test.
+    expect(
+      scheme.previousKey(
+        'enrich:rabbi.bio:5:abaye',
+        producer('rabbi.bio', '5', 'global', 'enrich'),
+      ),
+    ).toBe('enrich:rabbi.bio:4:abaye');
+    expect(
+      scheme.previousKey(
+        'enrich:tidbit:1:f35cd02cd97b',
+        producer('tidbit', '1', 'global', 'enrich'),
+      ),
+    ).toBeNull();
+  });
+});
+
+describe('templateKeyScheme — the tanach literal key family', () => {
+  // Templates copied byte-exactly from packages/tanach/src/worker/index.ts:
+  //   `events:v2:${book}:${chapter}`
+  //   `note:v1:${book}:${chapter}:${start}-${end}`
+  //   `synthesis:v1:${book}:${chapter}:${verse}`
+  //   `midrash:v1:${book}:${chapter}:${verse}`
+  //   `midrash-synth:v1:${book}:${chapter}:${verse}`   (producer: midrash-synthesis)
+  // book/chapter ride in addr.unit ({work: book, unit: chapter}); verse and
+  // start/end ride as open extra fields. Producer IDS are the app's producer
+  // names; the key PREFIX is whatever literal the app stored under — they need
+  // not match (midrash-synthesis writes midrash-synth:v1:* keys).
+  //
+  // tanach's `translate:v1:${norm}` cache is deliberately NOT modeled here: it
+  // stores a RAW STRING with a 30-day TTL, not a StoredArtifact envelope, so
+  // it stays outside ArtifactStore (decided at the tanach migration stage).
+  type A = ArtifactAddress & Record<string, unknown>;
+  const scheme = templateKeyScheme({
+    events: { key: (a: A) => `events:v2:${a.unit?.work}:${a.unit?.unit}` },
+    note: { key: (a: A) => `note:v1:${a.unit?.work}:${a.unit?.unit}:${a.start}-${a.end}` },
+    synthesis: { key: (a: A) => `synthesis:v1:${a.unit?.work}:${a.unit?.unit}:${a.verse}` },
+    midrash: { key: (a: A) => `midrash:v1:${a.unit?.work}:${a.unit?.unit}:${a.verse}` },
+    'midrash-synthesis': {
+      key: (a: A) => `midrash-synth:v1:${a.unit?.work}:${a.unit?.unit}:${a.verse}`,
+    },
+  });
+  const p = (id: string) => producer(id, '1', 'local', 'enrich');
+
+  it('reproduces every tanach key byte-exactly', () => {
+    expect(scheme.key(p('events'), { unit: { work: 'Genesis', unit: '1' } })).toBe(
+      'events:v2:Genesis:1',
+    );
+    expect(
+      scheme.key(p('note'), { unit: { work: 'Genesis', unit: '1' }, start: 3, end: 5 } as A),
+    ).toBe('note:v1:Genesis:1:3-5');
+    expect(
+      scheme.key(p('synthesis'), { unit: { work: 'Genesis', unit: '1' }, verse: '1' } as A),
+    ).toBe('synthesis:v1:Genesis:1:1');
+    expect(scheme.key(p('midrash'), { unit: { work: 'Exodus', unit: '3' }, verse: '2' } as A)).toBe(
+      'midrash:v1:Exodus:3:2',
+    );
+    // Producer id and key prefix differ on purpose — the id routes, the
+    // template owns the literal bytes.
+    expect(
+      scheme.key(p('midrash-synthesis'), { unit: { work: 'Exodus', unit: '3' }, verse: '2' } as A),
+    ).toBe('midrash-synth:v1:Exodus:3:2');
+  });
+
+  it('previousKey defaults to null (no version segment in the templates)', () => {
+    expect(scheme.previousKey('events:v2:Genesis:1', p('events'))).toBeNull();
+  });
+
+  it('throws on an unregistered producer id', () => {
+    expect(() => scheme.key(p('unknown'), {})).toThrow(/no key template/);
+  });
+});

--- a/packages/talmud/tests/store-key-parity.test.ts
+++ b/packages/talmud/tests/store-key-parity.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Store-vs-legacy key parity over the REAL registry — the load-bearing proof
+ * for the migration: for EVERY code-defined mark and enrichment, the new
+ * ArtifactStore (talmudLegacyKeyScheme over the projected Producer) derives a
+ * key byte-equal to the legacy derivation (keyForMark / keyForEnrichment),
+ * with the same fixtures as producer-key-golden.test.ts: Berakhot 5a, the
+ * named 'abaye' instance, the whole-daf hash instance, en + he, and the
+ * qualified `.qa` case. If this is green, adopting the store cannot cold-miss
+ * a single production KV entry.
+ */
+
+import { producerFromEnrichment, producerFromMark } from '@corpus/core/model/compat';
+import { ArtifactStore, type KVStore } from '@corpus/core/store/artifact-store';
+import { talmudLegacyKeyScheme } from '@corpus/core/store/key-schemes';
+import { describe, expect, it } from 'vitest';
+import {
+  instanceIdOf,
+  keyForEnrichment,
+  keyForMark,
+  qualifierHash,
+} from '../src/worker/cache-keys';
+import { CODE_ENRICHMENTS, CODE_MARKS } from '../src/worker/code-marks';
+
+const DAF = { tractate: 'Berakhot', page: '5a' } as const;
+const UNIT = { work: DAF.tractate, unit: DAF.page };
+const NAMED_INSTANCE = { fields: { name: 'Abaye' } };
+const WHOLE_DAF_INSTANCE = { fields: {} };
+
+const noopKV: KVStore = {
+  get: async () => null,
+  put: async () => {},
+  delete: async () => {},
+};
+const store = new ArtifactStore(noopKV, talmudLegacyKeyScheme());
+
+describe('ArtifactStore.keyFor parity with the legacy derivation (Berakhot 5a)', () => {
+  it('every CODE_MARKS def, en + he (with the production he-collapse rule)', () => {
+    // Parity target is the PRODUCTION derivation (cacheKeyForRunBody), not a
+    // bare keyForMark(lang): a lang='he' request keys onto ':he' only when the
+    // def declares system_prompt_he, else it collapses to the English key.
+    // The store implements this via hasHePrompt derived from the producer's
+    // recipe, so passing the full projected Producer must reproduce it.
+    expect(CODE_MARKS.length).toBeGreaterThan(0);
+    let heCollapsed = 0;
+    let heKept = 0;
+    for (const def of CODE_MARKS) {
+      const producer = producerFromMark(def);
+      const ext = def.extractor as { system_prompt_he?: string };
+      for (const lang of ['en', 'he'] as const) {
+        const resolved = lang === 'he' && ext.system_prompt_he ? 'he' : 'en';
+        if (lang === 'he') resolved === 'he' ? heKept++ : heCollapsed++;
+        expect(store.keyFor(producer, { unit: UNIT, lang }), `${def.id} lang=${lang}`).toBe(
+          keyForMark(def, DAF.tractate, DAF.page, resolved),
+        );
+      }
+    }
+    // The registry exercises BOTH branches of the rule (otherwise this test
+    // proves less than it claims).
+    expect(heCollapsed).toBeGreaterThan(0);
+    expect(heKept).toBeGreaterThan(0);
+  });
+
+  it('every CODE_ENRICHMENTS def, named + whole-daf instance, en + he', async () => {
+    expect(CODE_ENRICHMENTS.length).toBeGreaterThan(0);
+    const namedId = await instanceIdOf(NAMED_INSTANCE);
+    const wholeDafId = await instanceIdOf(WHOLE_DAF_INSTANCE);
+    expect(namedId).toBe('abaye');
+    for (const def of CODE_ENRICHMENTS) {
+      const producer = producerFromEnrichment(def);
+      // The legacy call sites (cacheKeyForRunBody / runEnrichmentOnce) pass the
+      // daf ONLY for scope='local'; the store passes addr.unit always and the
+      // scheme applies it per scope — parity proves the two agree.
+      const dafForKey = def.scope === 'local' ? DAF : undefined;
+      for (const instanceId of [namedId, wholeDafId]) {
+        for (const lang of ['en', 'he'] as const) {
+          expect(
+            store.keyFor(producer, { instanceId, unit: UNIT, lang }),
+            `${def.id} inst=${instanceId} lang=${lang}`,
+          ).toBe(keyForEnrichment(def, instanceId, dafForKey, undefined, lang));
+        }
+      }
+    }
+  });
+
+  it('the qualified .qa case (user question through qualifierHash)', async () => {
+    const qa = CODE_ENRICHMENTS.find((e) => e.id.endsWith('.qa'));
+    expect(qa, 'expected at least one .qa enrichment in the registry').toBeTruthy();
+    if (!qa) return;
+    const namedId = await instanceIdOf(NAMED_INSTANCE);
+    const qHash = await qualifierHash('What is the halacha?');
+    const producer = producerFromEnrichment(qa);
+    expect(store.keyFor(producer, { instanceId: namedId, unit: UNIT, qualifier: qHash })).toBe(
+      keyForEnrichment(qa, namedId, qa.scope === 'local' ? DAF : undefined, qHash, 'en'),
+    );
+  });
+});


### PR DESCRIPTION
Stage 3 of the four-primitive consolidation (#356 → #357 → this). The KV store layer at `@corpus/core/store` — additive only.

## What's here

- **`StoredArtifact`** — the legacy RunResult envelope field-for-field (existing entries parse unchanged) + optional `provenance`/`anchors`. Verified that response-time injections (`total_ms`/`stale`/`refreshing`) never enter the stored shape.
- **Key schemes** — `talmudLegacyKeyScheme` delegates every byte to the frozen `cache/keys.ts` contract; `templateKeyScheme` carries tanach's literal templates. The production **he-collapse rule** is implemented and locked: a `lang=he` mark request keys onto `:he` only when the def declares `system_prompt_he` (derived from the producer's recipe), enrichments key by requested lang always.
- **`ArtifactStore`** — `get` (parse-error→null, mirroring `readCachedResult`), `getSWR` (returns `canonicalKey` for refresh targeting + `servedKey` for the read source, with an `accept` predicate generalizing the `section_range` guard over both reads), `getWithAliases` (read aliases, write canonical), `put` with the **human-edit guard** (`provenance.authority='human'` entries are never overwritten by non-human writes — the standing rule becomes code), `evict`, and four-state `staleness` (recipe-hash leg mirrors `/api/stale`; input-hash leg is conservative).

## Review notes

Codex review surfaced six issues, all fixed: the he-collapse rule missing from mark keys (the one genuine cold-miss hazard), page-less local addresses silently deriving a wrong key namespace, `getSWR` returning the previous key as THE key (refresh jobs would have targeted the dying version), no accept hook for the section_range guard, tanach's `translate` raw-string+TTL cache mismodeled as an artifact (now documented out of scope), and the `midrash-synthesis` producer id vs `midrash-synth:` key prefix conflation.

Tests: 42 new core tests + a talmud parity test deriving keys for every registry def through the store, byte-equal to the production derivation including both branches of the he rule. Full suite: core 103, talmud 2046, tanach 19; typecheck + biome clean.