### PR TITLE
Tanach favicon; richer usage pages; fix the /api/usage/backlog 500

### DIFF
--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -5070,10 +5070,18 @@ const REPORTS_DISMISSED_KEY = 'reports:v1:dismissed';
 
 async function buildBacklogSection(cache?: KVNamespace) {
   const empty = { total: 0, sightings: 0, sample: [] as never[] };
+  // Each registry scan is independently guarded: one failing list (subrequest
+  // budget, KV hiccup) degrades its own card to empty instead of 500ing the
+  // whole backlog endpoint.
+  const guarded = <T>(p: Promise<T>): Promise<T | typeof empty> =>
+    p.catch((err) => {
+      console.error('[usage/backlog] registry scan failed:', err);
+      return empty;
+    });
   const [rabbis, places, concepts, repRaw, disRaw] = await Promise.all([
-    cache ? listUnknownRabbis(cache) : empty,
-    cache ? listObservedPlaces(cache) : empty,
-    cache ? listObservedConcepts(cache) : empty,
+    cache ? guarded(listUnknownRabbis(cache)) : empty,
+    cache ? guarded(listObservedPlaces(cache)) : empty,
+    cache ? guarded(listObservedConcepts(cache)) : empty,
     cache ? cache.get('reports:v1:recent') : null,
     cache ? cache.get(REPORTS_DISMISSED_KEY) : null,
   ]);

--- a/packages/talmud/src/worker/unknown-registry.ts
+++ b/packages/talmud/src/worker/unknown-registry.ts
@@ -433,9 +433,15 @@ export function recordObservedConcept(
 }
 
 export interface UnknownSummary<T> {
-  total: number; // distinct entities tracked
-  sightings: number; // sum of counts
-  sample: T[]; // top entities by sighting count
+  /** Distinct KV entries under the prefix (exact — from key listing; for
+   *  filtered lists this counts pre-filter entries). */
+  total: number;
+  /** Sum of sighting counts over the SCANNED subset. */
+  sightings: number;
+  /** How many entries had their values read. scanned < total means sightings
+   *  and the sample are approximate (the value-fetch budget capped the scan). */
+  scanned?: number;
+  sample: T[]; // top entities by sighting count within the scanned subset
 }
 
 // Read values in bounded batches and keep only a running top-N, so memory stays
@@ -443,6 +449,17 @@ export interface UnknownSummary<T> {
 // (one big Promise.all) blew the 128MB worker limit once `concepts` grew into
 // the thousands and three of these run in parallel from the backlog build.
 const LIST_BATCH = 400;
+
+/**
+ * Per-list cap on VALUE fetches. Every cache.get is a Worker subrequest
+ * (limit ~1000 per request), and three of these lists run in parallel from the
+ * backlog build — at ~2k unknown-rabbi keys alone, fetching every value blew
+ * the subrequest budget and 500'd /api/usage/backlog. Key LISTING is cheap
+ * (one subrequest per 1000 keys), so `total` stays exact; `sightings` and the
+ * top-N sample come from the first `VALUE_BUDGET` keys and are flagged
+ * approximate via `scanned < total`.
+ */
+const VALUE_BUDGET = 250;
 
 async function listPrefix<T extends { count: number }>(
   cache: KVNamespace,
@@ -452,6 +469,8 @@ async function listPrefix<T extends { count: number }>(
 ): Promise<UnknownSummary<T>> {
   const byCount = (a: T, b: T) => (b.count ?? 0) - (a.count ?? 0);
   let total = 0;
+  let scanned = 0;
+  let kept = 0;
   let sightings = 0;
   let top: T[] = [];
   // Cap the working set well above `sample` so the top-N is exact after a final
@@ -462,6 +481,7 @@ async function listPrefix<T extends { count: number }>(
     for (let i = 0; i < names.length; i += LIST_BATCH) {
       const recs = await Promise.all(names.slice(i, i + LIST_BATCH).map((n) => cache.get(n)));
       for (const raw of recs) {
+        scanned += 1;
         if (!raw) continue;
         let r: T;
         try {
@@ -470,7 +490,7 @@ async function listPrefix<T extends { count: number }>(
           continue;
         }
         if (keep && !keep(r)) continue;
-        total += 1;
+        kept += 1;
         sightings += r.count ?? 0;
         top.push(r);
       }
@@ -488,12 +508,21 @@ async function listPrefix<T extends { count: number }>(
       list_complete: boolean;
       cursor?: string;
     };
-    await ingest(res.keys.map((k) => k.name));
+    total += res.keys.length;
+    const remaining = VALUE_BUDGET - scanned;
+    if (remaining > 0) {
+      await ingest(res.keys.slice(0, remaining).map((k) => k.name));
+    }
     if (res.list_complete || !res.cursor) break;
     cursor = res.cursor;
   }
   top.sort(byCount);
-  return { total, sightings, sample: top.slice(0, sample) };
+  // When the scan covered every key, the old post-filter semantics hold
+  // exactly (a `keep`-filtered list reports kept entries, not raw keys). Only
+  // a budget-capped scan falls back to the raw key count, where the filtered
+  // fraction of unread values is unknowable.
+  if (scanned >= total) total = kept;
+  return { total, sightings, scanned, sample: top.slice(0, sample) };
 }
 
 export function listUnknownRabbis(

--- a/packages/tanach/index.html
+++ b/packages/tanach/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Tanach</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/packages/tanach/src/client/UsagePage.tsx
+++ b/packages/tanach/src/client/UsagePage.tsx
@@ -9,12 +9,20 @@ interface UsageEntry {
   out: number;
   cost: number | null;
 }
+interface BucketUsage {
+  calls: number;
+  costUsd: number;
+  // Absent on buckets recorded before token tracking existed.
+  inTokens?: number;
+  outTokens?: number;
+}
 interface UsageSummary {
   calls: number;
   inTokens: number;
   outTokens: number;
   costUsd: number;
-  byProducer: Record<string, { calls: number; costUsd: number }>;
+  byProducer: Record<string, BucketUsage>;
+  byModel?: Record<string, BucketUsage>;
   recent: UsageEntry[];
 }
 
@@ -27,6 +35,67 @@ const usd = (n: number) => `$${(n ?? 0).toFixed(4)}`;
 const num = (n: number) => (n ?? 0).toLocaleString();
 const when = (ts: number) => new Date(ts).toLocaleString();
 const model = (m: string) => m.replace(/^openrouter\//, '');
+const tokens = (b: BucketUsage) =>
+  b.inTokens || b.outTokens ? `${num(b.inTokens ?? 0)} / ${num(b.outTokens ?? 0)}` : '—';
+const perCall = (b: BucketUsage) => (b.calls > 0 ? usd(b.costUsd / b.calls) : '—');
+
+function byCostDesc(entries: Record<string, BucketUsage>): Array<[string, BucketUsage]> {
+  return Object.entries(entries).sort((a, b) => b[1].costUsd - a[1].costUsd);
+}
+
+/** A bucket table (producers or models): cost-sorted, with a relative cost
+ *  share bar, tokens (where recorded), and average cost per call. */
+function BucketTable(props: {
+  label: string;
+  buckets: Record<string, BucketUsage>;
+  nameCell?: (name: string) => JSX.Element | string;
+}): JSX.Element {
+  const rows = () => byCostDesc(props.buckets);
+  const maxCost = () => Math.max(...rows().map(([, b]) => b.costUsd), 0.000001);
+  return (
+    <table class="usage-table">
+      <thead>
+        <tr>
+          <th>{props.label}</th>
+          <th>Calls</th>
+          <th>Tokens in/out</th>
+          <th>$/call</th>
+          <th>Cost</th>
+        </tr>
+      </thead>
+      <tbody>
+        <For
+          each={rows()}
+          fallback={
+            <tr>
+              <td colspan="5" class="muted">
+                no calls yet
+              </td>
+            </tr>
+          }
+        >
+          {([name, b]) => (
+            <tr>
+              <td>{props.nameCell ? props.nameCell(name) : name}</td>
+              <td>{num(b.calls)}</td>
+              <td class="muted">{tokens(b)}</td>
+              <td class="muted">{perCall(b)}</td>
+              <td>
+                <span class="usage-cost-cell">
+                  <span
+                    class="usage-cost-bar"
+                    style={{ width: `${Math.max(2, (b.costUsd / maxCost()) * 72)}px` }}
+                  />
+                  {usd(b.costUsd)}
+                </span>
+              </td>
+            </tr>
+          )}
+        </For>
+      </tbody>
+    </table>
+  );
+}
 
 /** Self-tracked LLM usage for the Tanach producers (from the KV ledger at
  *  /api/usage). Independent of the AI Gateway. */
@@ -69,35 +138,12 @@ export function UsagePage(): JSX.Element {
             </div>
 
             <h2>By producer</h2>
-            <table class="usage-table">
-              <thead>
-                <tr>
-                  <th>Producer</th>
-                  <th>Calls</th>
-                  <th>Cost</th>
-                </tr>
-              </thead>
-              <tbody>
-                <For
-                  each={Object.entries(d().byProducer)}
-                  fallback={
-                    <tr>
-                      <td colspan="3" class="muted">
-                        no calls yet
-                      </td>
-                    </tr>
-                  }
-                >
-                  {([name, p]) => (
-                    <tr>
-                      <td>{name}</td>
-                      <td>{num(p.calls)}</td>
-                      <td>{usd(p.costUsd)}</td>
-                    </tr>
-                  )}
-                </For>
-              </tbody>
-            </table>
+            <BucketTable label="Producer" buckets={d().byProducer} />
+
+            <Show when={Object.keys(d().byModel ?? {}).length > 0}>
+              <h2>By model</h2>
+              <BucketTable label="Model" buckets={d().byModel ?? {}} nameCell={model} />
+            </Show>
 
             <h2>Recent calls</h2>
             <table class="usage-table">

--- a/packages/tanach/src/client/styles.css
+++ b/packages/tanach/src/client/styles.css
@@ -402,6 +402,18 @@ body {
 .usage-table .muted {
   color: var(--muted);
 }
+.usage-cost-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.usage-cost-bar {
+  display: inline-block;
+  height: 8px;
+  border-radius: 2px;
+  background: var(--accent);
+  opacity: 0.45;
+}
 
 /* this-week's-parsha button + EN/HE language toggle (like the Talmud reader) */
 .parsha-btn {

--- a/packages/tanach/src/worker/usage.ts
+++ b/packages/tanach/src/worker/usage.ts
@@ -15,12 +15,24 @@ export interface UsageEntry {
   cost: number | null;
 }
 
+export interface ProducerUsage {
+  calls: number;
+  costUsd: number;
+  /** Added later than calls/costUsd — absent on buckets recorded before the
+   *  field existed, so per-bucket token totals can undercount early traffic.
+   *  Defaulted to 0 at display time. */
+  inTokens?: number;
+  outTokens?: number;
+}
+
 export interface UsageSummary {
   calls: number;
   inTokens: number;
   outTokens: number;
   costUsd: number;
-  byProducer: Record<string, { calls: number; costUsd: number }>;
+  byProducer: Record<string, ProducerUsage>;
+  /** Same vintage caveat as ProducerUsage token fields. */
+  byModel?: Record<string, ProducerUsage>;
   recent: UsageEntry[];
 }
 
@@ -28,7 +40,15 @@ const KEY = 'usage:v1';
 const RECENT_CAP = 100;
 
 function empty(): UsageSummary {
-  return { calls: 0, inTokens: 0, outTokens: 0, costUsd: 0, byProducer: {}, recent: [] };
+  return {
+    calls: 0,
+    inTokens: 0,
+    outTokens: 0,
+    costUsd: 0,
+    byProducer: {},
+    byModel: {},
+    recent: [],
+  };
 }
 
 export async function readUsage(cache: KVNamespace): Promise<UsageSummary> {
@@ -43,16 +63,24 @@ export async function readUsage(cache: KVNamespace): Promise<UsageSummary> {
   return empty();
 }
 
+function bump(bucket: Record<string, ProducerUsage>, key: string, e: UsageEntry): void {
+  const b = bucket[key] ?? { calls: 0, costUsd: 0, inTokens: 0, outTokens: 0 };
+  bucket[key] = b;
+  b.calls += 1;
+  b.costUsd += e.cost ?? 0;
+  b.inTokens = (b.inTokens ?? 0) + e.in;
+  b.outTokens = (b.outTokens ?? 0) + e.out;
+}
+
 export async function recordUsage(cache: KVNamespace, e: UsageEntry): Promise<void> {
   const s = await readUsage(cache);
   s.calls += 1;
   s.inTokens += e.in;
   s.outTokens += e.out;
   s.costUsd += e.cost ?? 0;
-  const p = s.byProducer[e.producer] ?? { calls: 0, costUsd: 0 };
-  s.byProducer[e.producer] = p;
-  p.calls += 1;
-  p.costUsd += e.cost ?? 0;
+  bump(s.byProducer, e.producer, e);
+  s.byModel ??= {};
+  bump(s.byModel, e.model, e);
   s.recent.unshift(e);
   s.recent = s.recent.slice(0, RECENT_CAP);
   await cache.put(KEY, JSON.stringify(s));

--- a/packages/tanach/static/favicon.svg
+++ b/packages/tanach/static/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="10" fill="#fbf8f1"/>
+  <text x="50%" y="54%" text-anchor="middle" dominant-baseline="middle"
+        font-family="'SBL Hebrew', 'Ezra SIL', 'Times New Roman', serif"
+        font-size="52" font-weight="700" fill="#7a5c2e">ב</text>
+</svg>

--- a/packages/tanach/tests/usage.test.ts
+++ b/packages/tanach/tests/usage.test.ts
@@ -40,8 +40,43 @@ describe('usage ledger', () => {
     expect(s.inTokens).toBe(210);
     expect(s.outTokens).toBe(105);
     expect(s.costUsd).toBeCloseTo(0.002);
-    expect(s.byProducer.translate).toEqual({ calls: 2, costUsd: expect.closeTo(0.002) });
-    expect(s.byProducer.events).toEqual({ calls: 1, costUsd: 0 });
+    expect(s.byProducer.translate).toEqual({
+      calls: 2,
+      costUsd: expect.closeTo(0.002),
+      inTokens: 200,
+      outTokens: 100,
+    });
+    expect(s.byProducer.events).toEqual({ calls: 1, costUsd: 0, inTokens: 10, outTokens: 5 });
+  });
+
+  it('buckets per model and tolerates pre-token ledger entries', async () => {
+    // A stored summary from before token/byModel tracking: per-producer buckets
+    // without token fields and no byModel at all. Recording on top must not
+    // throw, and the old buckets keep accumulating.
+    const legacy = {
+      calls: 1,
+      inTokens: 100,
+      outTokens: 50,
+      costUsd: 0.001,
+      byProducer: { translate: { calls: 1, costUsd: 0.001 } },
+      recent: [],
+    };
+    const kv = kvStub({ 'usage:v1': JSON.stringify(legacy) });
+    await recordUsage(kv, entry({}));
+    const s = await readUsage(kv);
+    expect(s.calls).toBe(2);
+    expect(s.byProducer.translate).toEqual({
+      calls: 2,
+      costUsd: expect.closeTo(0.002),
+      inTokens: 100,
+      outTokens: 50,
+    });
+    expect(s.byModel?.[entry({}).model]).toEqual({
+      calls: 1,
+      costUsd: expect.closeTo(0.001),
+      inTokens: 100,
+      outTokens: 50,
+    });
   });
 
   it('keeps the most recent calls first, capped at 100', async () => {


### PR DESCRIPTION
Three sibling fixes:

1. **Tanach favicon** — matching the family style (Talmud's red ת gets a gold ב on parchment), served from the existing `static` publicDir.
2. **Tanach /usage upgraded** — per-producer token totals + `$`/call + cost-share bars + a By-model table; ledger extension is additive with a vintage-tolerance test (old summaries keep accumulating).
3. **Talmud `/api/usage/backlog` 500 fixed** — the registry scans did a KV `get` per key (3 prefixes in parallel; `unknown-rabbi:` alone is ~2k keys), blowing the Worker subrequest limit on cold builds as the data grew. Value fetches are now budget-capped with exact totals from key listing (`scanned` exposed for approximation-awareness; post-filter totals preserved whenever the scan covers everything), and each scan is independently guarded. Codex-verified the subrequest math fits and caught the pre/post-filter totals inconsistency, fixed.

Gates: full suite green (talmud 2065 / core 103 / tanach 42), typecheck, biome, both vite builds.