### PR TITLE
Unified producer registry: one KV+code resolution behind both loaders

### DIFF
--- a/packages/talmud/scripts/audit-kv-defs.ts
+++ b/packages/talmud/scripts/audit-kv-defs.ts
@@ -1,0 +1,252 @@
+/**
+ * READ-ONLY audit of the remote KV definition registries against the unified
+ * producer registry (src/worker/producer-registry.ts).
+ *
+ * For every id in mark-defs:v2:_index and enrichment-defs:v2:_index it fetches
+ * the stored flat def, runs it through BOTH:
+ *   - the OLD loader behavior (inline golden copies of the pre-unification
+ *     index.ts bodies: the flat->rich mark synthesis / the verbatim
+ *     enrichment passthrough), and
+ *   - the NEW path (producer-registry's loadMarkDef / loadEnrichmentDef,
+ *     i.e. resolve -> Producer -> project back),
+ * then diffs every field plus the derived cache keys (keyForMark /
+ * keyForEnrichment on a fixed probe daf + instance, en + he). Any mismatch is
+ * printed and the process exits 1; a clean run prints per-id OK lines.
+ *
+ * How to run (from packages/talmud; wrangler must be logged in):
+ *
+ *   npx tsx scripts/audit-kv-defs.ts
+ *
+ * (tsx is not a repo dependency; npx fetches it. The script resolves the
+ * worker's TS modules directly — same raw-.ts setup vitest uses.)
+ *
+ * KV access is via `wrangler kv key get --remote` against the CACHE namespace
+ * id parsed from wrangler.toml — the only wrangler subcommand used; nothing is
+ * written. Each key is one wrangler invocation, so a large hand-authored
+ * registry will be slow but safe.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { keyForEnrichment, keyForMark } from '../src/worker/cache-keys.ts';
+import { loadEnrichmentDef, loadMarkDef } from '../src/worker/producer-registry.ts';
+import type {
+  EnrichmentDefinition as KvEnrichmentDefinition,
+  MarkDefinition as KvMarkDefinition,
+  RegistryEnv,
+} from '../src/worker/studio-registry.ts';
+import type { MarkDefinition as SchemaMarkDefinition } from '../src/worker/studio-schema.ts';
+
+const PKG_DIR = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+// --- wrangler plumbing (read-only) ------------------------------------------
+
+function cacheNamespaceId(): string {
+  const toml = readFileSync(join(PKG_DIR, 'wrangler.toml'), 'utf8');
+  // The [[kv_namespaces]] block with binding = "CACHE": take the id that
+  // follows it (comments between the two lines are fine).
+  const m = toml.match(/binding\s*=\s*"CACHE"[\s\S]*?\nid\s*=\s*"([0-9a-f]{32})"/);
+  if (!m) throw new Error('could not find the CACHE kv_namespaces id in wrangler.toml');
+  return m[1];
+}
+
+function kvGet(namespaceId: string, key: string): string | null {
+  const res = spawnSync(
+    'pnpm',
+    ['exec', 'wrangler', 'kv', 'key', 'get', '--remote', '--namespace-id', namespaceId, key],
+    { cwd: PKG_DIR, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 },
+  );
+  if (res.status !== 0) {
+    // Missing keys come back non-zero; treat as absent but surface other noise.
+    if (/not found/i.test(res.stderr ?? '')) return null;
+    process.stderr.write(res.stderr ?? '');
+    return null;
+  }
+  return res.stdout;
+}
+
+function kvGetJson<T>(namespaceId: string, key: string): T | null {
+  const raw = kvGet(namespaceId, key);
+  if (raw === null) return null;
+  const trimmed = raw.trim();
+  try {
+    return JSON.parse(trimmed) as T;
+  } catch {
+    // Some wrangler versions prefix a banner on stdout; skip to the JSON.
+    const start = Math.min(
+      ...['{', '['].map((c) => {
+        const i = trimmed.indexOf(c);
+        return i === -1 ? Number.POSITIVE_INFINITY : i;
+      }),
+    );
+    if (!Number.isFinite(start)) return null;
+    try {
+      return JSON.parse(trimmed.slice(start)) as T;
+    } catch {
+      return null;
+    }
+  }
+}
+
+// --- golden copies of the OLD index.ts loader behavior ----------------------
+
+function oldKvMarkSynthesis(kv: KvMarkDefinition): SchemaMarkDefinition {
+  return {
+    id: kv.id,
+    label: kv.label,
+    description: kv.description,
+    anchor: 'phrase',
+    render: { kind: 'inline', style: 'underline', color: '#0066CC' },
+    extractor: {
+      kind: 'llm',
+      system_prompt: kv.system_prompt ?? '',
+      user_prompt_template: kv.user_prompt_template ?? '',
+    },
+    dependencies: kv.dependencies,
+    status: 'draft',
+    def_hash: 'kv',
+    cache_version: kv.cache_version,
+    source: 'kv',
+    updated_at: kv.updated_at,
+  };
+}
+
+// Old loadEnrichmentDef returned the stored KV def verbatim.
+const oldKvEnrichmentPassthrough = (kv: KvEnrichmentDefinition): KvEnrichmentDefinition => kv;
+
+// --- structural diff ---------------------------------------------------------
+
+function diffPaths(a: unknown, b: unknown, path = ''): string[] {
+  if (Object.is(a, b)) return [];
+  const isObj = (x: unknown): x is Record<string, unknown> => typeof x === 'object' && x !== null;
+  if (!isObj(a) || !isObj(b) || Array.isArray(a) !== Array.isArray(b)) {
+    return [`${path || '<root>'}: old=${JSON.stringify(a)} new=${JSON.stringify(b)}`];
+  }
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  const out: string[] = [];
+  for (const k of keys) {
+    const p = path ? `${path}.${k}` : k;
+    if (!(k in a)) out.push(`${p}: missing in old, new=${JSON.stringify(b[k])}`);
+    else if (!(k in b)) out.push(`${p}: missing in new, old=${JSON.stringify(a[k])}`);
+    else out.push(...diffPaths(a[k], b[k], p));
+  }
+  return out;
+}
+
+// --- main --------------------------------------------------------------------
+
+const PROBE_DAF = { tractate: 'Berakhot', page: '5a' };
+const PROBE_INSTANCE = 'audit-instance';
+
+async function main(): Promise<void> {
+  const ns = cacheNamespaceId();
+  console.log(`CACHE namespace: ${ns}`);
+
+  const markIds = kvGetJson<string[]>(ns, 'mark-defs:v2:_index') ?? [];
+  const enrichmentIds = kvGetJson<string[]>(ns, 'enrichment-defs:v2:_index') ?? [];
+  console.log(`mark-defs:v2:_index        -> ${markIds.length} ids`);
+  console.log(`enrichment-defs:v2:_index  -> ${enrichmentIds.length} ids`);
+
+  // Mirror the fetched defs into a Map-backed RegistryEnv so the NEW loaders
+  // run exactly as in the worker, against exactly the remote bytes.
+  const store = new Map<string, string>();
+  const env: RegistryEnv = {
+    CACHE: {
+      get: async (k: string) => store.get(k) ?? null,
+    } as unknown as KVNamespace,
+  };
+
+  let mismatches = 0;
+
+  for (const id of markIds) {
+    const raw = kvGet(ns, `mark-defs:v2:${id}`);
+    if (raw === null) {
+      console.log(`MARK ${id}: indexed but entry missing (skipped)`);
+      continue;
+    }
+    let kv: KvMarkDefinition;
+    try {
+      kv = JSON.parse(raw.trim()) as KvMarkDefinition;
+    } catch {
+      console.log(`MARK ${id}: entry is not valid JSON (skipped)`);
+      continue;
+    }
+    store.set(`mark-defs:v2:${id}`, JSON.stringify(kv));
+
+    const oldDef = oldKvMarkSynthesis(kv);
+    const newDef = await loadMarkDef(env, id);
+    const fieldDiffs = diffPaths(oldDef, newDef);
+    const keyDiffs: string[] = [];
+    for (const lang of ['en', 'he'] as const) {
+      const oldKey = keyForMark(oldDef, PROBE_DAF.tractate, PROBE_DAF.page, lang);
+      const newKey = newDef ? keyForMark(newDef, PROBE_DAF.tractate, PROBE_DAF.page, lang) : null;
+      if (oldKey !== newKey) keyDiffs.push(`key(${lang}): old=${oldKey} new=${newKey}`);
+    }
+    report('MARK', id, fieldDiffs, keyDiffs);
+    mismatches += fieldDiffs.length + keyDiffs.length;
+  }
+
+  for (const id of enrichmentIds) {
+    const raw = kvGet(ns, `enrichment-defs:v2:${id}`);
+    if (raw === null) {
+      console.log(`ENRICH ${id}: indexed but entry missing (skipped)`);
+      continue;
+    }
+    let kv: KvEnrichmentDefinition;
+    try {
+      kv = JSON.parse(raw.trim()) as KvEnrichmentDefinition;
+    } catch {
+      console.log(`ENRICH ${id}: entry is not valid JSON (skipped)`);
+      continue;
+    }
+    store.set(`enrichment-defs:v2:${id}`, JSON.stringify(kv));
+
+    const oldDef = oldKvEnrichmentPassthrough(kv);
+    const newDef = await loadEnrichmentDef(env, id);
+    const fieldDiffs = diffPaths(oldDef, newDef);
+    const keyDiffs: string[] = [];
+    // local/spine scopes need the daf; global must not get one.
+    const daf = oldDef.scope === 'global' ? undefined : PROBE_DAF;
+    for (const lang of ['en', 'he'] as const) {
+      const oldKey = safeKey(() => keyForEnrichment(oldDef, PROBE_INSTANCE, daf, undefined, lang));
+      const newKey = newDef
+        ? safeKey(() => keyForEnrichment(newDef, PROBE_INSTANCE, daf, undefined, lang))
+        : null;
+      if (oldKey !== newKey) keyDiffs.push(`key(${lang}): old=${oldKey} new=${newKey}`);
+    }
+    report('ENRICH', id, fieldDiffs, keyDiffs);
+    mismatches += fieldDiffs.length + keyDiffs.length;
+  }
+
+  if (mismatches > 0) {
+    console.log(
+      `\n${mismatches} mismatch(es) — the unified registry diverges from the old loaders.`,
+    );
+    process.exit(1);
+  }
+  console.log('\nAll KV defs project identically through old and new loaders.');
+}
+
+function safeKey(fn: () => string): string {
+  try {
+    return fn();
+  } catch (e) {
+    return `<throws: ${(e as Error).message}>`;
+  }
+}
+
+function report(kind: string, id: string, fieldDiffs: string[], keyDiffs: string[]): void {
+  if (fieldDiffs.length === 0 && keyDiffs.length === 0) {
+    console.log(`${kind} ${id}: OK`);
+    return;
+  }
+  console.log(`${kind} ${id}: MISMATCH`);
+  for (const d of [...keyDiffs, ...fieldDiffs]) console.log(`  ${d}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -153,6 +153,7 @@ import {
   ENRICH_JSON_SCHEMA,
   TRANSLATE_BIO_JSON_SCHEMA,
 } from './output-schemas';
+import { loadEnrichmentDef, loadMarkDef } from './producer-registry';
 import { groundRabbiInstances, groundRabbiNames, lookupRelationships } from './rabbi-graph';
 import {
   buildObservationSlices,
@@ -203,7 +204,6 @@ import type {
   EnrichmentDependency,
   LLMExtractor,
   MarkDependency,
-  EnrichmentDefinition as SchemaEnrichmentDefinition,
   MarkDefinition as SchemaMarkDefinition,
 } from './studio-schema';
 import { classifyError, recordTelemetry, runTelemetryRec, type TelemetryRecord } from './telemetry';
@@ -2255,71 +2255,12 @@ function renderTemplate(tpl: string, vars: Record<string, unknown>): string {
 }
 
 // ===========================================================================
-// Definition lookup — KV first, then code-defined fallback. Both shapes are
-// adapted to the KV-flat shape the runner expects.
+// Definition lookup — KV first, then code-defined fallback; both shapes
+// adapted to what the runner expects. The single resolution implementation
+// lives in producer-registry.ts (resolve → Producer → project back); the
+// `loadMarkDef` / `loadEnrichmentDef` imported at the top of this file are
+// thin, behavior-identical projections over it.
 // ===========================================================================
-
-function adaptCodeEnrichment(code: SchemaEnrichmentDefinition): EnrichmentDefinition | null {
-  // 'computed' enrichments carry no prompts — they're intercepted by a
-  // `def.id`-keyed short-circuit in runEnrichmentOnce (like rabbi.identity)
-  // and never hit the LLM path. Pass them through with empty prompt fields so
-  // the runner can still load + cache them; everything the short-circuit needs
-  // (scope, dependencies, cache_version) is preserved below.
-  if (code.extractor.kind !== 'llm' && code.extractor.kind !== 'computed') return null;
-  const llm = code.extractor.kind === 'llm' ? code.extractor : null;
-  return {
-    id: code.id,
-    label: code.label,
-    description: code.description,
-    mark: code.target_mark,
-    scope: code.scope,
-    dependencies: code.dependencies,
-    passes: code.passes,
-    system_prompt: llm?.system_prompt ?? '',
-    user_prompt_template: llm?.user_prompt_template ?? '',
-    system_prompt_he: llm?.system_prompt_he,
-    user_prompt_template_he: llm?.user_prompt_template_he,
-    model: llm?.model,
-    output_schema: llm?.output_schema,
-    thinking_off: llm?.thinking_off,
-    reasoning_effort: llm?.reasoning_effort,
-    cache_version: code.cache_version,
-    source: 'code',
-    updated_at: code.updated_at,
-  };
-}
-
-async function loadEnrichmentDef(env: Bindings, id: string): Promise<EnrichmentDefinition | null> {
-  const kv = await readEnrichment(env, id);
-  if (kv) return kv;
-  const code = findCodeEnrichment(id);
-  return code ? adaptCodeEnrichment(code) : null;
-}
-
-async function loadMarkDef(env: Bindings, id: string): Promise<SchemaMarkDefinition | null> {
-  const kv = await readMark(env, id);
-  if (kv) {
-    return {
-      id: kv.id,
-      label: kv.label,
-      description: kv.description,
-      anchor: 'phrase',
-      render: { kind: 'inline', style: 'underline', color: '#0066CC' },
-      extractor: {
-        kind: 'llm',
-        system_prompt: kv.system_prompt ?? '',
-        user_prompt_template: kv.user_prompt_template ?? '',
-      },
-      dependencies: kv.dependencies,
-      status: 'draft',
-      def_hash: 'kv',
-      cache_version: kv.cache_version,
-      source: 'kv',
-      updated_at: kv.updated_at,
-    };
-  }
-  return findCodeMark(id);
-}
 
 // ===========================================================================
 // Dependency resolution — walks `dependencies` and feeds the prompt template.

--- a/packages/talmud/src/worker/producer-registry.ts
+++ b/packages/talmud/src/worker/producer-registry.ts
@@ -1,0 +1,390 @@
+/**
+ * Unified producer registry — ONE resolution of "what is producer `id`?" over
+ * the two definition stores (runtime-mutable KV defs + code-defined defs in
+ * code-marks.ts) and the two definition flavors (marks + enrichments),
+ * projected into the four-primitive `Producer` shape from @corpus/core/model.
+ *
+ * This module is the single source of truth behind the legacy loaders the run
+ * path uses (`loadMarkDef` / `loadEnrichmentDef`, formerly private to
+ * index.ts): each is now a thin projection over the same resolution —
+ * resolve → Producer → project back to the legacy shape. The projections are
+ * LOSSLESS (locked by tests/producer-projection.test.ts +
+ * tests/producer-registry.test.ts), so behavior — including derived cache
+ * keys — is byte-identical to the pre-unification loaders.
+ *
+ * Resolution order (exactly today's, per flavor): KV wins over code.
+ *   mark:    readMark (flat KV def → the rich synthesis below) → findCodeMark
+ *   enrich:  readEnrichment (flat KV def, returned verbatim)   → findCodeEnrichment → adaptCodeEnrichment
+ *
+ * The unified `loadProducer(env, id)` tries KV mark, KV enrichment, code mark,
+ * code enrichment. This is safe because mark ids and enrichment ids never
+ * collide (enrichment ids are dotted, e.g. 'rabbi.bio'; asserted over the code
+ * registry in tests/producer-registry.test.ts). The run path uses the
+ * shape-pinned `loadProducerOfShape`, which has no such ambiguity.
+ *
+ * KV def shapes (see studio-registry.ts):
+ *   mark-defs:v2:{id}            — flat MarkDefinition (flat prompts, no
+ *                                  anchor/render/extractor nesting)
+ *   mark-defs:v2:_index          — JSON string[] of known mark ids
+ *   enrichment-defs:v2:{id}      — flat EnrichmentDefinition
+ *   enrichment-defs:v2:_index    — JSON string[] of known enrichment ids
+ */
+
+import {
+  enrichmentFromProducer,
+  markFromProducer,
+  producerFromEnrichment,
+  producerFromMark,
+} from '@corpus/core/model/compat';
+import type { Producer } from '@corpus/core/model/producer';
+import { CODE_ENRICHMENTS, CODE_MARKS, findCodeEnrichment, findCodeMark } from './code-marks';
+import {
+  type EnrichmentDefinition as KvEnrichmentDefinition,
+  type MarkDefinition as KvMarkDefinition,
+  listEnrichments,
+  listMarks,
+  type RegistryEnv,
+  readEnrichment,
+  readMark,
+} from './studio-registry';
+import type {
+  LLMExtractor,
+  EnrichmentDefinition as SchemaEnrichmentDefinition,
+  MarkDefinition as SchemaMarkDefinition,
+} from './studio-schema';
+
+export type ProducerShape = 'mark' | 'enrich';
+
+// ---------------------------------------------------------------------------
+// Own-key helpers (same semantics as @corpus/core/model/compat): a spread that
+// carries `key: undefined` as an own key when the source had one and omits it
+// entirely when it didn't — so strict (own-key) round-trips hold.
+// ---------------------------------------------------------------------------
+
+function ownKey<T extends object, K extends keyof T>(obj: T, key: K): Partial<Pick<T, K>> {
+  return key in obj ? ({ [key]: obj[key] } as Partial<Pick<T, K>>) : {};
+}
+
+function restExcept(obj: object, known: ReadonlySet<string>): Record<string, unknown> {
+  const rest: Record<string, unknown> = {};
+  for (const k of Object.keys(obj)) {
+    if (!known.has(k)) rest[k] = (obj as Record<string, unknown>)[k];
+  }
+  return rest;
+}
+
+// ---------------------------------------------------------------------------
+// Flat KV mark def → rich (studio-schema) def. EXACTLY the synthesis the old
+// index.ts loadMarkDef performed: KV marks are prompt experiments authored in
+// the dev UI, so they get fixed presentation defaults (phrase anchor, inline
+// underline render), draft status, and the 'kv' def_hash sentinel. Flat
+// fields with no slot in the synthesis (fields_schema, passes, parent_mark,
+// experimental) are dropped — exactly as before.
+// ---------------------------------------------------------------------------
+
+export function richMarkFromKvDef(kv: KvMarkDefinition): SchemaMarkDefinition {
+  return {
+    id: kv.id,
+    label: kv.label,
+    description: kv.description,
+    anchor: 'phrase',
+    render: { kind: 'inline', style: 'underline', color: '#0066CC' },
+    extractor: {
+      kind: 'llm',
+      system_prompt: kv.system_prompt ?? '',
+      user_prompt_template: kv.user_prompt_template ?? '',
+    },
+    dependencies: kv.dependencies,
+    status: 'draft',
+    def_hash: 'kv',
+    cache_version: kv.cache_version,
+    source: 'kv',
+    updated_at: kv.updated_at,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Flat KV enrichment def ↔ rich (studio-schema) def. The old loadEnrichmentDef
+// returned the flat KV def VERBATIM (the runner consumes the flat shape), so
+// unlike marks there was no synthesis to copy — this pair exists so the KV def
+// can ride through the Producer projection and come back byte-identical:
+//   flat ─richEnrichmentFromKvDef→ rich ─producerFromEnrichment→ Producer
+//        ─enrichmentFromProducer→ rich ─kvEnrichmentFromRichDef→ flat (verbatim)
+// Synthesis constants mirror the mark synthesis (status 'draft', def_hash
+// 'kv') plus mode 'augment-content' (KV enrichments are per-instance prompt
+// experiments; the old code never assigned them a mode at all — the constant
+// only shapes Producer metadata and is stripped again by the inverse, so no
+// behavior changes). Unknown KV-authored extra fields ride along verbatim
+// (→ Producer.legacy.rest), preserving the old "return kv verbatim" contract;
+// the one unrepresentable case is an extra whose name collides with a rich
+// field (mode/target_mark/extractor/…) — impossible via the CRUD, which
+// validates + strips extras on write.
+// ---------------------------------------------------------------------------
+
+const KV_ENRICHMENT_FLAT_FIELDS = new Set([
+  'id',
+  'label',
+  'description',
+  'mark',
+  'scope',
+  'dependencies',
+  'passes',
+  'system_prompt',
+  'user_prompt_template',
+  'system_prompt_he',
+  'user_prompt_template_he',
+  'model',
+  'output_schema',
+  'thinking_off',
+  'reasoning_effort',
+  'cache_version',
+  'source',
+  'updated_at',
+]);
+
+const RICH_ENRICHMENT_FIELDS = new Set([
+  'id',
+  'label',
+  'description',
+  'category',
+  'target_mark',
+  'mode',
+  'scope',
+  'dependencies',
+  'passes',
+  'extractor',
+  'status',
+  'def_hash',
+  'cache_version',
+  'source',
+  'updated_at',
+]);
+
+export function richEnrichmentFromKvDef(kv: KvEnrichmentDefinition): SchemaEnrichmentDefinition {
+  const extractor: LLMExtractor = {
+    kind: 'llm',
+    system_prompt: kv.system_prompt,
+    user_prompt_template: kv.user_prompt_template,
+    ...ownKey(kv, 'system_prompt_he'),
+    ...ownKey(kv, 'user_prompt_template_he'),
+    ...ownKey(kv, 'model'),
+    ...ownKey(kv, 'output_schema'),
+    ...ownKey(kv, 'thinking_off'),
+    ...ownKey(kv, 'reasoning_effort'),
+  };
+  return {
+    ...restExcept(kv, KV_ENRICHMENT_FLAT_FIELDS),
+    id: kv.id,
+    label: kv.label,
+    ...ownKey(kv, 'description'),
+    target_mark: kv.mark,
+    mode: 'augment-content',
+    scope: kv.scope,
+    ...ownKey(kv, 'dependencies'),
+    ...ownKey(kv, 'passes'),
+    extractor,
+    status: 'draft',
+    def_hash: 'kv',
+    cache_version: kv.cache_version,
+    source: kv.source,
+    updated_at: kv.updated_at,
+  } as SchemaEnrichmentDefinition;
+}
+
+/** Exact inverse of {@link richEnrichmentFromKvDef}: strips the synthesis
+ *  constants (mode/status/def_hash) and unnests the LLM extractor back into
+ *  the flat prompt fields. Only ever applied to KV-resolved defs, whose
+ *  extractor is always the 'llm' shape the synthesis built. */
+export function kvEnrichmentFromRichDef(def: SchemaEnrichmentDefinition): KvEnrichmentDefinition {
+  const llm = def.extractor as LLMExtractor;
+  return {
+    ...restExcept(def, RICH_ENRICHMENT_FIELDS),
+    id: def.id,
+    label: def.label,
+    ...ownKey(def, 'description'),
+    mark: def.target_mark,
+    scope: def.scope,
+    ...ownKey(def, 'dependencies'),
+    ...ownKey(def, 'passes'),
+    system_prompt: llm.system_prompt,
+    user_prompt_template: llm.user_prompt_template,
+    ...ownKey(llm, 'system_prompt_he'),
+    ...ownKey(llm, 'user_prompt_template_he'),
+    ...ownKey(llm, 'model'),
+    ...ownKey(llm, 'output_schema'),
+    ...ownKey(llm, 'thinking_off'),
+    ...ownKey(llm, 'reasoning_effort'),
+    cache_version: def.cache_version,
+    source: def.source,
+    updated_at: def.updated_at,
+  } as KvEnrichmentDefinition;
+}
+
+// ---------------------------------------------------------------------------
+// Code enrichment def → the flat shape the runner expects. Moved VERBATIM from
+// index.ts (the old loadEnrichmentDef's code-fallback adaptation).
+// ---------------------------------------------------------------------------
+
+export function adaptCodeEnrichment(
+  code: SchemaEnrichmentDefinition,
+): KvEnrichmentDefinition | null {
+  // 'computed' enrichments carry no prompts — they're intercepted by a
+  // `def.id`-keyed short-circuit in runEnrichmentOnce (like rabbi.identity)
+  // and never hit the LLM path. Pass them through with empty prompt fields so
+  // the runner can still load + cache them; everything the short-circuit needs
+  // (scope, dependencies, cache_version) is preserved below.
+  if (code.extractor.kind !== 'llm' && code.extractor.kind !== 'computed') return null;
+  const llm = code.extractor.kind === 'llm' ? code.extractor : null;
+  return {
+    id: code.id,
+    label: code.label,
+    description: code.description,
+    mark: code.target_mark,
+    scope: code.scope,
+    dependencies: code.dependencies,
+    passes: code.passes,
+    system_prompt: llm?.system_prompt ?? '',
+    user_prompt_template: llm?.user_prompt_template ?? '',
+    system_prompt_he: llm?.system_prompt_he,
+    user_prompt_template_he: llm?.user_prompt_template_he,
+    model: llm?.model,
+    output_schema: llm?.output_schema,
+    thinking_off: llm?.thinking_off,
+    reasoning_effort: llm?.reasoning_effort,
+    cache_version: code.cache_version,
+    source: 'code',
+    updated_at: code.updated_at,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The ONE resolution (KV first, then code) — everything below routes through
+// these two functions.
+// ---------------------------------------------------------------------------
+
+async function resolveMarkRich(env: RegistryEnv, id: string): Promise<SchemaMarkDefinition | null> {
+  const kv = await readMark(env, id);
+  if (kv) return richMarkFromKvDef(kv);
+  return findCodeMark(id);
+}
+
+async function resolveEnrichmentRich(
+  env: RegistryEnv,
+  id: string,
+): Promise<
+  | { def: SchemaEnrichmentDefinition; from: 'kv'; kv: KvEnrichmentDefinition }
+  | { def: SchemaEnrichmentDefinition; from: 'code' }
+  | null
+> {
+  const kv = await readEnrichment(env, id);
+  // The verbatim parsed KV object rides along so the legacy loader can return
+  // it UNTOUCHED (identity, like the old loadEnrichmentDef) — the rich
+  // synthesis is for the Producer projection only.
+  if (kv) return { def: richEnrichmentFromKvDef(kv), from: 'kv', kv };
+  const code = findCodeEnrichment(id);
+  return code ? { def: code, from: 'code' } : null;
+}
+
+// ---------------------------------------------------------------------------
+// Producer lookups
+// ---------------------------------------------------------------------------
+
+/** The shape-pinned lookup the run path uses: the caller knows whether it is
+ *  asking for a mark or an enrichment (today's loadMarkDef vs loadEnrichmentDef
+ *  split), so there is no cross-flavor ambiguity. KV beats code. */
+export async function loadProducerOfShape(
+  env: RegistryEnv,
+  id: string,
+  shape: ProducerShape,
+): Promise<Producer | null> {
+  if (shape === 'mark') {
+    const def = await resolveMarkRich(env, id);
+    return def ? producerFromMark(def) : null;
+  }
+  const r = await resolveEnrichmentRich(env, id);
+  return r ? producerFromEnrichment(r.def) : null;
+}
+
+/** Convenience unified lookup: KV mark, KV enrichment, code mark, code
+ *  enrichment. Equivalent to trying both shapes because mark and enrichment
+ *  ids never collide (asserted in tests/producer-registry.test.ts); KV is
+ *  still preferred over code across flavors. */
+export async function loadProducer(env: RegistryEnv, id: string): Promise<Producer | null> {
+  const kvMark = await readMark(env, id);
+  if (kvMark) return producerFromMark(richMarkFromKvDef(kvMark));
+  const kvEnrich = await readEnrichment(env, id);
+  if (kvEnrich) return producerFromEnrichment(richEnrichmentFromKvDef(kvEnrich));
+  const codeMark = findCodeMark(id);
+  if (codeMark) return producerFromMark(codeMark);
+  const codeEnrich = findCodeEnrichment(id);
+  return codeEnrich ? producerFromEnrichment(codeEnrich) : null;
+}
+
+/** Every known producer, both flavors, both stores, projected. KV wins on an
+ *  id collision with code (same precedence as the per-id lookups and the
+ *  /api/marks list endpoint). With an empty KV this is exactly
+ *  [...CODE_MARKS, ...CODE_ENRICHMENTS] projected, in that order — the
+ *  dep-graph parity test relies on it. */
+export async function listProducers(env: RegistryEnv): Promise<Producer[]> {
+  const [kvMarks, kvEnrichments] = await Promise.all([listMarks(env), listEnrichments(env)]);
+  const out: Producer[] = [];
+  const seen = new Set<string>();
+  for (const kv of kvMarks) {
+    if (seen.has(kv.id)) continue;
+    seen.add(kv.id);
+    out.push(producerFromMark(richMarkFromKvDef(kv)));
+  }
+  for (const kv of kvEnrichments) {
+    if (seen.has(kv.id)) continue;
+    seen.add(kv.id);
+    out.push(producerFromEnrichment(richEnrichmentFromKvDef(kv)));
+  }
+  for (const def of CODE_MARKS) {
+    if (seen.has(def.id)) continue;
+    seen.add(def.id);
+    out.push(producerFromMark(def));
+  }
+  for (const def of CODE_ENRICHMENTS) {
+    if (seen.has(def.id)) continue;
+    seen.add(def.id);
+    out.push(producerFromEnrichment(def));
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Legacy loaders — the signatures the run path has always used, now thin
+// projections over the unified resolution: resolve → Producer → project back.
+// Output is byte-identical to the old index.ts implementations (locked by
+// tests/producer-registry.test.ts).
+// ---------------------------------------------------------------------------
+
+export async function loadMarkDef(
+  env: RegistryEnv,
+  id: string,
+): Promise<SchemaMarkDefinition | null> {
+  const def = await resolveMarkRich(env, id);
+  if (!def) return null;
+  // Round-trip through the Producer currency — lossless (strict-equal) over
+  // the whole registry, so this is the same def the old loader returned.
+  return markFromProducer(producerFromMark(def)) as SchemaMarkDefinition;
+}
+
+export async function loadEnrichmentDef(
+  env: RegistryEnv,
+  id: string,
+): Promise<KvEnrichmentDefinition | null> {
+  const r = await resolveEnrichmentRich(env, id);
+  if (!r) return null;
+  // KV defs return VERBATIM — identity with the old loader by construction,
+  // even for hand-authored entries carrying fields that collide with the rich
+  // schema's names (mode/target_mark/extractor/...), which a reconstruction
+  // through the synthesis inverse would overwrite or strip.
+  if (r.from === 'kv') return r.kv;
+  // Code defs flatten exactly as the old loader did — including its null for
+  // extractors that are neither 'llm' nor 'computed'.
+  const rich = enrichmentFromProducer(
+    producerFromEnrichment(r.def),
+  ) as unknown as SchemaEnrichmentDefinition;
+  return adaptCodeEnrichment(rich);
+}

--- a/packages/talmud/tests/producer-registry.test.ts
+++ b/packages/talmud/tests/producer-registry.test.ts
@@ -1,0 +1,405 @@
+/**
+ * The unified producer registry (src/worker/producer-registry.ts) must be
+ * BEHAVIOR-IDENTICAL to the two private loaders it replaced in index.ts:
+ *
+ *   - loadMarkDef:       readMark (flat KV def → rich synthesis) → findCodeMark
+ *   - loadEnrichmentDef: readEnrichment (verbatim) → findCodeEnrichment →
+ *                        adaptCodeEnrichment
+ *
+ * The old implementations are copied INLINE below as golden references (they
+ * no longer exist in index.ts), and the new loaders — which route through the
+ * Producer projection — are compared strict-equal against them over the whole
+ * code registry plus KV-seeded defs in both flat shapes:
+ *
+ *   mark-defs:v2:{id}         { id, label, description?, extractor:'llm',
+ *                               system_prompt?, user_prompt_template?,
+ *                               fields_schema?, dependencies?, experimental?,
+ *                               cache_version, source:'kv', updated_at }
+ *   enrichment-defs:v2:{id}   { id, label, description?, mark, scope,
+ *                               dependencies?, system_prompt,
+ *                               user_prompt_template, system_prompt_he?,
+ *                               user_prompt_template_he?, model?,
+ *                               output_schema?, thinking_off?,
+ *                               reasoning_effort?, cache_version,
+ *                               source:'kv', updated_at }
+ *   *-defs:v2:_index          JSON string[] of ids (powers listing only;
+ *                               per-id reads go straight to the entry key)
+ */
+
+import { producerFromEnrichment, rawDependenciesOf } from '@corpus/core/model/compat';
+import { producerNodesFrom } from '@corpus/core/registry/depGraph';
+import { describe, expect, it } from 'vitest';
+import { keyForEnrichment, keyForMark } from '../src/worker/cache-keys';
+import { CODE_ENRICHMENTS, CODE_MARKS, findCodeMark } from '../src/worker/code-marks';
+import {
+  listProducers,
+  loadEnrichmentDef,
+  loadMarkDef,
+  loadProducer,
+  loadProducerOfShape,
+  richEnrichmentFromKvDef,
+} from '../src/worker/producer-registry';
+import type {
+  EnrichmentDefinition as KvEnrichmentDefinition,
+  MarkDefinition as KvMarkDefinition,
+  RegistryEnv,
+} from '../src/worker/studio-registry';
+import type {
+  EnrichmentDefinition as SchemaEnrichmentDefinition,
+  MarkDefinition as SchemaMarkDefinition,
+} from '../src/worker/studio-schema';
+
+// --- harness ---------------------------------------------------------------
+
+function makeEnv(seed: Record<string, string> = {}): RegistryEnv {
+  const store = new Map(Object.entries(seed));
+  const kv = {
+    get: async (k: string) => store.get(k) ?? null,
+    put: async (k: string, v: string) => {
+      store.set(k, v);
+    },
+    delete: async (k: string) => {
+      store.delete(k);
+    },
+    list: async () => ({ keys: [], list_complete: true, cursor: '' }),
+    getWithMetadata: async () => ({ value: null, metadata: null }),
+  };
+  return { CACHE: kv as unknown as KVNamespace };
+}
+
+const EMPTY = makeEnv();
+
+// --- golden references: the OLD index.ts loader bodies, verbatim ------------
+
+/** Old index.ts adaptCodeEnrichment, copied byte-for-byte (incl. its own-key
+ *  materialization of absent optionals and the null for extractors that are
+ *  neither 'llm' nor 'computed'). */
+function oldAdaptCodeEnrichment(code: SchemaEnrichmentDefinition): KvEnrichmentDefinition | null {
+  if (code.extractor.kind !== 'llm' && code.extractor.kind !== 'computed') return null;
+  const llm = code.extractor.kind === 'llm' ? code.extractor : null;
+  return {
+    id: code.id,
+    label: code.label,
+    description: code.description,
+    mark: code.target_mark,
+    scope: code.scope,
+    dependencies: code.dependencies,
+    passes: code.passes,
+    system_prompt: llm?.system_prompt ?? '',
+    user_prompt_template: llm?.user_prompt_template ?? '',
+    system_prompt_he: llm?.system_prompt_he,
+    user_prompt_template_he: llm?.user_prompt_template_he,
+    model: llm?.model,
+    output_schema: llm?.output_schema,
+    thinking_off: llm?.thinking_off,
+    reasoning_effort: llm?.reasoning_effort,
+    cache_version: code.cache_version,
+    source: 'code',
+    updated_at: code.updated_at,
+  };
+}
+
+/** Old index.ts loadMarkDef KV branch, copied byte-for-byte: the flat→rich
+ *  synthesis (phrase anchor, the inline underline render literal, draft
+ *  status, the 'kv' def_hash sentinel). */
+function oldKvMarkSynthesis(kv: KvMarkDefinition): SchemaMarkDefinition {
+  return {
+    id: kv.id,
+    label: kv.label,
+    description: kv.description,
+    anchor: 'phrase',
+    render: { kind: 'inline', style: 'underline', color: '#0066CC' },
+    extractor: {
+      kind: 'llm',
+      system_prompt: kv.system_prompt ?? '',
+      user_prompt_template: kv.user_prompt_template ?? '',
+    },
+    dependencies: kv.dependencies,
+    status: 'draft',
+    def_hash: 'kv',
+    cache_version: kv.cache_version,
+    source: 'kv',
+    updated_at: kv.updated_at,
+  };
+}
+
+// --- (a) empty KV: the new loaders equal the old ones for every code def ----
+
+describe('empty KV — code-def parity with the old loaders', () => {
+  it('loadMarkDef returns the code def verbatim for every code mark', async () => {
+    for (const def of CODE_MARKS) {
+      // Old loader with empty KV = findCodeMark(id) = the def itself.
+      expect(await loadMarkDef(EMPTY, def.id)).toStrictEqual(def);
+    }
+  });
+
+  it('loadEnrichmentDef returns oldAdaptCodeEnrichment(def) for every code enrichment', async () => {
+    for (const def of CODE_ENRICHMENTS) {
+      expect(await loadEnrichmentDef(EMPTY, def.id)).toStrictEqual(oldAdaptCodeEnrichment(def));
+    }
+  });
+
+  it('loadProducerOfShape projects every code def into the right producer flavor', async () => {
+    for (const def of CODE_MARKS) {
+      const p = await loadProducerOfShape(EMPTY, def.id, 'mark');
+      expect(p).not.toBeNull();
+      expect(p!.key_shape).toBe('mark');
+      expect(p!.cacheVersion).toBe(def.cache_version);
+    }
+    for (const def of CODE_ENRICHMENTS) {
+      const p = await loadProducerOfShape(EMPTY, def.id, 'enrich');
+      expect(p).not.toBeNull();
+      expect(p!.key_shape).toBe('enrich');
+      expect(p!.cacheVersion).toBe(def.cache_version);
+    }
+  });
+
+  it('the shape-pinned lookup misses across flavors; the unified one resolves both', async () => {
+    const markId = CODE_MARKS[0].id;
+    const enrichId = CODE_ENRICHMENTS[0].id;
+    expect(await loadProducerOfShape(EMPTY, markId, 'enrich')).toBeNull();
+    expect(await loadProducerOfShape(EMPTY, enrichId, 'mark')).toBeNull();
+    expect((await loadProducer(EMPTY, markId))?.key_shape).toBe('mark');
+    expect((await loadProducer(EMPTY, enrichId))?.key_shape).toBe('enrich');
+    expect(await loadProducer(EMPTY, 'no.such.producer')).toBeNull();
+  });
+});
+
+// --- (b) a KV-seeded FLAT mark def overrides code ----------------------------
+
+describe('KV mark def overrides code', () => {
+  // 'rabbi' exists in CODE_MARKS — the KV entry must shadow it.
+  const flat: KvMarkDefinition = {
+    id: 'rabbi',
+    label: 'Rabbi (KV override)',
+    description: 'authored in the dev UI',
+    extractor: 'llm',
+    system_prompt: 'SYSTEM',
+    user_prompt_template: 'USER {{gemara}}',
+    dependencies: ['gemara'],
+    cache_version: '99',
+    source: 'kv',
+    updated_at: '2026-01-01T00:00:00.000Z',
+  };
+  const env = makeEnv({
+    'mark-defs:v2:rabbi': JSON.stringify(flat),
+    'mark-defs:v2:_index': JSON.stringify(['rabbi']),
+  });
+  // What KV actually hands back (JSON round-trip, like production reads).
+  const kvRead = JSON.parse(JSON.stringify(flat)) as KvMarkDefinition;
+
+  it('loadMarkDef returns EXACTLY the old flat→rich synthesis', async () => {
+    const def = await loadMarkDef(env, 'rabbi');
+    expect(def).toStrictEqual(oldKvMarkSynthesis(kvRead));
+    expect(def!.anchor).toBe('phrase');
+    expect(def!.render).toEqual({ kind: 'inline', style: 'underline', color: '#0066CC' });
+    expect(def!.status).toBe('draft');
+    expect(def!.def_hash).toBe('kv');
+    expect(def!.source).toBe('kv');
+  });
+
+  it('the KV cache_version flows into the projected producer and key derivation', async () => {
+    const p = await loadProducerOfShape(env, 'rabbi', 'mark');
+    expect(p!.cacheVersion).toBe('99');
+    expect(p!.source).toBe('kv');
+    expect(p!.status).toBe('draft');
+    expect(p!.legacy?.def_hash).toBe('kv');
+    expect(p!.legacy?.anchorKind).toBe('phrase');
+
+    const oldKey = keyForMark(oldKvMarkSynthesis(kvRead), 'Berakhot', '5a', 'en');
+    const newKey = keyForMark((await loadMarkDef(env, 'rabbi'))!, 'Berakhot', '5a', 'en');
+    expect(newKey).toBe(oldKey);
+    expect(newKey).toContain(':99:');
+    // ...and differs from the code def's key (the override is effective).
+    expect(newKey).not.toBe(keyForMark(findCodeMark('rabbi')!, 'Berakhot', '5a', 'en'));
+  });
+});
+
+// --- (c) a KV-seeded FLAT enrichment def overrides code ----------------------
+
+describe('KV enrichment def overrides code', () => {
+  // 'rabbi.bio' exists in CODE_ENRICHMENTS — the KV entry must shadow it.
+  const flat: KvEnrichmentDefinition = {
+    id: 'rabbi.bio',
+    label: 'Bio (KV override)',
+    mark: 'rabbi',
+    scope: 'local',
+    dependencies: ['gemara', { mark: 'rabbi' }, { enrichment: 'rabbi.relationships' }],
+    system_prompt: 'SYS',
+    user_prompt_template: 'USR {{mark_input}}',
+    system_prompt_he: 'SYS-HE',
+    user_prompt_template_he: 'USR-HE',
+    model: 'openrouter/deepseek/deepseek-chat' as KvEnrichmentDefinition['model'],
+    output_schema: { type: 'object', properties: { bio: { type: 'string' } } },
+    thinking_off: true,
+    reasoning_effort: 'low',
+    cache_version: '77',
+    source: 'kv',
+    updated_at: '2026-01-02T00:00:00.000Z',
+  };
+  const env = makeEnv({
+    'enrichment-defs:v2:rabbi.bio': JSON.stringify(flat),
+    'enrichment-defs:v2:_index': JSON.stringify(['rabbi.bio']),
+  });
+  const kvRead = JSON.parse(JSON.stringify(flat)) as KvEnrichmentDefinition;
+
+  it('loadEnrichmentDef returns the stored KV def VERBATIM (old behavior)', async () => {
+    expect(await loadEnrichmentDef(env, 'rabbi.bio')).toStrictEqual(kvRead);
+  });
+
+  it('a KV def carrying RICH-SCHEMA-COLLIDING stray fields still returns verbatim', async () => {
+    // A hand-authored or legacy KV entry could carry fields whose names
+    // collide with the intermediate rich schema (mode/target_mark/extractor/
+    // status/def_hash). The loader returns the stored object untouched — a
+    // reconstruction through the synthesis inverse would overwrite or strip
+    // these. (Codex-flagged hazard; identity by construction is the fix.)
+    const withCollisions = {
+      ...flat,
+      id: 'odd.kv',
+      mode: 'aggregate',
+      target_mark: 'NOT-THE-MARK',
+      extractor: { kind: 'weird' },
+      status: 'promoted',
+      def_hash: 'hand-set',
+      some_future_field: 42,
+    };
+    const env3 = makeEnv({
+      'enrichment-defs:v2:odd.kv': JSON.stringify(withCollisions),
+      'enrichment-defs:v2:_index': JSON.stringify(['odd.kv']),
+    });
+    expect(await loadEnrichmentDef(env3, 'odd.kv')).toStrictEqual(
+      JSON.parse(JSON.stringify(withCollisions)),
+    );
+  });
+
+  it('a minimal KV def (no optionals) also round-trips verbatim', async () => {
+    const minimal: KvEnrichmentDefinition = {
+      id: 'scratch.note',
+      label: 'Scratch',
+      mark: 'daf',
+      scope: 'global',
+      system_prompt: 'S',
+      user_prompt_template: 'U',
+      cache_version: '1',
+      source: 'kv',
+      updated_at: '2026-01-03T00:00:00.000Z',
+    };
+    const env2 = makeEnv({
+      'enrichment-defs:v2:scratch.note': JSON.stringify(minimal),
+      'enrichment-defs:v2:_index': JSON.stringify(['scratch.note']),
+    });
+    expect(await loadEnrichmentDef(env2, 'scratch.note')).toStrictEqual(
+      JSON.parse(JSON.stringify(minimal)),
+    );
+  });
+
+  it('the KV cache_version flows into the projected producer and key derivation', async () => {
+    const p = await loadProducerOfShape(env, 'rabbi.bio', 'enrich');
+    expect(p!.cacheVersion).toBe('77');
+    expect(p!.scope).toBe('local');
+    expect(p!.source).toBe('kv');
+    expect(p!.status).toBe('draft');
+    expect(p!.legacy?.def_hash).toBe('kv');
+    expect(p!.anchoring.target).toBe('rabbi');
+
+    const daf = { tractate: 'Berakhot', page: '5a' };
+    const oldKey = keyForEnrichment(kvRead, 'Abaye', daf, undefined, 'en');
+    const newKey = keyForEnrichment((await loadEnrichmentDef(env, 'rabbi.bio'))!, 'Abaye', daf);
+    expect(newKey).toBe(oldKey);
+    expect(newKey).toContain(':77:');
+    const codeDef = CODE_ENRICHMENTS.find((d) => d.id === 'rabbi.bio')!;
+    expect(newKey).not.toBe(
+      keyForEnrichment(
+        oldAdaptCodeEnrichment(codeDef)!,
+        'Abaye',
+        codeDef.scope === 'local' ? daf : undefined,
+      ),
+    );
+  });
+});
+
+// --- (d) the no-collision invariant the unified lookup relies on -------------
+
+describe('mark and enrichment ids never collide', () => {
+  it('no id appears in both code registries', () => {
+    const markIds = new Set(CODE_MARKS.map((d) => d.id));
+    for (const e of CODE_ENRICHMENTS) {
+      expect(markIds.has(e.id), `id '${e.id}' exists as BOTH a mark and an enrichment`).toBe(false);
+    }
+  });
+
+  it('every code enrichment id is dotted; no code mark id is', () => {
+    // The structural reason collisions cannot happen: enrichment ids are
+    // namespaced under their mark ('rabbi.bio'); mark ids are bare slugs.
+    // (KV-authored defs share one id grammar, so this is a convention, not a
+    // hard guarantee — the unified loadProducer still prefers marks first,
+    // matching the order documented in producer-registry.ts.)
+    for (const e of CODE_ENRICHMENTS) expect(e.id).toContain('.');
+    for (const m of CODE_MARKS) expect(m.id).not.toContain('.');
+  });
+});
+
+// --- listProducers ------------------------------------------------------------
+
+describe('listProducers', () => {
+  it('empty KV: projects exactly [...CODE_MARKS, ...CODE_ENRICHMENTS], in order', async () => {
+    const producers = await listProducers(EMPTY);
+    expect(producers.map((p) => p.id)).toEqual(
+      [...CODE_MARKS, ...CODE_ENRICHMENTS].map((d) => d.id),
+    );
+  });
+
+  it('dep-graph parity: producerNodesFrom over projected producers === over the code defs', async () => {
+    const producers = await listProducers(EMPTY);
+    const viaProducers = producerNodesFrom(
+      producers.map((p) => ({ id: p.id, dependencies: rawDependenciesOf(p) })),
+    );
+    const viaDefs = producerNodesFrom([...CODE_MARKS, ...CODE_ENRICHMENTS]);
+    expect(viaProducers).toEqual(viaDefs);
+  });
+
+  it('KV wins on id collision with code; KV-only ids appear too', async () => {
+    const kvMark: KvMarkDefinition = {
+      id: 'rabbi',
+      label: 'Rabbi (KV)',
+      extractor: 'llm',
+      system_prompt: 'S',
+      user_prompt_template: 'U',
+      cache_version: '42',
+      source: 'kv',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    };
+    const kvEnrich: KvEnrichmentDefinition = {
+      id: 'custom.experiment',
+      label: 'Custom',
+      mark: 'daf',
+      scope: 'local',
+      system_prompt: 'S',
+      user_prompt_template: 'U',
+      cache_version: '1',
+      source: 'kv',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    };
+    const env = makeEnv({
+      'mark-defs:v2:rabbi': JSON.stringify(kvMark),
+      'mark-defs:v2:_index': JSON.stringify(['rabbi']),
+      'enrichment-defs:v2:custom.experiment': JSON.stringify(kvEnrich),
+      'enrichment-defs:v2:_index': JSON.stringify(['custom.experiment']),
+    });
+    const producers = await listProducers(env);
+    const rabbi = producers.filter((p) => p.id === 'rabbi');
+    expect(rabbi).toHaveLength(1);
+    expect(rabbi[0].cacheVersion).toBe('42');
+    expect(rabbi[0].source).toBe('kv');
+    expect(producers.some((p) => p.id === 'custom.experiment')).toBe(true);
+    // Everything from the code registry (minus the shadowed id) is still there.
+    const ids = new Set(producers.map((p) => p.id));
+    for (const d of [...CODE_MARKS, ...CODE_ENRICHMENTS]) expect(ids.has(d.id)).toBe(true);
+    // KV enrichment defs project to enrich-shaped producers.
+    const custom = producers.find((p) => p.id === 'custom.experiment')!;
+    expect(custom.key_shape).toBe('enrich');
+    expect(custom).toEqual(
+      producerFromEnrichment(richEnrichmentFromKvDef(JSON.parse(JSON.stringify(kvEnrich)))),
+    );
+  });
+});


### PR DESCRIPTION
Stage 4 of the four-primitive consolidation (#356 → #357 → #358 → this). The talmud registry adapter: one resolution path for producer definitions, projected through the unified `Producer` shape.

## What changes

- New `producer-registry.ts`: `loadProducerOfShape` (the unambiguous run-path lookup), `loadProducer`, `listProducers` — KV (both `*-defs:v2` prefixes, KV wins) → code fallback, all projected via `producerFromMark`/`producerFromEnrichment`.
- `loadMarkDef`/`loadEnrichmentDef` keep their exact signatures and move out of `index.ts` (−65 lines): marks reproduce the old flat-KV→rich synthesis byte-for-byte; **KV enrichment defs return verbatim** — identity by construction (Codex flagged that reconstructing them through the projection could overwrite hand-authored fields colliding with rich-schema names; fixed by carrying the parsed KV object through untouched, locked by a collision-field test).
- `adaptCodeEnrichment` moved verbatim. Dep-graph feed parity and mark/enrichment id-disjointness locked by tests.
- `scripts/audit-kv-defs.ts` — read-only remote KV audit (old loaders vs new, field + derived-key diff). **To run before fully trusting prod KV defs:** `cd packages/talmud && npx tsx scripts/audit-kv-defs.ts`.

Zero behavior change: all #356 characterization baselines (golden keys, run contract, resolve-deps, envelope) pass untouched. Full suite: talmud 2061, core 103, tanach 19; typecheck + biome clean.