### PR TITLE
Tanach onto the shared runtime — the corpus-agnosticism proof

### DIFF
--- a/packages/tanach/src/worker/index.ts
+++ b/packages/tanach/src/worker/index.ts
@@ -1,50 +1,44 @@
 /**
  * Tanach worker — Hono on Cloudflare Workers.
  *
- * v1 surface: GET /api/chapter/:book/:chapter returns a chapter's verses
- * (Hebrew + English) plus next/prev chapter refs, fetched live from Sefaria via
- * the shared @corpus/core SefariaClient. Everything else falls through to the
- * built Solid client (the ASSETS binding, SPA fallback). No KV / LLM yet — that
- * arrives with caching + the producers.
+ * GET /api/chapter/:book/:chapter returns a chapter's verses (Hebrew +
+ * English) plus next/prev chapter refs, fetched live from Sefaria via the
+ * shared @corpus/core SefariaClient. The producer routes (events / note /
+ * synthesis / midrash-synthesis) run through the SAME corpus-agnostic
+ * runProducer the talmud worker runs — synchronously, no queue — with their
+ * app-specific wiring (key templates, source resolvers, LLM knobs, usage
+ * ledger) in run-ports.ts. translate stays on bespoke plumbing (raw-string +
+ * TTL cache; see producers/translate.ts). Everything else falls through to
+ * the built Solid client (the ASSETS binding, SPA fallback).
  */
 
-import type { LLMEnv } from '@corpus/core/llm/llm';
-import { flattenPieces, pickV3Version, SefariaClient } from '@corpus/core/sefaria/client';
+import { flattenPieces, pickV3Version } from '@corpus/core/sefaria/client';
+import type { StoredArtifact } from '@corpus/core/store/envelope';
+import type { Context } from 'hono';
 import { Hono } from 'hono';
 import { isBook } from '../lib/books.ts';
 import { COMMENTATORS } from '../lib/commentators.ts';
-import { eventSections } from './producers/events.ts';
-import { midrashSynthesis } from './producers/midrash.ts';
-import { sectionNote } from './producers/note.ts';
-import { synthesize } from './producers/synthesis.ts';
+import type { EventSection } from './producers/events.ts';
 import { translateHebrew } from './producers/translate.ts';
+import type { TanachEnv, TanachRunCtx } from './run-ports.ts';
+import { runTanachEnrichment, runTanachEvents, TanachSourceError } from './run-ports.ts';
+import { asVerses, fetchPassages, fetchVerseCommentaries, sefaria } from './sefaria-sources.ts';
 import { readUsage, recordUsage } from './usage.ts';
 
-interface Env extends LLMEnv {
+interface Env extends TanachEnv {
   ASSETS: Fetcher;
-  CACHE: KVNamespace;
-}
-
-const sefaria = new SefariaClient();
-
-/** Strip Sefaria's inline footnote apparatus (the marker + the expanded note
- *  text), which otherwise renders mid-verse. Keeps benign inline tags like the
- *  large/small-letter <big>/<small> markup. */
-function stripFootnotes(html: string): string {
-  return html
-    .replace(/<sup class="footnote-marker">.*?<\/sup>/g, '')
-    .replace(/<i class="footnote">.*?<\/i>/g, '')
-    .trim();
-}
-
-/** Sefaria returns he/text as a per-verse string array for a chapter ref (or a
- *  bare string for a single verse). Normalize to a string[], footnotes stripped. */
-function asVerses(v: string | string[] | undefined): string[] {
-  if (Array.isArray(v)) return v.map((s) => (typeof s === 'string' ? stripFootnotes(s) : ''));
-  return typeof v === 'string' ? [stripFootnotes(v)] : [];
 }
 
 const app = new Hono<{ Bindings: Env }>();
+
+/** Map a producer-run failure to the legacy route responses: a source error
+ *  keeps its specific status + body (404 ref-not-found / not-enough-material,
+ *  502 upstream fetch failures with their original messages); anything else is
+ *  the legacy `Producer failed: …` 502. */
+function runErrorResponse(c: Context<{ Bindings: Env }>, e: unknown) {
+  if (e instanceof TanachSourceError) return c.json({ error: e.message }, e.status);
+  return c.json({ error: `Producer failed: ${(e as Error).message}` }, 502);
+}
 
 app.get('/api/chapter/:book/:chapter', async (c) => {
   const book = c.req.param('book');
@@ -57,7 +51,7 @@ app.get('/api/chapter/:book/:chapter', async (c) => {
   }
 
   const ref = `${book} ${chapter}`;
-  let data: Awaited<ReturnType<SefariaClient['getText']>>;
+  let data: Awaited<ReturnType<typeof sefaria.getText>>;
   try {
     data = await sefaria.getText(ref);
   } catch (e) {
@@ -145,58 +139,29 @@ app.get('/api/mikraot/:book/:chapter', async (c) => {
 
 // Events anchor (first producer): short margin labels for a chapter's natural
 // narrative units ("Day One", "The Burning Bush"), pinned to the verse where
-// each begins. Cached per chapter in KV; computed once via the LLM.
+// each begins. Runs through the core runProducer (cache key events:v2:* via
+// the template scheme — pre-migration raw-payload entries keep serving through
+// the legacy read adapter; fresh runs cache a StoredArtifact envelope with
+// provenance). Usage is attributed inside the run ports.
 app.get('/api/events/:book/:chapter', async (c) => {
   const book = c.req.param('book');
   const chapter = c.req.param('chapter');
   if (!isBook(book)) return c.json({ error: `Unknown book: ${book}` }, 400);
   if (!/^\d+$/.test(chapter)) return c.json({ error: `Bad chapter: ${chapter}` }, 400);
 
-  const key = `events:v2:${book}:${chapter}`;
-  const cached = await c.env.CACHE.get(key);
-  if (cached) return c.json(JSON.parse(cached));
-
   const ref = `${book} ${chapter}`;
-  let text: Awaited<ReturnType<SefariaClient['getText']>>;
+  const rc: TanachRunCtx = { env: c.env, ctx: c.executionCtx, ref };
+  let artifact: StoredArtifact;
   try {
-    text = await sefaria.getText(ref);
+    artifact = await runTanachEvents(rc, book, chapter);
   } catch (e) {
-    return c.json({ error: `Sefaria fetch failed: ${(e as Error).message}` }, 502);
+    return runErrorResponse(c, e);
   }
-  if (text.error) return c.json({ error: text.error }, 404);
-
-  const he = asVerses(text.he);
-  const en = asVerses(text.text);
-  const verses = Array.from({ length: Math.max(he.length, en.length) }, (_, i) => ({
-    n: i + 1,
-    he: he[i] ?? '',
-    en: en[i] ?? '',
-  }));
-
-  let result: Awaited<ReturnType<typeof eventSections>>;
-  try {
-    result = await eventSections(c.env, ref, verses);
-  } catch (e) {
-    return c.json({ error: `Producer failed: ${(e as Error).message}` }, 502);
-  }
-
-  const payload = { book, chapter: Number(chapter), ref, sections: result.sections };
-  // Persist the result + a usage entry (best-effort; never block the response).
-  c.executionCtx.waitUntil(
-    Promise.all([
-      c.env.CACHE.put(key, JSON.stringify(payload)),
-      recordUsage(c.env.CACHE, {
-        ts: Date.now(),
-        ref,
-        producer: 'events',
-        model: result.model,
-        in: result.inTokens,
-        out: result.outTokens,
-        cost: result.costUsd,
-      }),
-    ]).then(() => undefined),
-  );
-  return c.json(payload);
+  // Project the envelope back to the legacy response JSON. `parsed` is the
+  // normalized {sections} on fresh/envelope entries and the full legacy
+  // payload (which carries the same `sections`) on pre-migration entries.
+  const parsed = artifact.parsed as { sections?: EventSection[] } | null;
+  return c.json({ book, chapter: Number(chapter), ref, sections: parsed?.sections ?? [] });
 });
 
 // This week's Torah portion (parashat hashavua), from Sefaria's calendar.
@@ -244,7 +209,9 @@ app.get('/api/parsha', async (c) => {
 
 // Section note (second producer, composes on events): a short bilingual p'shat
 // note for the verse range [start..end] of a chapter. Triggered when the reader
-// clicks a margin anchor. Cached per range.
+// clicks a margin anchor. Runs through the core runProducer; the markInput's
+// `id` (`${start}-${end}`) is the legacy key component, so note:v1:* keys stay
+// byte-identical and pre-migration entries keep serving.
 app.get('/api/note/:book/:chapter/:start', async (c) => {
   const book = c.req.param('book');
   const chapter = c.req.param('chapter');
@@ -254,54 +221,41 @@ app.get('/api/note/:book/:chapter/:start', async (c) => {
   if (!isBook(book)) return c.json({ error: `Unknown book: ${book}` }, 400);
   if (!/^\d+$/.test(chapter) || !start) return c.json({ error: 'Bad chapter/verse' }, 400);
 
-  const key = `note:v1:${book}:${chapter}:${start}-${end}`;
-  const cached = await c.env.CACHE.get(key);
-  if (cached) return c.json(JSON.parse(cached));
-
-  let text: Awaited<ReturnType<SefariaClient['getText']>>;
-  try {
-    text = await sefaria.getText(`${book} ${chapter}`);
-  } catch (e) {
-    return c.json({ error: `Sefaria fetch failed: ${(e as Error).message}` }, 502);
-  }
-  if (text.error) return c.json({ error: text.error }, 404);
-
-  const en = asVerses(text.text);
-  const last = Math.min(end, en.length);
-  const slice: string[] = [];
-  for (let n = start; n <= last; n++) {
-    slice.push(`${n}. ${(en[n - 1] ?? '').replace(/<[^>]+>/g, '').trim()}`);
-  }
   const ref = end > start ? `${book} ${chapter}:${start}-${end}` : `${book} ${chapter}:${start}`;
-
-  let result: Awaited<ReturnType<typeof sectionNote>>;
+  const rc: TanachRunCtx = { env: c.env, ctx: c.executionCtx, ref };
+  let artifact: StoredArtifact;
   try {
-    result = await sectionNote(c.env, ref, label, slice.join('\n'));
+    artifact = await runTanachEnrichment(rc, 'note', book, chapter, {
+      id: `${start}-${end}`,
+      start,
+      end,
+      label,
+    });
   } catch (e) {
-    return c.json({ error: `Producer failed: ${(e as Error).message}` }, 502);
+    return runErrorResponse(c, e);
   }
-
-  const payload = { book, chapter: Number(chapter), start, end, en: result.en, he: result.he };
-  c.executionCtx.waitUntil(
-    Promise.all([
-      c.env.CACHE.put(key, JSON.stringify(payload)),
-      recordUsage(c.env.CACHE, {
-        ts: Date.now(),
-        ref,
-        producer: 'note',
-        model: result.model,
-        in: result.inTokens,
-        out: result.outTokens,
-        cost: result.costUsd,
-      }),
-    ]).then(() => undefined),
-  );
-  return c.json(payload);
+  const p = artifact.parsed as { en?: string; he?: string } | null;
+  return c.json({
+    book,
+    chapter: Number(chapter),
+    start,
+    end,
+    en: String(p?.en ?? '').trim(),
+    he: String(p?.he ?? '').trim(),
+  });
 });
 
 // Word / phrase translation: the reader selects Hebrew and gets an English
 // gloss (in the sense it carries in the given verse context). Cached per
 // normalized selection.
+//
+// DELIBERATELY NOT on runProducer/ArtifactStore (the one producer route kept
+// on bespoke plumbing): the cache stores a RAW STRING with a 30-day TTL —
+// the value isn't a StoredArtifact envelope and the TTL contradicts the
+// store's no-TTL contract. Migrating only the orchestration would change
+// either the stored bytes or the expiry semantics for zero benefit. The
+// producer is still declared in producers/defs.ts (registry completeness);
+// see producers/translate.ts for the full rationale.
 app.get('/api/translate', async (c) => {
   const q = (c.req.query('q') ?? '').trim();
   const ctx = (c.req.query('ctx') ?? '').trim().slice(0, 400);
@@ -339,38 +293,6 @@ app.get('/api/translate', async (c) => {
   return c.json({ q, translation: result.translation });
 });
 
-interface VerseCommentary {
-  key: string;
-  en: string;
-  heName: string;
-  he: string[];
-  enText: string[];
-}
-
-/** Fetch each curated commentator's note on a verse from Sefaria (he+en), drop
- *  the empties. Shared by the commentary drawer and the synthesis producer. */
-async function fetchVerseCommentaries(
-  book: string,
-  chapter: string,
-  verse: string,
-): Promise<VerseCommentary[]> {
-  const results = await Promise.all(
-    COMMENTATORS.map(async (cm) => {
-      const ref = `${cm.title} on ${book} ${chapter}:${verse}`;
-      try {
-        const v3 = await sefaria.getTextV3(ref);
-        const he = flattenPieces(pickV3Version(v3.versions, 'he')).filter((s) => s.trim());
-        const en = flattenPieces(pickV3Version(v3.versions, 'en')).filter((s) => s.trim());
-        if (!he.length && !en.length) return null;
-        return { key: cm.key, en: cm.en, heName: cm.he, he, enText: en };
-      } catch {
-        return null;
-      }
-    }),
-  );
-  return results.filter((r): r is VerseCommentary => r !== null);
-}
-
 // Classic commentary for a single verse: each commentator's note from Sefaria
 // (Hebrew + English), the empties skipped. Cached per verse. No AI — raw Rishonim.
 app.get('/api/commentary/:book/:chapter/:verse', async (c) => {
@@ -393,7 +315,9 @@ app.get('/api/commentary/:book/:chapter/:verse', async (c) => {
 
 // Commentary synthesis (AI): a short balanced overview of how the Rishonim read
 // the verse. The reader only requests it on "rich" verses (per the source
-// index), so it isn't generated for every pasuk. Cached + usage-tracked.
+// index), so it isn't generated for every pasuk. Runs through the core
+// runProducer; the 'commentaries' source resolver reuses the drawer's
+// commentary:v1 cache and raises the legacy 404 when fewer than two comment.
 app.get('/api/synthesis/:book/:chapter/:verse', async (c) => {
   const book = c.req.param('book');
   const chapter = c.req.param('chapter');
@@ -402,63 +326,26 @@ app.get('/api/synthesis/:book/:chapter/:verse', async (c) => {
   if (!/^\d+$/.test(chapter) || !/^\d+$/.test(verse))
     return c.json({ error: 'Bad chapter/verse' }, 400);
 
-  const key = `synthesis:v1:${book}:${chapter}:${verse}`;
-  const cached = await c.env.CACHE.get(key);
-  if (cached) return c.json(JSON.parse(cached));
-
-  // Reuse the cached commentary if the drawer already fetched it.
-  const cc = await c.env.CACHE.get(`commentary:v1:${book}:${chapter}:${verse}`);
-  const commentaries: VerseCommentary[] = cc
-    ? (JSON.parse(cc).commentaries as VerseCommentary[])
-    : await fetchVerseCommentaries(book, chapter, verse);
-  if (commentaries.length < 2) return c.json({ error: 'Not enough commentary to synthesize' }, 404);
-
-  let verseText = '';
+  const rc: TanachRunCtx = { env: c.env, ctx: c.executionCtx, ref: `${book} ${chapter}:${verse}` };
+  let artifact: StoredArtifact;
   try {
-    const t = await sefaria.getText(`${book} ${chapter}:${verse}`);
-    verseText = (asVerses(t.text)[0] || asVerses(t.he)[0] || '').replace(/<[^>]+>/g, '').trim();
-  } catch {
-    /* verse text is optional context */
-  }
-  const ctext = commentaries
-    .map(
-      (cm) =>
-        `${cm.en}: ${cm.he
-          .join(' ')
-          .replace(/<[^>]+>/g, '')
-          .slice(0, 600)}`,
-    )
-    .join('\n\n');
-
-  let result: Awaited<ReturnType<typeof synthesize>>;
-  try {
-    result = await synthesize(c.env, `${book} ${chapter}:${verse}`, verseText, ctext);
+    // RAW verse string throughout (legacy parity): '007' must reach the source
+    // ref, the prompt, and the output key identically.
+    artifact = await runTanachEnrichment(rc, 'synthesis', book, chapter, {
+      id: verse,
+      verse,
+    });
   } catch (e) {
-    return c.json({ error: `Producer failed: ${(e as Error).message}` }, 502);
+    return runErrorResponse(c, e);
   }
-
-  const payload = {
+  const p = artifact.parsed as { en?: string; he?: string } | null;
+  return c.json({
     book,
     chapter: Number(chapter),
     verse: Number(verse),
-    en: result.en,
-    he: result.he,
-  };
-  c.executionCtx.waitUntil(
-    Promise.all([
-      c.env.CACHE.put(key, JSON.stringify(payload)),
-      recordUsage(c.env.CACHE, {
-        ts: Date.now(),
-        ref: `${book} ${chapter}:${verse}`,
-        producer: 'synthesis',
-        model: result.model,
-        in: result.inTokens,
-        out: result.outTokens,
-        cost: result.costUsd,
-      }),
-    ]).then(() => undefined),
-  );
-  return c.json(payload);
+    en: String(p?.en ?? '').trim(),
+    he: String(p?.he ?? '').trim(),
+  });
 });
 
 // Per-chapter rishonim index: how many of the curated commentators comment on
@@ -561,63 +448,6 @@ app.get('/api/sources-index/:book/:chapter', async (c) => {
   return c.json(payload);
 });
 
-interface SourcePassage {
-  ref: string;
-  he: string;
-  en: string;
-}
-
-/** Distinct citing passages of one Sefaria category for a verse (Talmud /
- *  Midrash), capped, each with a fetched text snippet. `bavliFirst` floats the
- *  Bavli ahead of Yerushalmi / minor tractates. */
-async function fetchPassages(
-  ref: string,
-  category: string,
-  cap: number,
-  bavliFirst = false,
-): Promise<{ count: number; passages: SourcePassage[] }> {
-  type Link = { category?: string; ref?: string; sourceRef?: string; index_title?: string };
-  const r = await fetch(`https://www.sefaria.org/api/links/${encodeURIComponent(ref)}?with_text=0`);
-  const links = (await r.json()) as Link[];
-  const seen = new Set<string>();
-  const picked: { ref: string; title: string }[] = [];
-  for (const l of Array.isArray(links) ? links : []) {
-    if (l.category !== category) continue;
-    const sref = l.sourceRef || l.ref;
-    if (!sref || seen.has(sref)) continue;
-    seen.add(sref);
-    picked.push({ ref: sref, title: l.index_title ?? '' });
-  }
-  if (bavliFirst) {
-    picked.sort(
-      (a, b) =>
-        Number(/^(Jerusalem|Tractate)/.test(a.title)) -
-        Number(/^(Jerusalem|Tractate)/.test(b.title)),
-    );
-  }
-  const passages = await Promise.all(
-    picked.slice(0, cap).map(async (p) => {
-      try {
-        const v3 = await sefaria.getTextV3(p.ref);
-        const he = flattenPieces(pickV3Version(v3.versions, 'he'))
-          .join(' ')
-          .replace(/<[^>]+>/g, '')
-          .trim()
-          .slice(0, 420);
-        const en = flattenPieces(pickV3Version(v3.versions, 'en'))
-          .join(' ')
-          .replace(/<[^>]+>/g, '')
-          .trim()
-          .slice(0, 420);
-        return { ref: p.ref, he, en };
-      } catch {
-        return { ref: p.ref, he: '', en: '' };
-      }
-    }),
-  );
-  return { count: picked.length, passages };
-}
-
 // Reverse Gemara lookup: how a verse is used in the Talmud (Sefaria's link
 // graph, category "Talmud"). Cached per verse.
 app.get('/api/gemara/:book/:chapter/:verse', async (c) => {
@@ -681,7 +511,11 @@ app.get('/api/midrash/:book/:chapter/:verse', async (c) => {
 });
 
 // Midrash synthesis (AI): distills the verse's midrashim into a thematic
-// overview. Requested for verses with substantial midrash. Cached + tracked.
+// overview. Requested for verses with substantial midrash. Runs through the
+// core runProducer (producer id 'midrash-synthesis'; the key template owns the
+// legacy midrash-synth:v1:* bytes). The 'midrash-passages' source resolver
+// reuses the midrash:v1 SOURCE cache (which stays on direct KV above) and
+// raises the legacy 404/502s.
 app.get('/api/midrash-synthesis/:book/:chapter/:verse', async (c) => {
   const book = c.req.param('book');
   const chapter = c.req.param('chapter');
@@ -690,63 +524,24 @@ app.get('/api/midrash-synthesis/:book/:chapter/:verse', async (c) => {
   if (!/^\d+$/.test(chapter) || !/^\d+$/.test(verse))
     return c.json({ error: 'Bad chapter/verse' }, 400);
 
-  const key = `midrash-synth:v1:${book}:${chapter}:${verse}`;
-  const cached = await c.env.CACHE.get(key);
-  if (cached) return c.json(JSON.parse(cached));
-
-  let passages: SourcePassage[];
-  const cm = await c.env.CACHE.get(`midrash:v1:${book}:${chapter}:${verse}`);
-  if (cm) {
-    passages = JSON.parse(cm).passages as SourcePassage[];
-  } else {
-    try {
-      passages = (await fetchPassages(`${book} ${chapter}:${verse}`, 'Midrash', 14)).passages;
-    } catch (e) {
-      return c.json({ error: `Links fetch failed: ${(e as Error).message}` }, 502);
-    }
-  }
-  if (passages.length < 2) return c.json({ error: 'Not enough midrash to synthesize' }, 404);
-
-  let verseText = '';
+  const rc: TanachRunCtx = { env: c.env, ctx: c.executionCtx, ref: `${book} ${chapter}:${verse}` };
+  let artifact: StoredArtifact;
   try {
-    const t = await sefaria.getText(`${book} ${chapter}:${verse}`);
-    verseText = (asVerses(t.text)[0] || asVerses(t.he)[0] || '').replace(/<[^>]+>/g, '').trim();
-  } catch {
-    /* optional */
-  }
-  const mtext = passages
-    .map((p) => p.he || p.en)
-    .filter(Boolean)
-    .join('\n\n');
-
-  let result: Awaited<ReturnType<typeof midrashSynthesis>>;
-  try {
-    result = await midrashSynthesis(c.env, `${book} ${chapter}:${verse}`, verseText, mtext);
+    artifact = await runTanachEnrichment(rc, 'midrash-synthesis', book, chapter, {
+      id: verse,
+      verse,
+    });
   } catch (e) {
-    return c.json({ error: `Producer failed: ${(e as Error).message}` }, 502);
+    return runErrorResponse(c, e);
   }
-  const payload = {
+  const p = artifact.parsed as { en?: string; he?: string } | null;
+  return c.json({
     book,
     chapter: Number(chapter),
     verse: Number(verse),
-    en: result.en,
-    he: result.he,
-  };
-  c.executionCtx.waitUntil(
-    Promise.all([
-      c.env.CACHE.put(key, JSON.stringify(payload)),
-      recordUsage(c.env.CACHE, {
-        ts: Date.now(),
-        ref: `${book} ${chapter}:${verse}`,
-        producer: 'midrash-synthesis',
-        model: result.model,
-        in: result.inTokens,
-        out: result.outTokens,
-        cost: result.costUsd,
-      }),
-    ]).then(() => undefined),
-  );
-  return c.json(payload);
+    en: String(p?.en ?? '').trim(),
+    he: String(p?.he ?? '').trim(),
+  });
 });
 
 // Self-tracked LLM usage (totals + per-producer + recent calls).

--- a/packages/tanach/src/worker/producers/defs.ts
+++ b/packages/tanach/src/worker/producers/defs.ts
@@ -1,0 +1,240 @@
+/**
+ * The tanach producers, expressed as core Producer objects (the four-primitive
+ * model: Spine / Anchor / Artifact / Producer) — the corpus-agnosticism proof
+ * that a queue-less, registry-less app's producers fit the SAME shape the
+ * talmud registry projects into.
+ *
+ * Five producers:
+ *   events            — mark; discovers verse anchors on the tanach spine
+ *   note              — enrichment; inherits its anchor from an events section
+ *   synthesis         — enrichment; per-verse (commentary overview)
+ *   midrash-synthesis — enrichment; per-verse (midrash overview; key prefix
+ *                       midrash-synth:v1 — the id routes, the template owns
+ *                       the bytes)
+ *   translate         — enrichment; global (selection-keyed) — DECLARED here
+ *                       but NOT run through runProducer/ArtifactStore: its
+ *                       cache is a raw string with a 30-day TTL (see
+ *                       producers/translate.ts for the rationale)
+ *
+ * key_shape note: these producers are TEMPLATE-keyed, not mark:/enrich:-keyed.
+ * templateKeyScheme routes purely by producer id and ignores key_shape, so the
+ * values here ('mark' for events, 'enrich' for the rest) are NOMINAL — the
+ * literal templates in run-ports.ts own the key bytes, copied byte-exactly
+ * from the legacy hand-built keys (locked by tests/producer-keys.test.ts and
+ * core's key-schemes tests).
+ */
+
+import type { Producer } from '@corpus/core/model/producer';
+import type { EnrichmentRunDef, MarkRunDef } from '@corpus/core/run/run-producer';
+import { EVENTS_SCHEMA, EVENTS_SYSTEM, EVENTS_USER_TEMPLATE } from './events.ts';
+import {
+  MIDRASH_SYNTH_SCHEMA,
+  MIDRASH_SYNTH_SYSTEM,
+  MIDRASH_SYNTH_USER_TEMPLATE,
+} from './midrash.ts';
+import { NOTE_SCHEMA, NOTE_SYSTEM, NOTE_USER_TEMPLATE } from './note.ts';
+import { SYNTHESIS_SCHEMA, SYNTHESIS_SYSTEM, SYNTHESIS_USER_TEMPLATE } from './synthesis.ts';
+import { TRANSLATE_SCHEMA, TRANSLATE_SYSTEM, TRANSLATE_USER_TEMPLATE } from './translate.ts';
+
+export type TanachProducerId = 'events' | 'note' | 'synthesis' | 'midrash-synthesis' | 'translate';
+
+/** The recipe extractor every tanach producer carries: an LLM call with fixed
+ *  prompts + a strict JSON schema + the exact call knobs the legacy producer
+ *  functions passed to runLLM (max_tokens / temperature / tag preserved
+ *  byte-for-byte so generation behavior is unchanged). */
+export interface TanachLLMExtractor {
+  kind: 'llm';
+  system_prompt: string;
+  user_prompt_template: string;
+  output_schema: unknown;
+  max_tokens: number;
+  temperature: number;
+  tag: string;
+}
+
+const eventsExtractor: TanachLLMExtractor = {
+  kind: 'llm',
+  system_prompt: EVENTS_SYSTEM,
+  user_prompt_template: EVENTS_USER_TEMPLATE,
+  output_schema: EVENTS_SCHEMA,
+  max_tokens: 900,
+  temperature: 0.2,
+  tag: 'tanach:events',
+};
+
+const noteExtractor: TanachLLMExtractor = {
+  kind: 'llm',
+  system_prompt: NOTE_SYSTEM,
+  user_prompt_template: NOTE_USER_TEMPLATE,
+  output_schema: NOTE_SCHEMA,
+  max_tokens: 700,
+  temperature: 0.3,
+  tag: 'tanach:note',
+};
+
+const synthesisExtractor: TanachLLMExtractor = {
+  kind: 'llm',
+  system_prompt: SYNTHESIS_SYSTEM,
+  user_prompt_template: SYNTHESIS_USER_TEMPLATE,
+  output_schema: SYNTHESIS_SCHEMA,
+  max_tokens: 800,
+  temperature: 0.3,
+  tag: 'tanach:synthesis',
+};
+
+const midrashSynthExtractor: TanachLLMExtractor = {
+  kind: 'llm',
+  system_prompt: MIDRASH_SYNTH_SYSTEM,
+  user_prompt_template: MIDRASH_SYNTH_USER_TEMPLATE,
+  output_schema: MIDRASH_SYNTH_SCHEMA,
+  max_tokens: 800,
+  temperature: 0.35,
+  tag: 'tanach:midrash-synthesis',
+};
+
+const translateExtractor: TanachLLMExtractor = {
+  kind: 'llm',
+  system_prompt: TRANSLATE_SYSTEM,
+  user_prompt_template: TRANSLATE_USER_TEMPLATE,
+  output_schema: TRANSLATE_SCHEMA,
+  max_tokens: 120,
+  temperature: 0.2,
+  tag: 'tanach:translate',
+};
+
+export const TANACH_PRODUCERS: Record<TanachProducerId, Producer> = {
+  events: {
+    id: 'events',
+    label: 'Narrative events',
+    description: "A chapter's natural narrative units, each labelled and pinned to its first verse",
+    kind: 'mark-instance',
+    inputs: [{ source: 'chapter-verses' }],
+    recipe: { extractor: eventsExtractor },
+    // discovers: the extractor finds WHERE the units begin (verse anchors on
+    // the tanach spine; 'segment' = verse, the spine's finest level).
+    anchoring: { behavior: 'discovers', precision: 'segment', spine: 'tanach' },
+    cardinality: 'many',
+    scope: 'local',
+    key_shape: 'mark', // nominal — templateKeyScheme owns the bytes (events:v2:{book}:{chapter})
+    cacheVersion: '2',
+    source: 'code',
+  },
+  note: {
+    id: 'note',
+    label: 'Section note',
+    description: "A short bilingual p'shat note for one events section (a verse range)",
+    kind: 'enrichment',
+    inputs: [{ source: 'section-verses' }],
+    recipe: { extractor: noteExtractor },
+    // inherits: the note sits where its events section sits.
+    anchoring: { behavior: 'inherits', precision: 'segment', spine: 'tanach', target: 'events' },
+    cardinality: 'per-input',
+    scope: 'local',
+    key_shape: 'enrich', // nominal — template owns note:v1:{book}:{chapter}:{start}-{end}
+    cacheVersion: '1',
+    source: 'code',
+  },
+  synthesis: {
+    id: 'synthesis',
+    label: 'Commentary synthesis',
+    description: 'A balanced overview of how the classic commentators read one verse',
+    kind: 'enrichment',
+    inputs: [{ source: 'verse-text' }, { source: 'commentaries' }],
+    recipe: { extractor: synthesisExtractor },
+    // inherits: per-verse — the verse IS the input instance (no parent mark;
+    // the tanach spine addresses verses directly).
+    anchoring: { behavior: 'inherits', precision: 'segment', spine: 'tanach' },
+    cardinality: 'per-input',
+    scope: 'local',
+    key_shape: 'enrich', // nominal — template owns synthesis:v1:{book}:{chapter}:{verse}
+    cacheVersion: '1',
+    source: 'code',
+  },
+  'midrash-synthesis': {
+    id: 'midrash-synthesis',
+    label: 'Midrash synthesis',
+    description: 'A thematic overview of the midrashim on one verse',
+    kind: 'enrichment',
+    inputs: [{ source: 'verse-text' }, { source: 'midrash-passages' }],
+    recipe: { extractor: midrashSynthExtractor },
+    anchoring: { behavior: 'inherits', precision: 'segment', spine: 'tanach' },
+    cardinality: 'per-input',
+    scope: 'local',
+    key_shape: 'enrich', // nominal — template owns midrash-synth:v1:{book}:{chapter}:{verse}
+    cacheVersion: '1',
+    source: 'code',
+  },
+  translate: {
+    id: 'translate',
+    label: 'Selection translation',
+    description: 'An in-context English gloss for a selected Hebrew word or phrase',
+    kind: 'enrichment',
+    inputs: [{ source: 'selection' }],
+    recipe: { extractor: translateExtractor },
+    // The gloss isn't pinned to a spine position — it's keyed by the
+    // normalized selection text, shared across every place it appears.
+    anchoring: { behavior: 'inherits' },
+    cardinality: 'per-input',
+    scope: 'global',
+    key_shape: 'enrich', // nominal — and NOT template-keyed at all: the live
+    // cache is translate:v1:{norm}, a raw string with a 30-day TTL, kept on
+    // bespoke plumbing (see producers/translate.ts).
+    cacheVersion: '1',
+    source: 'code',
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Run-def projections — the minimal structural views runProducer consumes
+// (MarkRunDef / EnrichmentRunDef), extended with the tanach call knobs the
+// LLM ports read. Projected from the Producer objects above so the registry
+// shape stays the single source of truth.
+// ---------------------------------------------------------------------------
+
+export interface TanachMarkDef extends MarkRunDef {
+  extractor: TanachLLMExtractor;
+}
+
+export interface TanachEnrichmentDef extends EnrichmentRunDef {
+  output_schema: unknown;
+  max_tokens: number;
+  temperature: number;
+  tag: string;
+}
+
+function sourceDeps(p: Producer): string[] {
+  return p.inputs.flatMap((i) => ('source' in i ? [i.source] : []));
+}
+
+export function markRunDefOf(id: 'events'): TanachMarkDef {
+  const p = TANACH_PRODUCERS[id];
+  return {
+    id: p.id,
+    cache_version: p.cacheVersion,
+    dependencies: sourceDeps(p),
+    extractor: p.recipe.extractor as TanachLLMExtractor,
+  };
+}
+
+export function enrichRunDefOf(
+  id: 'note' | 'synthesis' | 'midrash-synthesis',
+): TanachEnrichmentDef {
+  const p = TANACH_PRODUCERS[id];
+  const ext = p.recipe.extractor as TanachLLMExtractor;
+  return {
+    id: p.id,
+    cache_version: p.cacheVersion,
+    // EnrichmentRunDef requires the feeding mark's id. note genuinely targets
+    // the events mark; the per-verse producers have no parent mark (the spine
+    // addresses verses directly), so 'verse' is a nominal stand-in — nothing
+    // resolves it (no {mark:...} deps, and sectionRange is null for tanach).
+    mark: p.anchoring.target ?? 'verse',
+    dependencies: sourceDeps(p),
+    system_prompt: ext.system_prompt,
+    user_prompt_template: ext.user_prompt_template,
+    output_schema: ext.output_schema,
+    max_tokens: ext.max_tokens,
+    temperature: ext.temperature,
+    tag: ext.tag,
+  };
+}

--- a/packages/tanach/src/worker/producers/events.ts
+++ b/packages/tanach/src/worker/producers/events.ts
@@ -10,10 +10,14 @@
  * This is a mark in the framework sense: it identifies WHERE things are. The
  * anchor is an exact verse (Sefaria gives us that), so there is no placement
  * risk — only the labelling is the model's job.
+ *
+ * This module carries the producer's RECIPE (prompts + schema); the run itself
+ * goes through the corpus-agnostic runProducer (producers/defs.ts assembles
+ * the Producer, run-ports.ts wires the ports). Output normalization (the
+ * verse-range filter, the 40-char label caps, ordering) lives in the
+ * markPostParse hook in run-ports.ts — byte-for-byte the filtering the old
+ * eventSections wrapper applied.
  */
-
-import { type LLMEnv, runLLM } from '@corpus/core/llm/llm';
-import { costUsd } from '@corpus/core/llm/pricing';
 
 export interface EventSection {
   /** 1-based verse number where this unit begins. */
@@ -24,15 +28,7 @@ export interface EventSection {
   he: string;
 }
 
-export interface EventsResult {
-  sections: EventSection[];
-  model: string;
-  costUsd: number | null;
-  inTokens: number;
-  outTokens: number;
-}
-
-const SYSTEM = [
+export const EVENTS_SYSTEM = [
   'You divide a chapter of the Hebrew Bible into its natural narrative units and',
   'give each a short label in BOTH English and Hebrew.',
   '',
@@ -51,7 +47,12 @@ const SYSTEM = [
   '- Return them in order.',
 ].join('\n');
 
-const SCHEMA = {
+/** Rendered with vars from the 'chapter-verses' source resolver. Byte-equal to
+ *  the legacy hand-built user prompt:
+ *  `Chapter: ${ref} (${maxVerse} verses)\n\n${versesForPrompt(verses)}`. */
+export const EVENTS_USER_TEMPLATE = 'Chapter: {{ref}} ({{max_verse}} verses)\n\n{{verses_text}}';
+
+export const EVENTS_SCHEMA = {
   name: 'event_sections',
   strict: true,
   schema: {
@@ -79,54 +80,4 @@ const SCHEMA = {
 /** Render the chapter's verses as a compact numbered English prompt. */
 export function versesForPrompt(verses: { n: number; en: string; he: string }[]): string {
   return verses.map((v) => `${v.n}. ${(v.en || '').replace(/<[^>]+>/g, '').trim()}`).join('\n');
-}
-
-export async function eventSections(
-  env: LLMEnv,
-  ref: string,
-  verses: { n: number; en: string; he: string }[],
-): Promise<EventsResult> {
-  const maxVerse = verses.length;
-  const res = await runLLM(env, {
-    messages: [
-      { role: 'system', content: SYSTEM },
-      {
-        role: 'user',
-        content: `Chapter: ${ref} (${maxVerse} verses)\n\n${versesForPrompt(verses)}`,
-      },
-    ],
-    max_tokens: 900,
-    temperature: 0.2,
-    response_format: { type: 'json_schema', json_schema: SCHEMA },
-    tag: 'tanach:events',
-  });
-
-  let sections: EventSection[] = [];
-  try {
-    const parsed = JSON.parse(res.content) as { sections?: EventSection[] };
-    sections = (parsed.sections ?? [])
-      .filter(
-        (s) => Number.isInteger(s.verse) && s.verse >= 1 && s.verse <= maxVerse && (s.en || s.he),
-      )
-      .map((s) => ({
-        verse: s.verse,
-        en: String(s.en ?? '')
-          .trim()
-          .slice(0, 40),
-        he: String(s.he ?? '')
-          .trim()
-          .slice(0, 40),
-      }))
-      .sort((a, b) => a.verse - b.verse);
-  } catch {
-    sections = [];
-  }
-
-  return {
-    sections,
-    model: res.model,
-    costUsd: costUsd(res.model, res.usage),
-    inTokens: res.usage?.prompt_tokens ?? 0,
-    outTokens: res.usage?.completion_tokens ?? 0,
-  };
 }

--- a/packages/tanach/src/worker/producers/midrash.ts
+++ b/packages/tanach/src/worker/producers/midrash.ts
@@ -5,21 +5,14 @@
  * directions), bilingual, so the reader gets the gist before the source list.
  *
  * Composes on the midrash fetch (the Midrash-category links for the verse).
+ *
+ * This module carries the producer's RECIPE (prompts + schema); the run goes
+ * through the corpus-agnostic runProducer (producers/defs.ts + run-ports.ts).
+ * NOTE the id/key split: the producer id is 'midrash-synthesis' but its legacy
+ * key family is `midrash-synth:v1:*` — the key template owns those bytes.
  */
 
-import { type LLMEnv, runLLM } from '@corpus/core/llm/llm';
-import { costUsd } from '@corpus/core/llm/pricing';
-
-export interface MidrashSynthResult {
-  en: string;
-  he: string;
-  model: string;
-  costUsd: number | null;
-  inTokens: number;
-  outTokens: number;
-}
-
-const SYSTEM = [
+export const MIDRASH_SYNTH_SYSTEM = [
   'You summarize the midrashic material on a verse of the Hebrew Bible for a',
   'reader — what the midrashim draw out of it.',
   '',
@@ -35,7 +28,13 @@ const SYSTEM = [
   '- Give it in BOTH English ("en") and natural, fluent Hebrew ("he").',
 ].join('\n');
 
-const SCHEMA = {
+/** Rendered with vars from the 'verse-text' + 'midrash-passages' resolvers.
+ *  Byte-equal to the legacy hand-built user prompt:
+ *  `Verse ${ref}: ${verseText}\n\nMidrashim:\n${midrashText}`. */
+export const MIDRASH_SYNTH_USER_TEMPLATE =
+  'Verse {{ref}}: {{verse_text}}\n\nMidrashim:\n{{midrash_text}}';
+
+export const MIDRASH_SYNTH_SCHEMA = {
   name: 'midrash_synthesis',
   strict: true,
   schema: {
@@ -45,40 +44,3 @@ const SCHEMA = {
     properties: { en: { type: 'string' }, he: { type: 'string' } },
   },
 };
-
-export async function midrashSynthesis(
-  env: LLMEnv,
-  ref: string,
-  verseText: string,
-  midrashText: string,
-): Promise<MidrashSynthResult> {
-  const res = await runLLM(env, {
-    messages: [
-      { role: 'system', content: SYSTEM },
-      { role: 'user', content: `Verse ${ref}: ${verseText}\n\nMidrashim:\n${midrashText}` },
-    ],
-    max_tokens: 800,
-    temperature: 0.35,
-    response_format: { type: 'json_schema', json_schema: SCHEMA },
-    tag: 'tanach:midrash-synthesis',
-  });
-
-  let en = '';
-  let he = '';
-  try {
-    const p = JSON.parse(res.content) as { en?: string; he?: string };
-    en = String(p.en ?? '').trim();
-    he = String(p.he ?? '').trim();
-  } catch {
-    /* leave empty */
-  }
-
-  return {
-    en,
-    he,
-    model: res.model,
-    costUsd: costUsd(res.model, res.usage),
-    inTokens: res.usage?.prompt_tokens ?? 0,
-    outTokens: res.usage?.completion_tokens ?? 0,
-  };
-}

--- a/packages/tanach/src/worker/producers/note.ts
+++ b/packages/tanach/src/worker/producers/note.ts
@@ -5,21 +5,12 @@
  * producer delimited) it writes a short plain-language p'shat note about what
  * happens there, in both English and Hebrew. Rendered when the reader clicks a
  * margin anchor. Strictly plain sense — no midrash, no homily.
+ *
+ * This module carries the producer's RECIPE (prompts + schema); the run goes
+ * through the corpus-agnostic runProducer (producers/defs.ts + run-ports.ts).
  */
 
-import { type LLMEnv, runLLM } from '@corpus/core/llm/llm';
-import { costUsd } from '@corpus/core/llm/pricing';
-
-export interface NoteResult {
-  en: string;
-  he: string;
-  model: string;
-  costUsd: number | null;
-  inTokens: number;
-  outTokens: number;
-}
-
-const SYSTEM = [
+export const NOTE_SYSTEM = [
   'You write a short note explaining what happens in a passage of the Hebrew',
   "Bible, on the p'shat (plain, contextual) level — for a reader who just",
   'arrived at this section.',
@@ -33,7 +24,12 @@ const SYSTEM = [
   '- Give the note in BOTH English ("en") and natural, fluent Hebrew ("he").',
 ].join('\n');
 
-const SCHEMA = {
+/** Rendered with vars from the 'section-verses' source resolver. Byte-equal to
+ *  the legacy hand-built user prompt:
+ *  `Passage: ${ref}${label ? ` — "${label}"` : ''}\n\n${versesText}`. */
+export const NOTE_USER_TEMPLATE = 'Passage: {{passage_header}}\n\n{{verses_text}}';
+
+export const NOTE_SCHEMA = {
   name: 'section_note',
   strict: true,
   schema: {
@@ -43,40 +39,3 @@ const SCHEMA = {
     properties: { en: { type: 'string' }, he: { type: 'string' } },
   },
 };
-
-export async function sectionNote(
-  env: LLMEnv,
-  ref: string,
-  label: string,
-  versesText: string,
-): Promise<NoteResult> {
-  const res = await runLLM(env, {
-    messages: [
-      { role: 'system', content: SYSTEM },
-      { role: 'user', content: `Passage: ${ref}${label ? ` — "${label}"` : ''}\n\n${versesText}` },
-    ],
-    max_tokens: 700,
-    temperature: 0.3,
-    response_format: { type: 'json_schema', json_schema: SCHEMA },
-    tag: 'tanach:note',
-  });
-
-  let en = '';
-  let he = '';
-  try {
-    const p = JSON.parse(res.content) as { en?: string; he?: string };
-    en = String(p.en ?? '').trim();
-    he = String(p.he ?? '').trim();
-  } catch {
-    /* leave empty */
-  }
-
-  return {
-    en,
-    he,
-    model: res.model,
-    costUsd: costUsd(res.model, res.usage),
-    inTokens: res.usage?.prompt_tokens ?? 0,
-    outTokens: res.usage?.completion_tokens ?? 0,
-  };
-}

--- a/packages/tanach/src/worker/producers/synthesis.ts
+++ b/packages/tanach/src/worker/producers/synthesis.ts
@@ -5,21 +5,12 @@
  * (the reader gates this by the source index), so it isn't generated per pasuk.
  *
  * Composes on the commentary fetch: its input is the per-verse Rishonim.
+ *
+ * This module carries the producer's RECIPE (prompts + schema); the run goes
+ * through the corpus-agnostic runProducer (producers/defs.ts + run-ports.ts).
  */
 
-import { type LLMEnv, runLLM } from '@corpus/core/llm/llm';
-import { costUsd } from '@corpus/core/llm/pricing';
-
-export interface SynthesisResult {
-  en: string;
-  he: string;
-  model: string;
-  costUsd: number | null;
-  inTokens: number;
-  outTokens: number;
-}
-
-const SYSTEM = [
+export const SYNTHESIS_SYSTEM = [
   'You summarize how the classic Jewish commentators read a verse of the Hebrew',
   'Bible, for a reader deciding what to dig into.',
   '',
@@ -35,7 +26,13 @@ const SYSTEM = [
   '- Give it in BOTH English ("en") and natural, fluent Hebrew ("he").',
 ].join('\n');
 
-const SCHEMA = {
+/** Rendered with vars from the 'verse-text' + 'commentaries' source resolvers.
+ *  Byte-equal to the legacy hand-built user prompt:
+ *  `Verse ${ref}: ${verseText}\n\nCommentators:\n${commentatorsText}`. */
+export const SYNTHESIS_USER_TEMPLATE =
+  'Verse {{ref}}: {{verse_text}}\n\nCommentators:\n{{commentators_text}}';
+
+export const SYNTHESIS_SCHEMA = {
   name: 'commentary_synthesis',
   strict: true,
   schema: {
@@ -45,40 +42,3 @@ const SCHEMA = {
     properties: { en: { type: 'string' }, he: { type: 'string' } },
   },
 };
-
-export async function synthesize(
-  env: LLMEnv,
-  ref: string,
-  verseText: string,
-  commentatorsText: string,
-): Promise<SynthesisResult> {
-  const res = await runLLM(env, {
-    messages: [
-      { role: 'system', content: SYSTEM },
-      { role: 'user', content: `Verse ${ref}: ${verseText}\n\nCommentators:\n${commentatorsText}` },
-    ],
-    max_tokens: 800,
-    temperature: 0.3,
-    response_format: { type: 'json_schema', json_schema: SCHEMA },
-    tag: 'tanach:synthesis',
-  });
-
-  let en = '';
-  let he = '';
-  try {
-    const p = JSON.parse(res.content) as { en?: string; he?: string };
-    en = String(p.en ?? '').trim();
-    he = String(p.he ?? '').trim();
-  } catch {
-    /* leave empty */
-  }
-
-  return {
-    en,
-    he,
-    model: res.model,
-    costUsd: costUsd(res.model, res.usage),
-    inTokens: res.usage?.prompt_tokens ?? 0,
-    outTokens: res.usage?.completion_tokens ?? 0,
-  };
-}

--- a/packages/tanach/src/worker/producers/translate.ts
+++ b/packages/tanach/src/worker/producers/translate.ts
@@ -3,6 +3,14 @@
  * a word, or drag across a phrase) and gets a concise English gloss. Context
  * (the surrounding verse) is passed so a word is translated in the sense it has
  * here. Cached per normalized selection.
+ *
+ * DELIBERATELY NOT migrated onto runProducer/ArtifactStore (the only one of the
+ * five producers left on bespoke plumbing): its cache stores a RAW STRING with
+ * a 30-day TTL — both incompatible with the StoredArtifact envelope and the
+ * store's no-TTL contract (decided at the tanach migration stage; also locked
+ * in core's key-schemes tests, which exclude translate:v1 from the template
+ * scheme). The producer is still DECLARED in producers/defs.ts so the registry
+ * is complete; this module remains its live implementation.
  */
 
 import { type LLMEnv, runLLM } from '@corpus/core/llm/llm';
@@ -16,7 +24,7 @@ export interface TranslateResult {
   outTokens: number;
 }
 
-const SYSTEM = [
+export const TRANSLATE_SYSTEM = [
   'You translate Biblical Hebrew into concise, plain English.',
   '',
   'You are given a word or short phrase (it may carry niqqud and cantillation)',
@@ -25,7 +33,11 @@ const SYSTEM = [
   'context. No explanation, no transliteration, no notes.',
 ].join('\n');
 
-const SCHEMA = {
+/** DESCRIPTIVE template for the registry (the live call below builds the same
+ *  prompt by hand — this producer does not run through runProducer). */
+export const TRANSLATE_USER_TEMPLATE = 'Hebrew: {{q}}{{context_suffix}}';
+
+export const TRANSLATE_SCHEMA = {
   name: 'translation',
   strict: true,
   schema: {
@@ -43,12 +55,12 @@ export async function translateHebrew(
 ): Promise<TranslateResult> {
   const res = await runLLM(env, {
     messages: [
-      { role: 'system', content: SYSTEM },
+      { role: 'system', content: TRANSLATE_SYSTEM },
       { role: 'user', content: `Hebrew: ${q}${context ? `\n\nFrom this verse: ${context}` : ''}` },
     ],
     max_tokens: 120,
     temperature: 0.2,
-    response_format: { type: 'json_schema', json_schema: SCHEMA },
+    response_format: { type: 'json_schema', json_schema: TRANSLATE_SCHEMA },
     tag: 'tanach:translate',
   });
 

--- a/packages/tanach/src/worker/run-ports.ts
+++ b/packages/tanach/src/worker/run-ports.ts
@@ -1,0 +1,575 @@
+/**
+ * Tanach's wiring for the corpus-agnostic producer run — the PR-8 proof that a
+ * queue-less, registry-less app runs the IDENTICAL core runProducer the talmud
+ * worker runs. Everything app-specific enters here:
+ *
+ *  - ArtifactStore over env.CACHE with templateKeyScheme — the per-producer-id
+ *    literal key templates, copied BYTE-EXACTLY from the legacy hand-built
+ *    keys in index.ts (events:v2:{book}:{chapter}, note:v1:{book}:{chapter}:
+ *    {start}-{end}, synthesis:v1:{book}:{chapter}:{verse}, midrash-synth:v1:
+ *    {book}:{chapter}:{verse}). Canonical key == legacy key, so no alias
+ *    indirection is needed for the BYTES; what differs is the VALUE shape —
+ *    see the legacy read adapter below.
+ *  - LEGACY VALUE ADAPTER (cacheRead): pre-migration entries are the raw
+ *    response payloads (events: {book,chapter,ref,sections}; note:
+ *    {book,chapter,start,end,en,he}; synthesis / midrash-synthesis:
+ *    {book,chapter,verse,en,he}), NOT StoredArtifact envelopes. A read that
+ *    finds a non-envelope wraps it in a synthetic envelope (model/transport
+ *    'legacy-cache', parsed = the payload) so runProducer serves it as a
+ *    cache hit — ZERO regeneration cost for existing entries. Fresh writes
+ *    store real envelopes (with provenance); both shapes serve through the
+ *    same routes because the routes project from `parsed`, whose payload
+ *    fields are a superset/equal in both shapes.
+ *  - Source resolvers ('chapter-verses', 'section-verses', 'verse-text',
+ *    'commentaries', 'midrash-passages') wrapping the existing Sefaria fetch
+ *    helpers; route-visible failures throw TanachSourceError so the routes
+ *    keep their legacy status codes + bodies.
+ *  - The LLM port via the existing runLLM (model choice, call knobs and the
+ *    `tanach:*` cost tags exactly as the legacy producer functions).
+ *  - Usage attribution to the existing usage:v1 ledger (fire-and-forget via
+ *    waitUntil, as before).
+ *  - Passes/hooks: tanach has none — no-op ports — except markPostParse,
+ *    which applies the events producer's legacy output normalization.
+ */
+
+import { instanceIdOf, recipeHash } from '@corpus/core/cache/keys';
+import type { LLMEnv, LLMUsage } from '@corpus/core/llm/llm';
+import { runLLM } from '@corpus/core/llm/llm';
+import { costSplitUsd, costUsd, normalizeUsage } from '@corpus/core/llm/pricing';
+import type { CostStamp } from '@corpus/core/model/provenance';
+import type {
+  ResolveInputsPorts,
+  RunDependency,
+  SourceResolver,
+} from '@corpus/core/run/producer-run';
+import { recordSource, resolveInputs } from '@corpus/core/run/producer-run';
+import type { RunProducerPorts } from '@corpus/core/run/run-producer';
+import { runProducer } from '@corpus/core/run/run-producer';
+import { ArtifactStore } from '@corpus/core/store/artifact-store';
+import type { StoredArtifact } from '@corpus/core/store/envelope';
+import type { ArtifactAddress, KeyTemplate, ProducerKeyInfo } from '@corpus/core/store/key-schemes';
+import { templateKeyScheme } from '@corpus/core/store/key-schemes';
+import type { TanachEnrichmentDef, TanachMarkDef } from './producers/defs.ts';
+import { enrichRunDefOf, markRunDefOf } from './producers/defs.ts';
+import type { EventSection } from './producers/events.ts';
+import { versesForPrompt } from './producers/events.ts';
+import type { SourcePassage, VerseCommentary } from './sefaria-sources.ts';
+import { asVerses, fetchPassages, fetchVerseCommentaries, sefaria } from './sefaria-sources.ts';
+import type { UsageEntry } from './usage.ts';
+import { recordUsage as recordUsageEntry } from './usage.ts';
+
+export interface TanachEnv extends LLMEnv {
+  CACHE: KVNamespace;
+}
+
+/** Per-request run context: env + executionCtx (for fire-and-forget usage
+ *  writes) + the usage-ledger ref the route attributes this run to (the same
+ *  ref strings the legacy routes recorded: 'Genesis 1', 'Genesis 1:3-5', …). */
+export interface TanachRunCtx {
+  env: TanachEnv;
+  ctx: ExecutionContext;
+  ref: string;
+}
+
+/** A source-resolution failure the route should surface with a specific HTTP
+ *  status + body — preserving the legacy routes' error responses exactly
+ *  (404 for a Sefaria "ref not found" / not-enough-material, 502 for upstream
+ *  fetch failures). Anything else a run throws maps to the legacy
+ *  `Producer failed: …` 502. */
+export class TanachSourceError extends Error {
+  readonly status: 404 | 502;
+  constructor(status: 404 | 502, message: string) {
+    super(message);
+    this.status = status;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Key scheme — the literal templates, byte-exact to the legacy keys.
+// translate:v1:{norm} is deliberately absent (raw string + TTL — outside
+// ArtifactStore; see producers/translate.ts). midrash:v1:* is a SOURCE cache,
+// not a producer output, and stays on direct KV in index.ts.
+// ---------------------------------------------------------------------------
+
+type TanachAddress = ArtifactAddress & {
+  start?: string | number;
+  end?: string | number;
+  verse?: string | number;
+};
+
+const KEY_TEMPLATES: Record<string, KeyTemplate> = {
+  events: { key: (a: TanachAddress) => `events:v2:${a.unit?.work}:${a.unit?.unit}` },
+  note: {
+    key: (a: TanachAddress) => `note:v1:${a.unit?.work}:${a.unit?.unit}:${a.start}-${a.end}`,
+  },
+  synthesis: {
+    key: (a: TanachAddress) => `synthesis:v1:${a.unit?.work}:${a.unit?.unit}:${a.verse}`,
+  },
+  // Producer id and key prefix differ on purpose — the id routes, the
+  // template owns the literal bytes.
+  'midrash-synthesis': {
+    key: (a: TanachAddress) => `midrash-synth:v1:${a.unit?.work}:${a.unit?.unit}:${a.verse}`,
+  },
+};
+
+export const TANACH_KEY_SCHEME = templateKeyScheme(KEY_TEMPLATES);
+
+export function tanachArtifactStore(env: TanachEnv): ArtifactStore {
+  return new ArtifactStore(env.CACHE, TANACH_KEY_SCHEME);
+}
+
+function keyInfoOf(
+  def: { id: string; cache_version: string },
+  key_shape: 'mark' | 'enrich',
+): ProducerKeyInfo {
+  // scope/key_shape are nominal here — templateKeyScheme routes by id only.
+  return { id: def.id, cacheVersion: def.cache_version, scope: 'local', key_shape };
+}
+
+/** The template address for an enrichment run. runProducer hands the ports an
+ *  instanceId (instanceIdOf of the route's markInput); the routes construct
+ *  markInput with an explicit `id` that IS the legacy key component —
+ *  `${start}-${end}` for note, `${verse}` for the per-verse producers — so
+ *  instanceIdOf passes it through verbatim (digits and '-' survive slugId;
+ *  locked by tests/producer-keys.test.ts) and we can map it back onto the
+ *  template's semantic fields here. */
+export function enrichmentAddress(
+  id: string,
+  instanceId: string,
+  book: string,
+  chapter: string,
+): TanachAddress {
+  const unit = { work: book, unit: chapter };
+  if (id === 'note') {
+    const [start, end] = instanceId.split('-');
+    return { unit, instanceId, start, end };
+  }
+  return { unit, instanceId, verse: instanceId };
+}
+
+// ---------------------------------------------------------------------------
+// Legacy value adapter — what each producer's PRE-MIGRATION stored value looks
+// like, and how it keeps serving (wrapped as a synthetic envelope; never
+// rewritten, never regenerated):
+//   events            events:v2:{book}:{chapter}         {book,chapter,ref,sections}
+//   note              note:v1:{b}:{c}:{start}-{end}      {book,chapter,start,end,en,he}
+//   synthesis         synthesis:v1:{b}:{c}:{verse}       {book,chapter,verse,en,he}
+//   midrash-synthesis midrash-synth:v1:{b}:{c}:{verse}   {book,chapter,verse,en,he}
+// A StoredArtifact envelope always carries string `content` + `model` and a
+// `parsed` key; no legacy payload has any of those, so detection is safe.
+// ---------------------------------------------------------------------------
+
+export function isStoredArtifact(v: unknown): v is StoredArtifact {
+  if (!v || typeof v !== 'object') return false;
+  const o = v as Record<string, unknown>;
+  return typeof o.content === 'string' && typeof o.model === 'string' && 'parsed' in o;
+}
+
+function wrapLegacyValue(value: unknown): StoredArtifact {
+  const note = '(legacy tanach cache entry — pre-envelope payload, served as-is)';
+  return {
+    content: JSON.stringify(value),
+    parsed: value,
+    parse_error: null,
+    model: 'legacy-cache',
+    transport: 'legacy-cache',
+    attempts: 0,
+    usage: null,
+    elapsed_ms: 0,
+    prompt_chars: 0,
+    resolved: { system_prompt: note, user_prompt: note },
+    cache_hit: true,
+  };
+}
+
+async function readArtifactOrLegacy(env: TanachEnv, key: string): Promise<StoredArtifact | null> {
+  // store.get keeps the legacy read semantics (null on miss, null on corrupt
+  // JSON); the envelope check decides whether a wrap is needed.
+  const stored = await tanachArtifactStore(env).get(key);
+  if (!stored) return null;
+  return isStoredArtifact(stored) ? stored : wrapLegacyValue(stored);
+}
+
+// ---------------------------------------------------------------------------
+// Source resolvers — thin wrappers over the existing Sefaria helpers. Each
+// writes the template vars its producer's user prompt interpolates, byte-equal
+// to the strings the legacy route bodies built.
+// ---------------------------------------------------------------------------
+
+async function fetchChapterText(book: string, chapter: string) {
+  let text: Awaited<ReturnType<typeof sefaria.getText>>;
+  try {
+    text = await sefaria.getText(`${book} ${chapter}`);
+  } catch (e) {
+    throw new TanachSourceError(502, `Sefaria fetch failed: ${(e as Error).message}`);
+  }
+  if (text.error) throw new TanachSourceError(404, text.error);
+  return text;
+}
+
+/** The RAW verse path component, exactly as the route received it. The legacy
+ *  routes used the raw string everywhere (source refs, prompts, output keys),
+ *  so '007' stays '007' — numerifying here would split the output key from the
+ *  source key/prompt for zero-padded inputs. */
+function verseOf(markInput: unknown): string {
+  const v = (markInput as { verse?: string | number } | null)?.verse;
+  return v === undefined ? '' : String(v);
+}
+
+/** The chapter's verses, numbered, for the events prompt. */
+const chapterVersesResolver: SourceResolver<TanachRunCtx> = async ({
+  out,
+  tractate: book,
+  page: chapter,
+}) => {
+  const text = await fetchChapterText(book, chapter);
+  const he = asVerses(text.he);
+  const en = asVerses(text.text);
+  const verses = Array.from({ length: Math.max(he.length, en.length) }, (_, i) => ({
+    n: i + 1,
+    he: he[i] ?? '',
+    en: en[i] ?? '',
+  }));
+  const versesText = versesForPrompt(verses);
+  out.vars.ref = `${book} ${chapter}`;
+  out.vars.max_verse = verses.length;
+  out.vars.verses_text = versesText;
+  recordSource(out, 'chapter-verses', versesText);
+};
+
+/** The [start..end] verse slice + header for the note prompt. */
+const sectionVersesResolver: SourceResolver<TanachRunCtx> = async ({
+  out,
+  tractate: book,
+  page: chapter,
+  markInput,
+}) => {
+  const mi = markInput as { start: number; end: number; label: string };
+  const text = await fetchChapterText(book, chapter);
+  const en = asVerses(text.text);
+  const last = Math.min(mi.end, en.length);
+  const slice: string[] = [];
+  for (let n = mi.start; n <= last; n++) {
+    slice.push(`${n}. ${(en[n - 1] ?? '').replace(/<[^>]+>/g, '').trim()}`);
+  }
+  const ref =
+    mi.end > mi.start
+      ? `${book} ${chapter}:${mi.start}-${mi.end}`
+      : `${book} ${chapter}:${mi.start}`;
+  out.vars.passage_header = `${ref}${mi.label ? ` — "${mi.label}"` : ''}`;
+  out.vars.verses_text = slice.join('\n');
+  recordSource(out, 'section-verses', out.vars.verses_text as string);
+};
+
+/** The focal verse's text (best-effort — optional context, '' on failure). */
+const verseTextResolver: SourceResolver<TanachRunCtx> = async ({
+  out,
+  tractate: book,
+  page: chapter,
+  markInput,
+}) => {
+  const verse = verseOf(markInput);
+  let verseText = '';
+  try {
+    const t = await sefaria.getText(`${book} ${chapter}:${verse}`);
+    verseText = (asVerses(t.text)[0] || asVerses(t.he)[0] || '').replace(/<[^>]+>/g, '').trim();
+  } catch {
+    /* verse text is optional context */
+  }
+  out.vars.ref = `${book} ${chapter}:${verse}`;
+  out.vars.verse_text = verseText;
+  recordSource(out, 'verse-text', verseText);
+};
+
+/** The verse's classic commentaries — reuses the commentary drawer's cache
+ *  (commentary:v1:*) when warm, exactly as the legacy route did. */
+const commentariesResolver: SourceResolver<TanachRunCtx> = async ({
+  ctx: rc,
+  out,
+  tractate: book,
+  page: chapter,
+  markInput,
+}) => {
+  const verse = verseOf(markInput);
+  const cc = await rc.env.CACHE.get(`commentary:v1:${book}:${chapter}:${verse}`);
+  const commentaries: VerseCommentary[] = cc
+    ? (JSON.parse(cc).commentaries as VerseCommentary[])
+    : await fetchVerseCommentaries(book, chapter, String(verse));
+  if (commentaries.length < 2) {
+    throw new TanachSourceError(404, 'Not enough commentary to synthesize');
+  }
+  const ctext = commentaries
+    .map(
+      (cm) =>
+        `${cm.en}: ${cm.he
+          .join(' ')
+          .replace(/<[^>]+>/g, '')
+          .slice(0, 600)}`,
+    )
+    .join('\n\n');
+  out.vars.commentators_text = ctext;
+  recordSource(out, 'commentaries', ctext);
+};
+
+/** The verse's midrash excerpts — reuses the midrash drawer's SOURCE cache
+ *  (midrash:v1:*, which stays on direct KV) when warm, as the legacy route did. */
+const midrashPassagesResolver: SourceResolver<TanachRunCtx> = async ({
+  ctx: rc,
+  out,
+  tractate: book,
+  page: chapter,
+  markInput,
+}) => {
+  const verse = verseOf(markInput);
+  let passages: SourcePassage[];
+  const cm = await rc.env.CACHE.get(`midrash:v1:${book}:${chapter}:${verse}`);
+  if (cm) {
+    passages = JSON.parse(cm).passages as SourcePassage[];
+  } else {
+    try {
+      passages = (await fetchPassages(`${book} ${chapter}:${verse}`, 'Midrash', 14)).passages;
+    } catch (e) {
+      throw new TanachSourceError(502, `Links fetch failed: ${(e as Error).message}`);
+    }
+  }
+  if (passages.length < 2) {
+    throw new TanachSourceError(404, 'Not enough midrash to synthesize');
+  }
+  const mtext = passages
+    .map((p) => p.he || p.en)
+    .filter(Boolean)
+    .join('\n\n');
+  out.vars.midrash_text = mtext;
+  recordSource(out, 'midrash-passages', mtext);
+};
+
+const RESOLVE_PORTS: ResolveInputsPorts<TanachRunCtx, TanachEnrichmentDef, TanachMarkDef> = {
+  sources: {
+    'chapter-verses': chapterVersesResolver,
+    'section-verses': sectionVersesResolver,
+    'verse-text': verseTextResolver,
+    commentaries: commentariesResolver,
+    'midrash-passages': midrashPassagesResolver,
+  },
+  defaultSource: 'chapter-verses',
+  // Producer-to-producer deps: only the four runProducer-backed producers
+  // exist; nothing declares {enrichment}/{mark} deps today, but the lookups
+  // are real so the recursion closes through core if one ever does.
+  loadEnrichmentDef: async (_rc, id) =>
+    id === 'note' || id === 'synthesis' || id === 'midrash-synthesis' ? enrichRunDefOf(id) : null,
+  loadMarkDef: async (_rc, id) => (id === 'events' ? markRunDefOf(id) : null),
+  runEnrichment: (rc, def, book, chapter, markInput, bypassCache, parentChain) =>
+    runProducer(RUN_PORTS, rc, 'enrich', def, book, chapter, markInput, {
+      bypassCache,
+      lang: 'en',
+      parentChain,
+    }),
+  runMark: (rc, def, book, chapter, bypassCache) =>
+    runProducer(RUN_PORTS, rc, 'mark', def, book, chapter, undefined, {
+      bypassCache,
+      lang: 'en',
+    }),
+};
+
+// ---------------------------------------------------------------------------
+// The run ports.
+// ---------------------------------------------------------------------------
+
+/** Minimal {{var}} template rendering — the tanach prompts only interpolate
+ *  scalar vars the resolvers set (no array/anchors formatting like talmud's). */
+function renderTanachTemplate(tpl: string, vars: Record<string, unknown>): string {
+  return tpl.replace(/\{\{(\w+)\}\}/g, (_, key: string) => {
+    const v = vars[key];
+    if (v === undefined || v === null) return '';
+    return typeof v === 'string' ? v : String(v);
+  });
+}
+
+const RUN_PORTS: RunProducerPorts<TanachRunCtx, TanachEnrichmentDef, TanachMarkDef> = {
+  cacheRead: (rc, key) => readArtifactOrLegacy(rc.env, key),
+  // Writes go through the store's put (the human-edit guard chokepoint), with
+  // the legacy semantics: plain JSON, no TTL.
+  cacheWrite: async (rc, key, value) => {
+    await tanachArtifactStore(rc.env).put(key, value);
+  },
+  markKey: (def, book, chapter, lang) =>
+    TANACH_KEY_SCHEME.key(keyInfoOf(def, 'mark'), { unit: { work: book, unit: chapter }, lang }),
+  enrichmentKey: (def, instanceId, book, chapter, _qualifier, _lang) =>
+    TANACH_KEY_SCHEME.key(
+      keyInfoOf(def, 'enrich'),
+      enrichmentAddress(def.id, instanceId, book, chapter),
+    ),
+  // Content hash of the generation inputs — stamped on fresh enrichment writes
+  // (StoredArtifact.recipe_hash) so staleness is detectable later.
+  enrichmentRecipeHash: (def) =>
+    recipeHash({
+      extractor: {
+        system_prompt: def.system_prompt,
+        user_prompt_template: def.user_prompt_template,
+        output_schema: def.output_schema,
+        max_tokens: def.max_tokens,
+        temperature: def.temperature,
+      },
+    }),
+  // No title-keyed section enrichments in tanach — keys are verse/range-exact.
+  sectionRange: () => null,
+  resolveInputs: (rc, dependencies, book, chapter, markInput, bypassCache, parentChain) =>
+    resolveInputs(
+      RESOLVE_PORTS,
+      rc,
+      dependencies as ReadonlyArray<RunDependency> | undefined,
+      book,
+      chapter,
+      markInput,
+      bypassCache,
+      parentChain,
+    ),
+  renderTemplate: renderTanachTemplate,
+  // The mark LLM call — the exact runLLM options the legacy eventSections
+  // passed (default model chain, max_tokens 900, temperature 0.2, strict
+  // schema, tag 'tanach:events').
+  markLLM: async (rc, a) => {
+    const ext = a.def.extractor;
+    const systemPrompt = renderTanachTemplate(a.sysTpl, a.vars);
+    const userPrompt = renderTanachTemplate(a.usrTpl, a.vars);
+    const result = await runLLM(rc.env, {
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: userPrompt },
+      ],
+      max_tokens: ext.max_tokens,
+      temperature: ext.temperature,
+      response_format: { type: 'json_schema', json_schema: ext.output_schema },
+      tag: ext.tag,
+    });
+    return { result, systemPrompt, userPrompt };
+  },
+  // The enrichment LLM call — knobs per producer, exactly as the legacy
+  // sectionNote / synthesize / midrashSynthesis functions passed them.
+  enrichmentLLM: async (rc, a) => {
+    const def = a.def;
+    return runLLM(rc.env, {
+      messages: [
+        { role: 'system', content: a.systemPrompt },
+        { role: 'user', content: a.userPrompt },
+      ],
+      max_tokens: def.max_tokens,
+      temperature: def.temperature,
+      response_format: { type: 'json_schema', json_schema: def.output_schema },
+      tag: def.tag,
+    });
+  },
+  // No check layer in tanach (no def declares passes, so core never calls
+  // these — kept honest as no-ops rather than stubs that pretend to check).
+  runChecks: async (_rc, a) => ({ parsed: a.parsed, issues: [] }),
+  lintGate: async () => true,
+  costStamp: (model, usage, lang, cacheVersion) => {
+    const u = usage as LLMUsage | null | undefined;
+    const { input, output } = normalizeUsage(u);
+    const { costInUsd, costOutUsd } = costSplitUsd(model, u);
+    const stamp: CostStamp = {
+      billedUsd: u && typeof u.cost === 'number' ? u.cost : null,
+      estimatedUsd: costUsd(model, u),
+      costInUsd,
+      costOutUsd,
+      tokensIn: input,
+      tokensOut: output,
+      lang,
+      cacheVersion,
+      computedAt: Date.now(),
+    };
+    return stamp;
+  },
+  // The existing usage:v1 ledger, fed the same entry the legacy routes wrote
+  // (fire-and-forget via waitUntil so it never blocks the response).
+  recordUsage: (rc, args) => {
+    const usage = args.result.usage as LLMUsage | null | undefined;
+    const model = args.result.model ?? '';
+    const entry: UsageEntry = {
+      ts: Date.now(),
+      ref: rc.ref,
+      producer: args.id,
+      model,
+      in: usage?.prompt_tokens ?? 0,
+      out: usage?.completion_tokens ?? 0,
+      cost: costUsd(model, usage),
+    };
+    rc.ctx.waitUntil(recordUsageEntry(rc.env.CACHE, entry));
+  },
+  hooks: {
+    computedMark: async (_rc, def) => {
+      throw new Error(`mark ${def.id}: tanach has no computed marks`);
+    },
+    // The events producer's legacy output normalization, byte-for-byte the
+    // filtering the old eventSections wrapper applied: in-range integer verse,
+    // non-empty label, 40-char caps, verse order.
+    markPostParse: async (_rc, a) => {
+      if (a.def.id !== 'events' || !a.parsed) return a.parsed;
+      // The old eventSections wrapper caught ANY malformed-but-valid-JSON
+      // output (e.g. sections as an object) and degraded to sections: [] —
+      // a 502 here would turn a recoverable model quirk into a hard failure.
+      try {
+        const maxVerse = Number(a.vars.max_verse ?? 0);
+        const p = a.parsed as { sections?: EventSection[] };
+        const raw = Array.isArray(p.sections) ? p.sections : [];
+        const sections = raw
+          .filter(
+            (s) =>
+              Number.isInteger(s.verse) && s.verse >= 1 && s.verse <= maxVerse && (s.en || s.he),
+          )
+          .map((s) => ({
+            verse: s.verse,
+            en: String(s.en ?? '')
+              .trim()
+              .slice(0, 40),
+            he: String(s.he ?? '')
+              .trim()
+              .slice(0, 40),
+          }))
+          .sort((x, y) => x.verse - y.verse);
+        return { sections };
+      } catch {
+        return { sections: [] };
+      }
+    },
+    enrichmentPreResolve: async () => null,
+    enrichmentPostResolve: async () => ({}),
+    enrichmentPostParse: () => {},
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Route entry points — synchronous runProducer calls (no queue: that a
+// queue-less app runs the identical core function IS the proof).
+// ---------------------------------------------------------------------------
+
+export async function runTanachEvents(
+  rc: TanachRunCtx,
+  book: string,
+  chapter: string,
+): Promise<StoredArtifact> {
+  return runProducer(RUN_PORTS, rc, 'mark', markRunDefOf('events'), book, chapter, undefined, {
+    bypassCache: false,
+    lang: 'en',
+  });
+}
+
+export async function runTanachEnrichment(
+  rc: TanachRunCtx,
+  id: 'note' | 'synthesis' | 'midrash-synthesis',
+  book: string,
+  chapter: string,
+  /** The instance the enrichment is FOR. Its `id` field is the legacy key
+   *  component (`${start}-${end}` / `${verse}`) — see enrichmentAddress. */
+  markInput: Record<string, unknown> & { id: string },
+): Promise<StoredArtifact> {
+  return runProducer(RUN_PORTS, rc, 'enrich', enrichRunDefOf(id), book, chapter, markInput, {
+    bypassCache: false,
+    lang: 'en',
+  });
+}
+
+/** Exposed for tests: proves the markInput `id` carrier survives instanceIdOf
+ *  verbatim (digits + '-' pass slugId untouched), which is what makes the
+ *  template keys byte-exact end-to-end. */
+export { instanceIdOf };

--- a/packages/tanach/src/worker/sefaria-sources.ts
+++ b/packages/tanach/src/worker/sefaria-sources.ts
@@ -1,0 +1,118 @@
+/**
+ * Shared Sefaria source helpers for the tanach worker — the one SefariaClient
+ * instance plus the fetch/normalize helpers both the plain routes
+ * (/api/commentary, /api/gemara, /api/midrash) and the producer source
+ * resolvers (run-ports.ts) consume. Extracted from index.ts verbatim so the
+ * producer pipeline can import them without a circular dependency on the app.
+ */
+
+import { flattenPieces, pickV3Version, SefariaClient } from '@corpus/core/sefaria/client';
+import { COMMENTATORS } from '../lib/commentators.ts';
+
+export const sefaria = new SefariaClient();
+
+/** Strip Sefaria's inline footnote apparatus (the marker + the expanded note
+ *  text), which otherwise renders mid-verse. Keeps benign inline tags like the
+ *  large/small-letter <big>/<small> markup. */
+export function stripFootnotes(html: string): string {
+  return html
+    .replace(/<sup class="footnote-marker">.*?<\/sup>/g, '')
+    .replace(/<i class="footnote">.*?<\/i>/g, '')
+    .trim();
+}
+
+/** Sefaria returns he/text as a per-verse string array for a chapter ref (or a
+ *  bare string for a single verse). Normalize to a string[], footnotes stripped. */
+export function asVerses(v: string | string[] | undefined): string[] {
+  if (Array.isArray(v)) return v.map((s) => (typeof s === 'string' ? stripFootnotes(s) : ''));
+  return typeof v === 'string' ? [stripFootnotes(v)] : [];
+}
+
+export interface VerseCommentary {
+  key: string;
+  en: string;
+  heName: string;
+  he: string[];
+  enText: string[];
+}
+
+/** Fetch each curated commentator's note on a verse from Sefaria (he+en), drop
+ *  the empties. Shared by the commentary drawer and the synthesis producer. */
+export async function fetchVerseCommentaries(
+  book: string,
+  chapter: string,
+  verse: string,
+): Promise<VerseCommentary[]> {
+  const results = await Promise.all(
+    COMMENTATORS.map(async (cm) => {
+      const ref = `${cm.title} on ${book} ${chapter}:${verse}`;
+      try {
+        const v3 = await sefaria.getTextV3(ref);
+        const he = flattenPieces(pickV3Version(v3.versions, 'he')).filter((s) => s.trim());
+        const en = flattenPieces(pickV3Version(v3.versions, 'en')).filter((s) => s.trim());
+        if (!he.length && !en.length) return null;
+        return { key: cm.key, en: cm.en, heName: cm.he, he, enText: en };
+      } catch {
+        return null;
+      }
+    }),
+  );
+  return results.filter((r): r is VerseCommentary => r !== null);
+}
+
+export interface SourcePassage {
+  ref: string;
+  he: string;
+  en: string;
+}
+
+/** Distinct citing passages of one Sefaria category for a verse (Talmud /
+ *  Midrash), capped, each with a fetched text snippet. `bavliFirst` floats the
+ *  Bavli ahead of Yerushalmi / minor tractates. */
+export async function fetchPassages(
+  ref: string,
+  category: string,
+  cap: number,
+  bavliFirst = false,
+): Promise<{ count: number; passages: SourcePassage[] }> {
+  type Link = { category?: string; ref?: string; sourceRef?: string; index_title?: string };
+  const r = await fetch(`https://www.sefaria.org/api/links/${encodeURIComponent(ref)}?with_text=0`);
+  const links = (await r.json()) as Link[];
+  const seen = new Set<string>();
+  const picked: { ref: string; title: string }[] = [];
+  for (const l of Array.isArray(links) ? links : []) {
+    if (l.category !== category) continue;
+    const sref = l.sourceRef || l.ref;
+    if (!sref || seen.has(sref)) continue;
+    seen.add(sref);
+    picked.push({ ref: sref, title: l.index_title ?? '' });
+  }
+  if (bavliFirst) {
+    picked.sort(
+      (a, b) =>
+        Number(/^(Jerusalem|Tractate)/.test(a.title)) -
+        Number(/^(Jerusalem|Tractate)/.test(b.title)),
+    );
+  }
+  const passages = await Promise.all(
+    picked.slice(0, cap).map(async (p) => {
+      try {
+        const v3 = await sefaria.getTextV3(p.ref);
+        const he = flattenPieces(pickV3Version(v3.versions, 'he'))
+          .join(' ')
+          .replace(/<[^>]+>/g, '')
+          .trim()
+          .slice(0, 420);
+        const en = flattenPieces(pickV3Version(v3.versions, 'en'))
+          .join(' ')
+          .replace(/<[^>]+>/g, '')
+          .trim()
+          .slice(0, 420);
+        return { ref: p.ref, he, en };
+      } catch {
+        return { ref: p.ref, he: '', en: '' };
+      }
+    }),
+  );
+  return { count: picked.length, passages };
+}

--- a/packages/tanach/src/worker/spines.ts
+++ b/packages/tanach/src/worker/spines.ts
@@ -1,0 +1,31 @@
+/**
+ * The tanach spine — the one addressable text space this app's artifacts pin
+ * to, expressed through the SAME core SpineRegistry the talmud app uses
+ * (@corpus/core/model/spine). Levels are book/chapter/verse (the analogue of
+ * bavli's tractate/page/seg); a truncated path names the containing division
+ * (['Genesis'] = the book, ['Genesis', 1] = the chapter — what the events
+ * producer anchors at chapter depth, and synthesis at verse depth).
+ *
+ * Path validation grounds against the BOOKS registry (src/lib/books.ts), so a
+ * misspelled or non-Sefaria book name fails at ref-construction time instead
+ * of producing an unreachable cache key.
+ */
+
+import { createSpineRegistry } from '@corpus/core/model/spine';
+import { isBook } from '../lib/books.ts';
+
+export const tanachSpines = createSpineRegistry([
+  {
+    id: 'tanach',
+    kind: 'text',
+    label: 'Tanach',
+    levels: ['book', 'chapter', 'verse'],
+    normalizePath: (path) => {
+      const book = path[0];
+      if (typeof book !== 'string' || !isBook(book)) {
+        throw new Error(`unknown Tanach book: ${String(book)}`);
+      }
+      return path;
+    },
+  },
+]);

--- a/packages/tanach/tests/producer-defs.test.ts
+++ b/packages/tanach/tests/producer-defs.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { enrichRunDefOf, markRunDefOf, TANACH_PRODUCERS } from '../src/worker/producers/defs';
+import { tanachSpines } from '../src/worker/spines';
+
+describe('tanach spine registry', () => {
+  it('declares the tanach text spine with book/chapter/verse levels', () => {
+    const spine = tanachSpines.get('tanach');
+    expect(spine?.kind).toBe('text');
+    expect(spine?.levels).toEqual(['book', 'chapter', 'verse']);
+  });
+
+  it('accepts truncated paths (division refs) down to verse depth', () => {
+    expect(tanachSpines.ref('tanach', ['Genesis'])).toEqual(['Genesis']);
+    expect(tanachSpines.ref('tanach', ['Genesis', 1])).toEqual(['Genesis', 1]);
+    expect(tanachSpines.ref('tanach', ['I Samuel', 3, 4])).toEqual(['I Samuel', 3, 4]);
+  });
+
+  it('rejects bad depth and validates the book against the BOOKS registry', () => {
+    expect(() => tanachSpines.ref('tanach', [])).toThrow(/depth/);
+    expect(() => tanachSpines.ref('tanach', ['Genesis', 1, 1, 1])).toThrow(/depth/);
+    expect(() => tanachSpines.ref('tanach', ['Bereshit', 1])).toThrow(/unknown Tanach book/);
+  });
+});
+
+describe('the five producers as core Producer objects', () => {
+  it('declares all five with their model shapes', () => {
+    expect(Object.keys(TANACH_PRODUCERS).sort()).toEqual([
+      'events',
+      'midrash-synthesis',
+      'note',
+      'synthesis',
+      'translate',
+    ]);
+
+    const events = TANACH_PRODUCERS.events;
+    expect(events.kind).toBe('mark-instance');
+    expect(events.anchoring).toEqual({
+      behavior: 'discovers',
+      precision: 'segment',
+      spine: 'tanach',
+    });
+    expect(events.cardinality).toBe('many');
+    expect(events.key_shape).toBe('mark');
+    expect(events.cacheVersion).toBe('2'); // events:v2:*
+
+    const note = TANACH_PRODUCERS.note;
+    expect(note.anchoring.behavior).toBe('inherits');
+    expect(note.anchoring.target).toBe('events');
+    expect(note.cardinality).toBe('per-input');
+
+    for (const id of ['synthesis', 'midrash-synthesis'] as const) {
+      expect(TANACH_PRODUCERS[id].anchoring).toEqual({
+        behavior: 'inherits',
+        precision: 'segment',
+        spine: 'tanach',
+      });
+      expect(TANACH_PRODUCERS[id].scope).toBe('local');
+    }
+
+    const translate = TANACH_PRODUCERS.translate;
+    expect(translate.anchoring.behavior).toBe('inherits');
+    expect(translate.scope).toBe('global');
+  });
+
+  it('every recipe carries real prompts, a strict schema, and the legacy call knobs', () => {
+    const knobs: Record<string, { max_tokens: number; temperature: number; tag: string }> = {
+      events: { max_tokens: 900, temperature: 0.2, tag: 'tanach:events' },
+      note: { max_tokens: 700, temperature: 0.3, tag: 'tanach:note' },
+      synthesis: { max_tokens: 800, temperature: 0.3, tag: 'tanach:synthesis' },
+      'midrash-synthesis': { max_tokens: 800, temperature: 0.35, tag: 'tanach:midrash-synthesis' },
+      translate: { max_tokens: 120, temperature: 0.2, tag: 'tanach:translate' },
+    };
+    for (const [id, p] of Object.entries(TANACH_PRODUCERS)) {
+      const ext = p.recipe.extractor as {
+        kind: string;
+        system_prompt: string;
+        user_prompt_template: string;
+        output_schema: { strict?: boolean };
+        max_tokens: number;
+        temperature: number;
+        tag: string;
+      };
+      expect(ext.kind).toBe('llm');
+      expect(ext.system_prompt.length).toBeGreaterThan(50);
+      expect(ext.user_prompt_template).toContain('{{');
+      expect(ext.output_schema.strict).toBe(true);
+      expect({ max_tokens: ext.max_tokens, temperature: ext.temperature, tag: ext.tag }).toEqual(
+        knobs[id],
+      );
+    }
+  });
+
+  it('projects run defs runProducer consumes', () => {
+    const events = markRunDefOf('events');
+    expect(events.id).toBe('events');
+    expect(events.cache_version).toBe('2');
+    expect(events.dependencies).toEqual(['chapter-verses']);
+    expect(events.extractor.kind).toBe('llm');
+
+    const note = enrichRunDefOf('note');
+    expect(note.mark).toBe('events');
+    expect(note.dependencies).toEqual(['section-verses']);
+    expect(note.system_prompt.length).toBeGreaterThan(50);
+
+    const synth = enrichRunDefOf('synthesis');
+    expect(synth.dependencies).toEqual(['verse-text', 'commentaries']);
+    const midrash = enrichRunDefOf('midrash-synthesis');
+    expect(midrash.dependencies).toEqual(['verse-text', 'midrash-passages']);
+  });
+});

--- a/packages/tanach/tests/producer-keys.test.ts
+++ b/packages/tanach/tests/producer-keys.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Key byte-parity — the load-bearing cache-compatibility guarantee: every key
+ * the runProducer wiring derives is BYTE-IDENTICAL to the legacy hand-built
+ * literal the route used to write, so no warmed entry ever cold-misses.
+ * Expected literals are copied from the pre-migration index.ts:
+ *
+ *   `events:v2:${book}:${chapter}`
+ *   `note:v1:${book}:${chapter}:${start}-${end}`
+ *   `synthesis:v1:${book}:${chapter}:${verse}`
+ *   `midrash-synth:v1:${book}:${chapter}:${verse}`   (producer: midrash-synthesis)
+ *
+ * translate:v1:* is deliberately absent (kept on bespoke raw-string+TTL
+ * plumbing); midrash:v1:* is a source cache, not a producer output.
+ */
+
+import { instanceIdOf } from '@corpus/core/cache/keys';
+import type { ProducerKeyInfo } from '@corpus/core/store/key-schemes';
+import { describe, expect, it } from 'vitest';
+import { enrichRunDefOf, markRunDefOf } from '../src/worker/producers/defs';
+import { enrichmentAddress, TANACH_KEY_SCHEME } from '../src/worker/run-ports';
+
+function info(
+  def: { id: string; cache_version: string },
+  key_shape: 'mark' | 'enrich',
+): ProducerKeyInfo {
+  return { id: def.id, cacheVersion: def.cache_version, scope: 'local', key_shape };
+}
+
+describe('key byte-parity with the legacy literals', () => {
+  it('events — events:v2:{book}:{chapter}, raw book name (spaces preserved)', () => {
+    const def = info(markRunDefOf('events'), 'mark');
+    expect(TANACH_KEY_SCHEME.key(def, { unit: { work: 'Genesis', unit: '1' } })).toBe(
+      'events:v2:Genesis:1',
+    );
+    expect(TANACH_KEY_SCHEME.key(def, { unit: { work: 'I Samuel', unit: '3' } })).toBe(
+      'events:v2:I Samuel:3',
+    );
+    expect(TANACH_KEY_SCHEME.key(def, { unit: { work: 'Song of Songs', unit: '8' } })).toBe(
+      'events:v2:Song of Songs:8',
+    );
+  });
+
+  it('note — note:v1:{book}:{chapter}:{start}-{end}', () => {
+    const def = info(enrichRunDefOf('note'), 'enrich');
+    expect(TANACH_KEY_SCHEME.key(def, enrichmentAddress('note', '3-5', 'Genesis', '1'))).toBe(
+      'note:v1:Genesis:1:3-5',
+    );
+    // Single-verse sections still key as `${start}-${end}` with start === end
+    // (the legacy route always wrote both numbers).
+    expect(TANACH_KEY_SCHEME.key(def, enrichmentAddress('note', '7-7', 'Exodus', '20'))).toBe(
+      'note:v1:Exodus:20:7-7',
+    );
+  });
+
+  it('synthesis — synthesis:v1:{book}:{chapter}:{verse}', () => {
+    const def = info(enrichRunDefOf('synthesis'), 'enrich');
+    expect(TANACH_KEY_SCHEME.key(def, enrichmentAddress('synthesis', '1', 'Genesis', '1'))).toBe(
+      'synthesis:v1:Genesis:1:1',
+    );
+  });
+
+  it('midrash-synthesis — id routes, the template owns midrash-synth:v1 bytes', () => {
+    const def = info(enrichRunDefOf('midrash-synthesis'), 'enrich');
+    expect(
+      TANACH_KEY_SCHEME.key(def, enrichmentAddress('midrash-synthesis', '2', 'Exodus', '3')),
+    ).toBe('midrash-synth:v1:Exodus:3:2');
+  });
+
+  it('previousKey is null (no SWR decrement in the literal templates)', () => {
+    const def = info(markRunDefOf('events'), 'mark');
+    expect(TANACH_KEY_SCHEME.previousKey('events:v2:Genesis:1', def)).toBeNull();
+  });
+});
+
+describe('the markInput id carrier survives instanceIdOf verbatim', () => {
+  // runProducer derives the enrichment instance id via instanceIdOf(markInput);
+  // the routes set markInput.id to the legacy key component. Digits and '-'
+  // pass slugId untouched, which is what keeps the keys byte-exact end-to-end.
+  it('note range ids and verse ids pass through unchanged', async () => {
+    expect(await instanceIdOf({ id: '3-5', start: 3, end: 5, label: 'Creation' })).toBe('3-5');
+    expect(await instanceIdOf({ id: '7-7', start: 7, end: 7, label: '' })).toBe('7-7');
+    expect(await instanceIdOf({ id: '12', verse: 12 })).toBe('12');
+  });
+});

--- a/packages/tanach/tests/producer-routes.test.ts
+++ b/packages/tanach/tests/producer-routes.test.ts
@@ -1,0 +1,335 @@
+/**
+ * The rewired producer routes, end to end through the core runProducer:
+ *
+ *  1. CACHE COMPATIBILITY — a seeded LEGACY-shape entry (the raw response
+ *     payload the old routes stored, NOT a StoredArtifact envelope) keeps
+ *     serving through the new route byte-for-byte, with runLLM mocked to
+ *     throw and the network stubbed to throw: zero regeneration cost.
+ *  2. FRESH RUNS — an empty cache produces the legacy response shape, sends
+ *     the legacy prompts byte-for-byte, and writes a StoredArtifact envelope
+ *     (with provenance + cost) that then serves subsequent requests.
+ *  3. translate stays on its bespoke raw-string+TTL plumbing, untouched.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@corpus/core/llm/llm', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('@corpus/core/llm/llm')>();
+  return {
+    ...mod,
+    runLLM: vi.fn(async () => {
+      throw new Error('runLLM must not be called');
+    }),
+  };
+});
+
+import { runLLM } from '@corpus/core/llm/llm';
+import app from '../src/worker/index';
+
+const runLLMMock = vi.mocked(runLLM);
+
+function mockKV(seed: Record<string, string> = {}) {
+  const map = new Map(Object.entries(seed));
+  return {
+    map,
+    get: async (k: string) => map.get(k) ?? null,
+    put: async (k: string, v: string) => {
+      map.set(k, v);
+    },
+    delete: async (k: string) => {
+      map.delete(k);
+    },
+  };
+}
+
+function makeExec() {
+  const tasks: Promise<unknown>[] = [];
+  return {
+    tasks,
+    waitUntil: (p: Promise<unknown>) => {
+      tasks.push(p);
+    },
+    passThroughOnException: () => {},
+  };
+}
+
+function envOf(kv: ReturnType<typeof mockKV>) {
+  return { CACHE: kv, ASSETS: { fetch: async () => new Response('') } } as never;
+}
+
+async function getJson(path: string, kv: ReturnType<typeof mockKV>) {
+  const exec = makeExec();
+  const res = await app.request(path, {}, envOf(kv), exec as never);
+  const body = await res.json();
+  await Promise.all(exec.tasks);
+  return { status: res.status, body };
+}
+
+const llmResult = (content: string) => ({
+  content,
+  reasoning_content: '',
+  finish_reason: 'stop',
+  usage: { prompt_tokens: 100, completion_tokens: 20 },
+  prompt_chars: 500,
+  elapsed_ms: 10,
+  model: 'openrouter/deepseek/deepseek-chat-v3-0324' as const,
+  transport: 'openrouter-gateway' as const,
+  attempts: 1,
+});
+
+/** Sefaria /api/texts stub for "Genesis 1" (2 verses). */
+const sefariaChapter = () =>
+  new Response(
+    JSON.stringify({
+      ref: 'Genesis 1',
+      heRef: '',
+      he: ['בְּרֵאשִׁית בָּרָא', 'וְהָאָרֶץ הָיְתָה'],
+      text: ['In the beginning God created', 'And the earth was unformed'],
+    }),
+    { headers: { 'content-type': 'application/json' } },
+  );
+
+beforeEach(() => {
+  runLLMMock.mockReset();
+  runLLMMock.mockImplementation(async () => {
+    throw new Error('runLLM must not be called');
+  });
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => {
+      throw new Error('network must not be hit');
+    }),
+  );
+});
+
+describe('legacy-shape cache entries keep serving (no LLM, no network, no rewrite)', () => {
+  it('events — raw {book,chapter,ref,sections} payload', async () => {
+    const payload = {
+      book: 'Genesis',
+      chapter: 1,
+      ref: 'Genesis 1',
+      sections: [{ verse: 1, en: 'Day One', he: 'יום ראשון' }],
+    };
+    const kv = mockKV({ 'events:v2:Genesis:1': JSON.stringify(payload) });
+    const { status, body } = await getJson('/api/events/Genesis/1', kv);
+    expect(status).toBe(200);
+    expect(body).toEqual(payload);
+    expect(runLLMMock).not.toHaveBeenCalled();
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+    // Served, not migrated: the stored bytes are untouched.
+    expect(kv.map.get('events:v2:Genesis:1')).toBe(JSON.stringify(payload));
+  });
+
+  it('note — raw {book,chapter,start,end,en,he} payload', async () => {
+    const payload = { book: 'Genesis', chapter: 1, start: 3, end: 5, en: 'A note.', he: 'הערה.' };
+    const kv = mockKV({ 'note:v1:Genesis:1:3-5': JSON.stringify(payload) });
+    const { status, body } = await getJson('/api/note/Genesis/1/3?end=5&label=x', kv);
+    expect(status).toBe(200);
+    expect(body).toEqual(payload);
+    expect(runLLMMock).not.toHaveBeenCalled();
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+  });
+
+  it('synthesis — raw {book,chapter,verse,en,he} payload', async () => {
+    const payload = { book: 'Genesis', chapter: 1, verse: 1, en: 'Overview.', he: 'סקירה.' };
+    const kv = mockKV({ 'synthesis:v1:Genesis:1:1': JSON.stringify(payload) });
+    const { status, body } = await getJson('/api/synthesis/Genesis/1/1', kv);
+    expect(status).toBe(200);
+    expect(body).toEqual(payload);
+    expect(runLLMMock).not.toHaveBeenCalled();
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+  });
+
+  it('midrash-synthesis — raw payload under the midrash-synth:v1 key', async () => {
+    const payload = { book: 'Exodus', chapter: 3, verse: 2, en: 'Themes.', he: 'נושאים.' };
+    const kv = mockKV({ 'midrash-synth:v1:Exodus:3:2': JSON.stringify(payload) });
+    const { status, body } = await getJson('/api/midrash-synthesis/Exodus/3/2', kv);
+    expect(status).toBe(200);
+    expect(body).toEqual(payload);
+    expect(runLLMMock).not.toHaveBeenCalled();
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+  });
+
+  it('translate — untouched bespoke plumbing (raw string, cached flag)', async () => {
+    const kv = mockKV({ 'translate:v1:שלום': 'peace' });
+    const { status, body } = await getJson(`/api/translate?q=${encodeURIComponent('שלום')}`, kv);
+    expect(status).toBe(200);
+    expect(body).toEqual({ q: 'שלום', translation: 'peace', cached: true });
+    expect(runLLMMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('fresh runs — legacy response shape + legacy prompts + envelope writes', () => {
+  it('events: normalizes output, responds in the legacy shape, stores an envelope', async () => {
+    const kv = mockKV();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => sefariaChapter()),
+    );
+    runLLMMock.mockImplementation(async () =>
+      llmResult(
+        JSON.stringify({
+          sections: [
+            { verse: 1, en: '  Day One  ', he: 'יום ראשון' },
+            { verse: 99, en: 'Out of range', he: '' }, // filtered: > maxVerse
+          ],
+        }),
+      ),
+    );
+
+    const { status, body } = await getJson('/api/events/Genesis/1', kv);
+    expect(status).toBe(200);
+    expect(body).toEqual({
+      book: 'Genesis',
+      chapter: 1,
+      ref: 'Genesis 1',
+      sections: [{ verse: 1, en: 'Day One', he: 'יום ראשון' }],
+    });
+
+    // The prompt the producer sent is byte-equal to the legacy hand-built one.
+    const call = runLLMMock.mock.calls[0][1];
+    expect(call.messages[1].content).toBe(
+      'Chapter: Genesis 1 (2 verses)\n\n1. In the beginning God created\n2. And the earth was unformed',
+    );
+    expect(call.max_tokens).toBe(900);
+    expect(call.temperature).toBe(0.2);
+    expect(call.tag).toBe('tanach:events');
+
+    // The cache now holds a StoredArtifact envelope with provenance + cost.
+    const stored = JSON.parse(kv.map.get('events:v2:Genesis:1') ?? 'null');
+    expect(typeof stored.content).toBe('string');
+    expect(stored.model).toBe('openrouter/deepseek/deepseek-chat-v3-0324');
+    expect(stored.parsed).toEqual({ sections: [{ verse: 1, en: 'Day One', he: 'יום ראשון' }] });
+    expect(stored.provenance.authority).toBe('ai');
+    expect(stored.provenance.producerId).toBe('events');
+    expect(stored.cost.tokensIn).toBe(100);
+
+    // The usage ledger got the legacy-shaped entry.
+    const usage = JSON.parse(kv.map.get('usage:v1') ?? 'null');
+    expect(usage.byProducer.events.calls).toBe(1);
+    expect(usage.recent[0].ref).toBe('Genesis 1');
+
+    // And the envelope SERVES the next request with the LLM dead again.
+    runLLMMock.mockImplementation(async () => {
+      throw new Error('runLLM must not be called');
+    });
+    const again = await getJson('/api/events/Genesis/1', kv);
+    expect(again.body).toEqual(body);
+  });
+
+  it('note: legacy prompt + response shape, envelope carries recipe_hash', async () => {
+    const kv = mockKV();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => sefariaChapter()),
+    );
+    runLLMMock.mockImplementation(async () =>
+      llmResult(JSON.stringify({ en: ' A plain note. ', he: ' הערה פשוטה. ' })),
+    );
+
+    const { status, body } = await getJson('/api/note/Genesis/1/1?end=2&label=Creation', kv);
+    expect(status).toBe(200);
+    expect(body).toEqual({
+      book: 'Genesis',
+      chapter: 1,
+      start: 1,
+      end: 2,
+      en: 'A plain note.',
+      he: 'הערה פשוטה.',
+    });
+
+    const call = runLLMMock.mock.calls[0][1];
+    expect(call.messages[1].content).toBe(
+      'Passage: Genesis 1:1-2 — "Creation"\n\n1. In the beginning God created\n2. And the earth was unformed',
+    );
+    expect(call.tag).toBe('tanach:note');
+
+    const stored = JSON.parse(kv.map.get('note:v1:Genesis:1:1-2') ?? 'null');
+    expect(typeof stored.recipe_hash).toBe('string'); // enrichments stamp it
+    expect(stored.provenance.producerId).toBe('note');
+    expect(stored.parsed).toEqual({ en: ' A plain note. ', he: ' הערה פשוטה. ' });
+  });
+
+  it('synthesis: reuses the commentary:v1 cache, 404s below two commentators', async () => {
+    const commentaries = (n: number) => ({
+      commentaries: Array.from({ length: n }, (_, i) => ({
+        key: `c${i}`,
+        en: `Commentator ${i}`,
+        heName: '',
+        he: [`פירוש ${i}`],
+        enText: [],
+      })),
+    });
+
+    // Not enough commentary — the legacy 404, before any LLM call.
+    const thin = mockKV({ 'commentary:v1:Genesis:1:1': JSON.stringify(commentaries(1)) });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => sefariaChapter()),
+    );
+    const miss = await getJson('/api/synthesis/Genesis/1/1', thin);
+    expect(miss.status).toBe(404);
+    expect(miss.body).toEqual({ error: 'Not enough commentary to synthesize' });
+    expect(runLLMMock).not.toHaveBeenCalled();
+
+    // Two commentators — fresh run, legacy shape, envelope written.
+    const kv = mockKV({ 'commentary:v1:Genesis:1:1': JSON.stringify(commentaries(2)) });
+    runLLMMock.mockImplementation(async () =>
+      llmResult(JSON.stringify({ en: 'They differ.', he: 'הם חלוקים.' })),
+    );
+    const { status, body } = await getJson('/api/synthesis/Genesis/1/1', kv);
+    expect(status).toBe(200);
+    expect(body).toEqual({
+      book: 'Genesis',
+      chapter: 1,
+      verse: 1,
+      en: 'They differ.',
+      he: 'הם חלוקים.',
+    });
+    const call = runLLMMock.mock.calls[0][1];
+    expect(call.messages[1].content).toContain('Commentators:\nCommentator 0: פירוש 0');
+    const stored = JSON.parse(kv.map.get('synthesis:v1:Genesis:1:1') ?? 'null');
+    expect(stored.provenance.producerId).toBe('synthesis');
+  });
+
+  it('midrash-synthesis: reuses the midrash:v1 source cache, writes midrash-synth:v1', async () => {
+    const kv = mockKV({
+      'midrash:v1:Exodus:3:2': JSON.stringify({
+        passages: [
+          { ref: 'M1', he: 'מדרש אחד', en: '' },
+          { ref: 'M2', he: '', en: 'A second midrash' },
+        ],
+      }),
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => sefariaChapter()),
+    );
+    runLLMMock.mockImplementation(async () =>
+      llmResult(JSON.stringify({ en: 'The themes.', he: 'הנושאים.' })),
+    );
+    const { status, body } = await getJson('/api/midrash-synthesis/Exodus/3/2', kv);
+    expect(status).toBe(200);
+    expect(body).toEqual({
+      book: 'Exodus',
+      chapter: 3,
+      verse: 2,
+      en: 'The themes.',
+      he: 'הנושאים.',
+    });
+    const call = runLLMMock.mock.calls[0][1];
+    expect(call.messages[1].content).toContain('Midrashim:\nמדרש אחד\n\nA second midrash');
+    expect(call.tag).toBe('tanach:midrash-synthesis');
+    const stored = JSON.parse(kv.map.get('midrash-synth:v1:Exodus:3:2') ?? 'null');
+    expect(stored.provenance.producerId).toBe('midrash-synthesis');
+    expect(typeof stored.recipe_hash).toBe('string');
+  });
+
+  it('a dead upstream maps to the legacy 502 body', async () => {
+    const kv = mockKV();
+    // global fetch stub throws (the beforeEach default) → Sefaria fetch fails.
+    const { status, body } = await getJson('/api/events/Genesis/1', kv);
+    expect(status).toBe(502);
+    expect((body as { error: string }).error).toMatch(/^Sefaria fetch failed: /);
+  });
+});


### PR DESCRIPTION
Stage 9 of the four-primitive consolidation. The tanach app's producers now run through the same `@corpus/core` `runProducer` as talmud — queue-less, registry-less, only the ports differ. That a second corpus runs the identical core function is the test the framework doc set for itself.

- Tanach spine (`book/chapter/verse`), producers as core `Producer` objects, `templateKeyScheme` owning the legacy literal key bytes.
- **Cache compatibility:** existing KV entries (which predate the envelope) serve byte-equal responses through a read-side synthetic wrapper — zero regeneration, zero rewrites, locked by tests with the LLM and network mocked dead. Fresh writes are full `StoredArtifact` envelopes with provenance, through the human-edit-guarded `store.put`.
- Deliberately not migrated: `translate` (raw string + 30-day TTL, incompatible with the no-TTL envelope contract — documented), and the midrash/commentary source caches.

Codex review found three real regressions, all fixed before this PR: cache writes had moved onto the request path (a KV failure would have 502'd a successful generation — restored to non-fatal), the events normalization catch-all was lost (malformed `sections` would 502 instead of degrading to `[]`), and zero-padded verse params split identity between output key and source ref/prompt (raw strings now flow end-to-end).

Gates: tanach 41 (22 new), talmud 2065 + core 103 untouched; typecheck + biome clean. tanach `index.ts` −~400 lines.