### PR TITLE
Inspect dock: provenance, staleness, and the freshness loop

### DIFF
--- a/packages/talmud/src/client/RunTreeDag.tsx
+++ b/packages/talmud/src/client/RunTreeDag.tsx
@@ -24,6 +24,7 @@ import {
 import { lang } from './i18n';
 import {
   ACTIVE_STROKE,
+  AuthorityBadge,
   BADGE_LLM,
   BADGE_PRO,
   BADGE_SRC,
@@ -41,9 +42,11 @@ import {
   NODE_H,
   NODE_W,
   NodeIcon,
+  ProvenanceSection,
   ROW_H,
   type RunResult,
   type RunTree,
+  StalenessDot,
   TOP_PAD,
   type TreeNode,
   variantOf,
@@ -301,9 +304,21 @@ export function RunTreeDag(props: {
                           >
                             {fmtMs(n().cold_ms)}
                           </span>
+                          <Show when={n().staleness}>
+                            {(s) => (
+                              <StalenessDot
+                                staleness={s()}
+                                inputsChanged={n().inputsChanged}
+                                isMark={n().producer === 'mark'}
+                              />
+                            )}
+                          </Show>
                         </div>
                         <div
                           style={{
+                            display: 'flex',
+                            'align-items': 'center',
+                            gap: '0.3rem',
                             'font-size': '0.66rem',
                             'font-family': 'ui-monospace, Menlo, monospace',
                             color: isLLM() ? '#9a8fb5' : '#9aa4ad',
@@ -312,6 +327,9 @@ export function RunTreeDag(props: {
                             'text-overflow': 'ellipsis',
                           }}
                         >
+                          <Show when={n().authority}>
+                            {(a) => <AuthorityBadge authority={a()} />}
+                          </Show>
                           {isLLM()
                             ? `${(n().model ?? '').split('/').pop()} · ${fmtCost(n().cost)}`
                             : 'source · $0'}
@@ -520,6 +538,7 @@ export function RunTreeDag(props: {
                         nothing cached for this node on this daf yet.
                       </div>
                     </Show>
+                    <ProvenanceSection node={n()} />
                   </>
                 }
               >

--- a/packages/talmud/src/client/RunTreeDock.tsx
+++ b/packages/talmud/src/client/RunTreeDock.tsx
@@ -31,6 +31,8 @@ import { lang } from './i18n';
 import { inspectRequest } from './inspectBridge';
 import {
   ACTIVE_STROKE,
+  type Authority,
+  AuthorityBadge,
   BADGE_LLM,
   BADGE_PRO,
   BADGE_SRC,
@@ -49,9 +51,13 @@ import {
   NODE_H,
   NODE_W,
   NodeIcon,
+  ProvenanceSection,
   ROW_H,
   type RunResult,
   type RunTree,
+  STALENESS_COLOR,
+  type Staleness,
+  StalenessDot,
   TOP_PAD,
   type TreeNode,
   variantOf,
@@ -67,6 +73,9 @@ interface DafRun {
   cold_ms: number | null;
   cost: number | null;
   tokens: number | null;
+  // additive (older payloads omit them)
+  authority?: Authority | null;
+  staleness?: Staleness | null;
 }
 
 /** One waterfall row — a piece run with a cold-time bar. Used as the collapsed
@@ -184,6 +193,19 @@ function RunRow(props: {
       >
         {isLLM() ? fmtCost(r().cost) : '—'}
       </span>
+      {/* staleness dot — only when the payload carries a verdict (cached rows) */}
+      <span
+        style={{
+          width: '10px',
+          'flex-shrink': 0,
+          display: 'inline-flex',
+          'justify-content': 'center',
+        }}
+      >
+        <Show when={!props.loading && r().staleness}>
+          {(s) => <StalenessDot staleness={s()} isMark={r().producer === 'mark'} />}
+        </Show>
+      </span>
       <span
         style={{ width: '1.9rem', 'text-align': 'right', 'font-size': '0.62rem', 'flex-shrink': 0 }}
       >
@@ -232,6 +254,216 @@ function RunRow(props: {
         </button>
       </Show>
     </div>
+  );
+}
+
+/** Studio secret for the privileged rewarm endpoint — the SAME localStorage
+ *  convention as MarksRegistryPanel's studioHeaders(): the owner sets it once
+ *  via `localStorage.setItem('talmud_studio_secret', '<secret>')`. */
+function studioSecret(): string | null {
+  try {
+    return localStorage.getItem('talmud_studio_secret');
+  } catch {
+    return null;
+  }
+}
+
+interface StaleVerdict {
+  status: 'fresh' | 'stale' | 'unknown' | 'miss' | 'n/a';
+  cached_recipe?: string | null;
+  current_recipe?: string | null;
+}
+interface Dependents {
+  id: string;
+  direct: string[];
+  transitive: string[];
+  count: number;
+}
+
+/** Collapsed-by-default freshness section for the currently drilled producer:
+ *  the /api/stale recipe verdict, the /api/dependents re-warm blast radius, and
+ *  a studio-gated 'Rewarm cascade' button (POST /api/admin/rewarm). */
+function FreshnessPanel(props: {
+  tractate: string;
+  page: string;
+  pieceId: string;
+  onRewarmed: () => void;
+}): JSX.Element {
+  const [open, setOpen] = createSignal(false);
+  const [rewarm, setRewarm] = createSignal<
+    | { kind: 'idle' }
+    | { kind: 'busy' }
+    | { kind: 'ok'; runId: string }
+    | { kind: 'err'; msg: string }
+  >({ kind: 'idle' });
+  // New piece → stale rewarm status no longer applies.
+  createEffect(() => {
+    void props.pieceId;
+    setRewarm({ kind: 'idle' });
+  });
+  const [stale] = createResource(
+    () => (open() ? `${props.tractate}|${props.page}|${props.pieceId}|${lang()}` : null),
+    async (): Promise<StaleVerdict> => {
+      const r = await fetch(
+        `/api/stale/${encodeURIComponent(props.pieceId)}/${encodeURIComponent(props.tractate)}/${encodeURIComponent(props.page)}?lang=${lang()}`,
+      );
+      // 404 = not an enrichment (marks have no recipe stamp / stale probe).
+      if (!r.ok) return { status: 'n/a' };
+      return (await r.json()) as StaleVerdict;
+    },
+  );
+  const [deps] = createResource(
+    () => (open() ? props.pieceId : null),
+    async (): Promise<Dependents | null> => {
+      const r = await fetch(`/api/dependents/${encodeURIComponent(props.pieceId)}`);
+      return r.ok ? ((await r.json()) as Dependents) : null;
+    },
+  );
+  const verdictColor = (s: StaleVerdict['status']): string =>
+    s === 'fresh'
+      ? STALENESS_COLOR.fresh
+      : s === 'stale'
+        ? STALENESS_COLOR['stale-recipe']
+        : s === 'unknown'
+          ? STALENESS_COLOR.unknown
+          : '#bbb';
+  const doRewarm = async () => {
+    const secret = studioSecret();
+    if (!secret) return;
+    setRewarm({ kind: 'busy' });
+    try {
+      const r = await fetch(
+        `/api/admin/rewarm/${encodeURIComponent(props.pieceId)}/${encodeURIComponent(props.tractate)}/${encodeURIComponent(props.page)}?lang=${lang()}`,
+        { method: 'POST', headers: { 'x-studio-secret': secret } },
+      );
+      const j = (await r.json()) as { runId?: string; error?: string };
+      if (!r.ok || !j.runId) {
+        setRewarm({ kind: 'err', msg: j.error ?? `HTTP ${r.status}` });
+        return;
+      }
+      setRewarm({ kind: 'ok', runId: j.runId });
+      props.onRewarmed();
+    } catch (e) {
+      setRewarm({ kind: 'err', msg: String(e) });
+    }
+  };
+  const mono = { 'font-family': 'ui-monospace, Menlo, monospace' } as const;
+  return (
+    <details
+      onToggle={(e) => setOpen((e.currentTarget as HTMLDetailsElement).open)}
+      style={{ 'border-top': '1px solid #eee', 'flex-shrink': 0, background: '#fcfcfa' }}
+    >
+      <summary
+        style={{
+          cursor: 'pointer',
+          padding: '0.35rem 0.7rem',
+          'font-size': '0.72rem',
+          color: '#777',
+          'user-select': 'none',
+        }}
+      >
+        Freshness · <span style={mono}>{props.pieceId}</span>
+      </summary>
+      <div style={{ padding: '0.2rem 0.7rem 0.6rem', 'font-size': '0.74rem' }}>
+        <div style={{ display: 'flex', 'align-items': 'center', gap: '0.45rem' }}>
+          <span style={{ color: '#999', 'font-size': '0.68rem' }}>recipe</span>
+          <Show when={stale()} fallback={<span style={{ color: '#bbb' }}>checking…</span>}>
+            {(s) => (
+              <span
+                title={
+                  s().status === 'n/a'
+                    ? 'no stale probe for this producer (marks don’t stamp a recipe hash)'
+                    : `cached ${s().cached_recipe?.slice(0, 12) ?? '—'} vs current ${s().current_recipe?.slice(0, 12) ?? '—'}`
+                }
+                style={{
+                  ...mono,
+                  'font-size': '0.7rem',
+                  color: '#fff',
+                  background: verdictColor(s().status),
+                  'border-radius': '4px',
+                  padding: '0.05rem 0.45rem',
+                }}
+              >
+                {s().status}
+              </span>
+            )}
+          </Show>
+          <button
+            type="button"
+            onClick={doRewarm}
+            disabled={!studioSecret() || rewarm().kind === 'busy'}
+            title={
+              studioSecret()
+                ? 'evict + regenerate this producer and its whole dependent cascade on this daf'
+                : "set localStorage 'talmud_studio_secret' to enable rewarm"
+            }
+            style={{
+              'margin-left': 'auto',
+              font: 'inherit',
+              'font-size': '0.7rem',
+              padding: '0.15rem 0.55rem',
+              'border-radius': '4px',
+              border: '1px solid #d8c9c0',
+              background: '#fff',
+              color: studioSecret() ? '#8a2a2b' : '#bbb',
+              cursor: studioSecret() ? 'pointer' : 'not-allowed',
+            }}
+          >
+            {rewarm().kind === 'busy' ? 'rewarming…' : 'Rewarm cascade'}
+          </button>
+        </div>
+        <Show when={!studioSecret()}>
+          <div style={{ color: '#bbb', 'font-size': '0.66rem', 'margin-top': '0.2rem' }}>
+            rewarm needs the studio secret (localStorage 'talmud_studio_secret')
+          </div>
+        </Show>
+        <Show when={rewarm().kind === 'ok'}>
+          <div style={{ color: '#15803d', 'font-size': '0.7rem', 'margin-top': '0.25rem' }}>
+            enqueued <span style={mono}>{(rewarm() as { runId: string }).runId}</span>
+          </div>
+        </Show>
+        <Show when={rewarm().kind === 'err'}>
+          <div style={{ color: '#b91c1c', 'font-size': '0.7rem', 'margin-top': '0.25rem' }}>
+            {(rewarm() as { msg: string }).msg}
+          </div>
+        </Show>
+        <div style={{ 'margin-top': '0.35rem' }}>
+          <span style={{ color: '#999', 'font-size': '0.68rem' }}>
+            rewarm cascade ({deps()?.count ?? 0})
+          </span>
+          <div
+            style={{
+              display: 'flex',
+              'flex-wrap': 'wrap',
+              gap: '0.25rem',
+              'margin-top': '0.25rem',
+            }}
+          >
+            <Show when={(deps()?.transitive ?? []).length === 0}>
+              <span style={{ color: '#bbb', 'font-size': '0.7rem' }}>
+                nothing depends on this producer
+              </span>
+            </Show>
+            <For each={deps()?.transitive ?? []}>
+              {(d) => (
+                <span
+                  style={{
+                    ...mono,
+                    'font-size': '0.66rem',
+                    background: '#f1f1f3',
+                    color: '#555',
+                    'border-radius': '4px',
+                    padding: '0.05rem 0.4rem',
+                  }}
+                >
+                  {d}
+                </span>
+              )}
+            </For>
+          </div>
+        </div>
+      </div>
+    </details>
   );
 }
 
@@ -832,9 +1064,21 @@ export default function RunTreeDock(props: {
                               >
                                 {fmtMs(n().cold_ms)}
                               </span>
+                              <Show when={n().staleness}>
+                                {(s) => (
+                                  <StalenessDot
+                                    staleness={s()}
+                                    inputsChanged={n().inputsChanged}
+                                    isMark={n().producer === 'mark'}
+                                  />
+                                )}
+                              </Show>
                             </div>
                             <div
                               style={{
+                                display: 'flex',
+                                'align-items': 'center',
+                                gap: '0.3rem',
                                 'font-size': '0.66rem',
                                 'font-family': 'ui-monospace, Menlo, monospace',
                                 color: isLLM() ? '#9a8fb5' : '#9aa4ad',
@@ -843,6 +1087,9 @@ export default function RunTreeDock(props: {
                                 'text-overflow': 'ellipsis',
                               }}
                             >
+                              <Show when={n().authority}>
+                                {(a) => <AuthorityBadge authority={a()} />}
+                              </Show>
                               {isLLM()
                                 ? `${(n().model ?? '').split('/').pop()} · ${fmtCost(n().cost)}`
                                 : 'source · $0'}
@@ -885,6 +1132,17 @@ export default function RunTreeDock(props: {
               )}
             </Show>
           </div>
+        </Show>
+
+        {/* freshness (collapsed) — the drilled producer's stale verdict +
+            dependents cascade + the studio-gated rewarm action */}
+        <Show when={view() === 'dag'}>
+          <FreshnessPanel
+            tractate={props.tractate}
+            page={props.page}
+            pieceId={pieceId()}
+            onRewarmed={() => refetchRuns()}
+          />
         </Show>
 
         {/* node detail (bottom) — DAG mode only; drag its top edge to resize */}
@@ -1087,6 +1345,7 @@ export default function RunTreeDock(props: {
                               nothing cached for this node on this daf yet.
                             </div>
                           </Show>
+                          <ProvenanceSection node={n()} />
                         </>
                       }
                     >

--- a/packages/talmud/src/client/runTreeShared.tsx
+++ b/packages/talmud/src/client/runTreeShared.tsx
@@ -5,8 +5,16 @@
  * node icon, and the small formatters. One source of truth so the two surfaces
  * can never drift in their graph maths or visuals.
  */
-import { type JSX, Match, Switch } from 'solid-js';
+import { For, type JSX, Match, Show, Switch } from 'solid-js';
 
+export type Authority = 'human' | 'rule' | 'ai';
+export type Staleness = 'fresh' | 'stale-recipe' | 'stale-inputs' | 'unknown';
+/** Per-input freshness from the worker: did this dependency's content hash
+ *  move since the node was generated? */
+export interface TreeNodeInput {
+  sourceKey: string;
+  status: 'same' | 'changed' | 'unknown';
+}
 export interface TreeNode {
   id: string;
   label: string;
@@ -17,6 +25,14 @@ export interface TreeNode {
   cold_ms: number | null;
   cost: number | null;
   tokens: number | null;
+  // additive provenance/staleness fields (absent on older payloads + source
+  // leaves; null when nothing is cached) — every consumer must tolerate absence
+  authority?: Authority | null;
+  staleness?: Staleness | null;
+  createdAt?: string | null;
+  recipeHash?: string | null;
+  inputs?: TreeNodeInput[];
+  inputsChanged?: string[];
 }
 export interface RunTree {
   root: string;
@@ -244,3 +260,254 @@ export function NodeIcon(props: { variant: IconVariant; color: string }): JSX.El
 }
 export const variantOf = (n: { kind: string; producer?: string }): IconVariant =>
   n.kind !== 'llm' ? 'source' : n.producer === 'mark' ? 'mark' : 'enrichment';
+
+// ---------------------------------------------------------------------------
+// Provenance + staleness visuals (Inspect dock only)
+// ---------------------------------------------------------------------------
+
+export const AUTHORITY_COLOR: Record<Authority, string> = {
+  human: '#b45309', // amber — a human edit, locked against AI overwrite
+  rule: '#64748b', // gray — deterministic rule/computation
+  ai: BADGE_LLM, // blue — an LLM decided the content
+};
+export const AUTHORITY_TITLE: Record<Authority, string> = {
+  human: 'human-authored (locked: never overwritten by rule/AI output)',
+  rule: 'rule — deterministic, no model call',
+  ai: 'ai — an LLM generated this content',
+};
+
+/** Tiny authority glyph: human = lock, rule = gear, ai = sparkle. Same inline
+ *  SVG language as NodeIcon, 12px. */
+export function AuthorityBadge(props: { authority: Authority }): JSX.Element {
+  const color = () => AUTHORITY_COLOR[props.authority];
+  return (
+    <svg
+      aria-label={`authority: ${props.authority}`}
+      role="img"
+      width="12"
+      height="12"
+      viewBox="-6 -6 12 12"
+      style={{ display: 'inline-block', 'flex-shrink': 0, 'vertical-align': '-1px' }}
+    >
+      <title>{AUTHORITY_TITLE[props.authority]}</title>
+      <Switch>
+        <Match when={props.authority === 'human'}>
+          {/* padlock */}
+          <rect x={-4} y={-1} width={8} height={6} rx={1.2} fill={color()} />
+          <path
+            d="M -2.4 -1 V -2.6 A 2.4 2.4 0 0 1 2.4 -2.6 V -1"
+            fill="none"
+            stroke={color()}
+            stroke-width={1.4}
+          />
+        </Match>
+        <Match when={props.authority === 'rule'}>
+          {/* gear: ring + spokes */}
+          <circle cx={0} cy={0} r={2.9} fill="none" stroke={color()} stroke-width={1.5} />
+          <g stroke={color()} stroke-width={1.4} stroke-linecap="round">
+            <path d="M 0 -5.4 V -3.8" />
+            <path d="M 0 5.4 V 3.8" />
+            <path d="M -5.4 0 H -3.8" />
+            <path d="M 5.4 0 H 3.8" />
+            <path d="M -3.8 -3.8 L -2.7 -2.7" />
+            <path d="M 3.8 3.8 L 2.7 2.7" />
+            <path d="M -3.8 3.8 L -2.7 2.7" />
+            <path d="M 3.8 -3.8 L 2.7 -2.7" />
+          </g>
+        </Match>
+        <Match when={props.authority === 'ai'}>
+          {/* sparkle (the enrichment glyph, small) */}
+          <path
+            d="M0 -5.4 L1.4 -1.4 L5.4 0 L1.4 1.4 L0 5.4 L-1.4 1.4 L-5.4 0 L-1.4 -1.4 Z"
+            fill={color()}
+          />
+        </Match>
+      </Switch>
+    </svg>
+  );
+}
+
+export const STALENESS_COLOR: Record<Staleness, string> = {
+  fresh: '#15803d',
+  'stale-recipe': '#d97706',
+  'stale-inputs': '#dc2626',
+  unknown: '#9ca3af',
+};
+
+/** Human-readable WHY for the staleness dot's tooltip. */
+export function stalenessTitle(
+  staleness: Staleness,
+  inputsChanged?: string[] | null,
+  isMark?: boolean,
+): string {
+  switch (staleness) {
+    case 'fresh':
+      return 'fresh — recipe unchanged since generation';
+    case 'stale-recipe':
+      return 'stale — recipe changed (prompt/schema/model edited since this was generated)';
+    case 'stale-inputs':
+      return `stale — inputs changed: ${(inputsChanged ?? []).join(', ') || '(unnamed)'}`;
+    default:
+      return isMark
+        ? 'unknown — marks don’t stamp a recipe hash yet'
+        : 'unknown — cached before the recipe stamp existed (re-warm to resolve)';
+  }
+}
+
+/** 8px staleness dot: fresh = green, stale-recipe = orange, stale-inputs = red,
+ *  unknown = hollow. */
+export function StalenessDot(props: {
+  staleness: Staleness;
+  inputsChanged?: string[] | null;
+  isMark?: boolean;
+}): JSX.Element {
+  const hollow = () => props.staleness === 'unknown';
+  return (
+    <span
+      title={stalenessTitle(props.staleness, props.inputsChanged, props.isMark)}
+      data-staleness={props.staleness}
+      style={{
+        display: 'inline-block',
+        'flex-shrink': 0,
+        width: '8px',
+        height: '8px',
+        'border-radius': '50%',
+        'box-sizing': 'border-box',
+        background: hollow() ? 'transparent' : STALENESS_COLOR[props.staleness],
+        border: hollow() ? `1.5px solid ${STALENESS_COLOR.unknown}` : 'none',
+      }}
+    />
+  );
+}
+
+/** The Provenance section of a node's detail pane: authority, model, createdAt,
+ *  the (short) recipe hash, the stamped inputs with changed ones highlighted,
+ *  and cost. Shared by the dock + embeddable DAG detail panes. */
+export function ProvenanceSection(props: { node: TreeNode }): JSX.Element {
+  const n = () => props.node;
+  const mono = {
+    'font-family': 'ui-monospace, Menlo, monospace',
+    'font-size': '0.7rem',
+  } as const;
+  const row = {
+    display: 'flex',
+    gap: '0.5rem',
+    'align-items': 'baseline',
+    margin: '0.15rem 0',
+  } as const;
+  const key = { color: '#999', 'font-size': '0.68rem', width: '5.2rem', 'flex-shrink': 0 } as const;
+  return (
+    <Show when={n().authority != null || n().staleness != null}>
+      <div
+        style={{
+          'margin-top': '0.7rem',
+          'border-top': '1px dashed #e5e1d6',
+          'padding-top': '0.5rem',
+        }}
+      >
+        <div
+          style={{
+            'font-size': '0.66rem',
+            color: '#999',
+            'text-transform': 'uppercase',
+            'letter-spacing': '0.06em',
+            'margin-bottom': '0.25rem',
+          }}
+        >
+          Provenance
+        </div>
+        <div style={row}>
+          <span style={key}>authority</span>
+          <span style={{ display: 'inline-flex', 'align-items': 'center', gap: '0.3rem' }}>
+            <Show when={n().authority}>
+              {(a) => (
+                <>
+                  <AuthorityBadge authority={a()} />
+                  <span style={{ ...mono, color: AUTHORITY_COLOR[a()] }}>{a()}</span>
+                </>
+              )}
+            </Show>
+            <Show when={!n().authority}>
+              <span style={{ ...mono, color: '#bbb' }}>— (not cached)</span>
+            </Show>
+          </span>
+        </div>
+        <Show when={n().staleness}>
+          {(s) => (
+            <div style={row}>
+              <span style={key}>staleness</span>
+              <span style={{ display: 'inline-flex', 'align-items': 'center', gap: '0.35rem' }}>
+                <StalenessDot
+                  staleness={s()}
+                  inputsChanged={n().inputsChanged}
+                  isMark={n().producer === 'mark'}
+                />
+                <span style={{ ...mono, color: STALENESS_COLOR[s()] }}>{s()}</span>
+              </span>
+            </div>
+          )}
+        </Show>
+        <Show when={n().model}>
+          <div style={row}>
+            <span style={key}>model</span>
+            <span style={mono}>{n().model}</span>
+          </div>
+        </Show>
+        <Show when={n().createdAt}>
+          <div style={row}>
+            <span style={key}>created</span>
+            <span style={mono}>{n().createdAt}</span>
+          </div>
+        </Show>
+        <Show when={n().recipeHash}>
+          {(h) => (
+            <div style={row}>
+              <span style={key}>recipe</span>
+              <span style={mono} title={h()}>
+                {h().slice(0, 12)}
+              </span>
+            </div>
+          )}
+        </Show>
+        <Show when={n().cost != null}>
+          <div style={row}>
+            <span style={key}>cost</span>
+            <span style={mono}>{fmtCost(n().cost)}</span>
+          </div>
+        </Show>
+        <Show when={n().inputs?.length}>
+          <div style={{ ...row, 'align-items': 'flex-start' }}>
+            <span style={key}>inputs</span>
+            <span style={{ display: 'flex', 'flex-wrap': 'wrap', gap: '0.25rem', 'min-width': 0 }}>
+              <For each={n().inputs}>
+                {(inp) => (
+                  <span
+                    title={
+                      inp.status === 'changed'
+                        ? 'content hash moved since generation'
+                        : inp.status === 'same'
+                          ? 'content hash unchanged'
+                          : 'unknown (dependency not cached / not comparable)'
+                    }
+                    style={{
+                      ...mono,
+                      padding: '0.05rem 0.4rem',
+                      'border-radius': '4px',
+                      ...(inp.status === 'changed'
+                        ? { background: '#fee2e2', color: '#b91c1c', 'font-weight': 600 }
+                        : inp.status === 'same'
+                          ? { background: '#f0fdf4', color: '#15803d' }
+                          : { background: '#f4f4f5', color: '#9ca3af' }),
+                    }}
+                  >
+                    {inp.sourceKey}
+                  </span>
+                )}
+              </For>
+            </span>
+          </div>
+        </Show>
+      </div>
+    </Show>
+  );
+}

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -21,6 +21,7 @@ import {
   isLLMModelId,
   MODEL_PRESETS,
 } from '@corpus/core/llm/settings';
+import type { Authority } from '@corpus/core/model/provenance';
 import {
   forwardSubgraph,
   producerNodesFrom,
@@ -32,9 +33,13 @@ import {
   type ResolveInputsPorts,
   resolveInputs,
 } from '@corpus/core/run/producer-run';
-import { type RunProducerPorts, runProducer } from '@corpus/core/run/run-producer';
-import { ArtifactStore, type KVStore } from '@corpus/core/store/artifact-store';
-import type { StoredArtifact } from '@corpus/core/store/envelope';
+import {
+  provenanceInputRefs,
+  type RunProducerPorts,
+  runProducer,
+} from '@corpus/core/run/run-producer';
+import { ArtifactStore, type KVStore, type Staleness } from '@corpus/core/store/artifact-store';
+import { authorityOf, type StoredArtifact } from '@corpus/core/store/envelope';
 import { producerKeyInfo, talmudLegacyKeyScheme } from '@corpus/core/store/key-schemes';
 import { Hono } from 'hono';
 import {
@@ -154,7 +159,13 @@ import {
   ENRICH_JSON_SCHEMA,
   TRANSLATE_BIO_JSON_SCHEMA,
 } from './output-schemas';
-import { loadEnrichmentDef, loadMarkDef } from './producer-registry';
+import { rawDependenciesOf } from '@corpus/core/model/compat';
+import {
+  adaptCodeEnrichment,
+  listProducers,
+  loadEnrichmentDef,
+  loadMarkDef,
+} from './producer-registry';
 import {
   groundRabbiInstances,
   groundRabbiNames,
@@ -210,6 +221,7 @@ import type {
   EnrichmentDependency,
   LLMExtractor,
   MarkDependency,
+  EnrichmentDefinition as SchemaEnrichmentDefinition,
   MarkDefinition as SchemaMarkDefinition,
 } from './studio-schema';
 import { classifyError, recordTelemetry, runTelemetryRec, type TelemetryRecord } from './telemetry';
@@ -1099,14 +1111,29 @@ app.get('/api/links/:tractate/:page', async (c) => {
   return c.json({ tractate, page, count: links.length, links });
 });
 
+/** Producer nodes over the LIVE registry (KV-over-code via listProducers), so
+ *  cascades and dependents reflect Studio-defined or KV-overridden producers,
+ *  not just the code defs. Falls back to the code registry on a KV failure. */
+async function liveProducerNodes(env: Bindings) {
+  try {
+    const producers = await listProducers(env);
+    return producerNodesFrom(
+      producers.map((p) => ({ id: p.id, dependencies: rawDependenciesOf(p) })),
+    );
+  } catch (err) {
+    console.error('[dep-graph] live registry read failed; using code defs:', err);
+    return producerNodesFrom([...CODE_MARKS, ...CODE_ENRICHMENTS]);
+  }
+}
+
 // Reverse-dependency index over the producer graph: "if `id` (a producer or a
 // source input like 'gemara') changes, what must re-warm?" Computes the cascade
 // that is otherwise reasoned about by hand when bumping a cache_version — e.g.
 // bumping argument.background returns argument.synthesis (which depends on it)
-// and everything downstream. Read-only over the static registry; no daf, no KV.
-app.get('/api/dependents/:id', (c) => {
+// and everything downstream. Read-only over the LIVE registry (KV wins).
+app.get('/api/dependents/:id', async (c) => {
   const id = c.req.param('id');
-  const nodes = producerNodesFrom([...CODE_MARKS, ...CODE_ENRICHMENTS]);
+  const nodes = await liveProducerNodes(c.env);
   const rev = reverseDependencyIndex(nodes);
   const direct = [...(rev.get(id) ?? [])].sort();
   const transitive = [...transitiveDependents(rev, id)].sort();
@@ -1531,6 +1558,13 @@ app.get('/api/run-tree/:tractate/:page/:id', async (c) => {
 
   const { nodes: nodeIds, edges } = forwardSubgraph(producerNodesFrom(defs), id);
 
+  // Per-input freshness verdict for the inspector: 'same' (recomputed content
+  // hash matches the one stamped at generation), 'changed', or 'unknown' (the
+  // dep isn't cached / has no stamped hash / can't be recomputed cheaply).
+  interface TreeNodeInput {
+    sourceKey: string;
+    status: 'same' | 'changed' | 'unknown';
+  }
   interface TreeNode {
     id: string;
     label: string;
@@ -1541,6 +1575,14 @@ app.get('/api/run-tree/:tractate/:page/:id', async (c) => {
     cold_ms: number | null;
     cost: number | null;
     tokens: number | null;
+    // --- additive provenance/staleness fields (absent on source leaves; null
+    // when nothing is cached). Older clients ignore them. ---
+    authority?: Authority | null;
+    staleness?: Staleness | null;
+    createdAt?: string | null;
+    recipeHash?: string | null;
+    inputs?: TreeNodeInput[];
+    inputsChanged?: string[];
   }
   const out: Record<string, TreeNode> = {};
   let totalColdMs = 0,
@@ -1548,6 +1590,15 @@ app.get('/api/run-tree/:tractate/:page/:id', async (c) => {
     llmCount = 0,
     sourceCount = 0,
     cachedCount = 0;
+
+  // The cached entries + per-producer current recipe hashes collected during
+  // the walk, so the second (inputs) pass below recomputes dependency content
+  // hashes from entries ALREADY read — zero extra KV reads, no generation.
+  const store = artifactStore(c.env);
+  const entryOf = new Map<string, RunResult>();
+  const currentRecipeOf = new Map<string, string>();
+  const depsOf = new Map<string, ReadonlyArray<unknown>>();
+  const rootCustomInstance = JSON.stringify(rootInstance) !== JSON.stringify({ fields: {} });
 
   for (const nid of nodeIds) {
     const def = byId.get(nid);
@@ -1570,17 +1621,31 @@ app.get('/api/run-tree/:tractate/:page/:id', async (c) => {
     const isMark = markIds.has(nid);
     const ext = (def as { extractor?: { kind?: string; model?: string } }).extractor;
     const isLLM = ext?.kind === 'llm';
-    const job = (isMark
-      ? { mark_id: nid, tractate, page, lang }
-      : {
-          enrichment_id: nid,
-          tractate,
-          page,
-          mark_input: nid === id ? rootInstance : { fields: {} },
+    // Same key derivation (and the same KV def reads) cacheKeyForRunBody
+    // performs — inlined so the loaded def also yields the CURRENT recipe hash
+    // (enrichments stamp recipe_hash at generation; marks never have).
+    let key: string | null = null;
+    if (isMark) {
+      const ldef = await loadMarkDef(c.env, nid);
+      if (ldef) {
+        key = store.keyFor(markKeyInfo(ldef), { unit: { work: tractate, unit: page }, lang });
+        depsOf.set(nid, ldef.dependencies ?? []);
+      }
+    } else {
+      const ldef = await loadEnrichmentDef(c.env, nid);
+      if (ldef) {
+        const iid = await instanceIdOf(nid === id ? rootInstance : { fields: {} });
+        key = store.keyFor(enrichKeyInfo(ldef), {
+          instanceId: iid,
+          unit: { work: tractate, unit: page },
           lang,
-        }) as unknown as JobMessage;
-    const { key } = await cacheKeyForRunBody(c.env, job);
+        });
+        currentRecipeOf.set(nid, await recipeHash(enrichmentRecipe(ldef)));
+        depsOf.set(nid, ldef.dependencies ?? []);
+      }
+    }
     const res = key ? await readCachedResult(c.env, key) : null;
+    if (res) entryOf.set(nid, res);
     const usage = res?.usage as { cost?: number; total_tokens?: number } | undefined;
     const coldMs = typeof res?.elapsed_ms === 'number' ? res.elapsed_ms : null;
     const cost = typeof usage?.cost === 'number' ? usage.cost : null;
@@ -1601,6 +1666,80 @@ app.get('/api/run-tree/:tractate/:page/:id', async (c) => {
       cost,
       tokens: typeof usage?.total_tokens === 'number' ? usage.total_tokens : null,
     };
+  }
+
+  // Second pass: provenance + staleness per producer node, computed ONLY from
+  // the entries read above (cache reads only; no LLM, no extra KV).
+  for (const nid of nodeIds) {
+    const node = out[nid];
+    if (!node || node.kind === 'source') continue;
+    const res = entryOf.get(nid);
+    if (!res) {
+      node.authority = null;
+      node.staleness = null;
+      node.createdAt = null;
+      node.recipeHash = null;
+      continue;
+    }
+    const stored = res as unknown as StoredArtifact;
+    node.authority = authorityOf(stored);
+    node.createdAt = stored.provenance?.createdAt || null;
+    const storedHash = res.recipe_hash ?? stored.provenance?.recipeHash ?? null;
+    node.recipeHash = storedHash;
+    // Recompute each stamped input's CURRENT content hash from the dep's
+    // already-read cached entry, the same way provenanceInputRefs hashed the
+    // resolved value at generation (enrichment dep → parsed ?? content; mark
+    // dep → parsed.instances ?? content). 'unknown' when the dep isn't cached,
+    // is a fanOut aggregate (its generation value spanned per-instance runs we
+    // didn't read), or — for a custom-instance root — an enrichment dep that
+    // inherited that instance (whose whole-daf entry isn't what fed the run).
+    const stampedInputs = stored.provenance?.inputs;
+    if (stampedInputs?.length) {
+      const fanOutIds = new Set(
+        (depsOf.get(nid) ?? [])
+          .map((d) =>
+            d && typeof d === 'object' && (d as { fanOut?: boolean }).fanOut
+              ? (d as { enrichment?: string }).enrichment
+              : undefined,
+          )
+          .filter((x): x is string => typeof x === 'string'),
+      );
+      const inputs: TreeNodeInput[] = [];
+      for (const ref of stampedInputs) {
+        const k = ref.sourceKey;
+        if (!k) continue;
+        let status: TreeNodeInput['status'] = 'unknown';
+        const depRes = entryOf.get(k);
+        const depIsMark = markIds.has(k);
+        const comparable =
+          !!ref.contentHash &&
+          !!depRes &&
+          !fanOutIds.has(k) &&
+          (depIsMark || nid !== id || !rootCustomInstance);
+        if (comparable && depRes) {
+          const value = depIsMark
+            ? ((depRes.parsed as { instances?: unknown } | null)?.instances ?? depRes.content)
+            : (depRes.parsed ?? depRes.content);
+          const [cur] = await provenanceInputRefs({ depends: { [k]: value }, anchors: {} });
+          status = cur?.contentHash === ref.contentHash ? 'same' : 'changed';
+        }
+        inputs.push({ sourceKey: k, status });
+      }
+      node.inputs = inputs;
+      node.inputsChanged = inputs.filter((i) => i.status === 'changed').map((i) => i.sourceKey);
+    }
+    // Verdict mirrors ArtifactStore.staleness: the recipe leg first (no stamp
+    // → 'unknown'; marks never stamp one), then the input-hash leg.
+    const current = currentRecipeOf.get(nid) ?? null;
+    node.staleness = !storedHash
+      ? 'unknown'
+      : current && storedHash !== current
+        ? 'stale-recipe'
+        : node.inputsChanged?.length
+          ? 'stale-inputs'
+          : current
+            ? 'fresh'
+            : 'unknown';
   }
 
   return c.json({
@@ -1642,21 +1781,62 @@ app.get('/api/daf-runs/:tractate/:page', async (c) => {
     ...CODE_MARKS.map((def) => ({ def, isMark: true as const })),
     ...wholeDafEnrichments.map((def) => ({ def, isMark: false as const })),
   ];
+  // KV-overridden defs (Studio-authored, KV wins over code) change BOTH the
+  // cache key (cache_version) and the current recipe — read the indexes once
+  // and prefer the KV def per id, so the row reads the LIVE key and the
+  // staleness verdict compares against the LIVE recipe. (KV-ONLY producers
+  // still don't appear in this waterfall — it enumerates the code registry;
+  // acceptable known limit, the prod KV registry is empty today.)
+  const [kvEnrichList, kvMarkList] = await Promise.all([
+    listEnrichments(c.env).catch(() => []),
+    listMarks(c.env).catch(() => []),
+  ]);
+  const kvEnrichById = new Map(kvEnrichList.map((e) => [e.id, e]));
+  const kvMarkById = new Map(kvMarkList.map((m) => [m.id, m]));
 
   // Read all producers' cached results in PARALLEL — ~46 KV gets at once instead
   // of serially (the serial loop made the waterfall take seconds on first open).
-  // Keys are computed directly from the defs we already hold (no loadDef round-trip).
   const runs = await Promise.all(
     producers.map(async ({ def, isMark }) => {
-      const ext = def.extractor as
-        | { kind?: string; model?: string; system_prompt_he?: string }
-        | undefined;
-      const isLLM = ext?.kind === 'llm';
+      const kvEnrich = isMark ? undefined : kvEnrichById.get(def.id);
+      const kvMark = isMark ? kvMarkById.get(def.id) : undefined;
+      const ext = (kvEnrich ??
+        kvMark ??
+        (def.extractor as
+          | { kind?: string; model?: string; system_prompt_he?: string }
+          | undefined)) as { kind?: string; model?: string; system_prompt_he?: string } | undefined;
+      const isLLM = kvEnrich || kvMark ? true : ext?.kind === 'llm';
       const key = isMark
-        ? keyForMark(def, tractate, page, lang === 'he' && ext?.system_prompt_he ? 'he' : 'en')
-        : keyForEnrichment(def, iid, { tractate, page }, undefined, lang);
+        ? keyForMark(
+            kvMark ?? def,
+            tractate,
+            page,
+            lang === 'he' && ext?.system_prompt_he ? 'he' : 'en',
+          )
+        : keyForEnrichment(kvEnrich ?? def, iid, { tractate, page }, undefined, lang);
       const res = await readCachedResult(c.env, key);
       const usage = res?.usage as { cost?: number; total_tokens?: number } | undefined;
+      // Additive provenance fields for the waterfall dots — cheap (no extra KV
+      // reads; recipe-leg verdict only, the inputs leg needs the DAG's dep
+      // reads and stays on /api/run-tree). Marks never stamp a recipe_hash, so
+      // a cached mark is 'unknown'; an uncached row is null.
+      const stored = res as StoredArtifact | null;
+      const storedHash = res?.recipe_hash ?? stored?.provenance?.recipeHash ?? null;
+      let staleness: Staleness | null = null;
+      if (res) {
+        if (!storedHash) staleness = 'unknown';
+        else {
+          // Current recipe from the LIVE def: the KV override when one exists
+          // (already flat — same shape /api/stale hashes), else the code def
+          // flattened. Hashing the code recipe for a KV-overridden producer
+          // would report a false 'stale-recipe' against the wrong recipe.
+          const flat = isMark
+            ? null
+            : (kvEnrich ?? adaptCodeEnrichment(def as SchemaEnrichmentDefinition));
+          const current = flat ? await recipeHash(enrichmentRecipe(flat)) : null;
+          staleness = !current ? 'unknown' : storedHash === current ? 'fresh' : 'stale-recipe';
+        }
+      }
       return {
         id: def.id,
         label: def.label,
@@ -1667,6 +1847,8 @@ app.get('/api/daf-runs/:tractate/:page', async (c) => {
         cold_ms: typeof res?.elapsed_ms === 'number' ? res.elapsed_ms : null,
         cost: typeof usage?.cost === 'number' ? usage.cost : null,
         tokens: typeof usage?.total_tokens === 'number' ? usage.total_tokens : null,
+        authority: stored ? authorityOf(stored) : null,
+        staleness,
       };
     }),
   );
@@ -1827,7 +2009,7 @@ app.post('/api/admin/rewarm/:id/:tractate/:page', async (c) => {
   const tractate = c.req.param('tractate');
   const page = c.req.param('page');
   const lang: 'en' | 'he' = c.req.query('lang') === 'he' ? 'he' : 'en';
-  const rev = reverseDependencyIndex(producerNodesFrom([...CODE_MARKS, ...CODE_ENRICHMENTS]));
+  const rev = reverseDependencyIndex(await liveProducerNodes(c.env));
   const cascade = [id, ...transitiveDependents(rev, id)];
   const runId = `rewarm:${id}:${tractate}:${page}:${lang}:${Math.floor(Date.now() / 1000)}`
     .replace(/[^a-zA-Z0-9._:-]+/g, '_')

--- a/packages/talmud/tests/client/run-tree-provenance.test.tsx
+++ b/packages/talmud/tests/client/run-tree-provenance.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { render } from '@solidjs/testing-library';
+import { describe, expect, it } from 'vitest';
+import {
+  AuthorityBadge,
+  ProvenanceSection,
+  StalenessDot,
+  stalenessTitle,
+  type TreeNode,
+} from '../../src/client/runTreeShared';
+
+describe('stalenessTitle', () => {
+  it('names WHY for each verdict', () => {
+    expect(stalenessTitle('fresh')).toContain('recipe unchanged');
+    expect(stalenessTitle('stale-recipe')).toContain('recipe changed');
+    expect(stalenessTitle('stale-inputs', ['argument.background', 'rabbi'])).toContain(
+      'inputs changed: argument.background, rabbi',
+    );
+    expect(stalenessTitle('unknown')).toContain('recipe stamp');
+    expect(stalenessTitle('unknown', null, true)).toContain('marks');
+  });
+});
+
+describe('StalenessDot', () => {
+  it('renders a filled dot with the verdict tooltip', () => {
+    const { container } = render(() => (
+      <StalenessDot staleness="stale-inputs" inputsChanged={['rabbi']} />
+    ));
+    const dot = container.querySelector('span')!;
+    expect(dot.getAttribute('data-staleness')).toBe('stale-inputs');
+    expect(dot.getAttribute('title')).toContain('inputs changed: rabbi');
+    expect(dot.style.getPropertyValue('background')).toBeTruthy();
+  });
+
+  it('renders unknown as a hollow dot', () => {
+    const { container } = render(() => <StalenessDot staleness="unknown" />);
+    const dot = container.querySelector('span')!;
+    expect(dot.style.getPropertyValue('background')).toBe('transparent');
+    // jsdom normalizes the hex to rgb(); assert the hollow border is drawn
+    expect(dot.style.getPropertyValue('border')).toContain('1.5px solid');
+  });
+});
+
+describe('AuthorityBadge', () => {
+  it('labels the glyph with the authority', () => {
+    const { container } = render(() => <AuthorityBadge authority="human" />);
+    const svg = container.querySelector('svg')!;
+    expect(svg.getAttribute('aria-label')).toBe('authority: human');
+    expect(svg.querySelector('title')?.textContent).toContain('human-authored');
+  });
+});
+
+describe('ProvenanceSection', () => {
+  const node: TreeNode = {
+    id: 'argument-overview.synthesis',
+    label: 'Synthesis',
+    kind: 'llm',
+    producer: 'enrichment',
+    model: 'openrouter/test/model',
+    cached: true,
+    cold_ms: 1234,
+    cost: 0.001,
+    tokens: 150,
+    authority: 'ai',
+    staleness: 'stale-inputs',
+    createdAt: '2026-06-01T00:00:00.000Z',
+    recipeHash: 'abcdef123456',
+    inputs: [
+      { sourceKey: 'argument', status: 'changed' },
+      { sourceKey: 'rabbi', status: 'same' },
+    ],
+    inputsChanged: ['argument'],
+  };
+
+  it('shows authority, model, createdAt, recipe hash and highlights changed inputs', () => {
+    const { container } = render(() => <ProvenanceSection node={node} />);
+    const text = container.textContent ?? '';
+    expect(text).toContain('Provenance');
+    expect(text).toContain('ai');
+    expect(text).toContain('openrouter/test/model');
+    expect(text).toContain('2026-06-01T00:00:00.000Z');
+    expect(text).toContain('abcdef123456');
+    const chips = [...container.querySelectorAll('span[title]')].filter((el) =>
+      ['argument', 'rabbi'].includes(el.textContent ?? ''),
+    );
+    const changed = chips.find((el) => el.textContent === 'argument') as HTMLElement;
+    const same = chips.find((el) => el.textContent === 'rabbi') as HTMLElement;
+    expect(changed.title).toContain('moved since generation');
+    expect(same.title).toContain('unchanged');
+    expect(changed.style.getPropertyValue('font-weight')).toBe('600');
+  });
+
+  it('renders nothing for a node without provenance fields (older payloads)', () => {
+    const bare: TreeNode = {
+      id: 'gemara',
+      label: 'gemara',
+      kind: 'source',
+      cached: true,
+      cold_ms: null,
+      cost: null,
+      tokens: null,
+    };
+    const { container } = render(() => <ProvenanceSection node={bare} />);
+    expect(container.textContent).toBe('');
+  });
+});

--- a/packages/talmud/tests/run-tree-provenance.test.ts
+++ b/packages/talmud/tests/run-tree-provenance.test.ts
@@ -1,0 +1,286 @@
+import { provenanceInputRefs } from '@corpus/core/run/run-producer';
+import { describe, expect, it } from 'vitest';
+import { instanceIdOf, keyForEnrichment, keyForMark } from '../src/worker/cache-keys';
+import { CODE_ENRICHMENTS, CODE_MARKS } from '../src/worker/code-marks';
+import worker from '../src/worker/index';
+import type { Bindings } from '../src/worker/types';
+
+// The Inspect dock's provenance/staleness additions to GET /api/run-tree and
+// GET /api/daf-runs: nodes backed by a cached entry carry authority (from the
+// stored provenance, or derived from the transport for legacy entries), a
+// staleness verdict (recipe leg vs the CURRENT def + an input-content-hash leg
+// recomputed from ALREADY-CACHED dependency entries), createdAt, and the
+// stamped inputs with per-input same/changed/unknown. All additive; cache
+// reads only (no LLM, no queue). Harness mirrors run-contract.test.ts.
+
+// --- harness ---------------------------------------------------------------
+
+function makeFakeKV(initial: Record<string, string> = {}) {
+  const store = new Map(Object.entries(initial));
+  const kv = {
+    get: async (k: string) => store.get(k) ?? null,
+    put: async (k: string, v: string) => {
+      store.set(k, v);
+    },
+    delete: async (k: string) => {
+      store.delete(k);
+    },
+    list: async () => ({ keys: [], list_complete: true, cursor: '' }),
+    getWithMetadata: async () => ({ value: null, metadata: null }),
+  };
+  return { kv: kv as unknown as KVNamespace, store };
+}
+
+function makeEnv(seed: Record<string, string> = {}) {
+  const { kv, store } = makeFakeKV(seed);
+  const env = { CACHE: kv } as unknown as Bindings;
+  return { env, store };
+}
+
+function makeCtx(): ExecutionContext {
+  return {
+    waitUntil: (_p: Promise<unknown>) => {},
+    passThroughOnException: () => {},
+  } as unknown as ExecutionContext;
+}
+
+async function getJson(env: Bindings, path: string): Promise<{ status: number; json: unknown }> {
+  const res = await worker.fetch(new Request(`https://test.local${path}`), env, makeCtx());
+  return { status: res.status, json: await res.json() };
+}
+
+// A representative stored RunResult envelope (what writeCachedResult persists).
+const BASE = {
+  content: '{"x":1}',
+  parsed: { x: 1 },
+  parse_error: null,
+  model: 'openrouter/test/model',
+  transport: 'openrouter-gateway',
+  attempts: 1,
+  usage: { input_tokens: 100, output_tokens: 50, total_tokens: 150, cost: 0.001 },
+  elapsed_ms: 1234,
+  prompt_chars: 4321,
+  resolved: { system_prompt: 'sys', user_prompt: 'usr' },
+  cache_hit: false,
+};
+
+const ROOT = 'argument-overview.synthesis';
+const T = 'Berakhot';
+const P = '5a';
+
+const synthDef = CODE_ENRICHMENTS.find((e) => e.id === ROOT);
+const flowDef = CODE_ENRICHMENTS.find((e) => e.id === 'argument-overview.flow');
+const argDef = CODE_MARKS.find((m) => m.id === 'argument');
+const rabbiDef = CODE_MARKS.find((m) => m.id === 'rabbi');
+if (!synthDef || !flowDef || !argDef || !rabbiDef) {
+  throw new Error('expected argument-overview.synthesis + flow + argument + rabbi in the registry');
+}
+
+// Dependency values exactly as resolveInputs exposes them (enrichment dep →
+// parsed ?? content; mark dep → parsed.instances ?? content).
+const FLOW_PARSED = { edges: [{ from: 0, to: 1, type: 'continues' }] };
+const ARG_INSTANCES = [{ title: 'First sugya', startSegIdx: 0, endSegIdx: 2 }];
+const RABBI_INSTANCES = [{ name: 'Abaye' }];
+
+async function seedEntries(opts: {
+  rootRecipeHash: string;
+  inputs: Awaited<ReturnType<typeof provenanceInputRefs>>;
+}): Promise<Record<string, string>> {
+  const iid = await instanceIdOf({ fields: {} });
+  const daf = { tractate: T, page: P };
+  return {
+    [keyForEnrichment(flowDef!, iid, daf)]: JSON.stringify({
+      ...BASE,
+      parsed: FLOW_PARSED,
+      // legacy entry: no recipe_hash, no provenance — staleness must be 'unknown'
+    }),
+    [keyForMark(argDef!, T, P, 'en')]: JSON.stringify({
+      ...BASE,
+      parsed: { instances: ARG_INSTANCES },
+    }),
+    [keyForMark(rabbiDef!, T, P, 'en')]: JSON.stringify({
+      ...BASE,
+      parsed: { instances: RABBI_INSTANCES },
+      transport: 'computed', // deterministic → authority must derive to 'rule'
+    }),
+    [keyForEnrichment(synthDef!, iid, daf)]: JSON.stringify({
+      ...BASE,
+      parsed: { synthesis: 'one paragraph' },
+      recipe_hash: opts.rootRecipeHash,
+      provenance: {
+        authority: 'ai',
+        producerId: ROOT,
+        recipeHash: opts.rootRecipeHash,
+        inputs: opts.inputs,
+        model: BASE.model,
+        transport: BASE.transport,
+        usage: BASE.usage,
+        cost: null,
+        createdAt: '2026-06-01T00:00:00.000Z',
+      },
+    }),
+  };
+}
+
+/** The stamped input refs, hashed from the SAME values the seeds carry — so a
+ *  recomputation over the cached entries must agree ('same'). */
+function stampedInputs() {
+  return provenanceInputRefs({
+    depends: { 'argument-overview.flow': FLOW_PARSED },
+    anchors: { argument: ARG_INSTANCES, rabbi: RABBI_INSTANCES },
+  });
+}
+
+/** The producer's CURRENT recipe hash, read off the /api/stale probe (the same
+ *  enrichmentRecipe + recipeHash the write path uses). */
+async function currentRecipeHash(): Promise<string> {
+  const { env } = makeEnv();
+  const { status, json } = await getJson(env, `/api/stale/${ROOT}/${T}/${P}`);
+  expect(status).toBe(200);
+  const hash = (json as { current_recipe: string }).current_recipe;
+  expect(hash).toMatch(/^[0-9a-f]{12}$/);
+  return hash;
+}
+
+interface Node {
+  id: string;
+  kind: string;
+  cached: boolean;
+  authority?: string | null;
+  staleness?: string | null;
+  createdAt?: string | null;
+  recipeHash?: string | null;
+  inputs?: Array<{ sourceKey: string; status: string }>;
+  inputsChanged?: string[];
+}
+
+async function fetchTree(env: Bindings): Promise<Record<string, Node>> {
+  const { status, json } = await getJson(env, `/api/run-tree/${T}/${P}/${ROOT}`);
+  expect(status).toBe(200);
+  return (json as { nodes: Record<string, Node> }).nodes;
+}
+
+// --- /api/run-tree ----------------------------------------------------------
+
+describe('GET /api/run-tree — provenance + staleness fields', () => {
+  it('fresh root: authority/createdAt from provenance, staleness fresh, all inputs same', async () => {
+    const current = await currentRecipeHash();
+    const { env } = makeEnv(
+      await seedEntries({ rootRecipeHash: current, inputs: await stampedInputs() }),
+    );
+    const nodes = await fetchTree(env);
+
+    const root = nodes[ROOT];
+    expect(root.cached).toBe(true);
+    expect(root.authority).toBe('ai');
+    expect(root.createdAt).toBe('2026-06-01T00:00:00.000Z');
+    expect(root.recipeHash).toBe(current);
+    expect(root.staleness).toBe('fresh');
+    expect(root.inputs).toEqual([
+      { sourceKey: 'argument-overview.flow', status: 'same' },
+      { sourceKey: 'argument', status: 'same' },
+      { sourceKey: 'rabbi', status: 'same' },
+    ]);
+    expect(root.inputsChanged).toEqual([]);
+
+    // mark nodes: authority derived from the stored transport (legacy entries
+    // carry no provenance); staleness 'unknown' — marks never stamp recipe_hash
+    expect(nodes.argument.authority).toBe('ai');
+    expect(nodes.argument.staleness).toBe('unknown');
+    expect(nodes.argument.createdAt).toBeNull();
+    expect(nodes.rabbi.authority).toBe('rule'); // transport 'computed'
+
+    // legacy enrichment entry without a recipe stamp → 'unknown'
+    expect(nodes['argument-overview.flow'].staleness).toBe('unknown');
+    expect(nodes['argument-overview.flow'].authority).toBe('ai');
+
+    // source leaves carry none of the new fields
+    expect(nodes.gemara.kind).toBe('source');
+    expect(nodes.gemara.authority).toBeUndefined();
+    expect(nodes.gemara.staleness).toBeUndefined();
+  });
+
+  it('a changed dependency flips the root to stale-inputs and names it', async () => {
+    const current = await currentRecipeHash();
+    const seeds = await seedEntries({ rootRecipeHash: current, inputs: await stampedInputs() });
+    // Re-extract drifted: the argument mark's cached instances moved.
+    seeds[keyForMark(argDef!, T, P, 'en')] = JSON.stringify({
+      ...BASE,
+      parsed: { instances: [{ title: 'Re-extracted sugya', startSegIdx: 0, endSegIdx: 5 }] },
+    });
+    const { env } = makeEnv(seeds);
+    const nodes = await fetchTree(env);
+    expect(nodes[ROOT].staleness).toBe('stale-inputs');
+    expect(nodes[ROOT].inputsChanged).toEqual(['argument']);
+    expect(nodes[ROOT].inputs).toContainEqual({ sourceKey: 'argument', status: 'changed' });
+    expect(nodes[ROOT].inputs).toContainEqual({ sourceKey: 'rabbi', status: 'same' });
+  });
+
+  it('an uncached dependency reports unknown (and does not flip staleness)', async () => {
+    const current = await currentRecipeHash();
+    const iid = await instanceIdOf({ fields: {} });
+    const seeds = await seedEntries({ rootRecipeHash: current, inputs: await stampedInputs() });
+    delete seeds[keyForEnrichment(flowDef!, iid, { tractate: T, page: P })];
+    const { env } = makeEnv(seeds);
+    const nodes = await fetchTree(env);
+    expect(nodes[ROOT].inputs).toContainEqual({
+      sourceKey: 'argument-overview.flow',
+      status: 'unknown',
+    });
+    expect(nodes[ROOT].staleness).toBe('fresh');
+    expect(nodes['argument-overview.flow'].cached).toBe(false);
+    expect(nodes['argument-overview.flow'].authority).toBeNull();
+    expect(nodes['argument-overview.flow'].staleness).toBeNull();
+  });
+
+  it('a recipe edit wins over input checks: stale-recipe', async () => {
+    const { env } = makeEnv(
+      await seedEntries({ rootRecipeHash: 'deadbeefdeadbeef', inputs: await stampedInputs() }),
+    );
+    const nodes = await fetchTree(env);
+    expect(nodes[ROOT].staleness).toBe('stale-recipe');
+    expect(nodes[ROOT].recipeHash).toBe('deadbeefdeadbeef');
+  });
+
+  it('native provenance.authority wins over the transport derivation', async () => {
+    const current = await currentRecipeHash();
+    const seeds = await seedEntries({ rootRecipeHash: current, inputs: [] });
+    const iid = await instanceIdOf({ fields: {} });
+    const key = keyForEnrichment(synthDef!, iid, { tractate: T, page: P });
+    const entry = JSON.parse(seeds[key]);
+    entry.provenance.authority = 'human';
+    seeds[key] = JSON.stringify(entry);
+    const { env } = makeEnv(seeds);
+    const nodes = await fetchTree(env);
+    expect(nodes[ROOT].authority).toBe('human');
+  });
+});
+
+// --- /api/daf-runs ----------------------------------------------------------
+
+describe('GET /api/daf-runs — additive authority + recipe-leg staleness', () => {
+  it('cached rows carry a verdict; uncached rows carry nulls', async () => {
+    const current = await currentRecipeHash();
+    const { env } = makeEnv(
+      await seedEntries({ rootRecipeHash: current, inputs: await stampedInputs() }),
+    );
+    const { status, json } = await getJson(env, `/api/daf-runs/${T}/${P}`);
+    expect(status).toBe(200);
+    const runs = (json as { runs: Array<Node & { id: string }> }).runs;
+    const byId = new Map(runs.map((r) => [r.id, r]));
+
+    const root = byId.get(ROOT);
+    expect(root?.authority).toBe('ai');
+    expect(root?.staleness).toBe('fresh');
+
+    // cached mark: authority derived, staleness 'unknown' (no recipe stamp)
+    expect(byId.get('argument')?.authority).toBe('ai');
+    expect(byId.get('argument')?.staleness).toBe('unknown');
+    expect(byId.get('rabbi')?.authority).toBe('rule');
+
+    // an uncached row: both null
+    const uncached = runs.find((r) => !r.cached);
+    expect(uncached?.authority).toBeNull();
+    expect(uncached?.staleness).toBeNull();
+  });
+});


### PR DESCRIPTION
The Inspect dock now surfaces what the four-primitive engine records on every entry — dock only, reader untouched.

- **Per-node build forensics:** authority badges, staleness dots with why-tooltips ("stale — inputs changed: argument, rabbi"), and a Provenance detail section (model, createdAt, recipe hash, input chips with changed ones highlighted). The inputs-changed diff recomputes stamped content hashes over already-read cached deps — zero added KV reads, no LLM spend, and 'unknown' rather than false positives for anything unverifiable.
- **The freshness loop as UI:** a collapsed panel with the `/api/stale` verdict, the `/api/dependents` cascade, and a studio-gated one-click scoped rewarm — yesterday's hand-evicted KV rewarm becomes a button.
- **Codex findings fixed before this PR:** `/api/daf-runs` verdicts and the dependents/rewarm cascades were computed from static code defs — KV-overridden producers would have shown false staleness and wrong blast radii. Both now derive KV-first from the live registry.

Tests: 12 new (worker provenance fields over seeded KV + client badge/dot/tooltip rendering). Full suite: talmud 2110 / core 103 / tanach 42; typecheck + biome + vite build clean.