### PR TITLE
Unify the run lifecycle: one core runProducer + provenance build manifest

### DIFF
--- a/packages/core/src/model/provenance.ts
+++ b/packages/core/src/model/provenance.ts
@@ -67,6 +67,13 @@ export interface LegacyRunFields {
  *  ('computed', 'graph', 'lookup', …) is a deterministic rule. */
 const AI_TRANSPORTS = new Set(['workers-ai', 'openrouter-gateway']);
 
+/** Classify a transport into the deciding authority — the ONE place the
+ *  llm-vs-rule split lives (provenanceOf and the native write path both
+ *  delegate here). */
+export function authorityForTransport(transport: string): Authority {
+  return AI_TRANSPORTS.has(transport) ? 'ai' : 'rule';
+}
+
 /** Synthesize a Provenance from a legacy stored RunResult-shaped object.
  *  Inputs are the resolved dependency + anchor keys (legacy entries don't
  *  record real artifact ids or content hashes, so each becomes a sourceKey). */
@@ -76,7 +83,7 @@ export function provenanceOf(stored: LegacyRunFields, producerId: string): Prove
     ...Object.keys(stored.anchors_resolved ?? {}),
   ].map((k) => ({ sourceKey: k }));
   return {
-    authority: AI_TRANSPORTS.has(stored.transport) ? 'ai' : 'rule',
+    authority: authorityForTransport(stored.transport),
     producerId,
     recipeHash: stored.recipe_hash,
     inputs,

--- a/packages/core/src/run/run-producer.ts
+++ b/packages/core/src/run/run-producer.ts
@@ -1,0 +1,727 @@
+/**
+ * runProducer — the ONE corpus-agnostic producer-run orchestration (stage 4b of
+ * the run-layer extraction). It reproduces the talmud worker's runMarkOnce +
+ * runEnrichmentOnce control flow as a single skeleton whose branches are driven
+ * by `kind` ('mark' | 'enrich') plus definition properties; everything
+ * app-specific (key derivation, source resolution, the LLM call + telemetry,
+ * the check layer, the id-keyed short-circuits) enters through
+ * {@link RunProducerPorts}. The host's runMarkOnce / runEnrichmentOnce become
+ * thin shims over this function, so the recursion injected into
+ * `ResolveInputsPorts.runEnrichment` / `runMark` closes through core.
+ *
+ * Behavior contract: ZERO observable change vs the two legacy bodies — locked
+ * by the host's characterization suite (run-contract, envelope-roundtrip,
+ * resolve-deps-characterization, producer-key-golden). The ONE addition is the
+ * `provenance` build manifest stamped (additively) on every fresh cache write —
+ * see {@link buildRunProvenance}.
+ *
+ * Divergences between the two legacy bodies, preserved per kind branch:
+ *   - cache-key lang: marks namespace `:he` only when the extractor HAS a
+ *     Hebrew prompt (identical EN output otherwise — no point fanning the
+ *     cache); enrichments always key by request lang.
+ *   - section_range guard: enrichments only (marks key per-daf, no volatile
+ *     title in the key).
+ *   - recipe_hash: enrichments stamp it; marks never have (so far).
+ *   - parentChain: a mark RESETS the cycle-detection chain (its deps are a
+ *     fresh tree); an enrichment EXTENDS the chain with its own id.
+ *   - prompt vars: enrichments add mark_input / user_question / hook vars.
+ *   - usage attribution: marks record usage BEFORE building the result
+ *     envelope; enrichments after the cache-write gating. (Both fire-and-
+ *     forget; order kept to mirror the originals exactly.)
+ *   - check gating condition text: mark `if (parsed && passes)`, enrichment
+ *     `if (parsed && !parse_error && passes)` — same outcomes (parsed is only
+ *     non-null when parse succeeded), both kept verbatim.
+ *   - stored-envelope field ORDER differs per kind (mark: cost, check_issues,
+ *     lint_issues; enrichment: recipe_hash, cost, deps/anchors_resolved,
+ *     lint_issues, check_issues, section_range) — JSON.stringify preserves
+ *     insertion order, so this is part of the byte contract.
+ */
+
+import { instanceIdOf, normalizeQualifier, qualifierHash } from '../cache/keys.ts';
+import type { CostStamp, InputRef, Provenance } from '../model/provenance.ts';
+import { authorityForTransport } from '../model/provenance.ts';
+import type { StoredArtifact } from '../store/envelope.ts';
+import type { ResolvedInputs, RunDependency } from './producer-run.ts';
+
+export type RunLang = 'en' | 'he';
+
+/** The slice of an LLM call result the orchestration consumes — structurally
+ *  satisfied by the host's LLMResult. */
+export interface LLMResultLike {
+  content: string;
+  reasoning_content?: string;
+  usage: unknown;
+  prompt_chars: number;
+  elapsed_ms: number;
+  model: string;
+  transport: string;
+  attempts: number;
+}
+
+/** Minimal structural view of a mark extractor. The host's richer union
+ *  (llm | computed | …) flows through unchanged; core only branches on `kind`
+ *  and reads the prompt/schema/fan-out fields for kind='llm'. */
+export interface MarkExtractorLike {
+  kind: string;
+  system_prompt?: string;
+  user_prompt_template?: string;
+  system_prompt_he?: string;
+  user_prompt_template_he?: string;
+  output_schema?: unknown;
+  fan_out_over?: string;
+}
+
+/** Minimal structural view of a mark definition the run needs. */
+export interface MarkRunDef {
+  id: string;
+  cache_version: string;
+  dependencies?: ReadonlyArray<RunDependency>;
+  passes?: ReadonlyArray<string>;
+  extractor: MarkExtractorLike;
+}
+
+/** Minimal structural view of a (flattened, studio-registry-shaped) enrichment
+ *  definition the run needs. */
+export interface EnrichmentRunDef {
+  id: string;
+  cache_version: string;
+  /** ID of the mark whose instances feed this enrichment. */
+  mark: string;
+  dependencies?: ReadonlyArray<RunDependency>;
+  passes?: ReadonlyArray<string>;
+  system_prompt: string;
+  user_prompt_template: string;
+  system_prompt_he?: string;
+  user_prompt_template_he?: string;
+  output_schema?: unknown;
+}
+
+/** A post-generation check issue. Only `severity === 'hard'` is meaningful to
+ *  the orchestration (gates the cache write); everything else passes through. */
+export interface CheckIssueLike {
+  severity?: string;
+}
+
+export interface RunProducerOpts {
+  bypassCache: boolean;
+  /** Output language for prompts + cache keys (the host's rc.lang). */
+  lang: RunLang;
+  /** Enrichments only: per-call model override — skips the canonical cache
+   *  (cacheKey = null) to avoid polluting the default-traffic key. */
+  modelOverride?: string;
+  /** Enrichments only: cycle-detection ancestry. Marks always reset it. */
+  parentChain?: ReadonlySet<string>;
+  /** Enrichments only: free-text qualifier (e.g. the user's question for
+   *  argument-move.qa). Hashed into the cache key when present, and exposed
+   *  to the prompt template as {{user_question}}. */
+  userQuestion?: string;
+}
+
+/** Everything app-specific the orchestration calls out to. */
+export interface RunProducerPorts<
+  Ctx,
+  EDef extends EnrichmentRunDef = EnrichmentRunDef,
+  MDef extends MarkRunDef = MarkRunDef,
+> {
+  /** KV envelope read/write — the host's readCachedResult / writeCachedResult
+   *  byte-for-byte (no TTL; bump cache_version to invalidate). */
+  cacheRead(ctx: Ctx, key: string): Promise<StoredArtifact | null>;
+  cacheWrite(ctx: Ctx, key: string, value: StoredArtifact): Promise<void>;
+  /** Key derivation — MUST be the same keyForMark / keyForEnrichment the app
+   *  has always used (a derivation change cold-misses every warmed entry). */
+  markKey(def: MDef, tractate: string, page: string, lang: RunLang): string;
+  enrichmentKey(
+    def: EDef,
+    instanceId: string,
+    tractate: string,
+    page: string,
+    qualifier: string | undefined,
+    lang: RunLang,
+  ): string;
+  /** Content hash of the enrichment's recipe (the host projects its flat def
+   *  into the recipe shape, then recipeHash()). Stamped on every fresh
+   *  enrichment write; marks don't stamp one (legacy behavior, preserved). */
+  enrichmentRecipeHash(def: EDef): Promise<string>;
+  /** The segment-range stamp guarding title-keyed section enrichments
+   *  (null = no guard). App-specific (`def.mark === 'argument'` in talmud). */
+  sectionRange(def: EDef, markInput: unknown): string | null;
+  /** The dependency walk (resolveInputs wired to the app's source resolvers +
+   *  these same producer runs). */
+  resolveInputs(
+    ctx: Ctx,
+    dependencies: ReadonlyArray<RunDependency> | undefined,
+    tractate: string,
+    page: string,
+    markInput: unknown,
+    bypassCache: boolean,
+    parentChain: ReadonlySet<string>,
+  ): Promise<ResolvedInputs>;
+  renderTemplate(tpl: string, vars: Record<string, unknown>): string;
+  /** The mark LLM call: the host owns option construction (model/fallback/
+   *  attribution/tag) AND the fan_out_over branch; core owns when it's called
+   *  and with which (he-fallback-selected) templates + vars. */
+  markLLM(
+    ctx: Ctx,
+    args: {
+      def: MDef;
+      sysTpl: string;
+      usrTpl: string;
+      vars: Record<string, unknown>;
+      useHe: boolean;
+      tractate: string;
+      page: string;
+      bypassCache: boolean;
+    },
+  ): Promise<{ result: LLMResultLike; systemPrompt: string; userPrompt: string }>;
+  /** The enrichment LLM call (host owns options: model override / reasoning /
+   *  cost_class / attribution). Prompts are already rendered by core. */
+  enrichmentLLM(
+    ctx: Ctx,
+    args: {
+      def: EDef;
+      systemPrompt: string;
+      userPrompt: string;
+      useHe: boolean;
+      tractate: string;
+      page: string;
+      bypassCache: boolean;
+      modelOverride?: string;
+    },
+  ): Promise<LLMResultLike>;
+  /** The post-generation check layer (the host fetches whatever context its
+   *  passes need — segment grid, commentary text, the yerushalmi floor stashed
+   *  in inputs.vars — and runs its pass registry). Core gates on the returned
+   *  issues' `severity === 'hard'`. */
+  runChecks(
+    ctx: Ctx,
+    args: {
+      kind: 'mark' | 'enrich';
+      def: EDef | MDef;
+      parsed: unknown;
+      tractate: string;
+      page: string;
+      lang: RunLang;
+      inputs: ResolvedInputs;
+    },
+  ): Promise<{ parsed: unknown; issues: CheckIssueLike[] }>;
+  /** Bounded lint retry: returns true when the hard-failing output should be
+   *  pinned anyway (MAX_LINT_ATTEMPTS reached) — the host's noteLintAttempt. */
+  lintGate(
+    ctx: Ctx,
+    cacheKey: string,
+    info: {
+      producerId: string;
+      tractate: string;
+      page: string;
+      lang: RunLang;
+      issues: unknown[];
+    },
+  ): Promise<boolean>;
+  /** The per-entry cost stamp (host pricing helpers). */
+  costStamp(
+    model: string | undefined,
+    usage: unknown,
+    lang: RunLang,
+    cacheVersion: string,
+  ): CostStamp;
+  /** Daily-rollup usage attribution for a fresh LLM call (fire-and-forget). */
+  recordUsage(
+    ctx: Ctx,
+    args: {
+      kind: 'mark' | 'enrichment';
+      id: string;
+      result: { model?: string; usage?: unknown; parse_error?: string | null };
+    },
+  ): void;
+  /** Id-keyed app short-circuits + adjustments, cut (not copied) from the two
+   *  legacy bodies. Each either fully produces the result (skip the LLM) or
+   *  adjusts vars / the resolved inputs. */
+  hooks: {
+    /** The computed-extractor branch (deterministic, no LLM): produce the FULL
+     *  result envelope (model `computed:<fn>`, transport 'computed', …). Core
+     *  owns its cache read/write (always on the EN key). */
+    computedMark(ctx: Ctx, def: MDef, tractate: string, page: string): Promise<StoredArtifact>;
+    /** Mark post-parse processing (after the check passes): rabbi registry
+     *  grounding, places backlog logging. Returns the (possibly transformed)
+     *  parsed value. */
+    markPostParse(
+      ctx: Ctx,
+      args: {
+        def: MDef;
+        parsed: unknown;
+        vars: Record<string, unknown>;
+        tractate: string;
+        page: string;
+      },
+    ): Promise<unknown>;
+    /** Enrichment pre-resolve short-circuits (rabbi.relationships graph,
+     *  rabbi.identity lookup): a non-null return is the finished result —
+     *  core writes it (with provenance) and returns. */
+    enrichmentPreResolve(
+      ctx: Ctx,
+      args: {
+        def: EDef;
+        markInput: unknown;
+        tractate: string;
+        page: string;
+        recipeHash: string;
+      },
+    ): Promise<StoredArtifact | null>;
+    /** Enrichment post-resolve step (deps are resolved, LLM not yet called):
+     *  may fully produce (rabbi.observations — `shortCircuit`), and/or return
+     *  extra prompt vars (the pesukim Hebrew prefetch), and/or mutate
+     *  `inputs` in place (argument move-scoping). */
+    enrichmentPostResolve(
+      ctx: Ctx,
+      args: {
+        def: EDef;
+        inputs: ResolvedInputs;
+        markInput: unknown;
+        tractate: string;
+        page: string;
+      },
+    ): Promise<{ shortCircuit?: StoredArtifact; vars?: Record<string, unknown> }>;
+    /** Enrichment post-parse side effects (daf-background.concepts backlog). */
+    enrichmentPostParse(
+      ctx: Ctx,
+      args: {
+        def: EDef;
+        parsed: unknown;
+        parse_error: string | null;
+        tractate: string;
+        page: string;
+      },
+    ): void;
+  };
+}
+
+/** Resolved prompts are dev-only inspection; cap each at 2KB so multi-run
+ *  responses don't balloon (the full prompt already went to the LLM). */
+function capPrompt(s: string): string {
+  return s.length > 2000 ? `${s.slice(0, 2000)}… [+${s.length - 2000} chars]` : s;
+}
+
+/** JSON of a resolved input value with its TOP-LEVEL object keys sorted.
+ *  SHALLOW on purpose: the bucket values are produced deterministically by
+ *  their own producers (so nested order is already stable per producer run);
+ *  the shallow sort only removes the one source of nondeterminism we introduce
+ *  ourselves — object key insertion order under the parallel dependency walk.
+ *  Arrays keep their order (it is semantic). */
+function shallowStableJson(v: unknown): string {
+  if (v && typeof v === 'object' && !Array.isArray(v)) {
+    const src = v as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const k of Object.keys(src).sort()) out[k] = src[k];
+    return JSON.stringify(out);
+  }
+  return JSON.stringify(v);
+}
+
+/** One InputRef per resolved dependency: `sourceKey` is the dep id exactly as
+ *  it appears in deps_resolved / anchors_resolved (depends first, then
+ *  anchors, each id-sorted so the manifest is stable run-to-run), and
+ *  `contentHash` fingerprints the resolved VALUE — qualifierHash over its
+ *  shallow-stable JSON. (qualifierHash normalizes whitespace/case before
+ *  hashing; that's fine for a change-detection fingerprint, which is all this
+ *  is — it is NOT a canonical content address.) */
+export async function provenanceInputRefs(
+  resolved: Pick<ResolvedInputs, 'depends' | 'anchors'> | null,
+): Promise<InputRef[]> {
+  if (!resolved) return [];
+  const refs: InputRef[] = [];
+  for (const bucket of [resolved.depends, resolved.anchors]) {
+    for (const key of Object.keys(bucket).sort()) {
+      refs.push({
+        sourceKey: key,
+        contentHash: await qualifierHash(shallowStableJson(bucket[key])),
+      });
+    }
+  }
+  return refs;
+}
+
+/** The build manifest stamped on every FRESH cache write. Strictly additive:
+ *  every legacy top-level field (content/model/usage/recipe_hash/cost/…) keeps
+ *  being dual-written unchanged; `provenance` is appended after them. The
+ *  recipeHash is the SAME recipe_hash already stamped at top level (never a
+ *  second hash; absent on marks, which never stamped one). */
+export async function buildRunProvenance(
+  out: StoredArtifact,
+  producerId: string,
+  resolved: Pick<ResolvedInputs, 'depends' | 'anchors'> | null,
+): Promise<Provenance> {
+  return {
+    authority: authorityForTransport(out.transport),
+    producerId,
+    recipeHash: out.recipe_hash,
+    inputs: await provenanceInputRefs(resolved),
+    model: out.model,
+    transport: out.transport,
+    usage: out.usage,
+    cost: out.cost,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+/** Stamp + write + RETURN the stamped envelope. Provenance follows the same
+ *  lifecycle as recipe_hash/cost: stamped into the envelope at generation,
+ *  present on the fresh return AND on later cache-hit reads — additive JSON
+ *  consumers ignore unless they want it. (Returning the unstamped object would
+ *  make fresh responses and cache-hit responses diverge for no reason.) */
+async function writeWithProvenance<Ctx>(
+  ports: Pick<RunProducerPorts<Ctx>, 'cacheWrite'>,
+  ctx: Ctx,
+  key: string,
+  out: StoredArtifact,
+  producerId: string,
+  resolved: Pick<ResolvedInputs, 'depends' | 'anchors'> | null,
+): Promise<StoredArtifact> {
+  const provenance = await buildRunProvenance(out, producerId, resolved);
+  // Spread-then-append keeps every legacy field at its original position in
+  // the serialized JSON; `provenance` lands last (old readers ignore it).
+  const stamped = { ...out, provenance };
+  await ports.cacheWrite(ctx, key, stamped);
+  return stamped;
+}
+
+/**
+ * Run one producer (mark or enrichment): cache-first, dependency-fed, LLM- or
+ * rule-backed, check-gated, cost-stamped — and, on every fresh write, stamped
+ * with its provenance build manifest. `markInput` is the enrichment's target
+ * instance (ignored for marks).
+ */
+export async function runProducer<
+  Ctx,
+  EDef extends EnrichmentRunDef = EnrichmentRunDef,
+  MDef extends MarkRunDef = MarkRunDef,
+>(
+  ports: RunProducerPorts<Ctx, EDef, MDef>,
+  ctx: Ctx,
+  kind: 'mark' | 'enrich',
+  def: EDef | MDef,
+  tractate: string,
+  page: string,
+  markInput: unknown,
+  opts: RunProducerOpts,
+): Promise<StoredArtifact> {
+  const { bypassCache, lang } = opts;
+  const isMark = kind === 'mark';
+  const mdef = def as MDef;
+  const edef = def as EDef;
+
+  // -------------------------------------------------------------------------
+  // Mark: computed extractors — deterministic, no LLM. Same cache shape as LLM
+  // results so the rest of the pipeline is uniform. Computed marks are
+  // deterministic + language-neutral, so they stay on the English (suffix-free)
+  // key regardless of lang.
+  // -------------------------------------------------------------------------
+  if (isMark && mdef.extractor.kind === 'computed') {
+    const cacheKey = ports.markKey(mdef, tractate, page, 'en');
+    if (!bypassCache) {
+      const hit = await ports.cacheRead(ctx, cacheKey);
+      if (hit) return { ...hit, cache_hit: true };
+    }
+    const out = await ports.hooks.computedMark(ctx, mdef, tractate, page);
+    return writeWithProvenance(ports, ctx, cacheKey, out, mdef.id, null);
+  }
+  if (isMark && mdef.extractor.kind !== 'llm') {
+    throw new Error(`mark ${mdef.id} extractor.kind=${mdef.extractor.kind} not supported`);
+  }
+
+  // -------------------------------------------------------------------------
+  // Cache key + hit check. The two kinds' key/lang policies genuinely differ —
+  // see the divergence list in the module doc.
+  // -------------------------------------------------------------------------
+  let cacheKey: string | null;
+  let useHe: boolean;
+  let sectionRange: string | null = null;
+  let recipe_hash: string | undefined;
+
+  if (isMark) {
+    // Only fan the cache out by language when this mark actually has a Hebrew
+    // prompt — otherwise the :he run would produce byte-identical English
+    // structure and just waste a cache slot + an LLM call.
+    useHe = lang === 'he' && !!mdef.extractor.system_prompt_he;
+    cacheKey = ports.markKey(mdef, tractate, page, useHe ? 'he' : 'en');
+    if (!bypassCache) {
+      const hit = await ports.cacheRead(ctx, cacheKey);
+      if (hit) return { ...hit, cache_hit: true };
+    }
+  } else {
+    // Select the Hebrew prompt variant when lang='he' AND the def provides
+    // one; otherwise fall back to English (an enrichment without a *_he
+    // prompt still works in he mode — it just produces English prose).
+    useHe = lang === 'he';
+    const instance_id = await instanceIdOf(markInput);
+    const qHash = opts.userQuestion ? await qualifierHash(opts.userQuestion) : undefined;
+    cacheKey = opts.modelOverride
+      ? // Per-call model overrides skip the canonical cache to avoid polluting
+        // the default-traffic key. Re-running with the same override hits the
+        // gateway prompt cache but not KV — consistent with bypass behavior.
+        null
+      : ports.enrichmentKey(edef, instance_id, tractate, page, qHash, lang);
+    // Section enrichments key by title (see instanceIdOf); guard against a
+    // drifted title serving another section's cache by validating the stamped
+    // range. Null for non-section enrichments (no guard).
+    sectionRange = ports.sectionRange(edef, markInput);
+    if (cacheKey && !bypassCache) {
+      const hit = await ports.cacheRead(ctx, cacheKey);
+      // Reject a hit whose stamped range doesn't match the requested section
+      // (covers both a drifted title AND legacy entries with no stamp).
+      if (hit && (!sectionRange || hit.section_range === sectionRange)) {
+        return { ...hit, cache_hit: true };
+      }
+    }
+    // Content hash of this producer's recipe, stamped on every fresh write so
+    // staleness can be detected later. Computed once here, after the
+    // cache-hit early-return so hits don't pay for it.
+    recipe_hash = await ports.enrichmentRecipeHash(edef);
+
+    // Deterministic pre-resolve short-circuits (graph / lookup) — a non-null
+    // return is the finished result.
+    const pre = await ports.hooks.enrichmentPreResolve(ctx, {
+      def: edef,
+      markInput,
+      tractate,
+      page,
+      recipeHash: recipe_hash,
+    });
+    if (pre) {
+      if (cacheKey) return writeWithProvenance(ports, ctx, cacheKey, pre, edef.id, null);
+      return pre;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Dependency walk. A mark RESETS the cycle chain; an enrichment EXTENDS it.
+  // -------------------------------------------------------------------------
+  let chain: ReadonlySet<string>;
+  if (isMark) {
+    chain = new Set();
+  } else {
+    const next = new Set(opts.parentChain ?? []);
+    next.add(edef.id);
+    chain = next;
+  }
+  const inputs = await ports.resolveInputs(
+    ctx,
+    def.dependencies,
+    tractate,
+    page,
+    isMark ? undefined : markInput,
+    bypassCache,
+    chain,
+  );
+
+  // Enrichment post-resolve step: deterministic full-produce (observations),
+  // extra prompt vars (pesukim prefetch), in-place input scoping (argument
+  // move-scoping).
+  let extraVars: Record<string, unknown> = {};
+  if (!isMark) {
+    const post = await ports.hooks.enrichmentPostResolve(ctx, {
+      def: edef,
+      inputs,
+      markInput,
+      tractate,
+      page,
+    });
+    if (post.shortCircuit) {
+      const out = post.shortCircuit;
+      if (cacheKey) return writeWithProvenance(ports, ctx, cacheKey, out, edef.id, inputs);
+      return out;
+    }
+    extraVars = post.vars ?? {};
+  }
+
+  // -------------------------------------------------------------------------
+  // Prompt vars + the LLM call (he-prompt fallback selected here; the host
+  // owns option construction and the mark fan-out).
+  // -------------------------------------------------------------------------
+  const vars: Record<string, unknown> = isMark
+    ? {
+        ...inputs.vars,
+        depends: inputs.depends,
+        anchors: inputs.anchors,
+      }
+    : {
+        ...inputs.vars,
+        mark_input: markInput,
+        ...extraVars,
+        depends: inputs.depends,
+        anchors: inputs.anchors,
+        // Normalized so prompts see a clean version even when the user submits
+        // sloppy whitespace/casing. Empty string when absent so
+        // {{user_question}} is safe to interpolate in any prompt.
+        user_question: opts.userQuestion ? normalizeQualifier(opts.userQuestion) : '',
+      };
+  let result: LLMResultLike;
+  let systemPrompt: string;
+  let userPrompt: string;
+  if (isMark) {
+    const ext = mdef.extractor;
+    const sysTpl = (
+      useHe && ext.system_prompt_he ? ext.system_prompt_he : ext.system_prompt
+    ) as string;
+    const usrTpl = (
+      useHe && ext.user_prompt_template_he ? ext.user_prompt_template_he : ext.user_prompt_template
+    ) as string;
+    const r = await ports.markLLM(ctx, {
+      def: mdef,
+      sysTpl,
+      usrTpl,
+      vars,
+      useHe,
+      tractate,
+      page,
+      bypassCache,
+    });
+    result = r.result;
+    systemPrompt = r.systemPrompt;
+    userPrompt = r.userPrompt;
+  } else {
+    const sysTpl = useHe && edef.system_prompt_he ? edef.system_prompt_he : edef.system_prompt;
+    const usrTpl =
+      useHe && edef.user_prompt_template_he
+        ? edef.user_prompt_template_he
+        : edef.user_prompt_template;
+    systemPrompt = ports.renderTemplate(sysTpl, vars);
+    userPrompt = ports.renderTemplate(usrTpl, vars);
+    result = await ports.enrichmentLLM(ctx, {
+      def: edef,
+      systemPrompt,
+      userPrompt,
+      useHe,
+      tractate,
+      page,
+      bypassCache,
+      modelOverride: opts.modelOverride,
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Parse + check layer + post-processing.
+  // -------------------------------------------------------------------------
+  const outputSchema = isMark ? mdef.extractor.output_schema : edef.output_schema;
+  let parsed: unknown = null;
+  let parse_error: string | null = null;
+  if (outputSchema) {
+    try {
+      parsed = JSON.parse(result.content);
+    } catch (err) {
+      parse_error = String(err).slice(0, 200);
+    }
+  }
+
+  let checkIssues: unknown[] | undefined; // all severities → observation
+  let hardIssues: unknown[] | undefined; // hard subset → gating + /api/usage
+  // The conditions differ textually between the legacy bodies (mark omitted
+  // `!parse_error`); outcomes are identical — parsed is only non-null when the
+  // parse succeeded — but both are kept verbatim.
+  const wantChecks = isMark
+    ? Boolean(parsed && def.passes && def.passes.length > 0)
+    : Boolean(parsed && !parse_error && def.passes && def.passes.length > 0);
+  if (wantChecks) {
+    const checked = await ports.runChecks(ctx, {
+      kind,
+      def,
+      parsed,
+      tractate,
+      page,
+      lang,
+      inputs,
+    });
+    parsed = checked.parsed;
+    if (checked.issues.length > 0) {
+      checkIssues = checked.issues;
+      const hard = checked.issues.filter((i) => i.severity === 'hard');
+      if (hard.length > 0) hardIssues = hard;
+    }
+  }
+
+  if (isMark) {
+    // markPostParse sees the same prompt vars the LLM call did
+    // (postProcessRabbi reads the daf Hebrew off vars.hebrew).
+    parsed = await ports.hooks.markPostParse(ctx, { def: mdef, parsed, vars, tractate, page });
+    // Attribute this fresh LLM call's tokens + cost to the daily rollup.
+    // (Marks recorded usage BEFORE building the envelope; preserved.)
+    ports.recordUsage(ctx, {
+      kind: 'mark',
+      id: mdef.id,
+      result: { model: result.model, usage: result.usage, parse_error },
+    });
+  } else {
+    ports.hooks.enrichmentPostParse(ctx, { def: edef, parsed, parse_error, tractate, page });
+  }
+
+  // -------------------------------------------------------------------------
+  // Result envelope — field order is per-kind and part of the byte contract.
+  // -------------------------------------------------------------------------
+  const head = {
+    content: result.content,
+    reasoning: result.reasoning_content || undefined,
+    parsed,
+    parse_error,
+    model: result.model,
+    transport: result.transport,
+    attempts: result.attempts,
+    usage: result.usage,
+    elapsed_ms: result.elapsed_ms,
+    prompt_chars: result.prompt_chars,
+    resolved: {
+      system_prompt: capPrompt(systemPrompt),
+      user_prompt: capPrompt(userPrompt),
+    },
+    cache_hit: false,
+  };
+  const cost = ports.costStamp(result.model, result.usage, useHe ? 'he' : 'en', def.cache_version);
+  const out: StoredArtifact = isMark
+    ? {
+        ...head,
+        cost,
+        ...(checkIssues ? { check_issues: checkIssues } : {}),
+        ...(hardIssues ? { lint_issues: hardIssues } : {}),
+      }
+    : {
+        ...head,
+        recipe_hash,
+        cost,
+        deps_resolved: Object.keys(inputs.depends).length > 0 ? inputs.depends : undefined,
+        anchors_resolved: Object.keys(inputs.anchors).length > 0 ? inputs.anchors : undefined,
+        ...(hardIssues ? { lint_issues: hardIssues } : {}),
+        ...(checkIssues ? { check_issues: checkIssues } : {}),
+        ...(sectionRange ? { section_range: sectionRange } : {}),
+      };
+
+  // -------------------------------------------------------------------------
+  // Cache write, gated on hard check issues, BOUNDED. A clean output (or one
+  // with only soft issues) is pinned; a hard-failing one is left uncached so
+  // the next request regenerates — until MAX_LINT_ATTEMPTS (lintGate returns
+  // true), then pinned anyway so a persistently-failing card stops re-paying.
+  // -------------------------------------------------------------------------
+  let final: StoredArtifact = out;
+  if (cacheKey && !parse_error) {
+    if (!hardIssues) {
+      final = await writeWithProvenance(ports, ctx, cacheKey, out, def.id, inputs);
+    } else if (
+      await ports.lintGate(ctx, cacheKey, {
+        producerId: def.id,
+        tractate,
+        page,
+        lang,
+        issues: hardIssues,
+      })
+    ) {
+      final = await writeWithProvenance(ports, ctx, cacheKey, out, def.id, inputs);
+    }
+  }
+  if (!isMark) {
+    // Attribute this fresh LLM call's tokens + cost to the daily rollup.
+    // (Enrichments recorded usage AFTER the write gating; preserved.)
+    ports.recordUsage(ctx, {
+      kind: 'enrichment',
+      id: edef.id,
+      result: { model: result.model, usage: result.usage, parse_error },
+    });
+  }
+  return final;
+}

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -32,6 +32,7 @@ import {
   type ResolveInputsPorts,
   resolveInputs,
 } from '@corpus/core/run/producer-run';
+import { type RunProducerPorts, runProducer } from '@corpus/core/run/run-producer';
 import { Hono } from 'hono';
 import {
   GENERATION_IDS,
@@ -125,7 +126,6 @@ import {
   keyForRegion,
   keyForSpineLinks,
   keyForTranslate,
-  normalizeQualifier,
   prefixForRabbiObs,
   previousVersionKey,
   qualifierHash,
@@ -2680,128 +2680,88 @@ function postProcessRabbi(parsed: unknown, hebrewText: string): unknown {
   };
 }
 
-async function runMarkOnce(
-  rc: RunCtx,
-  def: SchemaMarkDefinition,
-  tractate: string,
-  page: string,
-  bypassCache: boolean,
-): Promise<RunResult> {
-  // Computed extractors — deterministic, no LLM. Same cache shape as LLM
-  // results so the rest of the pipeline (caching, dependency resolution,
-  // dev panel run-state) is uniform.
-  if (def.extractor.kind === 'computed') {
-    const fn = COMPUTED_FNS[def.extractor.fn];
-    if (!fn) throw new Error(`mark ${def.id}: no computed fn '${def.extractor.fn}' registered`);
-    // Computed marks are deterministic + language-neutral, so keep them on the
-    // English (suffix-free) key regardless of rc.lang — no point fanning the
-    // cache for identical output.
-    const cacheKey = keyForMark(def, tractate, page);
-    if (!bypassCache) {
-      const hit = await readCachedResult(rc.env, cacheKey);
-      if (hit) return { ...hit, cache_hit: true };
-    }
-    const t0 = Date.now();
-    const parsed = await fn(rc.env, tractate, page);
-    const elapsed_ms = Date.now() - t0;
-    const content = JSON.stringify(parsed);
-    const out: RunResult = {
-      content,
-      parsed,
-      parse_error: null,
-      model: `computed:${def.extractor.fn}`,
-      transport: 'computed',
-      attempts: 1,
-      usage: null,
-      elapsed_ms,
-      prompt_chars: 0,
-      resolved: {
-        system_prompt: `(computed fn: ${def.extractor.fn})`,
-        user_prompt: `(no LLM call — deterministic extraction from upstream data source)`,
-      },
-      cache_hit: false,
-    };
-    await writeCachedResult(rc.env, cacheKey, out);
-    return out;
-  }
+// ===========================================================================
+// runMarkOnce / runEnrichmentOnce — thin shims over the ONE corpus-agnostic
+// runProducer orchestration (@corpus/core/run/run-producer). Everything
+// app-specific enters through RUN_PORTS: key derivation (the same
+// keyForMark / keyForEnrichment as always), the LLM call + option
+// construction (incl. the argument-move fan-out), the check layer, and the
+// id-keyed short-circuits (rabbi graph/identity/observations, the pesukim
+// Hebrew prefetch, argument move-scoping, rabbi/places mark post-processing)
+// — all CUT from the two legacy bodies, not copied. Core owns the
+// orchestration (cache read/hit, dependency walk, he-prompt fallback, parse,
+// hard-issue gating with bounded lint retries, the per-kind envelope shape)
+// and ADDITIVELY stamps the `provenance` build manifest on every fresh write.
+// ===========================================================================
 
-  if (def.extractor.kind !== 'llm') {
-    throw new Error(`mark ${def.id} extractor.kind=${def.extractor.kind} not supported`);
-  }
-  const ext = def.extractor;
-  // Only fan the cache out by language when this mark actually has a Hebrew
-  // prompt — otherwise the :he run would produce byte-identical English
-  // structure and just waste a cache slot + an LLM call. Marks with a `_he`
-  // prompt (argument, halacha, aggadata, pesukim, argument-move) emit a
-  // Hebrew title/summary, so those get their own :he namespace.
-  const useHe = rc.lang === 'he' && !!ext.system_prompt_he;
-  const cacheKey = keyForMark(def, tractate, page, useHe ? 'he' : 'en');
-  if (!bypassCache) {
-    const hit = await readCachedResult(rc.env, cacheKey);
-    if (hit) return { ...hit, cache_hit: true };
-  }
-
-  const inputs = await resolveDependencies(
-    rc,
-    def.dependencies,
-    tractate,
-    page,
-    undefined,
-    bypassCache,
-    new Set(),
-  );
-  const vars: Record<string, unknown> = {
-    ...inputs.vars,
-    depends: inputs.depends,
-    anchors: inputs.anchors,
-  };
-  // Shared runLLM options (everything except messages + max_tokens, which the
-  // single-call and per-section-call paths set themselves).
-  const llmOptsBase = {
-    ...(ext.model ? { model: ext.model } : {}),
-    ...(ext.fallback && ext.fallback.length > 0 ? { fallback: ext.fallback } : {}),
-    temperature: 0.2,
-    response_format: ext.output_schema
-      ? { type: 'json_schema' as const, json_schema: ext.output_schema }
-      : undefined,
-    thinking: ext.thinking_off ? false : undefined,
-    bypass_cache: bypassCache,
-    // Cost-ledger attribution; the fan-out path spreads llmOptsBase, so this
-    // tags every argument-move sub-call too.
-    tag: `mark:${def.id}`,
-    attribution: {
-      kind: 'mark' as const,
-      producerId: def.id,
+const RUN_PORTS: RunProducerPorts<RunCtx, EnrichmentDefinition, SchemaMarkDefinition> = {
+  cacheRead: (rc, key) => readCachedResult(rc.env, key),
+  cacheWrite: (rc, key, value) => writeCachedResult(rc.env, key, value as RunResult),
+  markKey: (def, tractate, page, lang) => keyForMark(def, tractate, page, lang),
+  enrichmentKey: (def, instanceId, tractate, page, qualifier, lang) =>
+    keyForEnrichment(
+      def,
+      instanceId,
+      def.scope === 'local' ? { tractate, page } : undefined,
+      qualifier,
+      lang,
+    ),
+  enrichmentRecipeHash: (def) => recipeHash(enrichmentRecipe(def)),
+  sectionRange: (def, markInput) => sectionRangeOf(def, markInput),
+  resolveInputs: (rc, dependencies, tractate, page, markInput, bypassCache, parentChain) =>
+    resolveInputs(
+      RESOLVE_PORTS,
+      rc,
+      dependencies,
       tractate,
       page,
-      lang: useHe ? ('he' as const) : ('en' as const),
-      cache_version: def.cache_version,
-    },
-  };
-
-  let result: LLMResult;
-  let systemPrompt: string;
-  let userPrompt: string;
-  // Hebrew mode selects the *_he prompt variant when the mark defines one
-  // (mirrors runEnrichmentOnce). Falls back to English when absent.
-  const sysTpl = useHe && ext.system_prompt_he ? ext.system_prompt_he : ext.system_prompt;
-  const usrTpl =
-    useHe && ext.user_prompt_template_he ? ext.user_prompt_template_he : ext.user_prompt_template;
-  if (ext.fan_out_over) {
-    const fanned = await runExtractorFannedOut(
-      rc,
-      { ...ext, system_prompt: sysTpl, user_prompt_template: usrTpl },
-      vars,
-      ext.fan_out_over,
-      llmOptsBase,
-    );
-    result = fanned.result;
-    systemPrompt = fanned.systemPromptSample;
-    userPrompt = fanned.userPromptSample;
-  } else {
-    systemPrompt = renderTemplate(sysTpl, vars);
-    userPrompt = renderTemplate(usrTpl, vars);
-    result = await runLLM(rc.env, {
+      markInput,
+      bypassCache,
+      parentChain,
+    ),
+  renderTemplate: (tpl, vars) => renderTemplate(tpl, vars),
+  markLLM: async (rc, a) => {
+    const ext = a.def.extractor as LLMExtractor;
+    // Shared runLLM options (everything except messages + max_tokens, which the
+    // single-call and per-section-call paths set themselves).
+    const llmOptsBase = {
+      ...(ext.model ? { model: ext.model } : {}),
+      ...(ext.fallback && ext.fallback.length > 0 ? { fallback: ext.fallback } : {}),
+      temperature: 0.2,
+      response_format: ext.output_schema
+        ? { type: 'json_schema' as const, json_schema: ext.output_schema }
+        : undefined,
+      thinking: ext.thinking_off ? false : undefined,
+      bypass_cache: a.bypassCache,
+      // Cost-ledger attribution; the fan-out path spreads llmOptsBase, so this
+      // tags every argument-move sub-call too.
+      tag: `mark:${a.def.id}`,
+      attribution: {
+        kind: 'mark' as const,
+        producerId: a.def.id,
+        tractate: a.tractate,
+        page: a.page,
+        lang: a.useHe ? ('he' as const) : ('en' as const),
+        cache_version: a.def.cache_version,
+      },
+    };
+    if (ext.fan_out_over) {
+      const fanned = await runExtractorFannedOut(
+        rc,
+        { ...ext, system_prompt: a.sysTpl, user_prompt_template: a.usrTpl },
+        a.vars,
+        ext.fan_out_over,
+        llmOptsBase,
+      );
+      return {
+        result: fanned.result,
+        systemPrompt: fanned.systemPromptSample,
+        userPrompt: fanned.userPromptSample,
+      };
+    }
+    const systemPrompt = renderTemplate(a.sysTpl, a.vars);
+    const userPrompt = renderTemplate(a.usrTpl, a.vars);
+    const result = await runLLM(rc.env, {
       ...llmOptsBase,
       messages: [
         { role: 'system', content: systemPrompt },
@@ -2809,120 +2769,321 @@ async function runMarkOnce(
       ],
       max_tokens: 16000,
     });
-  }
-
-  let parsed: unknown = null;
-  let parse_error: string | null = null;
-  if (ext.output_schema) {
-    try {
-      parsed = JSON.parse(result.content);
-    } catch (err) {
-      parse_error = String(err).slice(0, 200);
-    }
-  }
-  // Per-mark post-processing via the declarative check layer
-  // (src/lib/check/passes.ts). Some extractors (notably argument-move) can't
-  // reliably emit segment indices for sub-ranges, so the verbatim re-anchorers
-  // (reanchor-argument/-move/-pesukim/-aggadata) re-derive them from the Hebrew
-  // excerpt the LLM IS good at copying, and compute token (word) offsets within
-  // the matched segment so the highlight painter can paint exactly the
-  // move/citation, not the whole containing segment. A definition opts in via
-  // `passes: []` in code-marks.ts; the transforms need the segment grid, so
-  // fetch the gemara slice once when any check runs.
-  let markCheckIssues: unknown[] | undefined;
-  let markHardIssues: unknown[] | undefined;
-  if (parsed && def.passes && def.passes.length > 0) {
-    const slice = await getGemaraSlice(rc.env, tractate, page, false);
-    const checked = await runPasses(def.passes, parsed, {
-      tractate,
-      page,
-      segmentsHe: slice.segments_he,
-      defId: def.id,
-      lang: rc.lang,
-      // The yerushalmi-floor transform needs the deterministic floor anchors the
-      // resolver stashed; harmless (and absent) for every other mark.
-      yerushalmiFloor: inputs.vars.__yerushalmiFloor as YerushalmiFloorGroup[] | undefined,
+    return { result, systemPrompt, userPrompt };
+  },
+  enrichmentLLM: async (rc, a) => {
+    const def = a.def;
+    const model = (a.modelOverride as LLMModelId | undefined) ?? def.model;
+    return runLLM(rc.env, {
+      ...(model ? { model } : {}),
+      messages: [
+        { role: 'system', content: a.systemPrompt },
+        { role: 'user', content: a.userPrompt },
+      ],
+      max_tokens: 16000,
+      temperature: 0.2,
+      response_format: def.output_schema
+        ? { type: 'json_schema', json_schema: def.output_schema }
+        : undefined,
+      thinking: def.thinking_off ? false : undefined,
+      reasoning_effort: def.reasoning_effort,
+      bypass_cache: a.bypassCache,
+      tag: `enrich:${def.id}`,
+      attribution: {
+        kind: def.id.endsWith('.qa') ? ('qa' as const) : ('enrichment' as const),
+        producerId: def.id,
+        tractate: a.tractate,
+        page: a.page,
+        lang: a.useHe ? ('he' as const) : ('en' as const),
+        cache_version: def.cache_version,
+      },
+      // Custom Q&A enrichments (<mark>.qa) count against the hourly custom-question
+      // budget; everything else only against the daily total. See ./budget.
+      cost_class: def.id.endsWith('.qa') ? 'custom-question' : undefined,
     });
-    parsed = checked.parsed;
-    // Attach all issues for observation; `hard` ones (e.g. anchor-verbatim on
-    // pesukim/aggadata, where it's promoted) gate the cache write below.
-    if (checked.issues.length > 0) {
-      markCheckIssues = checked.issues;
-      const hard = checked.issues.filter((i) => i.severity === 'hard');
-      if (hard.length > 0) markHardIssues = hard;
-    }
-  }
-  // Special cases that don't fit the segments-only transform signature yet:
-  //   - rabbi:  needs the daf Hebrew text, not the segment grid (A1b will port it).
-  //   - places: a side effect (backlog logging), not a parsed-output transform.
-  if (parsed && def.id === 'rabbi') {
-    parsed = postProcessRabbi(parsed, stripHtmlServer(String(vars.hebrew ?? '')));
-    // Ground each rabbi's generation through the registry (relational homonym
-    // disambiguation off the daf's cast): authoritative era when identified,
-    // neutral 'unknown' for a homonym we can't pin — so the reader's era color
-    // is grounded, not a freeform per-daf guess.
-    parsed = groundRabbiInstances(parsed);
-  } else if (parsed && def.id === 'places') {
-    // Places have no global gazetteer — log every observed location to the
-    // "needs global enrichment" backlog so we can see what to add over time.
-    recordObservedPlacesFromMark(rc, parsed, tractate, page);
-  }
-  // Attribute this fresh LLM call's tokens + cost to the daily rollup.
-  captureLlmUsage(rc, {
-    kind: 'mark',
-    id: def.id,
-    result: { model: result.model, usage: result.usage, parse_error },
-  });
-  const out: RunResult = {
-    content: result.content,
-    reasoning: result.reasoning_content || undefined,
-    parsed,
-    parse_error,
-    model: result.model,
-    transport: result.transport,
-    attempts: result.attempts,
-    usage: result.usage,
-    elapsed_ms: result.elapsed_ms,
-    prompt_chars: result.prompt_chars,
-    // Resolved prompts are dev-only inspection; cap each at 2KB so multi-run
-    // responses don't balloon. The full prompt was already sent to the LLM —
-    // we don't need to ship it back through workerd just for the dev tray.
-    resolved: {
-      system_prompt:
-        systemPrompt.length > 2000
-          ? `${systemPrompt.slice(0, 2000)}… [+${systemPrompt.length - 2000} chars]`
-          : systemPrompt,
-      user_prompt:
-        userPrompt.length > 2000
-          ? `${userPrompt.slice(0, 2000)}… [+${userPrompt.length - 2000} chars]`
-          : userPrompt,
-    },
-    cache_hit: false,
-    cost: costStampOf(result.model, result.usage, useHe ? 'he' : 'en', def.cache_version),
-    ...(markCheckIssues ? { check_issues: markCheckIssues } : {}),
-    ...(markHardIssues ? { lint_issues: markHardIssues } : {}),
-  };
-  // Gate on hard check issues, BOUNDED — same posture as runEnrichmentOnce. A
-  // clean output (or one with only soft issues) is pinned; a hard-failing one
-  // (e.g. a hallucinated pesukim/aggadata anchor) is left uncached so the next
-  // request regenerates — until MAX_LINT_ATTEMPTS, then pinned anyway so a
-  // persistently-failing card stops re-paying. Capped failures surface on /api/usage.
-  if (!parse_error) {
-    if (!markHardIssues) {
-      await writeCachedResult(rc.env, cacheKey, out);
-    } else if (
-      await noteLintAttempt(rc.env, rc.ctx, cacheKey, {
-        enrichmentId: def.id,
-        tractate,
-        page,
+  },
+  // Post-generation processing via the standardized check layer
+  // (src/lib/check/passes.ts). A definition opts in via `passes: []` in
+  // code-marks.ts. The transforms need the segment grid, so fetch the gemara
+  // slice once when any check runs. Marks additionally hand through the
+  // deterministic yerushalmi floor anchors the resolver stashed; enrichments
+  // fetch the daf's real Rashi/Tosafot text when a check wants to verify
+  // cited quotes against it.
+  runChecks: async (rc, a) => {
+    const slice = await getGemaraSlice(rc.env, a.tractate, a.page, false);
+    if (a.kind === 'mark') {
+      return runPasses(a.def.passes ?? [], a.parsed, {
+        tractate: a.tractate,
+        page: a.page,
+        segmentsHe: slice.segments_he,
+        defId: a.def.id,
         lang: rc.lang,
-        issues: markHardIssues,
-      })
-    ) {
-      await writeCachedResult(rc.env, cacheKey, out);
+        // The yerushalmi-floor transform needs the deterministic floor anchors the
+        // resolver stashed; harmless (and absent) for every other mark.
+        yerushalmiFloor: a.inputs.vars.__yerushalmiFloor as YerushalmiFloorGroup[] | undefined,
+      });
     }
-  }
-  return out;
+    // commentary-verbatim needs the daf's real Rashi/Tosafot text to verify
+    // cited quotes against — fetch it only when a check actually wants it.
+    let commentaryHe: string[] | undefined;
+    if (a.def.passes?.includes('commentary-verbatim')) {
+      const com = await getCommentariesSlice(rc.env, a.tractate, a.page, false);
+      commentaryHe = Object.values(com.by_commentator)
+        .map((c) => stripHtmlServer(c.hebrew))
+        .filter(Boolean);
+    }
+    return runPasses(a.def.passes ?? [], a.parsed, {
+      tractate: a.tractate,
+      page: a.page,
+      segmentsHe: slice.segments_he,
+      commentaryHe,
+      defId: a.def.id,
+      lang: rc.lang,
+    });
+  },
+  lintGate: (rc, cacheKey, info) =>
+    noteLintAttempt(rc.env, rc.ctx, cacheKey, {
+      enrichmentId: info.producerId,
+      tractate: info.tractate,
+      page: info.page,
+      lang: info.lang,
+      issues: info.issues,
+    }),
+  costStamp: (model, usage, lang, cacheVersion) =>
+    costStampOf(model, usage as LLMUsage | null | undefined, lang, cacheVersion),
+  recordUsage: (rc, args) =>
+    captureLlmUsage(rc, {
+      kind: args.kind,
+      id: args.id,
+      result: args.result as {
+        model?: string;
+        usage?: LLMUsage | null;
+        parse_error?: string | null;
+      },
+    }),
+  hooks: {
+    // Computed extractors — deterministic, no LLM. Same cache shape as LLM
+    // results so the rest of the pipeline (caching, dependency resolution,
+    // dev panel run-state) is uniform.
+    computedMark: async (rc, def, tractate, page) => {
+      const extractor = def.extractor;
+      if (extractor.kind !== 'computed') {
+        throw new Error(
+          `mark ${def.id}: computedMark hook called for extractor.kind=${extractor.kind}`,
+        );
+      }
+      const fn = COMPUTED_FNS[extractor.fn];
+      if (!fn) throw new Error(`mark ${def.id}: no computed fn '${extractor.fn}' registered`);
+      const t0 = Date.now();
+      const parsed = await fn(rc.env, tractate, page);
+      const elapsed_ms = Date.now() - t0;
+      const content = JSON.stringify(parsed);
+      return {
+        content,
+        parsed,
+        parse_error: null,
+        model: `computed:${extractor.fn}`,
+        transport: 'computed',
+        attempts: 1,
+        usage: null,
+        elapsed_ms,
+        prompt_chars: 0,
+        resolved: {
+          system_prompt: `(computed fn: ${extractor.fn})`,
+          user_prompt: `(no LLM call — deterministic extraction from upstream data source)`,
+        },
+        cache_hit: false,
+      };
+    },
+    // Special cases that don't fit the segments-only transform signature yet:
+    //   - rabbi:  needs the daf Hebrew text, not the segment grid (A1b will port it).
+    //   - places: a side effect (backlog logging), not a parsed-output transform.
+    markPostParse: async (rc, a) => {
+      let parsed = a.parsed;
+      if (parsed && a.def.id === 'rabbi') {
+        parsed = postProcessRabbi(parsed, stripHtmlServer(String(a.vars.hebrew ?? '')));
+        // Ground each rabbi's generation through the registry (relational homonym
+        // disambiguation off the daf's cast): authoritative era when identified,
+        // neutral 'unknown' for a homonym we can't pin — so the reader's era color
+        // is grounded, not a freeform per-daf guess.
+        parsed = groundRabbiInstances(parsed);
+      } else if (parsed && a.def.id === 'places') {
+        // Places have no global gazetteer — log every observed location to the
+        // "needs global enrichment" backlog so we can see what to add over time.
+        recordObservedPlacesFromMark(rc, parsed, a.tractate, a.page);
+      }
+      return parsed;
+    },
+    enrichmentPreResolve: async (rc, a) => {
+      const { def, markInput, tractate, page } = a;
+      // Graph short-circuit for rabbi.relationships. Sefaria's rabbi graph
+      // (src/lib/data/rabbi-hierarchy.json) is the source of truth for who
+      // a rabbi's teachers/students/colleagues were — much more reliable than
+      // an LLM call, deterministic, free, and instant. We only fall through to
+      // the LLM when the graph misses (rabbi not found OR node has no edges).
+      if (def.id === 'rabbi.relationships') {
+        const inst = markInput as { name?: string; nameHe?: string; generation?: string } | null;
+        if (inst?.name) {
+          const hit = lookupRelationships(inst.name, inst.nameHe, inst.generation);
+          if (hit) {
+            return {
+              content: JSON.stringify(hit.data),
+              parsed: hit.data,
+              parse_error: null,
+              model: `graph:${hit.slug}`,
+              transport: 'graph',
+              attempts: 0,
+              usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },
+              elapsed_ms: 0,
+              prompt_chars: 0,
+              resolved: {
+                system_prompt: `(graph lookup: ${hit.slug})`,
+                user_prompt: `(graph lookup for rabbi: ${inst.name})`,
+              },
+              cache_hit: false,
+              recipe_hash: a.recipeHash,
+            };
+          }
+          // Miss — fall through to the LLM path with the disambiguation prompt.
+        }
+        return null;
+      }
+      // Deterministic short-circuit for rabbi.identity. The slug / region / places
+      // / moved fields come from the precomputed rabbi-places.json join (the same
+      // enrichRabbi the legacy /api/daf-context used) — an LLM can't produce a
+      // Sefaria slug, so there's no fallback path: enrichRabbi always returns an
+      // IdentifiedRabbi (nulled fields for rabbis not in the dataset). This is the
+      // single source of canonical identity data the timeline + bio sidebar read.
+      if (def.id === 'rabbi.identity') {
+        // Always short-circuit — there is no useful LLM fallback (a model can't
+        // know a Sefaria slug), and the placeholder prompt must never run.
+        const inst = markInput as {
+          name?: string;
+          nameHe?: string;
+          generation?: GenerationId;
+        } | null;
+        const ident = enrichRabbi(
+          inst?.name ?? '',
+          inst?.nameHe ?? '',
+          inst?.generation ?? 'unknown',
+        );
+        // Rabbi not in the bundled dataset → add to the "needs global enrichment"
+        // backlog so we can track who to add a base bio for as usage grows.
+        if (!ident.slug && (inst?.name || inst?.nameHe)) {
+          recordUnknownRabbi(rc.env, rc.ctx, {
+            name: inst?.name,
+            nameHe: inst?.nameHe,
+            generation: inst?.generation,
+            tractate,
+            page,
+          });
+        }
+        return {
+          content: JSON.stringify(ident),
+          parsed: ident,
+          parse_error: null,
+          model: ident.slug ? `lookup:${ident.slug}` : 'lookup:miss',
+          transport: 'lookup',
+          attempts: 0,
+          usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },
+          elapsed_ms: 0,
+          prompt_chars: 0,
+          resolved: {
+            system_prompt: '(deterministic lookup: rabbi-places.json)',
+            user_prompt: `(identity lookup for rabbi: ${inst?.name ?? '(unnamed)'})`,
+          },
+          cache_hit: false,
+          recipe_hash: a.recipeHash,
+        };
+      }
+      return null;
+    },
+    enrichmentPostResolve: async (rc, a) => {
+      const { def, inputs, markInput, tractate, page } = a;
+      // Deterministic accumulation step — runs LAST (its mark deps are resolved
+      // above) and writes per-rabbi observation slices to KV as a side effect.
+      // No LLM. See runRabbiObservations + src/worker/rabbi-observations.ts.
+      if (def.id === 'rabbi.observations') {
+        return { shortCircuit: await runRabbiObservations(rc, def, tractate, page, inputs) };
+      }
+      // Pre-fetch the focal pasuk's Hebrew verbatim for pesukim.* enrichments so
+      // the LLM has a verbatim source to quote from. Without this the model
+      // translates the verse to English and quotes that — the regression the
+      // synthesisLint catches.
+      let pasukHe = '';
+      let crossRefsHe = '';
+      if (def.id.startsWith('pesukim.')) {
+        const mi = markInput as { verseRef?: string; fields?: { verseRef?: string } } | null;
+        const focalRef = mi?.verseRef ?? mi?.fields?.verseRef ?? '';
+        if (focalRef) pasukHe = await fetchPasukHebrewForPrompt(rc.env, focalRef);
+        // For synthesis only: also fetch Hebrew for every OTHER pasuk cited on
+        // the daf, so the LLM can quote cross-references (e.g. Tehillim 119:148
+        // when the focal is 119:62) without reconstructing from training memory.
+        if (def.id === 'pesukim.synthesis') {
+          const pesukimAnchors = inputs.anchors.pesukim as
+            | { fields?: { verseRef?: string } }[]
+            | undefined;
+          if (Array.isArray(pesukimAnchors) && pesukimAnchors.length > 0) {
+            const seen = new Set<string>([focalRef]);
+            const lines: string[] = [];
+            for (const inst of pesukimAnchors) {
+              const ref = inst?.fields?.verseRef;
+              if (!ref || seen.has(ref)) continue;
+              seen.add(ref);
+              const he = await fetchPasukHebrewForPrompt(rc.env, ref);
+              if (he) lines.push(`- ${ref}: "${he}"`);
+            }
+            crossRefsHe = lines.join('\n');
+          }
+        }
+      }
+      // Scope the moves injected into the section-level argument enrichments
+      // (argument.synthesis, argument.voices) to THIS section. The argument-move
+      // mark emits every move on the daf; handing the LLM the whole list with only
+      // a soft "filter to this section" instruction makes synthesis summarize the
+      // entire sugya (worst for a 1-segment opening excerpt) and lets voices pull
+      // in rabbis from other sections. selectSectionMoves narrows to the section's
+      // moves and dedupes them. Move-level (argument-move.*) enrichments are NOT
+      // scoped — they deliberately get the full list to cross-reference other moves.
+      if (def.mark === 'argument') {
+        const mi = markInput as { startSegIdx?: number; endSegIdx?: number } | null;
+        const all = inputs.anchors['argument-move'];
+        if (
+          mi &&
+          typeof mi.startSegIdx === 'number' &&
+          typeof mi.endSegIdx === 'number' &&
+          Array.isArray(all)
+        ) {
+          inputs.anchors['argument-move'] = selectSectionMoves(all as MoveLike[], {
+            startSegIdx: mi.startSegIdx,
+            endSegIdx: mi.endSegIdx,
+          });
+        }
+      }
+      return { vars: { pasuk_he: pasukHe, cross_refs_he: crossRefsHe } };
+    },
+    // daf-background.concepts has no global glossary — log every term it emits to
+    // the observed-concept backlog so the canonical glossary can be grown from
+    // real usage later (same collect-now pattern as observed-place).
+    enrichmentPostParse: (rc, a) => {
+      if (a.parsed && !a.parse_error && a.def.id === 'daf-background.concepts') {
+        recordObservedConceptsFromEnrichment(rc, a.parsed, a.tractate, a.page);
+      }
+    },
+  },
+};
+
+async function runMarkOnce(
+  rc: RunCtx,
+  def: SchemaMarkDefinition,
+  tractate: string,
+  page: string,
+  bypassCache: boolean,
+): Promise<RunResult> {
+  return (await runProducer(RUN_PORTS, rc, 'mark', def, tractate, page, undefined, {
+    bypassCache,
+    lang: rc.lang,
+  })) as RunResult;
 }
 
 /** The segment range a section-level argument enrichment is being computed for,
@@ -2977,369 +3138,13 @@ async function runEnrichmentOnce(
    *  template as {{user_question}}. */
   userQuestion?: string,
 ): Promise<RunResultEnrichment> {
-  const instance_id = await instanceIdOf(markInput);
-  const qHash = userQuestion ? await qualifierHash(userQuestion) : undefined;
-  const cacheKey = modelOverride
-    ? // Per-call model overrides skip the canonical cache to avoid polluting
-      // the default-traffic key. Re-running with the same override hits the
-      // gateway prompt cache but not KV — consistent with bypass behavior.
-      null
-    : keyForEnrichment(
-        def,
-        instance_id,
-        def.scope === 'local' ? { tractate, page } : undefined,
-        qHash,
-        rc.lang,
-      );
-  // Section enrichments key by title (see instanceIdOf); guard against a
-  // drifted title serving another section's cache by validating the stamped
-  // range. Null for non-section enrichments (no guard).
-  const sectionRange = sectionRangeOf(def, markInput);
-  if (cacheKey && !bypassCache) {
-    const hit = (await readCachedResult(rc.env, cacheKey)) as RunResultEnrichment | null;
-    // Reject a hit whose stamped range doesn't match the requested section
-    // (covers both a drifted title AND legacy entries with no stamp) so it
-    // recomputes for the correct range instead of returning stale content.
-    if (hit && (!sectionRange || hit.section_range === sectionRange)) {
-      return { ...hit, cache_hit: true };
-    }
-  }
-
-  // Content hash of this producer's recipe, stamped on every fresh write below
-  // so staleness can be detected later (GET /api/stale). Computed once here,
-  // after the cache-hit early-return so hits don't pay for it. Enrichments have
-  // no `render`, so this hashes the extractor (prompt/schema/model).
-  const recipe_hash = await recipeHash(enrichmentRecipe(def));
-
-  // Graph short-circuit for rabbi.relationships. Sefaria's rabbi graph
-  // (src/lib/data/rabbi-hierarchy.json) is the source of truth for who
-  // a rabbi's teachers/students/colleagues were — much more reliable than
-  // an LLM call, deterministic, free, and instant. We only fall through to
-  // the LLM when the graph misses (rabbi not found OR node has no edges).
-  if (def.id === 'rabbi.relationships') {
-    const inst = markInput as { name?: string; nameHe?: string; generation?: string } | null;
-    if (inst?.name) {
-      const hit = lookupRelationships(inst.name, inst.nameHe, inst.generation);
-      if (hit) {
-        const out: RunResultEnrichment = {
-          content: JSON.stringify(hit.data),
-          parsed: hit.data,
-          parse_error: null,
-          model: `graph:${hit.slug}`,
-          transport: 'graph',
-          attempts: 0,
-          usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },
-          elapsed_ms: 0,
-          prompt_chars: 0,
-          resolved: {
-            system_prompt: `(graph lookup: ${hit.slug})`,
-            user_prompt: `(graph lookup for rabbi: ${inst.name})`,
-          },
-          cache_hit: false,
-          recipe_hash,
-        };
-        if (cacheKey) await writeCachedResult(rc.env, cacheKey, out);
-        return out;
-      }
-      // Miss — fall through to the LLM path with the disambiguation prompt.
-    }
-  }
-
-  // Deterministic short-circuit for rabbi.identity. The slug / region / places
-  // / moved fields come from the precomputed rabbi-places.json join (the same
-  // enrichRabbi the legacy /api/daf-context used) — an LLM can't produce a
-  // Sefaria slug, so there's no fallback path: enrichRabbi always returns an
-  // IdentifiedRabbi (nulled fields for rabbis not in the dataset). This is the
-  // single source of canonical identity data the timeline + bio sidebar read.
-  if (def.id === 'rabbi.identity') {
-    // Always short-circuit — there is no useful LLM fallback (a model can't
-    // know a Sefaria slug), and the placeholder prompt must never run.
-    const inst = markInput as { name?: string; nameHe?: string; generation?: GenerationId } | null;
-    const ident = enrichRabbi(inst?.name ?? '', inst?.nameHe ?? '', inst?.generation ?? 'unknown');
-    // Rabbi not in the bundled dataset → add to the "needs global enrichment"
-    // backlog so we can track who to add a base bio for as usage grows.
-    if (!ident.slug && (inst?.name || inst?.nameHe)) {
-      recordUnknownRabbi(rc.env, rc.ctx, {
-        name: inst?.name,
-        nameHe: inst?.nameHe,
-        generation: inst?.generation,
-        tractate,
-        page,
-      });
-    }
-    const out: RunResultEnrichment = {
-      content: JSON.stringify(ident),
-      parsed: ident,
-      parse_error: null,
-      model: ident.slug ? `lookup:${ident.slug}` : 'lookup:miss',
-      transport: 'lookup',
-      attempts: 0,
-      usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },
-      elapsed_ms: 0,
-      prompt_chars: 0,
-      resolved: {
-        system_prompt: '(deterministic lookup: rabbi-places.json)',
-        user_prompt: `(identity lookup for rabbi: ${inst?.name ?? '(unnamed)'})`,
-      },
-      cache_hit: false,
-      recipe_hash,
-    };
-    if (cacheKey) await writeCachedResult(rc.env, cacheKey, out);
-    return out;
-  }
-
-  const nextChain = new Set(parentChain);
-  nextChain.add(def.id);
-  const inputs = await resolveDependencies(
-    rc,
-    def.dependencies,
-    tractate,
-    page,
-    markInput,
+  return (await runProducer(RUN_PORTS, rc, 'enrich', def, tractate, page, markInput, {
     bypassCache,
-    nextChain,
-  );
-
-  // Deterministic accumulation step — runs LAST (its mark deps are resolved
-  // above) and writes per-rabbi observation slices to KV as a side effect.
-  // No LLM. See runRabbiObservations + src/worker/rabbi-observations.ts.
-  if (def.id === 'rabbi.observations') {
-    const out = await runRabbiObservations(rc, def, tractate, page, inputs);
-    if (cacheKey) await writeCachedResult(rc.env, cacheKey, out);
-    return out;
-  }
-
-  // Pre-fetch the focal pasuk's Hebrew verbatim for pesukim.* enrichments so
-  // the LLM has a verbatim source to quote from. Without this the model
-  // translates the verse to English and quotes that — the regression the
-  // synthesisLint catches.
-  let pasukHe = '';
-  let crossRefsHe = '';
-  if (def.id.startsWith('pesukim.')) {
-    const mi = markInput as { verseRef?: string; fields?: { verseRef?: string } } | null;
-    const focalRef = mi?.verseRef ?? mi?.fields?.verseRef ?? '';
-    if (focalRef) pasukHe = await fetchPasukHebrewForPrompt(rc.env, focalRef);
-    // For synthesis only: also fetch Hebrew for every OTHER pasuk cited on
-    // the daf, so the LLM can quote cross-references (e.g. Tehillim 119:148
-    // when the focal is 119:62) without reconstructing from training memory.
-    if (def.id === 'pesukim.synthesis') {
-      const pesukimAnchors = inputs.anchors.pesukim as
-        | { fields?: { verseRef?: string } }[]
-        | undefined;
-      if (Array.isArray(pesukimAnchors) && pesukimAnchors.length > 0) {
-        const seen = new Set<string>([focalRef]);
-        const lines: string[] = [];
-        for (const inst of pesukimAnchors) {
-          const ref = inst?.fields?.verseRef;
-          if (!ref || seen.has(ref)) continue;
-          seen.add(ref);
-          const he = await fetchPasukHebrewForPrompt(rc.env, ref);
-          if (he) lines.push(`- ${ref}: "${he}"`);
-        }
-        crossRefsHe = lines.join('\n');
-      }
-    }
-  }
-
-  // Scope the moves injected into the section-level argument enrichments
-  // (argument.synthesis, argument.voices) to THIS section. The argument-move
-  // mark emits every move on the daf; handing the LLM the whole list with only
-  // a soft "filter to this section" instruction makes synthesis summarize the
-  // entire sugya (worst for a 1-segment opening excerpt) and lets voices pull
-  // in rabbis from other sections. selectSectionMoves narrows to the section's
-  // moves and dedupes them. Move-level (argument-move.*) enrichments are NOT
-  // scoped — they deliberately get the full list to cross-reference other moves.
-  if (def.mark === 'argument') {
-    const mi = markInput as { startSegIdx?: number; endSegIdx?: number } | null;
-    const all = inputs.anchors['argument-move'];
-    if (
-      mi &&
-      typeof mi.startSegIdx === 'number' &&
-      typeof mi.endSegIdx === 'number' &&
-      Array.isArray(all)
-    ) {
-      inputs.anchors['argument-move'] = selectSectionMoves(all as MoveLike[], {
-        startSegIdx: mi.startSegIdx,
-        endSegIdx: mi.endSegIdx,
-      });
-    }
-  }
-
-  const vars: Record<string, unknown> = {
-    ...inputs.vars,
-    mark_input: markInput,
-    pasuk_he: pasukHe,
-    cross_refs_he: crossRefsHe,
-    depends: inputs.depends,
-    anchors: inputs.anchors,
-    // Normalized so prompts see a clean version even when the user submits
-    // sloppy whitespace/casing. Empty string when absent so {{user_question}}
-    // is safe to interpolate in any prompt.
-    user_question: userQuestion ? normalizeQualifier(userQuestion) : '',
-  };
-  // Select the Hebrew prompt variant when this run is lang='he' AND the def
-  // provides one; otherwise fall back to English. Falling back (rather than
-  // erroring) means an enrichment without a *_he prompt still works in he
-  // mode — it just produces English prose until its Hebrew prompt is authored.
-  const useHe = rc.lang === 'he';
-  const systemPromptTpl = useHe && def.system_prompt_he ? def.system_prompt_he : def.system_prompt;
-  const userPromptTpl =
-    useHe && def.user_prompt_template_he ? def.user_prompt_template_he : def.user_prompt_template;
-  const systemPrompt = renderTemplate(systemPromptTpl, vars);
-  const userPrompt = renderTemplate(userPromptTpl, vars);
-
-  const model = modelOverride ?? def.model;
-  const result = await runLLM(rc.env, {
-    ...(model ? { model } : {}),
-    messages: [
-      { role: 'system', content: systemPrompt },
-      { role: 'user', content: userPrompt },
-    ],
-    max_tokens: 16000,
-    temperature: 0.2,
-    response_format: def.output_schema
-      ? { type: 'json_schema', json_schema: def.output_schema }
-      : undefined,
-    thinking: def.thinking_off ? false : undefined,
-    reasoning_effort: def.reasoning_effort,
-    bypass_cache: bypassCache,
-    tag: `enrich:${def.id}`,
-    attribution: {
-      kind: def.id.endsWith('.qa') ? ('qa' as const) : ('enrichment' as const),
-      producerId: def.id,
-      tractate,
-      page,
-      lang: useHe ? ('he' as const) : ('en' as const),
-      cache_version: def.cache_version,
-    },
-    // Custom Q&A enrichments (<mark>.qa) count against the hourly custom-question
-    // budget; everything else only against the daily total. See ./budget.
-    cost_class: def.id.endsWith('.qa') ? 'custom-question' : undefined,
-  });
-
-  let parsed: unknown = null;
-  let parse_error: string | null = null;
-  if (def.output_schema) {
-    try {
-      parsed = JSON.parse(result.content);
-    } catch (err) {
-      parse_error = String(err).slice(0, 200);
-    }
-  }
-  // Post-generation processing via the standardized check layer
-  // (src/lib/check/passes.ts). An enrichment opts in through `passes: []` in
-  // code-marks.ts. Transforms run first:
-  //   - rabbi.{relationships,geography}.evidence -> 'reanchor-rabbi-evidence'
-  //     resolves each evidence excerpt to (startSegIdx, endSegIdx, tokenStart,
-  //     tokenEnd) so the sidebar can paint click-to-highlight ranges.
-  // Then validators:
-  //   - pesukim.synthesis -> 'hebrew-excerpt' (pesukim cited with English-only
-  //     quotes and no Hebrew verbatim text);
-  //   - halacha.* -> 'hebrew-gloss' (HEBREW_GLOSS_STYLE violations: bare /
-  //     parenthesized transliterations, calques, across every prose field + chip);
-  //   - argument.voices -> 'edge-integrity' (soft, observe-only).
-  // Issues are attached to the result (visible in dev tray / cache) but never
-  // reject the run; only `hard` issues gate the cache write below. The transforms
-  // need the segment grid, so fetch the gemara slice once when any check runs.
-  let lint_issues: unknown[] | undefined; // hard subset → gating + /api/usage path
-  let check_issues: unknown[] | undefined; // all severities → observation
-  let hardIssueCount = 0;
-  if (parsed && !parse_error && def.passes && def.passes.length > 0) {
-    const slice = await getGemaraSlice(rc.env, tractate, page, false);
-    // commentary-verbatim needs the daf's real Rashi/Tosafot text to verify
-    // cited quotes against — fetch it only when a check actually wants it.
-    let commentaryHe: string[] | undefined;
-    if (def.passes.includes('commentary-verbatim')) {
-      const com = await getCommentariesSlice(rc.env, tractate, page, false);
-      commentaryHe = Object.values(com.by_commentator)
-        .map((c) => stripHtmlServer(c.hebrew))
-        .filter(Boolean);
-    }
-    const checked = await runPasses(def.passes, parsed, {
-      tractate,
-      page,
-      segmentsHe: slice.segments_he,
-      commentaryHe,
-      defId: def.id,
-      lang: rc.lang,
-    });
-    parsed = checked.parsed;
-    if (checked.issues.length > 0) {
-      check_issues = checked.issues;
-      const hard = checked.issues.filter((i) => i.severity === 'hard');
-      hardIssueCount = hard.length;
-      if (hard.length > 0) lint_issues = hard;
-    }
-  }
-  // daf-background.concepts has no global glossary — log every term it emits to
-  // the observed-concept backlog so the canonical glossary can be grown from
-  // real usage later (same collect-now pattern as observed-place).
-  if (parsed && !parse_error && def.id === 'daf-background.concepts') {
-    recordObservedConceptsFromEnrichment(rc, parsed, tractate, page);
-  }
-  const out: RunResultEnrichment = {
-    content: result.content,
-    reasoning: result.reasoning_content || undefined,
-    parsed,
-    parse_error,
-    model: result.model,
-    transport: result.transport,
-    attempts: result.attempts,
-    usage: result.usage,
-    elapsed_ms: result.elapsed_ms,
-    prompt_chars: result.prompt_chars,
-    // Resolved prompts are dev-only inspection; cap each at 2KB so multi-run
-    // responses don't balloon. The full prompt was already sent to the LLM —
-    // we don't need to ship it back through workerd just for the dev tray.
-    resolved: {
-      system_prompt:
-        systemPrompt.length > 2000
-          ? `${systemPrompt.slice(0, 2000)}… [+${systemPrompt.length - 2000} chars]`
-          : systemPrompt,
-      user_prompt:
-        userPrompt.length > 2000
-          ? `${userPrompt.slice(0, 2000)}… [+${userPrompt.length - 2000} chars]`
-          : userPrompt,
-    },
-    cache_hit: false,
-    recipe_hash,
-    cost: costStampOf(result.model, result.usage, useHe ? 'he' : 'en', def.cache_version),
-    deps_resolved: Object.keys(inputs.depends).length > 0 ? inputs.depends : undefined,
-    anchors_resolved: Object.keys(inputs.anchors).length > 0 ? inputs.anchors : undefined,
-    ...(lint_issues ? { lint_issues } : {}),
-    ...(check_issues ? { check_issues } : {}),
-    ...(sectionRange ? { section_range: sectionRange } : {}),
-  };
-  // Gate cache writes on the checks passing — but BOUND the retries. An output
-  // with no `hard` issues is pinned immediately. A hard-failing output is left
-  // uncached so the next request regenerates (the model is mildly
-  // nondeterministic, so a retry may come back clean) — UNTIL it has failed
-  // MAX_LINT_ATTEMPTS times, at which point we pin the best-effort output anyway
-  // so reads become cache hits and regeneration stops. Without this cap the warm
-  // crons re-pay for a persistently-failing card forever. (Soft issues never
-  // gate.) Capped failures surface on /api/usage.
-  if (cacheKey && !parse_error) {
-    if (hardIssueCount === 0) {
-      await writeCachedResult(rc.env, cacheKey, out);
-    } else if (
-      await noteLintAttempt(rc.env, rc.ctx, cacheKey, {
-        enrichmentId: def.id,
-        tractate,
-        page,
-        lang: rc.lang,
-        issues: lint_issues ?? [],
-      })
-    ) {
-      await writeCachedResult(rc.env, cacheKey, out);
-    }
-  }
-  // Attribute this fresh LLM call's tokens + cost to the daily rollup.
-  captureLlmUsage(rc, {
-    kind: 'enrichment',
-    id: def.id,
-    result: { model: result.model, usage: result.usage, parse_error },
-  });
-  return out;
+    lang: rc.lang,
+    modelOverride,
+    parentChain,
+    userQuestion,
+  })) as RunResultEnrichment;
 }
 
 // ===========================================================================

--- a/packages/talmud/tests/provenance-stamp.test.ts
+++ b/packages/talmud/tests/provenance-stamp.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it, vi } from 'vitest';
+import { instanceIdOf, keyForEnrichment, keyForGemara, keyForMark } from '../src/worker/cache-keys';
+import { CODE_ENRICHMENTS, CODE_MARKS } from '../src/worker/code-marks';
+import type { Bindings, JobMessage } from '../src/worker/types';
+
+// PROVENANCE STAMPING (stage 4b): every FRESH cache write now carries a
+// `provenance` build manifest APPENDED after the legacy envelope fields —
+// authority (llm transports → 'ai', computed/graph/lookup → 'rule'), the
+// producer id, the SAME recipe_hash already stamped at top level, one
+// InputRef per resolved dep/anchor key (content-fingerprinted), and the
+// model/transport/usage/cost passthrough. These tests drive a real fresh run
+// through the worker's queue consumer (the same path /api/run jobs take) with
+// runLLM mocked, then assert (a) the legacy fields are exactly what the old
+// bodies wrote — names, order, values — and (b) provenance mirrors them.
+// envelope-roundtrip.test.ts separately locks that legacy entries WITHOUT
+// provenance still serve unchanged.
+
+vi.mock('@corpus/core/llm/llm', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('@corpus/core/llm/llm')>();
+  return {
+    ...mod,
+    runLLM: vi.fn(async () => ({
+      content: '{"place":"Pumbedita","basis":"named in the sugya"}',
+      reasoning_content: '',
+      finish_reason: 'stop',
+      usage: { prompt_tokens: 120, completion_tokens: 30, total_tokens: 150 },
+      prompt_chars: 555,
+      elapsed_ms: 7,
+      model: 'openrouter/deepseek/deepseek-chat',
+      transport: 'openrouter-gateway',
+      attempts: 1,
+    })),
+  };
+});
+
+import { provenanceInputRefs } from '@corpus/core/run/run-producer';
+import worker from '../src/worker/index';
+
+// --- harness (same Map-backed KV stub as run-contract.test.ts) -------------
+
+function makeFakeKV(initial: Record<string, string> = {}) {
+  const store = new Map(Object.entries(initial));
+  const kv = {
+    get: async (k: string) => store.get(k) ?? null,
+    put: async (k: string, v: string) => {
+      store.set(k, v);
+    },
+    delete: async (k: string) => {
+      store.delete(k);
+    },
+    list: async () => ({ keys: [], list_complete: true, cursor: '' }),
+    getWithMetadata: async () => ({ value: null, metadata: null }),
+  };
+  return { kv: kv as unknown as KVNamespace, store };
+}
+
+function makeEnv(seed: Record<string, string> = {}) {
+  const { kv, store } = makeFakeKV(seed);
+  const env = { CACHE: kv } as unknown as Bindings;
+  return { env, store };
+}
+
+function makeCtx(): ExecutionContext {
+  return {
+    waitUntil: (_p: Promise<unknown>) => {},
+    passThroughOnException: () => {},
+  } as unknown as ExecutionContext;
+}
+
+/** Drive one job through the queue consumer (the real fresh-run path). */
+async function runJob(env: Bindings, body: Partial<JobMessage>): Promise<void> {
+  const msg = {
+    id: 'm1',
+    timestamp: new Date(),
+    attempts: 1,
+    body: { runId: 'prov-test', tractate: 'Berakhot', page: '5a', ...body } as JobMessage,
+    ack: () => {},
+    retry: () => {},
+  };
+  await worker.queue(
+    { queue: 'enrichment-jobs', messages: [msg] } as unknown as MessageBatch<JobMessage>,
+    env,
+    makeCtx(),
+  );
+}
+
+const GEMARA_SLICE = {
+  tractate: 'Berakhot',
+  page: '5a',
+  hebrew: 'טקסט עברי',
+  english: 'English text',
+  segments_he: ['קטע א', 'קטע ב'],
+  segments_en: ['segment one', 'segment two'],
+};
+
+function storedResult(overrides: Record<string, unknown>): string {
+  return JSON.stringify({
+    content: 'raw content',
+    parsed: null,
+    parse_error: null,
+    model: 'seeded',
+    transport: 'seeded',
+    attempts: 1,
+    usage: null,
+    elapsed_ms: 0,
+    prompt_chars: 0,
+    resolved: { system_prompt: '', user_prompt: '' },
+    cache_hit: false,
+    ...overrides,
+  });
+}
+
+const rabbiLocation = CODE_ENRICHMENTS.find((e) => e.id === 'rabbi.location');
+if (!rabbiLocation) throw new Error('expected rabbi.location in CODE_ENRICHMENTS');
+const rabbiGeography = CODE_ENRICHMENTS.find((e) => e.id === 'rabbi.geography');
+if (!rabbiGeography) throw new Error('expected rabbi.geography in CODE_ENRICHMENTS');
+const rabbiMark = CODE_MARKS.find((m) => m.id === 'rabbi');
+if (!rabbiMark) throw new Error('expected the rabbi mark in CODE_MARKS');
+const dafBackgroundMark = CODE_MARKS.find((m) => m.id === 'daf-background');
+if (!dafBackgroundMark) throw new Error('expected the daf-background mark in CODE_MARKS');
+if (dafBackgroundMark.extractor.kind !== 'computed') {
+  throw new Error('expected daf-background to be a computed mark');
+}
+
+const MARK_INPUT = { fields: { name: 'Abaye' } };
+
+describe('provenance stamping on fresh cache writes', () => {
+  it('an LLM enrichment write keeps the legacy envelope byte-shape and appends a matching provenance manifest', async () => {
+    const iid = await instanceIdOf(MARK_INPUT);
+    const geoKey = keyForEnrichment(
+      rabbiGeography,
+      iid,
+      rabbiGeography.scope === 'local' ? { tractate: 'Berakhot', page: '5a' } : undefined,
+    );
+    const rabbiInstances = [{ excerpt: 'אביי', fields: { name: 'Abaye', nameHe: 'אביי' } }];
+    const { env, store } = makeEnv({
+      [keyForGemara('Berakhot', '5a')]: JSON.stringify(GEMARA_SLICE),
+      [geoKey]: storedResult({ parsed: { region: 'bavel' } }),
+      [keyForMark(rabbiMark, 'Berakhot', '5a', 'en')]: storedResult({
+        parsed: { instances: rabbiInstances },
+      }),
+    });
+
+    await runJob(env, {
+      enrichment_id: 'rabbi.location',
+      mark_input: MARK_INPUT,
+    });
+
+    const locKey = keyForEnrichment(rabbiLocation, iid, { tractate: 'Berakhot', page: '5a' });
+    const raw = store.get(locKey);
+    expect(raw).toBeTruthy();
+    const stored = JSON.parse(raw as string);
+
+    // (a) legacy fields — exactly the names (and order: JSON.parse preserves
+    // insertion order) the old runEnrichmentOnce wrote, nothing dropped or
+    // renamed; `provenance` is appended LAST.
+    expect(Object.keys(stored)).toEqual([
+      'content',
+      'parsed',
+      'parse_error',
+      'model',
+      'transport',
+      'attempts',
+      'usage',
+      'elapsed_ms',
+      'prompt_chars',
+      'resolved',
+      'cache_hit',
+      'recipe_hash',
+      'cost',
+      'deps_resolved',
+      'anchors_resolved',
+      'provenance',
+    ]);
+    expect(stored.content).toBe('{"place":"Pumbedita","basis":"named in the sugya"}');
+    expect(stored.model).toBe('openrouter/deepseek/deepseek-chat');
+    expect(stored.transport).toBe('openrouter-gateway');
+    expect(stored.recipe_hash).toMatch(/^[0-9a-f]{12}$/);
+    expect(stored.deps_resolved).toEqual({ 'rabbi.geography': { region: 'bavel' } });
+    expect(stored.anchors_resolved).toEqual({ rabbi: rabbiInstances });
+
+    // (b) the provenance manifest mirrors the legacy fields — never a second
+    // hash, never a divergent cost — and classifies the gateway transport 'ai'.
+    const prov = stored.provenance;
+    expect(prov.authority).toBe('ai');
+    expect(prov.producerId).toBe('rabbi.location');
+    expect(prov.recipeHash).toBe(stored.recipe_hash);
+    expect(prov.model).toBe(stored.model);
+    expect(prov.transport).toBe(stored.transport);
+    expect(prov.usage).toEqual(stored.usage);
+    expect(prov.cost).toEqual(stored.cost);
+    expect(Number.isNaN(Date.parse(prov.createdAt))).toBe(false);
+
+    // (c) inputs enumerate the resolved dep keys (depends first, then anchors,
+    // id-sorted), each with a stable content fingerprint.
+    expect(prov.inputs.map((r: { sourceKey: string }) => r.sourceKey)).toEqual([
+      'rabbi.geography',
+      'rabbi',
+    ]);
+    for (const r of prov.inputs as { contentHash: string }[]) {
+      expect(r.contentHash).toMatch(/^[0-9a-f]{12}$/);
+    }
+    expect(prov.inputs).toEqual(
+      await provenanceInputRefs({
+        depends: stored.deps_resolved,
+        anchors: stored.anchors_resolved,
+      }),
+    );
+  });
+
+  it('a computed (no-LLM) mark write is stamped authority "rule" with no recipeHash and no inputs', async () => {
+    const { env, store } = makeEnv();
+    await runJob(env, { mark_id: 'daf-background' });
+
+    const key = keyForMark(dafBackgroundMark, 'Berakhot', '5a', 'en');
+    const raw = store.get(key);
+    expect(raw).toBeTruthy();
+    const stored = JSON.parse(raw as string);
+
+    // Legacy computed-mark envelope unchanged, provenance appended last.
+    expect(Object.keys(stored)).toEqual([
+      'content',
+      'parsed',
+      'parse_error',
+      'model',
+      'transport',
+      'attempts',
+      'usage',
+      'elapsed_ms',
+      'prompt_chars',
+      'resolved',
+      'cache_hit',
+      'provenance',
+    ]);
+    expect(stored.model).toBe('computed:whole-daf-instance');
+    expect(stored.transport).toBe('computed');
+    expect(stored.parsed).toEqual({ instances: [{ fields: {} }] });
+
+    const prov = stored.provenance;
+    expect(prov.authority).toBe('rule');
+    expect(prov.producerId).toBe('daf-background');
+    expect(prov.recipeHash).toBeUndefined(); // marks never stamped recipe_hash
+    expect(prov.inputs).toEqual([]); // computed branch resolves no deps
+    expect(prov.transport).toBe('computed');
+  });
+});


### PR DESCRIPTION
Stage 6 of the four-primitive consolidation (#356→#360, then this) — 4b, the unification itself.

## What changes

- `runMarkOnce` + `runEnrichmentOnce` collapse into one orchestration skeleton in `@corpus/core/run/run-producer.ts`; both keep their exact signatures as shims, so the queue consumer, deep-warm, and the 4a recursion ports are untouched. Every subtle divergence between the two old bodies (mark `:he` key rule, `parentChain` reset-vs-extend, usage-recording order, per-kind stored field order) is preserved under its kind branch and documented in the module doc.
- Talmud-specific short-circuits become id-keyed hooks wired from `index.ts`: rabbi.relationships graph, rabbi.identity lookup, rabbi.observations, pesukim prefetch, argument move-scoping + section_range stamp, postProcessRabbi/grounding, fan-out.
- **New (additive): the provenance build manifest.** Every fresh cache write appends `provenance` — `{authority: ai|rule, producerId, recipeHash (the same recipe_hash, never recomputed), inputs: one {sourceKey, contentHash} per resolved dependency, model, transport, usage, cost, createdAt}` — after all legacy fields, which keep being dual-written byte-identically. "Exactly how this artifact was made" is now data on every entry, and the per-entry dynamic dependency DAG (`provenance.inputs`) now exists alongside the static def-level graph.

## Review notes

Independent Codex review found one High: fresh-run returns lacked provenance while cache-hit responses (which spread the stored envelope, like `recipe_hash`/`cost` today) included it. Resolved by stamping the returned envelope too — provenance now follows exactly the `recipe_hash` lifecycle, strictly additive everywhere.

Zero snapshot churn, zero test edits; new `provenance-stamp.test.ts` locks the manifest against a real queued run (authority `ai`) and a computed mark (authority `rule`). Full suite: talmud 2063, core 103, tanach 19; typecheck + biome clean. `index.ts` net −195 (−591/+396).