### PR TITLE
Cleanup: dead-code sweep + client provenance type

### DIFF
--- a/packages/talmud/src/client/enrichmentQueue.ts
+++ b/packages/talmud/src/client/enrichmentQueue.ts
@@ -8,6 +8,7 @@
  * the reusable primitives.
  */
 
+import type { Provenance } from '@corpus/core/model/provenance';
 import { LruMap } from '../lib/lruMap';
 import { queueActivity } from './aiActivity';
 
@@ -43,6 +44,10 @@ export interface RunResult {
   stale?: boolean;
   refreshing?: boolean;
   cache_hit?: boolean;
+  /** Build manifest stamped (additively) by core's runProducer on every fresh
+   *  cache write — who decided (human/rule/ai), producer + recipe hash, input
+   *  refs, cost. Absent on entries written before the stamp existed. */
+  provenance?: Provenance;
 }
 
 /** True for an AbortError (DOMException or any error whose name is set). */

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -63,7 +63,7 @@ import {
   validateLLMRabbiOutput,
 } from '../lib/rabbi/types';
 import type { EntityPiece } from '../lib/registry/entity';
-import { adjacentAmud, type RishonimBundle, sefariaAPI, type TalmudPageData } from '../lib/sefref';
+import { adjacentAmud, sefariaAPI, type TalmudPageData } from '../lib/sefref';
 import { iterAmudim } from '../lib/sefref/amudim';
 import { getDafyomiMasechet } from '../lib/sefref/dafyomi/masechtos';
 import { fetchHebrewBooksDaf } from '../lib/sefref/hebrewbooks/client';
@@ -171,7 +171,6 @@ import {
   type RabbiPlacesEntry,
   resolveRabbi,
   resolveRabbiByName,
-  resolveRabbiName,
 } from './rabbi-places';
 import { placeRevachWithAi } from './revach-ai-place';
 import { buildSourceResolvers, type CommentariesSlice, type GemaraSlice } from './run-sources';
@@ -459,35 +458,6 @@ interface DafSkeleton {
     rabbiNames: string[];
   }>;
 }
-
-function _rishonimBlock(bundle: RishonimBundle, perCommentatorCap = 2500): string {
-  const entries = Object.entries(bundle);
-  if (entries.length === 0) return '';
-  const sliceStr = (s: string | undefined | null, cap: number) => {
-    if (!s) return '';
-    const cleaned = stripHtmlServer(s);
-    return cleaned.length > cap ? cleaned.slice(0, cap) : cleaned;
-  };
-  const parts = entries.map(([label, snip]) => {
-    const he = sliceStr(snip.hebrew, perCommentatorCap);
-    const en = sliceStr(snip.english, perCommentatorCap);
-    const body = [he && `<hebrew>${he}</hebrew>`, en && `<english>${en}</english>`]
-      .filter(Boolean)
-      .join('\n');
-    return `<commentator name="${label}" ref="${snip.ref}">\n${body}\n</commentator>`;
-  });
-  return `<rishonim_commentary>\n${parts.join('\n')}\n</rishonim_commentary>`;
-}
-
-const _STRATEGY_NAMES = [
-  'rabbis',
-  'references',
-  'parallels',
-  'commentaries',
-  'bigger-picture',
-  'background',
-  'synthesize',
-] as const;
 
 const app = new Hono<{ Bindings: Bindings }>();
 
@@ -6073,11 +6043,6 @@ const KNOWN_RABBIS_HE: KnownRabbi[] = (() => {
   out.sort((a, b) => b.nameHeNorm.length - a.nameHeNorm.length);
   return out;
 })();
-
-function _canonicalizeName(raw: string): string {
-  const hit = resolveRabbiName(raw);
-  return hit?.canonical ?? raw;
-}
 
 // Hebrew word-boundary test — match only when surrounded by whitespace or at
 // a string edge, so "רבא" doesn't match inside "דרבא" (prefix דְ־).

--- a/packages/talmud/src/worker/rabbi-places.ts
+++ b/packages/talmud/src/worker/rabbi-places.ts
@@ -121,8 +121,3 @@ export function resolveRabbi(name: string, nameHe?: string | null): RabbiResolut
   }
   return resolveRabbiByName(name);
 }
-
-// Back-compat shim: many call sites take just the canonical English name.
-export function resolveRabbiName(raw: string): RabbiPlacesEntry | null {
-  return resolveRabbiByName(raw)?.entry ?? null;
-}


### PR DESCRIPTION
Final stage of the four-primitive consolidation (#356–#364, then this). Smaller than the original estimate for the right reason: the deletion payoff landed incrementally inside the migration PRs themselves (−418, −195, −400 lines; the registry CRUD was already parameterized). This sweep removes the provably-dead remainder (−41) and adds the one type the client was owed: `provenance?: Provenance` on the client `RunResult`, making the build manifest type-visible for future inspector work.

Deliberate keeps documented in the commit: the run shims (single adaptation point, 5 call sites), the test-contract exports, the anchor×render matrix, and out-of-scope underscore-parked code flagged for a future sweep.

Gates: typecheck, full suite (core 103 / talmud 2065 / tanach 41, zero snapshot churn, zero test edits), biome, and both vite builds.