### PR TITLE
Rabbi disambiguation: honest homonyms, short-form recall, slug dedup

### DIFF
--- a/packages/core/src/run/run-producer.ts
+++ b/packages/core/src/run/run-producer.ts
@@ -256,7 +256,12 @@ export interface RunProducerPorts<
     ): Promise<unknown>;
     /** Enrichment pre-resolve short-circuits (rabbi.relationships graph,
      *  rabbi.identity lookup): a non-null return is the finished result —
-     *  core writes it (with provenance) and returns. */
+     *  core writes it (with provenance) and returns. A result marked
+     *  `transient: true` is SERVED but never written: some short-circuit
+     *  outputs are instance-specific while the cache key is shared across
+     *  instances (e.g. rabbi.identity is keyed by name slug, which every
+     *  same-name homonym instance shares) — a degraded/ambiguous payload
+     *  must not poison the shared key for instances that resolve. */
     enrichmentPreResolve(
       ctx: Ctx,
       args: {
@@ -266,7 +271,7 @@ export interface RunProducerPorts<
         page: string;
         recipeHash: string;
       },
-    ): Promise<StoredArtifact | null>;
+    ): Promise<(StoredArtifact & { transient?: boolean }) | null>;
     /** Enrichment post-resolve step (deps are resolved, LLM not yet called):
      *  may fully produce (rabbi.observations — `shortCircuit`), and/or return
      *  extra prompt vars (the pesukim Hebrew prefetch), and/or mutate
@@ -487,7 +492,12 @@ export async function runProducer<
       recipeHash: recipe_hash,
     });
     if (pre) {
-      if (cacheKey) return writeWithProvenance(ports, ctx, cacheKey, pre, edef.id, null);
+      // `transient` results are served without a cache write (shared-key
+      // protection — see the hook doc above). Cheap to re-serve: the
+      // pre-resolve short-circuits are deterministic lookups, no LLM.
+      if (cacheKey && !pre.transient) {
+        return writeWithProvenance(ports, ctx, cacheKey, pre, edef.id, null);
+      }
       return pre;
     }
   }

--- a/packages/talmud/src/client/ArgumentSidebar.tsx
+++ b/packages/talmud/src/client/ArgumentSidebar.tsx
@@ -1646,33 +1646,56 @@ function RabbiMeta(props: SpecialBlockProps): JSX.Element {
     if (pl.length > 0) parts.push(pl.join(', '));
     return parts;
   };
+  // Homonym uncertainty: grounding refused to pin this name (genSource
+  // 'ambiguous') because several registry rabbis share it — say so instead of
+  // leaving an unexplained gray "unknown" era.
+  const homonymNote = (): string | null => {
+    const n = f().homonyms;
+    if (f().genSource !== 'ambiguous' || typeof n !== 'number' || n <= 1) return null;
+    return t('rabbi.generationUncertain', { count: n });
+  };
   return (
-    <Show when={metaParts().length > 0}>
-      <div
-        style={{
-          display: 'flex',
-          'align-items': 'center',
-          gap: '0.45rem',
-          'font-size': '0.78rem',
-          color: '#666',
-          'margin-bottom': '0.85rem',
-          'flex-wrap': 'wrap',
-          'line-height': 1.5,
-        }}
-      >
-        <Show when={gen()}>
-          <span
+    <Show when={metaParts().length > 0 || homonymNote()}>
+      <div style={{ 'margin-bottom': '0.85rem' }}>
+        <Show when={metaParts().length > 0}>
+          <div
             style={{
-              display: 'inline-block',
-              width: '0.55rem',
-              height: '0.55rem',
-              'background-color': gen()!.color,
-              'border-radius': '50%',
-              'flex-shrink': 0,
+              display: 'flex',
+              'align-items': 'center',
+              gap: '0.45rem',
+              'font-size': '0.78rem',
+              color: '#666',
+              'flex-wrap': 'wrap',
+              'line-height': 1.5,
             }}
-          />
+          >
+            <Show when={gen()}>
+              <span
+                style={{
+                  display: 'inline-block',
+                  width: '0.55rem',
+                  height: '0.55rem',
+                  'background-color': gen()!.color,
+                  'border-radius': '50%',
+                  'flex-shrink': 0,
+                }}
+              />
+            </Show>
+            <span>{metaParts().join(' · ')}</span>
+          </div>
         </Show>
-        <span>{metaParts().join(' · ')}</span>
+        <Show when={homonymNote()}>
+          <div
+            style={{
+              'font-size': '0.74rem',
+              color: '#8a6d1a',
+              'line-height': 1.5,
+              'margin-top': metaParts().length > 0 ? '0.2rem' : '0',
+            }}
+          >
+            {homonymNote()}
+          </div>
+        </Show>
       </div>
     </Show>
   );
@@ -1757,7 +1780,8 @@ function RabbiGeography(props: SpecialBlockProps): JSX.Element {
   );
 }
 
-/** Display instance ({fields} for the heading + meta). */
+/** Display instance ({fields} for the heading + meta). genSource/homonyms are
+ *  the grounding stamps RabbiMeta uses to surface homonym uncertainty. */
 export function rabbiDisplayInstance(rabbi: IdentifiedRabbi): { fields: Record<string, unknown> } {
   return {
     fields: {
@@ -1766,11 +1790,18 @@ export function rabbiDisplayInstance(rabbi: IdentifiedRabbi): { fields: Record<s
       generation: rabbi.generation,
       region: rabbi.region,
       places: rabbi.places,
+      genSource: rabbi.genSource,
+      homonyms: rabbi.homonyms,
     },
   };
 }
-/** The FLAT shape the rabbi mark synthesis expects as mark_input (unchanged from
- *  the bespoke body, so the rabbi.synthesis cache stays valid). */
+/** The FLAT shape the rabbi mark synthesis expects as mark_input. Cache-key
+ *  safe: instanceIdOf keys this shape off `name` (we never set `id`), so the
+ *  grounding stamps below don't shift any enrichment cache key. slug/genSource/
+ *  homonyms are how the server short-circuits (rabbi.identity / .relationships
+ *  / .observations) see the mark's grounding verdict — without them the server
+ *  re-resolves by NAME (first-wins, homonym-blind) and can re-pin an
+ *  ambiguous "Rav Kahana" to the wrong registry entry. */
 export function rabbiSynthInstance(rabbi: IdentifiedRabbi): unknown {
   return {
     name: rabbi.name,
@@ -1778,6 +1809,9 @@ export function rabbiSynthInstance(rabbi: IdentifiedRabbi): unknown {
     generation: rabbi.generation,
     region: rabbi.region,
     places: rabbi.places,
+    ...(rabbi.slug ? { slug: rabbi.slug } : {}),
+    ...(rabbi.genSource ? { genSource: rabbi.genSource } : {}),
+    ...(typeof rabbi.homonyms === 'number' ? { homonyms: rabbi.homonyms } : {}),
   };
 }
 export const RABBI_BLOCKS: Record<string, (p: SpecialBlockProps) => JSX.Element> = {

--- a/packages/talmud/src/client/DafViewer.tsx
+++ b/packages/talmud/src/client/DafViewer.tsx
@@ -317,7 +317,7 @@ import { LruMap } from '../lib/lruMap';
 // eviction so they restore instantly on back-nav / language flip but don't
 // grow without limit over a long session (one entry per daf × lang). ~16 dapim
 // per language is far more than any realistic back-nav window.
-import type { IdentifiedRabbi } from './dafContext';
+import { dedupRabbiList, type IdentifiedRabbi } from './dafContext';
 
 const SESSION_CACHE_MAX = 32;
 const analysisSessionCache = new LruMap<string, DafAnalysis>(SESSION_CACHE_MAX);
@@ -863,7 +863,16 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
       | {
           instances?: Array<{
             excerpt?: string;
-            fields?: { name?: string; nameHe?: string; generation?: GenerationId };
+            fields?: {
+              name?: string;
+              nameHe?: string;
+              generation?: GenerationId;
+              // Grounding stamps (groundRabbiInstances): registry slug,
+              // resolution basis, homonym candidate count.
+              slug?: string;
+              genSource?: string;
+              homonyms?: number;
+            };
           }>;
         }
       | undefined;
@@ -885,20 +894,19 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
   });
 
   // Daf rabbi list as IdentifiedRabbi[] for the sidebar + routing. Thin —
-  // slug/region/places are null/empty here; the per-rabbi bio sidebar fills
-  // them from the rabbi.identity enrichment when a rabbi is opened. Deduped
-  // by canonical name.
+  // region/places are null/empty here; the per-rabbi bio sidebar fills them
+  // from the rabbi.identity enrichment when a rabbi is opened. Carries the
+  // grounding stamps (slug/genSource/homonyms) so list identity dedups
+  // slug-first ("Rabbi Yirmiyah"/"Rabbi Yirmeyah" are one rabbi) and the card
+  // can surface homonym uncertainty.
   const dafRabbis = createMemo<IdentifiedRabbi[]>(() => {
-    const seen = new Set<string>();
-    const out: IdentifiedRabbi[] = [];
+    const entries: IdentifiedRabbi[] = [];
     for (const i of rabbiMarkInstances()) {
       const name = String(i.fields?.name ?? '');
       const nameHe = String(i.fields?.nameHe ?? i.excerpt ?? '');
-      const dedupKey = name || nameHe;
-      if (!dedupKey || seen.has(dedupKey)) continue;
-      seen.add(dedupKey);
-      out.push({
-        slug: null,
+      if (!name && !nameHe) continue;
+      entries.push({
+        slug: typeof i.fields?.slug === 'string' ? i.fields.slug : null,
         name,
         nameHe,
         generation: (i.fields?.generation ?? 'unknown') as GenerationId,
@@ -908,9 +916,11 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
         bio: null,
         image: null,
         wiki: null,
+        genSource: typeof i.fields?.genSource === 'string' ? i.fields.genSource : undefined,
+        homonyms: typeof i.fields?.homonyms === 'number' ? i.fields.homonyms : undefined,
       });
     }
-    return out;
+    return dedupRabbiList(entries);
   });
 
   // This daf's background terms (daf-background.concepts), flattened for the
@@ -2824,7 +2834,7 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
       )?.instances?.find((i) => i.fields?.name === name);
       if (inst) {
         r = {
-          slug: null,
+          slug: typeof inst.fields.slug === 'string' ? inst.fields.slug : null,
           name,
           nameHe: String(inst.fields.nameHe ?? inst.excerpt ?? ''),
           generation: (inst.fields.generation ?? 'unknown') as GenerationId,
@@ -2834,6 +2844,8 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
           bio: null,
           image: null,
           wiki: null,
+          genSource: typeof inst.fields.genSource === 'string' ? inst.fields.genSource : undefined,
+          homonyms: typeof inst.fields.homonyms === 'number' ? inst.fields.homonyms : undefined,
         };
       }
     }
@@ -2878,6 +2890,9 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
   // useful sidebar entry. Push (not replace) so the back chip can pop.
   //
   // Resolution chain:
+  //   0. Slug match in dafContext, when the caller knows the slug (an
+  //      openRabbiSlug hand-off). Same-name homonyms can coexist in the
+  //      list with different slugs — a name lookup could open the WRONG one.
   //   1. Exact name match in dafContext.
   //   2. Normalized (strip Rabbi/Rav/R. prefix, lowercase) match in dafContext.
   //   3. Substring match: dafContext name contains the query, or vice
@@ -2889,12 +2904,15 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
   //      stub with a static descriptive bio.
   //   6. Stub fallback: open the sidebar with just the name + 'unknown'
   //      generation so the user at least sees what they clicked.
-  const pushRabbi = (name: string) => {
+  const pushRabbi = (name: string, slug?: string) => {
     const ctx = dafRabbis();
     let r: IdentifiedRabbi | null = null;
 
+    // 0. slug (strongest identity — survives same-name homonym pairs)
+    if (slug) r = ctx.find((x) => x.slug === slug) ?? null;
+
     // 1. exact
-    r = ctx.find((x) => x.name === name) ?? null;
+    if (!r) r = ctx.find((x) => x.name === name) ?? null;
 
     // 2. normalized
     if (!r) {
@@ -2924,7 +2942,7 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
       )?.instances?.find((i) => i.fields?.name === name);
       if (inst) {
         r = {
-          slug: null,
+          slug: typeof inst.fields.slug === 'string' ? inst.fields.slug : null,
           name,
           nameHe: String(inst.fields.nameHe ?? inst.excerpt ?? ''),
           generation: (inst.fields.generation ?? 'unknown') as GenerationId,
@@ -2934,6 +2952,8 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
           bio: null,
           image: null,
           wiki: null,
+          genSource: typeof inst.fields.genSource === 'string' ? inst.fields.genSource : undefined,
+          homonyms: typeof inst.fields.homonyms === 'number' ? inst.fields.homonyms : undefined,
         };
       }
     }
@@ -2979,12 +2999,15 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
   // from the dataset via /api/rabbi/:slug. ALWAYS pushes so chains of
   // rabbi → cited-rabbi → ... can be unwound by the back chip.
   const openRabbiSlug = async (slug: string) => {
-    // dafRabbis() carries null slugs (the join lives in the rabbi.identity
-    // enrichment now), so this won't match by slug — fall through to the
-    // standalone /api/rabbi/:slug fetch, which resolves the dataset entry.
+    // dafRabbis() carries the grounding-stamped slug when the registry pinned
+    // the rabbi (older cached runs may still have null slugs) — prefer the
+    // in-context entry, else fall through to the standalone /api/rabbi/:slug
+    // fetch, which resolves the dataset entry.
     const inCtx = dafRabbis().find((x) => x.slug === slug);
     if (inCtx) {
-      pushRabbi(inCtx.name);
+      // Thread the slug through — a name-only re-lookup could land on a
+      // SAME-NAME homonym that grounding pinned to a different slug.
+      pushRabbi(inCtx.name, slug);
       return;
     }
     try {

--- a/packages/talmud/src/client/dafContext.ts
+++ b/packages/talmud/src/client/dafContext.ts
@@ -17,4 +17,82 @@ export interface IdentifiedRabbi {
   bio: string | null;
   image: string | null;
   wiki: string | null;
+  /** Grounding provenance from the rabbi mark (unique | relational |
+   *  generation | ambiguous | none). 'ambiguous' = an unpinnable homonym. */
+  genSource?: string;
+  /** Registry candidate count for the name when >1 — lets the card say
+   *  "N rabbis share this name" for an ambiguous homonym. */
+  homonyms?: number;
+}
+
+/**
+ * List-identity dedup for daf rabbi lists. The LLM legitimately emits one
+ * instance per Hebrew FORM (anchors differ — "ר' ירמיה" and "רבי ירמיה" each
+ * underline their own occurrences), but the sidebar/timeline LIST should show
+ * one entry per rabbi. Identity, in order of strength:
+ *   1. the grounded registry slug (two transliteration variants of the same
+ *      rabbi — "Rabbi Yirmiyah"/"Rabbi Yirmeyah" — collapse once grounding
+ *      stamped them both);
+ *   2. the normalized Hebrew name (geresh title expanded: ר' ירמיה ≡ רבי
+ *      ירמיה) — Hebrew comes verbatim from the daf, so it folds English
+ *      spelling drift even when only one of the pair carries a slug. Two
+ *      entries with DIFFERENT slugs never collapse (a genuine same-name
+ *      homonym pair distinguished by grounding stays two rabbis). A
+ *      slugless entry folds into a slugged same-name entry ONLY when the
+ *      name is not a known homonym (homonyms absent or 1) — when several
+ *      registry rabbis share the name, the slugless mention may be a
+ *      DIFFERENT bearer than the one grounding pinned, so both stay. Two
+ *      SLUGLESS entries with identical Hebrew always collapse — with no
+ *      slug on either side they are indistinguishable, and one honest list
+ *      row beats two identical ones;
+ *   3. the lowercased English name, when there is no Hebrew form.
+ * Keeps the FIRST entry per identity. Anchors/underlines are NOT deduped —
+ * only list identity.
+ */
+export function dedupRabbiList<
+  T extends { slug?: string | null; name: string; nameHe: string; homonyms?: number },
+>(items: T[]): T[] {
+  const bySlug = new Set<string>();
+  // name key → first owner's {slug, homonyms} so later same-name entries can
+  // tell a unique pin from a pinned HOMONYM.
+  const byName = new Map<string, { slug: string | null; homonyms: number }>();
+  // name keys that already produced a SLUGLESS row — all later slugless
+  // same-name entries are indistinguishable from it and always collapse,
+  // even when the FIRST bearer of the name was a slugged homonym.
+  const keptSlugless = new Set<string>();
+  const out: T[] = [];
+  const heKey = (s: string): string =>
+    s
+      .replace(/[֑-ׇ]/g, '') // nikkud + cantillation
+      .replace(/^ר['׳]\s+/, 'רבי ') // geresh title shorthand → full title
+      .replace(/[.,:;?!"'״׳]/g, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+  for (const it of items) {
+    const slug = it.slug ?? null;
+    const homonyms = typeof it.homonyms === 'number' ? it.homonyms : 1;
+    const nameKey = it.nameHe ? heKey(it.nameHe) : it.name.trim().toLowerCase();
+    if (!slug && !nameKey) continue;
+    if (slug && bySlug.has(slug)) continue;
+    if (!slug && nameKey && keptSlugless.has(nameKey)) continue;
+    const owner = nameKey ? byName.get(nameKey) : undefined;
+    if (owner) {
+      // Same surface name. Collapse when:
+      //  - both slugless (indistinguishable — keep one honest row), or
+      //  - same slug (caught above via bySlug, kept for clarity), or
+      //  - exactly one side carries a slug AND the name is not a known
+      //    homonym — the slug then identifies the one bearer both refer to.
+      // Keep both when the slugs differ, or when one side is slugless and
+      // the name IS a homonym (the slugless mention may be another bearer).
+      const oneSideSlugless = !slug !== !owner.slug;
+      const isHomonym = owner.homonyms > 1 || homonyms > 1;
+      if (!slug && !owner.slug) continue;
+      if (oneSideSlugless && !isHomonym) continue;
+    }
+    if (slug) bySlug.add(slug);
+    if (!slug && nameKey) keptSlugless.add(nameKey);
+    if (nameKey && !owner) byName.set(nameKey, { slug, homonyms });
+    out.push(it);
+  }
+  return out;
 }

--- a/packages/talmud/src/client/i18n.ts
+++ b/packages/talmud/src/client/i18n.ts
@@ -982,6 +982,10 @@ const CATALOG = {
   'rabbi.onThisDaf': { en: 'On this daf: {text}', he: 'בדף זה: {text}' },
   'rabbi.row.highlight': { en: 'Click to highlight in daf', he: 'לחצו להדגשה בדף' },
   'rabbi.row.unhighlight': { en: 'Click to un-highlight', he: 'לחצו לביטול ההדגשה' },
+  'rabbi.generationUncertain': {
+    en: 'Generation uncertain — {count} rabbis share this name',
+    he: 'הדור אינו ודאי — {count} חכמים נושאים שם זה',
+  },
 
   // — Rabbi geography card —
   'rabbi.geography.title': { en: 'Geography', he: 'גאוגרפיה' },

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -155,7 +155,13 @@ import {
   TRANSLATE_BIO_JSON_SCHEMA,
 } from './output-schemas';
 import { loadEnrichmentDef, loadMarkDef } from './producer-registry';
-import { groundRabbiInstances, groundRabbiNames, lookupRelationships } from './rabbi-graph';
+import {
+  groundRabbiInstances,
+  groundRabbiNames,
+  lookupRelationships,
+  lookupRelationshipsBySlug,
+  type RelationshipsData,
+} from './rabbi-graph';
 import {
   buildObservationSlices,
   normalizeForMatch,
@@ -2683,7 +2689,7 @@ async function runExtractorFannedOut(
 // underline + timeline entry. Rebuilds the instance list from the augmented
 // rabbis — `excerpt` is non-load-bearing for the rabbi mark (the renderer and
 // sidebar key off fields.nameHe), so mirroring it from nameHe is safe.
-function postProcessRabbi(parsed: unknown, hebrewText: string): unknown {
+export function postProcessRabbi(parsed: unknown, hebrewText: string): unknown {
   const p = parsed as {
     instances?: Array<{ fields?: { name?: string; nameHe?: string; generation?: string } }>;
   } | null;
@@ -2698,17 +2704,40 @@ function postProcessRabbi(parsed: unknown, hebrewText: string): unknown {
     ...p,
     instances: augmented.map((r) => ({
       excerpt: r.nameHe,
-      // Fill an 'unknown' generation from the registry so a model-missed or
-      // model-unsure rabbi (the deterministic safety net adds known rabbis as
-      // 'unknown') still underlines on the right tier instead of neutral gray.
-      // The model's call wins whenever it assigned a generation.
+      // Keep the model's (or the augment's 'unknown') generation here. The
+      // registry fill for still-unknown generations happens AFTER grounding
+      // (fillUngroundedGenerations) — a name-keyed first-wins registry guess
+      // must not masquerade as the LLM's local generation read inside the
+      // homonym era-consistency veto.
       fields: {
         name: r.name,
         nameHe: r.nameHe,
-        generation: resolveGeneration(r.name, r.nameHe, r.generation),
+        generation: r.generation,
       },
     })),
   };
+}
+
+// After grounding: fill an 'unknown' generation from the rabbi-places registry
+// ONLY for instances the hierarchy registry has no opinion on (genSource
+// 'none') — so a model-missed later authority (Rashi, a named Gaon, …) still
+// lands on the right tier instead of neutral gray. Grounded instances already
+// carry the authoritative registry era, and 'ambiguous' homonyms stay honestly
+// 'unknown' (a name-keyed first-wins fill is precisely the homonym guess
+// grounding just refused to make).
+export function fillUngroundedGenerations(parsed: unknown): unknown {
+  const p = parsed as {
+    instances?: Array<{
+      fields?: { name?: string; nameHe?: string; generation?: string; genSource?: string };
+    }>;
+  } | null;
+  if (!p || !Array.isArray(p.instances)) return parsed;
+  for (const inst of p.instances) {
+    const f = inst.fields;
+    if (f?.genSource !== 'none' || f.generation !== 'unknown') continue;
+    f.generation = resolveGeneration(String(f.name ?? ''), String(f.nameHe ?? ''), 'unknown');
+  }
+  return parsed;
 }
 
 // ===========================================================================
@@ -2946,8 +2975,10 @@ const RUN_PORTS: RunProducerPorts<RunCtx, EnrichmentDefinition, SchemaMarkDefini
         // Ground each rabbi's generation through the registry (relational homonym
         // disambiguation off the daf's cast): authoritative era when identified,
         // neutral 'unknown' for a homonym we can't pin — so the reader's era color
-        // is grounded, not a freeform per-daf guess.
+        // is grounded, not a freeform per-daf guess. Then fill the generations
+        // grounding had no opinion on (genSource 'none') from rabbi-places.
         parsed = groundRabbiInstances(parsed);
+        parsed = fillUngroundedGenerations(parsed);
       } else if (parsed && a.def.id === 'places') {
         // Places have no global gazetteer — log every observed location to the
         // "needs global enrichment" backlog so we can see what to add over time.
@@ -2963,28 +2994,62 @@ const RUN_PORTS: RunProducerPorts<RunCtx, EnrichmentDefinition, SchemaMarkDefini
       // an LLM call, deterministic, free, and instant. We only fall through to
       // the LLM when the graph misses (rabbi not found OR node has no edges).
       if (def.id === 'rabbi.relationships') {
-        const inst = markInput as { name?: string; nameHe?: string; generation?: string } | null;
-        if (inst?.name) {
-          const hit = lookupRelationships(inst.name, inst.nameHe, inst.generation);
-          if (hit) {
-            return {
-              content: JSON.stringify(hit.data),
-              parsed: hit.data,
-              parse_error: null,
-              model: `graph:${hit.slug}`,
-              transport: 'graph',
-              attempts: 0,
-              usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },
-              elapsed_ms: 0,
-              prompt_chars: 0,
-              resolved: {
-                system_prompt: `(graph lookup: ${hit.slug})`,
-                user_prompt: `(graph lookup for rabbi: ${inst.name})`,
-              },
-              cache_hit: false,
-              recipe_hash: a.recipeHash,
-            };
-          }
+        const inst = rabbiMarkInputFields(markInput);
+        const envelope = (data: unknown, slug: string, transient?: boolean) => ({
+          content: JSON.stringify(data),
+          parsed: data,
+          parse_error: null,
+          model: `graph:${slug}`,
+          transport: 'graph',
+          attempts: 0,
+          usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },
+          elapsed_ms: 0,
+          prompt_chars: 0,
+          resolved: {
+            system_prompt: `(graph lookup: ${slug})`,
+            user_prompt: `(graph lookup for rabbi: ${inst.name || inst.nameHe})`,
+          },
+          cache_hit: false,
+          recipe_hash: a.recipeHash,
+          ...(transient ? { transient: true } : {}),
+        });
+        // Grounded instance → resolve the graph node by SLUG directly. A name
+        // re-resolution here is first-wins and homonym-blind — it re-pinned
+        // grounded "Rav Kahana" mentions to whatever bearer the index lists
+        // first, contradicting the mark's own verdict.
+        if (inst.slug) {
+          const hit = lookupRelationshipsBySlug(inst.slug, inst.name || undefined);
+          if (hit) return envelope(hit.data, hit.slug);
+          // Pinned but edge-less node — fall through to the LLM path (the
+          // prompt's mark_input now carries the slug as a disambiguator).
+          return null;
+        }
+        // Grounding says AMBIGUOUS homonym: several registry rabbis share the
+        // name and the daf evidence can't pin one. Do NOT first-win a graph
+        // node and do NOT let the LLM guess — serve an honest empty payload.
+        // `transient`: rabbi.relationships is scope-global keyed by the NAME
+        // slug, which a later-resolved same-name instance shares; the degraded
+        // payload must not occupy that key.
+        if (inst.genSource === 'ambiguous') {
+          const data: RelationshipsData = {
+            teachers: [],
+            students: [],
+            debatePartners: [],
+            family: [],
+            prose:
+              'Several rabbis in the sources share this name, and this mention ' +
+              'could not be pinned to one of them — so no relationship map is shown.',
+          };
+          return envelope(data, 'ambiguous', true);
+        }
+        if (inst.name) {
+          const hit = lookupRelationships(
+            inst.name,
+            inst.nameHe || undefined,
+            // 'unknown' must not scope findSlug's generation-prefix step.
+            inst.generation !== 'unknown' ? inst.generation : undefined,
+          );
+          if (hit) return envelope(hit.data, hit.slug);
           // Miss — fall through to the LLM path with the disambiguation prompt.
         }
         return null;
@@ -2998,32 +3063,74 @@ const RUN_PORTS: RunProducerPorts<RunCtx, EnrichmentDefinition, SchemaMarkDefini
       if (def.id === 'rabbi.identity') {
         // Always short-circuit — there is no useful LLM fallback (a model can't
         // know a Sefaria slug), and the placeholder prompt must never run.
-        const inst = markInput as {
-          name?: string;
-          nameHe?: string;
-          generation?: GenerationId;
-        } | null;
-        const ident = enrichRabbi(
-          inst?.name ?? '',
-          inst?.nameHe ?? '',
-          inst?.generation ?? 'unknown',
-        );
-        // Rabbi not in the bundled dataset → add to the "needs global enrichment"
-        // backlog so we can track who to add a base bio for as usage grows.
-        if (!ident.slug && (inst?.name || inst?.nameHe)) {
-          recordUnknownRabbi(rc.env, rc.ctx, {
-            name: inst?.name,
-            nameHe: inst?.nameHe,
-            generation: inst?.generation,
-            tractate,
-            page,
-          });
+        //
+        // KNOWN DEFERRED ISSUE (homonym cache collision): rabbi.identity is
+        // scope-global keyed by instance id = the NAME slug, so every
+        // same-name instance — ambiguous or resolved, and two DIFFERENTLY
+        // resolved homonyms — shares one cache key. We don't change keys
+        // (a key change cold-misses all of Shas). Mitigations here: (1) the
+        // ambiguous path serves a degraded payload marked `transient`, which
+        // runProducer serves WITHOUT writing, so it can't poison the shared
+        // key; (2) the slug path joins the dataset directly (no name
+        // first-wins). Residual: resolved homonyms sharing one name share one
+        // cached identity entry (first writer wins on later cache hits), and
+        // an ambiguous instance whose name already has a cached resolved
+        // entry is served that entry by the cache-hit path upstream of this
+        // hook. A real fix needs the slug in the cache key — deferred.
+        const inst = rabbiMarkInputFields(markInput);
+        // Grounded slug → direct dataset join, never a name re-resolution.
+        let ident = inst.slug
+          ? enrichRabbiBySlug(inst.slug, inst.name, inst.nameHe, inst.generation)
+          : null;
+        let transient = false;
+        if (!ident && !inst.slug && inst.genSource === 'ambiguous') {
+          // Grounding says: several registry rabbis share this name and the
+          // daf evidence can't pin one. Serve an honest name-only identity —
+          // a name join here would re-pin the first-listed bearer (the
+          // "Rav Kahana → rav-kahana-(ii), amora-ey-1" defect).
+          ident = {
+            slug: null,
+            name: inst.name || inst.nameHe,
+            nameHe: inst.nameHe,
+            generation: inst.generation,
+            region: null,
+            places: [],
+            moved: null,
+            bio: null,
+            image: null,
+            wiki: null,
+            genSource: 'ambiguous',
+            ...(inst.homonyms && inst.homonyms > 1 ? { homonyms: inst.homonyms } : {}),
+          };
+          transient = true;
+        }
+        if (!ident) {
+          // Ungrounded instance (older cached mark runs) — the legacy
+          // name-keyed join.
+          ident = enrichRabbi(inst.name, inst.nameHe, inst.generation);
+          // Rabbi not in the bundled dataset → add to the "needs global
+          // enrichment" backlog so we can track who to add a base bio for as
+          // usage grows. (Ambiguous homonyms are NOT recorded — they're in
+          // the registry several times over, not missing from it.)
+          if (!ident.slug && (inst.name || inst.nameHe)) {
+            recordUnknownRabbi(rc.env, rc.ctx, {
+              name: inst.name || undefined,
+              nameHe: inst.nameHe || undefined,
+              generation: inst.generation,
+              tractate,
+              page,
+            });
+          }
         }
         return {
           content: JSON.stringify(ident),
           parsed: ident,
           parse_error: null,
-          model: ident.slug ? `lookup:${ident.slug}` : 'lookup:miss',
+          model: ident.slug
+            ? `lookup:${ident.slug}`
+            : transient
+              ? 'lookup:ambiguous'
+              : 'lookup:miss',
           transport: 'lookup',
           attempts: 0,
           usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },
@@ -3031,10 +3138,11 @@ const RUN_PORTS: RunProducerPorts<RunCtx, EnrichmentDefinition, SchemaMarkDefini
           prompt_chars: 0,
           resolved: {
             system_prompt: '(deterministic lookup: rabbi-places.json)',
-            user_prompt: `(identity lookup for rabbi: ${inst?.name ?? '(unnamed)'})`,
+            user_prompt: `(identity lookup for rabbi: ${inst.name || inst.nameHe || '(unnamed)'})`,
           },
           cache_hit: false,
           recipe_hash: a.recipeHash,
+          ...(transient ? { transient: true } : {}),
         };
       }
       return null;
@@ -3261,8 +3369,23 @@ async function runRabbiObservations(
     const nameHe = String(fields.nameHe ?? inst.excerpt ?? '');
     if (!name && !nameHe) continue;
     const generation = (fields.generation ?? 'unknown') as GenerationId;
-    const ident = enrichRabbi(name, nameHe, generation);
-    const slug = ident.slug ?? obsSlugId(name || nameHe);
+    // Slug precedence: (1) the grounding stamp on the mark instance (the
+    // mark's own homonym verdict — never re-resolve a pinned instance by
+    // name); (2) SKIP an instance grounding marked AMBIGUOUS — accumulating
+    // its observations would require exactly the name-keyed first-wins pin
+    // grounding refused to make, attributing this daf's material to the
+    // wrong same-name rabbi in the reverse index; (3) the legacy name join
+    // for ungrounded (older-cache) instances.
+    const stampedSlug = typeof fields.slug === 'string' && fields.slug ? fields.slug : null;
+    let slug: string;
+    if (stampedSlug) {
+      slug = stampedSlug;
+    } else if (fields.genSource === 'ambiguous') {
+      continue;
+    } else {
+      const ident = enrichRabbi(name, nameHe, generation);
+      slug = ident.slug ?? obsSlugId(name || nameHe);
+    }
     if (!slug) continue;
     const segIdxs = resolveSegIdxs(String(inst.excerpt ?? nameHe), normSegs);
 
@@ -6052,20 +6175,73 @@ const KNOWN_RABBIS_HE: KnownRabbi[] = (() => {
   return out;
 })();
 
+// Short-form index: TITLE + FIRST GIVEN NAME of multi-part canonical names
+// ("רבי תנחום" from "רבי תנחום בר חנילאי"), built ONCE. The full-form-only scan
+// missed every daf that cites a rabbi by his everyday short name. Guards:
+//   - skip entries whose raw canonicalHe carries a parenthetical disambiguator
+//     ("רב (שם אמורא)", "רבי מנא (1)") — their stripped token soup yields junk
+//     shorts that falsely claim uniqueness;
+//   - skip when the would-be short form IS some rabbi's full canonical form
+//     ("רבי תנחום" is also Rabbi Tanhum's complete name) — the full-form scan
+//     above already owns that string;
+//   - skip patronymic second tokens (a "רבי בר..." shape has no given name).
+// A short form mapping to ONE entry identifies that rabbi; mapping to several
+// is still a real mention (the name IS in the text) that grounding gets to
+// disambiguate from candidates.
+const HE_PATRONYMIC_TOKENS: ReadonlySet<string> = new Set(['בר', 'בן', 'בריה', 'ברבי']);
+const KNOWN_RABBIS_HE_SHORT: Map<string, KnownRabbi[]> = (() => {
+  const fullForms = new Set(KNOWN_RABBIS_HE.map((k) => k.nameHeNorm));
+  const m = new Map<string, KnownRabbi[]>();
+  for (const k of KNOWN_RABBIS_HE) {
+    if (k.nameHe.includes('(')) continue;
+    const tokens = k.nameHeNorm.split(' ');
+    if (tokens.length < 3) continue;
+    if (!RABBI_HE_TITLE_RE.test(k.nameHeNorm)) continue;
+    if (HE_PATRONYMIC_TOKENS.has(tokens[1])) continue;
+    const short = `${tokens[0]} ${tokens[1]}`;
+    if (fullForms.has(short)) continue;
+    const list = m.get(short);
+    if (list) list.push(k);
+    else m.set(short, [k]);
+  }
+  return m;
+})();
+
+/** English TITLE + FIRST GIVEN NAME ("Rabbi Tanchum" from "Rabbi Tanchum bar
+ *  Chanilai") — the honest display name for a short-form mention that maps to
+ *  several registry entries. */
+function shortEnglishName(name: string): string {
+  const tokens = name.trim().split(/\s+/);
+  return tokens.length >= 2 ? `${tokens[0]} ${tokens[1]}` : name;
+}
+
 // Hebrew word-boundary test — match only when surrounded by whitespace or at
 // a string edge, so "רבא" doesn't match inside "דרבא" (prefix דְ־).
 function hasHebrewWordBoundaryMatch(haystack: string, needle: string): boolean {
-  if (!needle) return false;
+  return countHebrewWordBoundaryMatches(haystack, needle, 1) > 0;
+}
+
+// Count word-boundary occurrences (same boundary rule as above). `cap` bounds
+// the scan for callers that only need existence or a small comparison —
+// counting stops once the cap is reached.
+function countHebrewWordBoundaryMatches(
+  haystack: string,
+  needle: string,
+  cap = Number.POSITIVE_INFINITY,
+): number {
+  if (!needle) return 0;
+  let count = 0;
   let from = 0;
-  while (true) {
+  while (count < cap) {
     const idx = haystack.indexOf(needle, from);
-    if (idx < 0) return false;
+    if (idx < 0) break;
     const beforeOk = idx === 0 || /\s/.test(haystack[idx - 1]);
     const afterIdx = idx + needle.length;
     const afterOk = afterIdx === haystack.length || /\s/.test(haystack[afterIdx]);
-    if (beforeOk && afterOk) return true;
+    if (beforeOk && afterOk) count++;
     from = idx + 1;
   }
+  return count;
 }
 
 // Aramaic/Hebrew tokens that sometimes trail a rabbi's name when the model
@@ -6146,6 +6322,41 @@ export function augmentWithKnownRabbis(
     added.push({ name: k.name, nameHe: k.nameHe, generation: 'unknown' });
     seenHe.add(k.nameHeNorm);
   }
+  // Second pass: SHORT forms (title + first given name). Runs after the
+  // full-form pass so a daf that carries the full name never double-adds.
+  // The nameHe we stamp is the matched short span exactly as it appears in
+  // the (normalized) daf text — the client's verbatim matcher anchors it, so
+  // the mention gets an underline/gutter presence instead of being invisible.
+  for (const [short, entries] of KNOWN_RABBIS_HE_SHORT) {
+    if (seenHe.has(short)) continue;
+    const shortCount = countHebrewWordBoundaryMatches(textNorm, short);
+    if (shortCount === 0) continue;
+    // Skip the occurrences that are just the inside of a longer already-seen
+    // name (the daf says "רבי תנחום בר חנילאי", which the full pass already
+    // added) — OCCURRENCE-AWARE: each occurrence of a covering longer form
+    // accounts for exactly one short-form occurrence (the longer form's own
+    // word-boundary match contains one). Only skip the short form entirely
+    // when EVERY short occurrence is accounted for; a daf that carries
+    // "רבן יוחנן בן זכאי" AND a later standalone "רבן יוחנן" still gets the
+    // standalone mention.
+    let coveredCount = 0;
+    for (const s of seenHe) {
+      if (!s.startsWith(`${short} `)) continue;
+      coveredCount += countHebrewWordBoundaryMatches(textNorm, s, shortCount - coveredCount);
+      if (coveredCount >= shortCount) break;
+    }
+    if (coveredCount >= shortCount) continue;
+    const unique = entries.length === 1 ? entries[0] : null;
+    added.push({
+      // Unique mapping → the registry entry's canonical name (this IS that
+      // rabbi); several bearers → the honest short English name, generation
+      // 'unknown', and grounding disambiguates from the candidate set.
+      name: unique ? unique.name : shortEnglishName(entries[0].name),
+      nameHe: short,
+      generation: 'unknown',
+    });
+    seenHe.add(short);
+  }
   return [...sanitized, ...added];
 }
 
@@ -6165,6 +6376,80 @@ interface IdentifiedRabbi {
   bio: string | null;
   image: string | null;
   wiki: string | null;
+  /** Grounding provenance (mirrors the client type): stamped on the degraded
+   *  identity payload served for an unpinnable homonym so the reader can say
+   *  WHY there is no registry join. Absent on legacy/slug-resolved payloads. */
+  genSource?: string;
+  /** Registry candidate count for the name when >1 (homonym). */
+  homonyms?: number;
+}
+
+/**
+ * enrichRabbi for an instance grounding ALREADY pinned to a registry slug —
+ * a direct dataset join, no name re-resolution (the name path is first-wins
+ * and homonym-blind, so re-resolving a grounded "Rav Kahana" by name can land
+ * on a different same-name bearer). Null when the slug isn't in the dataset
+ * (shouldn't happen — grounding slugs come from the same Sefaria slug space).
+ */
+function enrichRabbiBySlug(
+  slug: string,
+  name: string,
+  nameHe: string,
+  generation: GenerationId,
+): IdentifiedRabbi | null {
+  const entry = RABBI_PLACES.rabbis[slug];
+  if (!entry) return null;
+  const finalGen: GenerationId =
+    generation !== 'unknown'
+      ? generation
+      : typeof entry.generation === 'string' && GENERATION_ID_SET.has(entry.generation)
+        ? (entry.generation as GenerationId)
+        : 'unknown';
+  return {
+    slug,
+    name: entry.canonical || name,
+    nameHe,
+    generation: finalGen,
+    region: entry.region ?? deriveRegionFromGeneration(finalGen),
+    places: entry.places ?? [],
+    moved: entry.moved ?? null,
+    bio: entry.bio ?? null,
+    image: entry.image ?? null,
+    wiki: entry.wiki ?? null,
+  };
+}
+
+/**
+ * Read a rabbi enrichment's mark_input in BOTH shapes it arrives in — the
+ * sidebar's flat `{name, nameHe, generation, ...}` and the warm queue's
+ * mark-instance `{excerpt, fields: {name, ...}}` — including the grounding
+ * stamps (slug / genSource / homonyms) groundRabbiInstances wrote onto the
+ * rabbi mark. The stamps are how the deterministic short-circuits below honor
+ * the mark's homonym verdict instead of re-resolving by name (first-wins).
+ */
+export function rabbiMarkInputFields(markInput: unknown): {
+  name: string;
+  nameHe: string;
+  generation: GenerationId;
+  slug: string | null;
+  genSource: string | null;
+  homonyms: number | null;
+} {
+  const o = (markInput && typeof markInput === 'object' ? markInput : {}) as Record<
+    string,
+    unknown
+  >;
+  const f = (o.fields && typeof o.fields === 'object' ? o.fields : o) as Record<string, unknown>;
+  const str = (v: unknown): string => (typeof v === 'string' ? v : '');
+  const gen = str(f.generation);
+  return {
+    name: str(f.name),
+    nameHe: str(f.nameHe) || str(o.excerpt),
+    generation: GENERATION_ID_SET.has(gen) ? (gen as GenerationId) : 'unknown',
+    slug: str(f.slug) || null,
+    genSource: str(f.genSource) || null,
+    homonyms: typeof f.homonyms === 'number' ? f.homonyms : null,
+  };
 }
 
 export function deriveRegionFromGeneration(g: GenerationId): 'israel' | 'bavel' | null {

--- a/packages/talmud/src/worker/rabbi-graph.ts
+++ b/packages/talmud/src/worker/rabbi-graph.ts
@@ -107,6 +107,10 @@ function normalizeName(name: string): string {
 const ALIASES: Record<string, string> = {
   'reish lakish': 'rabbi-shimon-b-lakish',
   'resh lakish': 'rabbi-shimon-b-lakish',
+  // The graph carries a duplicate "Rabbi Shimon b. Lakish" node (slug …-2,
+  // canonicalHe ריש לקיש) — the full English form always means THE Reish
+  // Lakish, so pin it rather than treating the data quirk as a homonym.
+  'rabbi shimon bar lakish': 'rabbi-shimon-b-lakish',
   'rabbi yohanan': 'rabbi-yochanan-b-napacha',
   'rabbi yohanan bar nappaha': 'rabbi-yochanan-b-napacha',
   rabbah: 'rabbah-b-nachmani',
@@ -158,18 +162,40 @@ function extractPatronymic(name: string): string | null {
   return null;
 }
 
+/** Normalize a HEBREW name for index keys + lookups: strip nikkud/cantillation,
+ *  drop a trailing digit disambiguator ("רבי יוחנן (1)" → "רבי יוחנן"), expand
+ *  the geresh title shorthand ("ר' ירמיה" → "רבי ירמיה" — the daf's most common
+ *  form, which the previous exact-string lookup silently missed), strip
+ *  punctuation, collapse whitespace. Idempotent. */
+function normalizeHeName(s: string): string {
+  return s
+    .replace(/[֑-ׇ]/g, '') // nikkud + cantillation
+    .replace(/\s*\(\d+\)\s*$/, '') // trailing digit disambiguator
+    .replace(/^ר['׳]\s+/, 'רבי ') // geresh title shorthand → full title
+    .replace(/[.,:;?!"'״׳]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
 // Build indices at module load. We map every name form we can think of to
 // the slug; multiple forms can point to the same slug (canonical, Hebrew,
 // normalized canonical).
+interface HeHit {
+  slug: string;
+  /** false when this key only exists because we stripped a "(N)" homonym
+   *  disambiguator off the stored canonicalHe — the bare Hebrew form is then
+   *  registry-AMBIGUOUS by Sefaria's own naming, not a unique pin. */
+  pinned: boolean;
+}
 interface IndexBuilt {
   nameToSlug: Map<string, string>; // normalized name → slug
-  heToSlug: Map<string, string>; // Hebrew name → slug
+  heIndex: Map<string, HeHit[]>; // normalized Hebrew name → ALL bearers
   slugToCanonical: Map<string, string>; // slug → canonical name (display)
 }
 
 function buildIndex(): IndexBuilt {
   const nameToSlug = new Map<string, string>();
-  const heToSlug = new Map<string, string>();
+  const heIndex = new Map<string, HeHit[]>();
   const slugToCanonical = new Map<string, string>();
   for (const [slug, node] of Object.entries(DATA.nodes)) {
     slugToCanonical.set(slug, node.canonical);
@@ -179,12 +205,16 @@ function buildIndex(): IndexBuilt {
     const slugAsName = slug.replace(/-/g, ' ').replace(/\((\w+)\)/g, '$1');
     if (!nameToSlug.has(slugAsName)) nameToSlug.set(slugAsName, slug);
     if (node.canonicalHe) {
-      // Normalize: trim, strip parenthetical disambiguators ("רבי יוחנן (1)").
-      const cleanHe = node.canonicalHe.replace(/\s*\(\d+\)\s*$/, '').trim();
-      if (cleanHe && !heToSlug.has(cleanHe)) heToSlug.set(cleanHe, slug);
+      const cleanHe = normalizeHeName(node.canonicalHe);
+      if (cleanHe) {
+        const pinned = !/\(\d+\)\s*$/.test(node.canonicalHe.trim());
+        const hits = heIndex.get(cleanHe);
+        if (hits) hits.push({ slug, pinned });
+        else heIndex.set(cleanHe, [{ slug, pinned }]);
+      }
     }
   }
-  return { nameToSlug, heToSlug, slugToCanonical };
+  return { nameToSlug, heIndex, slugToCanonical };
 }
 
 const INDEX = buildIndex();
@@ -201,10 +231,10 @@ function findSlug(name: string, nameHe?: string, generation?: string): string | 
   // 2. Exact normalized English match.
   let slug = INDEX.nameToSlug.get(norm) ?? null;
 
-  // 3. Hebrew match.
+  // 3. Hebrew match (single-best: prefer a pinned bearer, else the first).
   if (!slug && nameHe) {
-    const cleanHe = nameHe.replace(/\s*\(\d+\)\s*$/, '').trim();
-    slug = INDEX.heToSlug.get(cleanHe) ?? null;
+    const hits = INDEX.heIndex.get(normalizeHeName(nameHe)) ?? [];
+    slug = (hits.find((h) => h.pinned) ?? hits[0])?.slug ?? null;
   }
 
   // 4. Prefix match scoped by generation. Useful when the input is shorter
@@ -263,12 +293,21 @@ export function rabbiCandidates(name: string, nameHe?: string): string[] {
   }
   const ix = INDEX.nameToSlug.get(norm);
   if (ix) exact.add(ix);
+  // Hebrew form. A pinned single bearer is as good as an English exact. But a
+  // bearer whose stored canonicalHe carried a "(N)" homonym disambiguator
+  // ("רב כהנא (2)") must NOT pin the bare form — Sefaria numbered it precisely
+  // because the bare Hebrew is ambiguous; treating that stripped key as exact
+  // is how "Rav Kahana" silently collapsed to rav-kahana-(ii) and got stamped
+  // amora-ey-1. Such hits only JOIN the candidate set.
+  const heOpen = new Set<string>();
   if (nameHe) {
-    const cleanHe = nameHe.replace(/\s*\(\d+\)\s*$/, '').trim();
-    const he = INDEX.heToSlug.get(cleanHe);
-    if (he) exact.add(he);
+    const hits = INDEX.heIndex.get(normalizeHeName(nameHe)) ?? [];
+    if (hits.length === 1 && hits[0].pinned) exact.add(hits[0].slug);
+    else for (const h of hits) heOpen.add(h.slug);
   }
-  return exact.size ? [...exact] : [...prefix];
+  if (exact.size) return [...exact];
+  for (const s of heOpen) prefix.add(s);
+  return [...prefix];
 }
 
 export type ResolveBasis = 'unique' | 'relational' | 'generation' | 'ambiguous' | 'none';
@@ -277,6 +316,12 @@ export interface ResolvedRabbi {
   basis: ResolveBasis;
 }
 
+/** A relational win must beat the runner-up by this many shared edges. A
+ *  1-edge "win" is exactly what incidental co-presence produces (e.g. Rav
+ *  appearing in another sugya on the daf handed Rav Kahana to the early
+ *  Kahana), so a bare margin of one is treated as thin evidence. */
+const RELATIONAL_MARGIN = 2;
+
 /**
  * Registry-FIRST rabbi resolution with relational homonym disambiguation.
  *
@@ -284,11 +329,22 @@ export interface ResolvedRabbi {
  *  - 1 candidate          → it ('unique').
  *  - >1 (a homonym)       → disambiguate by DAF EVIDENCE: score each candidate
  *    by how many of the co-occurring rabbis on the daf sit in its registry
- *    teacher/student/colleague edges, and pick the unique best ('relational').
- *    e.g. the Rav Kahana who sits next to Rav resolves to the Kahana whose
- *    edges include Rav. If relational gives no clear winner, fall back to a
- *    generation match ONLY if it singles out one candidate; otherwise return
- *    null ('ambiguous') rather than guess. Precision over a confident-wrong id.
+ *    teacher/student/colleague edges. A candidate wins 'relational' only when
+ *    its score clears the runner-up by RELATIONAL_MARGIN — a single shared
+ *    edge is routinely incidental co-presence on a multi-sugya daf, not
+ *    identification. On a candidate set that itself SPANS generations (the
+ *    dangerous case: picking decides the era), a margin-clearing win is
+ *    additionally vetoed when it CONTRADICTS the LLM's local generation read
+ *    — daf-level co-occurrence can pile famous-name edges onto the wrong
+ *    bearer (Shabbat 21b: Rav+Rava+R. Yochanan all sit in the conflated
+ *    rav-kahana-(ii) node's edges), while the model at least read the sugya.
+ *    Below the margin, the LLM's generation guess may still single out one
+ *    candidate ('generation'), but ONLY when the relational evidence
+ *    corroborates it (the gen-matched candidate sits at the top of the
+ *    relational scores with score > 0) or the candidate set doesn't span
+ *    generations at all. Two independent signals must AGREE; conflicting or
+ *    thin evidence returns null ('ambiguous') — generation 'unknown' is the
+ *    honest output, not a confident-wrong era.
  */
 export function resolveRabbiSlug(
   name: string,
@@ -305,12 +361,13 @@ export function resolveRabbiSlug(
     const s = findSlug(co); // single best for context names
     if (s && !candSet.has(s)) coSlugs.add(s);
   }
-  let best: string | null = null;
-  let bestScore = 0;
-  let tie = false;
+  const scoreOf = new Map<string, number>();
   for (const slug of cands) {
     const node = DATA.nodes[slug];
-    if (!node) continue;
+    if (!node) {
+      scoreOf.set(slug, 0);
+      continue;
+    }
     const nbrs = new Set<string>([
       ...(node.teachers ?? []),
       ...(node.students ?? []),
@@ -318,17 +375,32 @@ export function resolveRabbiSlug(
     ]);
     let score = 0;
     for (const cs of coSlugs) if (nbrs.has(cs)) score++;
-    if (score > bestScore) {
-      bestScore = score;
-      best = slug;
-      tie = false;
-    } else if (score === bestScore && score > 0) tie = true;
+    scoreOf.set(slug, score);
   }
-  if (best && bestScore > 0 && !tie) return { slug: best, basis: 'relational' };
-
-  if (opts?.generation) {
-    const genMatch = cands.filter((s) => DATA.nodes[s]?.generation === opts.generation);
-    if (genMatch.length === 1) return { slug: genMatch[0], basis: 'generation' };
+  const ranked = [...scoreOf.entries()].sort((a, b) => b[1] - a[1]);
+  const [topSlug, topScore] = ranked[0];
+  const runnerScore = ranked[1]?.[1] ?? 0;
+  const genSpan = new Set(
+    cands.map((s) => DATA.nodes[s]?.generation).filter((g): g is string => Boolean(g)),
+  ).size;
+  const llmGen = opts?.generation && opts.generation !== 'unknown' ? opts.generation : null;
+  // Margin requirement (also subsumes the old tie check: a tie at the top
+  // means margin 0) + the era-consistency veto: on a cross-generation set, a
+  // relational win that contradicts the LLM's local generation read is
+  // conflicting evidence, not identification.
+  if (topScore > 0 && topScore >= runnerScore + RELATIONAL_MARGIN) {
+    const eraConsistent = genSpan <= 1 || !llmGen || DATA.nodes[topSlug]?.generation === llmGen;
+    if (eraConsistent) return { slug: topSlug, basis: 'relational' };
+  } else if (llmGen) {
+    const genMatch = cands.filter((s) => DATA.nodes[s]?.generation === llmGen);
+    if (genMatch.length === 1) {
+      // Below the margin the LLM's per-daf generation guess is exactly the
+      // overclaim this path exists to correct — so on a cross-generation set
+      // the guess only stands when the relational evidence, however thin,
+      // points at the SAME candidate.
+      const corroborated = topScore > 0 && (scoreOf.get(genMatch[0]) ?? 0) === topScore;
+      if (genSpan <= 1 || corroborated) return { slug: genMatch[0], basis: 'generation' };
+    }
   }
   return { slug: null, basis: 'ambiguous' };
 }
@@ -339,6 +411,9 @@ export interface GroundedRabbi {
   canonical: string | null;
   generation: string | null;
   genSource: ResolveBasis;
+  /** Registry candidate count for the name — >1 means a homonym. Lets the
+   *  client say "N rabbis share this name" when the basis is 'ambiguous'. */
+  homonyms: number;
 }
 
 /**
@@ -374,6 +449,7 @@ export function groundRabbiNames(
       canonical: slug ? slugToName(slug) : null,
       generation,
       genSource: basis,
+      homonyms: rabbiCandidates(it.name, it.nameHe).length,
     };
   });
 }
@@ -418,6 +494,10 @@ export function groundRabbiInstances(parsed: unknown): unknown {
   grounded.forEach((g, i) => {
     const f = targets[i].f;
     f.genSource = g.genSource;
+    // Candidate count, stamped only for homonyms — the client renders
+    // "generation uncertain — N rabbis share this name" off it when the
+    // basis is 'ambiguous'. Additive field; instances aren't strict-validated.
+    if (g.homonyms > 1) f.homonyms = g.homonyms;
     if (g.slug) {
       f.slug = g.slug;
       f.canonical = g.canonical;
@@ -500,8 +580,21 @@ export function lookupRelationships(
 ): LookupResult | null {
   const slug = findSlug(name, nameHe, generation);
   if (!slug) return null;
+  return lookupRelationshipsBySlug(slug, name);
+}
+
+/**
+ * Same as lookupRelationships but keyed DIRECTLY by a known registry slug —
+ * the path for mark instances grounding already pinned (their `fields.slug`).
+ * Skips name resolution entirely: a name lookup is first-wins and homonym-
+ * blind, so re-resolving a grounded instance by name can land on a different
+ * same-name bearer. `displayName` (the daf's English form) feeds the
+ * patronymic family derivation; defaults to the node's canonical name.
+ */
+export function lookupRelationshipsBySlug(slug: string, displayName?: string): LookupResult | null {
   const node = DATA.nodes[slug];
   if (!node) return null;
+  const name = displayName || node.canonical;
 
   // Cap each list at a sane number. Sefaria's graph can record 15-50+
   // students/colleagues for prolific sages (Rava has 22 students; R.

--- a/packages/talmud/tests/client/rabbi-dedup.test.ts
+++ b/packages/talmud/tests/client/rabbi-dedup.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { dedupRabbiList } from '../../src/client/dafContext';
+
+// List-identity dedup for daf rabbi lists (DafViewer.dafRabbis). Slug-first;
+// Hebrew-name fold (geresh title expanded) as the slugless fallback. Reproduces
+// the Shabbat 21b report: 'Rabbi Yirmiyah'/'Rabbi Yirmeyah' and 'Rabbi Yose bar
+// Avin'/'Rebbi Yose b. Rebbi Abun' rendered as distinct rabbis.
+
+const mk = (name: string, nameHe: string, slug: string | null = null, homonyms?: number) => ({
+  slug,
+  name,
+  nameHe,
+  homonyms,
+});
+
+describe('dedupRabbiList — slug-first list identity', () => {
+  it('collapses two name-variant instances with the same grounded slug', () => {
+    const out = dedupRabbiList([
+      mk('Rabbi Yirmiyah', "ר' ירמיה", 'rabbi-yirmeyah'),
+      mk('Rabbi Yirmeyah', 'רבי ירמיה', 'rabbi-yirmeyah'),
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].name).toBe('Rabbi Yirmiyah'); // first wins
+  });
+
+  it('collapses the geresh and full-title Hebrew spellings even when only one carries a slug', () => {
+    // The reported daf's cached state: the LLM-form instance was ungrounded
+    // (no slug) while the augmented full form carried one.
+    const out = dedupRabbiList([
+      mk('Rabbi Yose bar Avin', "ר' יוסי בר אבין", null),
+      mk('Rebbi Yose b. Rebbi Abun', 'רבי יוסי בר אבין', 'rebbi-yose-b-rebbu-abun'),
+    ]);
+    expect(out).toHaveLength(1);
+  });
+
+  it('keeps genuine same-name homonyms apart when grounding gave them different slugs', () => {
+    const out = dedupRabbiList([
+      mk('Rav Kahana', 'רב כהנא', 'rav-kahana-(ii)'),
+      mk('Rav Kahana', 'רב כהנא', 'rav-kahana-of-pum-nahara'),
+    ]);
+    expect(out).toHaveLength(2);
+  });
+
+  it('does NOT fold a slugless entry into a slugged KNOWN HOMONYM (it may be another bearer)', () => {
+    // The slugged entry was relationally pinned, but the name has several
+    // registry bearers — the slugless (ambiguous) mention may be a different
+    // Kahana, so both rows stay.
+    const out = dedupRabbiList([
+      mk('Rav Kahana', 'רב כהנא', 'rav-kahana-of-pum-nahara', 3),
+      mk('Rav Kahana', 'רב כהנא', null, 3),
+    ]);
+    expect(out).toHaveLength(2);
+  });
+
+  it('the homonym guard works in either arrival order (slugless first)', () => {
+    const out = dedupRabbiList([
+      mk('Rav Kahana', 'רב כהנא', null, 3),
+      mk('Rav Kahana', 'רב כהנא', 'rav-kahana-of-pum-nahara', 3),
+    ]);
+    expect(out).toHaveLength(2);
+  });
+
+  it('still folds slugless-into-slugged when the name is NOT a homonym', () => {
+    // One registry bearer (homonyms absent/1): the slug identifies the one
+    // rabbi both mentions refer to.
+    const out = dedupRabbiList([
+      mk('Rabbi Yirmeyah', 'רבי ירמיה', 'rabbi-yirmeyah'),
+      mk('Rabbi Yirmiyah', "ר' ירמיה", null),
+    ]);
+    expect(out).toHaveLength(1);
+  });
+
+  it('two SLUGLESS same-Hebrew entries collapse even for a homonym name (indistinguishable)', () => {
+    // Neither carries a slug — there is nothing to tell them apart, so one
+    // honest row beats two identical ones.
+    const out = dedupRabbiList([
+      mk('Rav Kahana', 'רב כהנא', null, 3),
+      mk('Rav Kahana', 'רב כהנא', null, 3),
+    ]);
+    expect(out).toHaveLength(1);
+  });
+
+  it('slugless duplicates collapse into ONE row even behind a slugged homonym owner', () => {
+    // Slugged pin + two indistinguishable slugless mentions of the homonym
+    // name → exactly two rows (the pin + one ambiguous), never three.
+    const out = dedupRabbiList([
+      mk('Rav Kahana', 'רב כהנא', 'rav-kahana-of-pum-nahara', 3),
+      mk('Rav Kahana', 'רב כהנא', null, 3),
+      mk('Rav Kahana', 'רב כהנא', null, 3),
+    ]);
+    expect(out).toHaveLength(2);
+  });
+
+  it('keeps different rabbis distinct (different names, no slugs)', () => {
+    const out = dedupRabbiList([mk('Rava', 'רבא'), mk('Abaye', 'אביי')]);
+    expect(out).toHaveLength(2);
+  });
+
+  it('falls back to the English name when there is no Hebrew form', () => {
+    const out = dedupRabbiList([mk('Rashi', ''), mk('Rashi', ''), mk('Tosafot', '')]);
+    expect(out).toHaveLength(2);
+  });
+
+  it('drops entries with no identity at all', () => {
+    const out = dedupRabbiList([mk('', ''), mk('Rava', 'רבא')]);
+    expect(out).toHaveLength(1);
+  });
+});

--- a/packages/talmud/tests/enrich.test.ts
+++ b/packages/talmud/tests/enrich.test.ts
@@ -4,6 +4,8 @@ import {
   augmentWithKnownRabbis,
   enrichAll,
   enrichRabbi,
+  postProcessRabbi,
+  rabbiMarkInputFields,
   sanitizeNameHe,
 } from '../src/worker/index';
 
@@ -120,5 +122,134 @@ describe('sanitizeNameHe — trim trailing context words', () => {
     ];
     const out = augmentWithKnownRabbis(input, 'רבי יוחנן אמר');
     expect(out.filter((r) => r.nameHe === 'רבי יוחנן')).toHaveLength(1);
+  });
+});
+
+describe('augmentWithKnownRabbis — short-form recall (title + first given name)', () => {
+  it('a daf carrying ONLY the short form of a uniquely-short-named rabbi augments it', () => {
+    // "רבן יוחנן" is the title+given-name short of exactly one registry entry
+    // (רבן יוחנן בן זכאי) and is no rabbi's full canonical form.
+    const out = augmentWithKnownRabbis([], 'אמר רבן יוחנן משום רבי שמעון בן יהוצדק');
+    const hit = out.find((r) => r.nameHe === 'רבן יוחנן');
+    expect(hit).toBeDefined();
+    expect(hit?.name).toBe('Rabban Yochanan ben Zakkai'); // unique → the entry itself
+    expect(hit?.generation).toBe('unknown'); // grounding/fill decides the era
+  });
+
+  it('a short form shared by MANY registry entries still augments, candidate-open', () => {
+    // "רבי אלעזר" is the short form of ~15 registry rabbis and no one's full
+    // canonical form. The mention is real (the name IS in the text); identity
+    // stays open for grounding.
+    const out = augmentWithKnownRabbis([], 'אמר רבי אלעזר מאי דכתיב');
+    const hit = out.find((r) => r.nameHe === 'רבי אלעזר');
+    expect(hit).toBeDefined();
+    expect(hit?.name).toBe('Rabbi Elazar'); // honest short English name
+    expect(hit?.generation).toBe('unknown');
+  });
+
+  it('does NOT add a short-form mention when the daf carries the full form (covered)', () => {
+    // Full pass adds רבן יוחנן בן זכאי; the short form then only matches
+    // inside that longer name — no second instance.
+    const out = augmentWithKnownRabbis([], 'אמר רבן יוחנן בן זכאי לתלמידיו');
+    expect(out.filter((r) => r.nameHe === 'רבן יוחנן בן זכאי')).toHaveLength(1);
+    expect(out.find((r) => r.nameHe === 'רבן יוחנן')).toBeUndefined();
+  });
+
+  it('DOES add a standalone short form alongside the full form (occurrence-aware coverage)', () => {
+    // One occurrence of the short form sits inside the full name, but the
+    // SECOND is standalone — the coverage check must count occurrences, not
+    // blanket-skip the short form once any longer name starts with it.
+    const out = augmentWithKnownRabbis(
+      [],
+      'אמר רבן יוחנן בן זכאי לתלמידיו ושוב אמר רבן יוחנן דבר אחר',
+    );
+    expect(out.filter((r) => r.nameHe === 'רבן יוחנן בן זכאי')).toHaveLength(1);
+    expect(out.filter((r) => r.nameHe === 'רבן יוחנן')).toHaveLength(1);
+  });
+
+  it('covers MULTIPLE full-form occurrences before adding a standalone short form', () => {
+    // Two full-form occurrences, zero standalone shorts → still no short add.
+    const out = augmentWithKnownRabbis(
+      [],
+      'אמר רבן יוחנן בן זכאי לתלמידיו וחזר רבן יוחנן בן זכאי ואמר',
+    );
+    expect(out.find((r) => r.nameHe === 'רבן יוחנן')).toBeUndefined();
+  });
+
+  it('does NOT add a short form the model already covered', () => {
+    const input = [
+      { name: 'Rabbi Elazar', nameHe: 'רבי אלעזר', generation: 'amora-ey-2' as GenerationId },
+    ];
+    const out = augmentWithKnownRabbis(input, 'אמר רבי אלעזר מאי דכתיב');
+    expect(out.filter((r) => r.nameHe === 'רבי אלעזר')).toHaveLength(1);
+    expect(out[0].generation).toBe('amora-ey-2'); // the model instance, untouched
+  });
+
+  it('full-form behavior unchanged: a full canonical match still augments as before', () => {
+    const out = augmentWithKnownRabbis([], 'דרש רבי שמעון בר יוחאי בהר');
+    const hit = out.find((r) => r.nameHe === 'רבי שמעון בר יוחאי');
+    expect(hit).toBeDefined();
+    expect(hit?.generation).toBe('unknown');
+  });
+});
+
+describe('postProcessRabbi — augmented short-form instances are anchorable', () => {
+  it('stamps the matched Hebrew span as BOTH excerpt and nameHe', () => {
+    const parsed = { instances: [] };
+    const out = postProcessRabbi(parsed, 'אמר רבן יוחנן משום רבי שמעון בן יהוצדק') as {
+      instances: Array<{ excerpt?: string; fields: Record<string, unknown> }>;
+    };
+    const inst = out.instances.find((i) => i.fields.nameHe === 'רבן יוחנן');
+    expect(inst).toBeDefined();
+    // The client's verbatim matcher anchors on the excerpt; it must be the
+    // exact matched span from the daf, not the registry's full canonical.
+    expect(inst?.excerpt).toBe('רבן יוחנן');
+  });
+});
+
+describe('rabbiMarkInputFields — both mark_input shapes, grounding stamps included', () => {
+  it('reads the sidebar FLAT shape', () => {
+    const f = rabbiMarkInputFields({
+      name: 'Rav Kahana',
+      nameHe: 'רב כהנא',
+      generation: 'amora-bavel-2',
+      slug: 'rav-kahana-of-pum-nahara',
+      genSource: 'relational',
+      homonyms: 3,
+    });
+    expect(f).toEqual({
+      name: 'Rav Kahana',
+      nameHe: 'רב כהנא',
+      generation: 'amora-bavel-2',
+      slug: 'rav-kahana-of-pum-nahara',
+      genSource: 'relational',
+      homonyms: 3,
+    });
+  });
+
+  it('reads the warm-queue MARK-INSTANCE shape ({excerpt, fields})', () => {
+    const f = rabbiMarkInputFields({
+      excerpt: 'רב כהנא',
+      fields: { name: 'Rav Kahana', generation: 'unknown', genSource: 'ambiguous', homonyms: 3 },
+    });
+    expect(f.name).toBe('Rav Kahana');
+    expect(f.nameHe).toBe('רב כהנא'); // excerpt fallback
+    expect(f.generation).toBe('unknown');
+    expect(f.slug).toBeNull();
+    expect(f.genSource).toBe('ambiguous');
+    expect(f.homonyms).toBe(3);
+  });
+
+  it('defaults stamps to null and an invalid generation to unknown', () => {
+    const f = rabbiMarkInputFields({ name: 'Rava', nameHe: 'רבא', generation: 'bogus' });
+    expect(f.generation).toBe('unknown');
+    expect(f.slug).toBeNull();
+    expect(f.genSource).toBeNull();
+    expect(f.homonyms).toBeNull();
+  });
+
+  it('tolerates null / non-object input', () => {
+    expect(rabbiMarkInputFields(null).name).toBe('');
+    expect(rabbiMarkInputFields(undefined).nameHe).toBe('');
   });
 });

--- a/packages/talmud/tests/instance-id.test.ts
+++ b/packages/talmud/tests/instance-id.test.ts
@@ -46,6 +46,20 @@ describe('instanceIdOf — Hebrew title collision', () => {
     expect(anchor).toBe('rabbi_yochanan');
   });
 
+  it('the rabbi grounding stamps (slug/genSource/homonyms) do NOT shift the instance id', async () => {
+    // Cache-key freeze: name stays the id source; the stamps the client now
+    // passes through in mark_input must be key-invisible on BOTH shapes.
+    const stamps = { slug: 'rav-kahana-of-pum-nahara', genSource: 'relational', homonyms: 3 };
+    const bare = await instanceIdOf({ name: 'Rav Kahana', nameHe: 'רב כהנא' });
+    const flat = await instanceIdOf({ name: 'Rav Kahana', nameHe: 'רב כהנא', ...stamps });
+    const anchor = await instanceIdOf({
+      excerpt: 'רב כהנא',
+      fields: { name: 'Rav Kahana', nameHe: 'רב כהנא', ...stamps },
+    });
+    expect(flat).toBe(bare);
+    expect(anchor).toBe(bare);
+  });
+
   it('prefers an explicit id/fields.id over a hash', async () => {
     expect(await instanceIdOf({ fields: { id: '6-8_0' } })).toBe('6-8_0');
   });

--- a/packages/talmud/tests/rabbi-resolve.test.ts
+++ b/packages/talmud/tests/rabbi-resolve.test.ts
@@ -4,6 +4,8 @@ import {
   generationOf,
   groundRabbiInstances,
   groundRabbiNames,
+  lookupRelationships,
+  lookupRelationshipsBySlug,
   rabbiCandidates,
   resolveRabbiSlug,
 } from '../src/worker/rabbi-graph';
@@ -42,51 +44,88 @@ describe('resolveRabbiSlug — registry-first, precision over a confident-wrong 
     expect(r.slug).toBe('rabbi-shimon-b-lakish');
   });
 
-  it('uses generation only as a last-resort tiebreaker among candidates', () => {
+  it('VETOES a bare generation guess on a cross-generation homonym set (era-consistency)', () => {
+    // The candidate Kahanas span generations and there is zero relational
+    // evidence here — the LLM's per-daf generation guess alone must NOT pick
+    // a winner (that guess is exactly the overclaim this path corrects).
     const r = resolveRabbiSlug('Rav Kahana', undefined, { generation: 'amora-bavel-3' });
-    expect(r.basis).toBe('generation');
-    expect(r.slug).toBe('rav-kahana-of-pum-nahara');
-    expect(generationOf(r.slug!)).toBe('amora-bavel-3');
+    expect(r.basis).toBe('ambiguous');
+    expect(r.slug).toBeNull();
   });
 
-  it('disambiguates a homonym RELATIONALLY from a co-occurring rabbi (daf evidence)', () => {
-    // Pick a Kahana candidate that has a registry edge, and use that neighbor —
-    // unique to this candidate among the candidates — as the co-occurring rabbi.
-    const cands = rabbiCandidates('Rav Kahana');
-    const nodes = (
-      hier as {
-        nodes: Record<
-          string,
-          { canonical: string; teachers?: string[]; students?: string[]; colleagues?: string[] }
-        >;
-      }
-    ).nodes;
-    const edgesOf = (slug: string) =>
-      new Set([
-        ...(nodes[slug]?.teachers ?? []),
-        ...(nodes[slug]?.students ?? []),
-        ...(nodes[slug]?.colleagues ?? []),
-      ]);
-    let picked: { cand: string; neighborName: string } | null = null;
-    for (const cand of cands) {
-      const others = cands.filter((c) => c !== cand);
-      for (const nb of edgesOf(cand)) {
-        if (others.some((o) => edgesOf(o).has(nb))) continue; // must discriminate
-        if (!nodes[nb]?.canonical) continue;
-        picked = { cand, neighborName: nodes[nb].canonical };
-        break;
-      }
-      if (picked) break;
+  it('accepts the generation pick when thin relational evidence CORROBORATES it', () => {
+    // One shared edge is below the relational margin, but when the LLM's
+    // generation guess singles out the SAME candidate the two weak signals
+    // agree — that resolves (basis 'generation').
+    const picked = pickDiscriminatingNeighbors('Rav Kahana', 1);
+    if (picked) {
+      const r = resolveRabbiSlug('Rav Kahana', undefined, {
+        coRabbis: picked.neighborNames,
+        generation: generationOf(picked.cand) ?? undefined,
+      });
+      expect(r.basis).toBe('generation');
+      expect(r.slug).toBe(picked.cand);
     }
-    // Only assert when the registry actually has a discriminating edge (it does
+  });
+
+  it('does NOT resolve relationally on a single shared edge (thin-evidence margin)', () => {
+    // A 1-edge "win" is routinely incidental co-presence on a multi-sugya daf
+    // (the Shabbat 21b Rav Kahana defect: Rav's co-presence handed the early
+    // Kahana the win). Below the margin → ambiguous, generation unknown.
+    const picked = pickDiscriminatingNeighbors('Rav Kahana', 1);
+    if (picked) {
+      const r = resolveRabbiSlug('Rav Kahana', undefined, { coRabbis: picked.neighborNames });
+      expect(r.basis).toBe('ambiguous');
+      expect(r.slug).toBeNull();
+    }
+  });
+
+  it('disambiguates a homonym RELATIONALLY when the margin is met (2+ discriminating edges)', () => {
+    const picked = pickDiscriminatingNeighbors('Rav Kahana', 2);
+    // Only assert when the registry actually has discriminating edges (it does
     // for Kahana; guard keeps the test honest if the data changes).
     if (picked) {
-      const r = resolveRabbiSlug('Rav Kahana', undefined, { coRabbis: [picked.neighborName] });
+      const r = resolveRabbiSlug('Rav Kahana', undefined, { coRabbis: picked.neighborNames });
       expect(r.basis).toBe('relational');
       expect(r.slug).toBe(picked.cand);
     }
   });
 });
+
+/** Pick a candidate of `name` plus `n` of its registry neighbors that are
+ *  unique to it among the candidates (i.e. edges that discriminate). Returns
+ *  null when the registry doesn't have enough discriminating edges. */
+function pickDiscriminatingNeighbors(
+  name: string,
+  n: number,
+): { cand: string; neighborNames: string[] } | null {
+  const cands = rabbiCandidates(name);
+  const nodes = (
+    hier as {
+      nodes: Record<
+        string,
+        { canonical: string; teachers?: string[]; students?: string[]; colleagues?: string[] }
+      >;
+    }
+  ).nodes;
+  const edgesOf = (slug: string) =>
+    new Set([
+      ...(nodes[slug]?.teachers ?? []),
+      ...(nodes[slug]?.students ?? []),
+      ...(nodes[slug]?.colleagues ?? []),
+    ]);
+  for (const cand of cands) {
+    const others = cands.filter((c) => c !== cand);
+    const neighborNames: string[] = [];
+    for (const nb of edgesOf(cand)) {
+      if (others.some((o) => edgesOf(o).has(nb))) continue; // must discriminate
+      if (!nodes[nb]?.canonical) continue;
+      neighborNames.push(nodes[nb].canonical);
+      if (neighborNames.length === n) return { cand, neighborNames };
+    }
+  }
+  return null;
+}
 
 describe('groundRabbiInstances — registry-grounded generation on rabbi mark instances', () => {
   const mk = (insts: { name: string; nameHe?: string; generation?: string }[]) => ({
@@ -122,34 +161,10 @@ describe('groundRabbiInstances — registry-grounded generation on rabbi mark in
     expect(f.slug).toBeUndefined();
   });
 
-  it('grounds a homonym RELATIONALLY from the daf cast', () => {
-    const cands = rabbiCandidates('Rav Kahana');
-    const nodes = (
-      hier as {
-        nodes: Record<
-          string,
-          { canonical: string; teachers?: string[]; students?: string[]; colleagues?: string[] }
-        >;
-      }
-    ).nodes;
-    const edgesOf = (slug: string) =>
-      new Set([
-        ...(nodes[slug]?.teachers ?? []),
-        ...(nodes[slug]?.students ?? []),
-        ...(nodes[slug]?.colleagues ?? []),
-      ]);
-    let picked: { cand: string; neighborName: string } | null = null;
-    for (const cand of cands) {
-      const others = cands.filter((c) => c !== cand);
-      for (const nb of edgesOf(cand)) {
-        if (others.some((o) => edgesOf(o).has(nb)) || !nodes[nb]?.canonical) continue;
-        picked = { cand, neighborName: nodes[nb].canonical };
-        break;
-      }
-      if (picked) break;
-    }
+  it('grounds a homonym RELATIONALLY from the daf cast (margin met)', () => {
+    const picked = pickDiscriminatingNeighbors('Rav Kahana', 2);
     if (picked) {
-      const p = mk([{ name: 'Rav Kahana' }, { name: picked.neighborName }]);
+      const p = mk([{ name: 'Rav Kahana' }, ...picked.neighborNames.map((name) => ({ name }))]);
       groundRabbiInstances(p);
       const f = fieldsAt(p, 0);
       expect(f.slug).toBe(picked.cand);
@@ -157,12 +172,29 @@ describe('groundRabbiInstances — registry-grounded generation on rabbi mark in
       expect(f.generation).toBe(generationOf(picked.cand));
     }
   });
+
+  it('stamps the homonym candidate count on ambiguous instances', () => {
+    const p = mk([{ name: 'Rav Kahana', generation: 'amora-bavel-2' }]);
+    groundRabbiInstances(p);
+    const f = fieldsAt(p, 0);
+    expect(f.genSource).toBe('ambiguous');
+    expect(typeof f.homonyms).toBe('number');
+    expect(f.homonyms as number).toBeGreaterThanOrEqual(2);
+  });
+
+  it('does NOT stamp homonyms on a unique resolution', () => {
+    const p = mk([{ name: 'Reish Lakish' }]);
+    groundRabbiInstances(p);
+    expect(fieldsAt(p, 0).homonyms).toBeUndefined();
+  });
 });
 
 describe('groundRabbiNames — the shared entry point for both attach paths', () => {
   it('resolves a batch against its own cast + extra context, uniform records', () => {
-    // Rav Kahana + Rav in the batch → relational pin; an alias → unique; a
-    // non-registry name → none. One call, the contract both paths rely on.
+    // An alias → unique; a non-registry name → none; Rav Kahana with only
+    // Rav's incidental co-presence (ONE shared edge, below the relational
+    // margin) → honest 'ambiguous', generation unknown — the Shabbat 21b
+    // defect: that single edge used to hand the win to the early Kahana.
     const out = groundRabbiNames(
       [{ name: 'Rav Kahana' }, { name: 'Reish Lakish' }, { name: 'Totally Made Up' }],
       ['Rav'], // extra co-occurring context (e.g. the daf's rabbi-mark cast)
@@ -172,9 +204,77 @@ describe('groundRabbiNames — the shared entry point for both attach paths', ()
     expect(byName['Reish Lakish'].genSource).toBe('unique');
     expect(byName['Totally Made Up'].slug).toBeNull();
     expect(byName['Totally Made Up'].genSource).toBe('none');
-    // Rav Kahana resolves relationally off "Rav" in the context (his registry edge).
-    expect(byName['Rav Kahana'].genSource).toBe('relational');
-    expect(byName['Rav Kahana'].slug).toContain('kahana');
-    expect(byName['Rav Kahana'].generation).toBe(generationOf(byName['Rav Kahana'].slug!));
+    expect(byName['Rav Kahana'].genSource).toBe('ambiguous');
+    expect(byName['Rav Kahana'].slug).toBeNull();
+    expect(byName['Rav Kahana'].generation).toBe('unknown');
+    expect(byName['Rav Kahana'].homonyms).toBeGreaterThanOrEqual(2);
+  });
+
+  it('the Shabbat 21b reproduction: Rav Kahana with the daf cast stays unresolved, not amora-ey-1', () => {
+    // The actual Shabbat 21b cast (where Rav Kahana quotes Rav Natan bar
+    // Minyomi, amora-bavel-5 — generationally impossible for the early
+    // Kahana). The HEBREW form רב כהנא must also not pin via the stripped
+    // "רב כהנא (2)" disambiguator key.
+    // Generations are the LLM's actual guesses from the prod run. The cast's
+    // famous names (Rav, Rava, R. Yochanan) all sit in the conflated
+    // rav-kahana-(ii) node's edge list, so the relational score alone picks
+    // it — the era-consistency veto (winner ey-1 vs the model's bavel-2 read
+    // on a cross-generation candidate set) is what keeps this honest.
+    const cast = [
+      { name: 'Rav Kahana', nameHe: 'רב כהנא', generation: 'amora-bavel-2' },
+      { name: 'Rav', nameHe: 'רב', generation: 'amora-bavel-1' },
+      { name: 'Rav Natan bar Minyomi', nameHe: 'רב נתן בר מניומי', generation: 'amora-bavel-5' },
+      { name: 'Rava', nameHe: 'רבא', generation: 'amora-bavel-4' },
+      { name: 'Abaye', nameHe: 'אביי', generation: 'amora-bavel-4' },
+      { name: 'Rabbi Yochanan', nameHe: "ר' יוחנן", generation: 'amora-ey-1' },
+    ];
+    const out = groundRabbiNames(cast);
+    const kahana = out.find((g) => g.name === 'Rav Kahana');
+    expect(kahana).toBeDefined();
+    expect(kahana?.generation).not.toBe('amora-ey-1');
+    // Either a margin-clearing relational pin or the honest unknown — never
+    // the incidental-co-presence overclaim.
+    if (kahana?.slug == null) {
+      expect(kahana?.genSource).toBe('ambiguous');
+      expect(kahana?.generation).toBe('unknown');
+    }
+  });
+
+  it('the geresh Hebrew form pins the same slug as the full form (list dedup upstream)', () => {
+    // "ר' ירמיה" and "רבי ירמיה" are the same daf rabbi in two spellings; the
+    // grounded slug is what the client dedups on.
+    const out = groundRabbiNames([
+      { name: 'Rabbi Yirmiyah', nameHe: "ר' ירמיה" },
+      { name: 'Rabbi Yirmeyah', nameHe: 'רבי ירמיה' },
+    ]);
+    expect(out[0].slug).not.toBeNull();
+    expect(out[0].slug).toBe(out[1].slug);
+  });
+});
+
+describe('lookupRelationshipsBySlug — slug-direct graph lookup (grounded instances)', () => {
+  it('two same-name homonym slugs return DIFFERENT relationship data', () => {
+    // The whole point of the slug path: a name lookup is first-wins and
+    // would hand both Kahanas the same node.
+    const a = lookupRelationshipsBySlug('rav-kahana-(ii)');
+    const b = lookupRelationshipsBySlug('rav-kahana-of-pum-nahara');
+    // Only assert when both nodes have edges in the registry data.
+    if (a && b) {
+      expect(a.slug).not.toBe(b.slug);
+      const names = (r: typeof a) => r.data.teachers.map((t) => t.name).join('|');
+      expect(names(a)).not.toBe(names(b));
+    }
+  });
+
+  it('agrees with the name path for an unambiguous rabbi', () => {
+    const byName = lookupRelationships('Reish Lakish');
+    expect(byName).not.toBeNull();
+    const bySlug = lookupRelationshipsBySlug(byName!.slug, 'Reish Lakish');
+    expect(bySlug?.slug).toBe(byName!.slug);
+    expect(bySlug?.data).toEqual(byName!.data);
+  });
+
+  it('returns null for an unknown slug', () => {
+    expect(lookupRelationshipsBySlug('not-a-real-slug')).toBeNull();
   });
 });


### PR DESCRIPTION
Fixes the user-reported defects on Shabbat 21b: Rav Kahana (a ~5-way homonym) asserted as an early-generation amora while quoting a 5th-generation one; Rabbi Tanchum extracted but unanchorable in the UI; duplicate rows for name variants (Yirmiyah/Yirmeyah).

**Root cause of the headline bug:** not the relational scorer — the Hebrew lookup index was first-wins, and `rav-kahana-(ii)`'s parenthetical disambiguator was stripped into a bare exact-match key that falsely pinned every רב כהנא as "unique". Fixed with a multi-map index where disambiguated keys never pin.

**Honesty over guessing (precision over recall):** relational homonym wins need a real margin; thin/contradicted picks degrade to "Generation uncertain — N rabbis share this name" in the sidebar. The grounded slug/ambiguity flows into the identity/relationships/observations enrichments (Codex-flagged High: they were re-pinning by name), with a new `transient` serve-without-write contract in core so degraded payloads can't poison shared cache keys. Residual same-name-homonym key collision documented as deferred (fixing it = key change = Shas cold-miss).

**Recall (the Tanchum case):** title+given-name short-form matching with occurrence-aware coverage and homonym safety; augmented instances carry the matched span as an anchorable excerpt.

**Dedup:** slug-first list identity; slugless entries never fold into a known homonym; slug-threaded rabbi opening.

Benchmark-gated: rabbi-resolve bench resolved 84%→85%, ambiguous 4.0% (ceiling 5%), no floor adjustments. Two Codex review rounds (4 findings fixed). No prompt change, no cache bump — existing dapim regenerate on demand; Shabbat 21b gets a targeted rewarm post-merge. Suite: talmud 2098 / core 103 / tanach 42.