### PR TITLE
Geography sidebar: loading state + re-fire the stale-empty race

### DIFF
--- a/packages/talmud/src/client/ArgumentSidebar.tsx
+++ b/packages/talmud/src/client/ArgumentSidebar.tsx
@@ -2485,6 +2485,10 @@ export const CHART_BLOCKS: Record<string, (p: SpecialBlockProps) => JSX.Element>
  *  highlight/navigation callbacks, assembled by DafViewer. */
 export interface GeographyExtras {
   model: DafGeoModel | null;
+  /** True while a dependency mark (rabbi, or places-if-loading) is still
+   *  resolving — so an empty/null model isn't yet trustworthy. The block shows
+   *  a loading line instead of the terminal "no rabbis" message. */
+  loading: boolean;
   activeLocation: string | null;
   activePlace: string | null;
   generationByName: Map<string, GenerationId> | null;
@@ -2497,13 +2501,35 @@ export interface GeographyExtras {
 function GeographyMapBlock(props: SpecialBlockProps): JSX.Element {
   const ex = (): GeographyExtras | undefined => props.extras as GeographyExtras | undefined;
   const model = (): DafGeoModel | null => ex()?.model ?? null;
+  const hasMap = (): boolean => !!model() && !model()!.empty;
   return (
     <Show
-      when={model() && !model()!.empty}
+      when={hasMap()}
       fallback={
-        <p style={{ margin: '0.4rem 0 0', color: '#888', 'font-size': '0.82rem' }}>
-          {t('geography.empty')}
-        </p>
+        // No map yet. If a dependency mark is still resolving, the empty/null
+        // model isn't trustworthy — show a loading line (italic muted, matching
+        // pasuk.loading) rather than the terminal "no rabbis" message, which
+        // would pin a false-empty until reload. Only once loading settles and
+        // the model is still empty do we show the terminal copy.
+        <Show
+          when={ex()?.loading}
+          fallback={
+            <p style={{ margin: '0.4rem 0 0', color: '#888', 'font-size': '0.82rem' }}>
+              {t('geography.empty')}
+            </p>
+          }
+        >
+          <p
+            style={{
+              margin: '0.4rem 0 0',
+              color: '#999',
+              'font-style': 'italic',
+              'font-size': '0.82rem',
+            }}
+          >
+            {t('geography.loading')}
+          </p>
+        </Show>
       }
     >
       <GeographyMap

--- a/packages/talmud/src/client/DafViewer.tsx
+++ b/packages/talmud/src/client/DafViewer.tsx
@@ -2993,8 +2993,33 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
   // The geography card's extras bundle: the computed model (from the geography
   // mark run) + the daf's highlight/navigation callbacks. Forwarded to the
   // sidebar's geography-map block (desktop + mobile).
+  // The geography model is COMPUTED server-side from the rabbi + places mark
+  // caches. On a cold daf the run loop fires every enabled mark concurrently,
+  // so geography can read those caches before they warm and return an empty
+  // model. Treat the model as not-yet-trustworthy while a dependency is still
+  // resolving: rabbi must reach 'ok' (it always runs on a real daf, so 'idle'
+  // = hasn't started = still not ready), geography itself mustn't be mid-run,
+  // and places only counts when it's ACTIVELY loading (it may be disabled and
+  // sit 'idle' forever — gating on places-ok would never clear). The block
+  // shows a loading line instead of the terminal "no rabbis" copy until this
+  // settles. (Re-running geography once its deps land is handled in the marks
+  // run loop via the server's `transient` flag.)
+  const geographyLoading = (): boolean => {
+    const statuses = markStatuses();
+    const rabbiStatus = statuses.find((s) => s.id === 'rabbi')?.kind;
+    const geographyStatus = statuses.find((s) => s.id === 'geography')?.kind;
+    const placesStatus = statuses.find((s) => s.id === 'places')?.kind;
+    return (
+      rabbiStatus === 'loading' ||
+      rabbiStatus === 'idle' ||
+      geographyStatus === 'loading' ||
+      placesStatus === 'loading'
+    );
+  };
+
   const geographyExtras = (): GeographyExtras => ({
     model: dafGeoModel(),
+    loading: geographyLoading(),
     activeLocation: activeLocation(),
     activePlace: activePlace(),
     generationByName: generationByName(),

--- a/packages/talmud/src/client/MarksRegistryPanel.tsx
+++ b/packages/talmud/src/client/MarksRegistryPanel.tsx
@@ -21,6 +21,7 @@
  */
 
 import {
+  dependencyId,
   producerNodesFrom,
   type RawDependency,
   reverseDependencyIndex,
@@ -174,6 +175,13 @@ export interface RunResult {
    *  hit total_ms is injected as 0, but elapsed_ms still carries the original
    *  generation time from when the result was first computed. */
   cache_hit?: boolean;
+  /** "Serve-but-don't-write" — the worker assembled this result while a
+   *  dependency wasn't ready yet (e.g. the geography computed mark read the
+   *  rabbi/places mark caches before they warmed) and so did NOT pin it to the
+   *  cache. The run loop treats a transient result as not-yet-final and
+   *  re-fires the mark once its dependency marks reach 'ok', so the empty model
+   *  isn't left pinned in the UI until a manual reload. */
+  transient?: boolean;
 }
 
 export type RunState =
@@ -181,6 +189,40 @@ export type RunState =
   | { kind: 'loading'; stamp: string }
   | { kind: 'ok'; stamp: string; at: number; result: RunResult }
   | { kind: 'error'; stamp: string; at: number; error: string };
+
+/** Per-(mark, stamp) cap on transient re-fires — a loop / runaway guard.
+ *  A genuinely-empty daf is NOT transient server-side (its dep entries exist),
+ *  so it never reaches the re-fire path; this only bounds the race window. */
+export const TRANSIENT_REFIRE_CAP = 3;
+
+/** Pure decision for the transient re-fire effect (extracted so it's unit-
+ *  testable without the component's resources / network). Returns true when a
+ *  mark whose current run is a SETTLED transient `ok` for `stamp` should be
+ *  re-fired: every enabled dependency mark must itself have reached a settled,
+ *  non-transient `ok` for the same stamp (so the caches the computed mark reads
+ *  server-side are warm), and the per-(mark, stamp) re-fire cap mustn't be hit.
+ *  A dependency that's disabled / idle / not-running doesn't block — it simply
+ *  contributes nothing (e.g. the places mark turned off). */
+export function shouldRefireTransientMark(args: {
+  markId: string;
+  stamp: string;
+  runs: Record<string, RunState>;
+  enabled: ReadonlySet<string>;
+  depMarkIds: ReadonlyArray<string>;
+  refireCount: number;
+}): boolean {
+  const { markId, stamp, runs, enabled, depMarkIds, refireCount } = args;
+  const cur = runs[markId];
+  if (cur?.kind !== 'ok' || cur.stamp !== stamp) return false;
+  if (!cur.result.transient) return false;
+  if (refireCount >= TRANSIENT_REFIRE_CAP) return false;
+  return depMarkIds.every((depId) => {
+    if (!enabled.has(depId)) return true; // disabled dep — won't warm; don't wait
+    const ds = runs[depId];
+    if (!ds || ds.kind === 'idle') return true; // not running — don't wait
+    return ds.kind === 'ok' && ds.stamp === stamp && !ds.result.transient;
+  });
+}
 
 const ENABLED_KEY = 'marks-registry:enabled:v1';
 
@@ -597,6 +639,83 @@ export default function MarksRegistryPanel(props: Props) {
           (err) => {
             if (currentStamp() === stamp)
               setRun(e.id, {
+                kind: 'error',
+                stamp,
+                at: Date.now(),
+                error: String((err as Error)?.message ?? err),
+              });
+          },
+        );
+      }
+    });
+  });
+
+  // --- Transient re-fire: re-run a "serve-but-don't-write" mark once its deps land ---
+  // A computed mark (geography) reads its DEPENDENCY marks' caches (rabbi +
+  // places) server-side. The run loop above fires every enabled mark
+  // concurrently, so on a cold daf geography can win the race and read those
+  // caches before they warm — the worker then returns an empty model tagged
+  // `transient: true` (served, never pinned). The client has no auto-rerun, so
+  // without this that empty model would stay on screen until a manual reload.
+  //
+  // Fix: when a mark's current OK result is `transient`, re-fire it — but only
+  // once every dependency mark that is itself enabled+running has reached a
+  // settled, non-transient `ok` (so we read warm caches, not busy-loop while
+  // rabbi is still pending). A small per-(mark, stamp) cap guards against any
+  // loop (and against a genuinely-empty daf, though that returns notReady=false
+  // server-side and so is NOT transient — it never reaches here). Once rabbi +
+  // places are cached, the re-fired run reads them, is no longer transient, and
+  // is cached normally → no further re-fires, no extra cost on warm dapim.
+  const refireCounts = new Map<string, number>();
+
+  const depMarkIds = (markId: string): string[] => {
+    const reg = registry();
+    const def = reg?.marks.find((m) => m.id === markId);
+    if (!def?.dependencies) return [];
+    const ids: string[] = [];
+    for (const d of def.dependencies) {
+      const id = dependencyId(d);
+      // Only mark deps gate the re-fire (a `{ mark }` dep resolves to a mark id
+      // present in the registry); source-input leaves aren't runnable marks.
+      if (id && reg?.marks.some((m) => m.id === id)) ids.push(id);
+    }
+    return ids;
+  };
+
+  createEffect(() => {
+    const reg = registry();
+    if (!reg) return;
+    const on = enabled();
+    const r = runs();
+    const stamp = `${props.tractate}/${props.page}/${lang()}`;
+
+    untrack(() => {
+      for (const m of visibleMarks(reg)) {
+        if (!on.has(m.id)) continue;
+        const countKey = `${m.id}:${stamp}`;
+        const count = refireCounts.get(countKey) ?? 0;
+        if (
+          !shouldRefireTransientMark({
+            markId: m.id,
+            stamp,
+            runs: r,
+            enabled: on,
+            depMarkIds: depMarkIds(m.id),
+            refireCount: count,
+          })
+        )
+          continue;
+        refireCounts.set(countKey, count + 1);
+
+        setRun(m.id, { kind: 'loading', stamp });
+        void runMark(m.id, props.tractate, props.page).then(
+          (result) => {
+            if (currentStamp() === stamp)
+              setRun(m.id, { kind: 'ok', stamp, at: Date.now(), result });
+          },
+          (err) => {
+            if (currentStamp() === stamp)
+              setRun(m.id, {
                 kind: 'error',
                 stamp,
                 at: Date.now(),

--- a/packages/talmud/src/client/i18n.ts
+++ b/packages/talmud/src/client/i18n.ts
@@ -1040,6 +1040,10 @@ const CATALOG = {
     en: 'No rabbis on this daf could be placed on the map yet.',
     he: 'לא ניתן עדיין למקם חכמים מדף זה על המפה.',
   },
+  'geography.loading': {
+    en: 'Mapping this daf’s rabbis…',
+    he: 'ממפה את חכמי הדף…',
+  },
   'geography.heading': {
     en: 'Geography · click a dot to highlight',
     he: 'גאוגרפיה · לחצו על נקודה להדגשה',

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -2789,13 +2789,18 @@ export async function computeGeographyModel(
   // key it never recomputes until a cache_version bump). We mark the result
   // `transient` so it renders this view but isn't pinned; the next request
   // recomputes until rabbi+places are warm, then it caches normally.
+  // Readiness gates on the RABBI mark ONLY — it is the load-bearing input
+  // (rabbis place the dots). The `places` mark is OPTIONAL (it only adds
+  // city-mention dots); gating on it too meant a daf where `places` is
+  // disabled/never-enqueued stayed transient forever, re-firing on every open
+  // and never settling (the places cache is permanently absent). So: rabbi
+  // absent = not-ready (transient, recompute next request); places absent =
+  // just no mentions, settle on the rabbi data.
   const rabbiDef = findCodeMark('rabbi');
-  const placesDef = findCodeMark('places');
-  const [rabbiEntry, placesEntry] = await Promise.all([
-    rabbiDef ? readCachedResult(env, keyForMark(rabbiDef, tractate, page, 'en')) : null,
-    placesDef ? readCachedResult(env, keyForMark(placesDef, tractate, page, 'en')) : null,
-  ]);
-  const notReady = rabbiEntry === null || placesEntry === null;
+  const rabbiEntry = rabbiDef
+    ? await readCachedResult(env, keyForMark(rabbiDef, tractate, page, 'en'))
+    : null;
+  const notReady = rabbiEntry === null;
 
   // 1. The daf's rabbis (the `rabbi` mark) — name / nameHe / slug / generation.
   const rabbiInsts = await readMarkInstances(env, 'rabbi', tractate, page);

--- a/packages/talmud/tests/client/geography-block-loading.test.tsx
+++ b/packages/talmud/tests/client/geography-block-loading.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+//
+// The geography sidebar block's fallback branch: while a dependency mark (the
+// rabbi mark) is still resolving, an empty/null model is NOT yet trustworthy —
+// the block must show the LOADING line, not the terminal "no rabbis" copy
+// (which would pin a false-empty until reload). Once loading settles and the
+// model is still empty, the terminal copy shows. A non-empty model always
+// renders the map regardless of loading.
+
+import { render } from '@solidjs/testing-library';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { GEOGRAPHY_BLOCKS, type GeographyExtras } from '../../src/client/ArgumentSidebar';
+import { setLang, t } from '../../src/client/i18n';
+import { buildGeoModel } from '../../src/lib/geographyModel';
+
+beforeEach(() => setLang('en'));
+afterEach(() => setLang('en'));
+
+const Block = GEOGRAPHY_BLOCKS['geography-map'];
+
+const baseExtras = (over: Partial<GeographyExtras>): GeographyExtras => ({
+  model: null,
+  loading: false,
+  activeLocation: null,
+  activePlace: null,
+  generationByName: null,
+  onHighlightLocation: () => {},
+  onHighlightSingleRabbi: () => {},
+  onHoverRabbi: () => {},
+  onHighlightPlace: () => {},
+  ...over,
+});
+
+const blockProps = (extras: GeographyExtras) => ({
+  deps: {},
+  anchors: {},
+  synthesisResolved: false,
+  instance: { fields: {} },
+  tractate: 'Berakhot',
+  page: '2a',
+  instanceKey: 'Berakhot/2a',
+  extras: extras as unknown as Record<string, unknown>,
+});
+
+describe('GeographyMapBlock — loading vs empty fallback', () => {
+  it('shows the LOADING line (not the terminal empty copy) while a dep is resolving', () => {
+    // model null + loading true = a dependency mark (rabbi) is still resolving.
+    const { container } = render(() =>
+      Block(blockProps(baseExtras({ model: null, loading: true }))),
+    );
+    const text = container.textContent ?? '';
+    expect(text).toContain(t('geography.loading'));
+    expect(text).not.toContain(t('geography.empty'));
+  });
+
+  it('shows the terminal EMPTY copy once loading settles with no placeable rabbis', () => {
+    // An assembled-but-empty model (deps settled, genuinely rabbi-less daf).
+    const empty = buildGeoModel([], []);
+    expect(empty.empty).toBe(true);
+    const { container } = render(() =>
+      Block(blockProps(baseExtras({ model: empty, loading: false }))),
+    );
+    const text = container.textContent ?? '';
+    expect(text).toContain(t('geography.empty'));
+    expect(text).not.toContain(t('geography.loading'));
+  });
+
+  it('renders the map (two region SVGs) when the model is non-empty, even mid-load', () => {
+    const model = buildGeoModel(
+      [{ name: 'Rav Huna', slug: 'rav-huna', identity: { places: ['Sura'], region: 'bavel' } }],
+      [{ name: 'Sura' }],
+    );
+    expect(model.empty).toBe(false);
+    // loading still true — a non-empty model must NOT be hidden behind the
+    // loading line; partial-but-present beats a spinner.
+    const { container } = render(() => Block(blockProps(baseExtras({ model, loading: true }))));
+    expect(container.querySelectorAll('svg').length).toBe(2);
+    const text = container.textContent ?? '';
+    expect(text).not.toContain(t('geography.loading'));
+    expect(text).not.toContain(t('geography.empty'));
+  });
+});

--- a/packages/talmud/tests/transient-refire.test.ts
+++ b/packages/talmud/tests/transient-refire.test.ts
@@ -1,0 +1,127 @@
+// The transient re-fire gate (Part 2 of the geography-loading fix): a computed
+// mark (geography) reads its dependency marks' caches server-side. On a cold
+// daf every enabled mark fires concurrently, so geography can read empty caches
+// and the worker returns the model tagged `transient` (served, not pinned). The
+// client must RE-FIRE that mark once its dependency marks (rabbi, places-if-on)
+// have reached a settled, non-transient `ok` — otherwise the empty model is
+// stuck on screen until a manual reload. shouldRefireTransientMark is the pure
+// decision behind that effect.
+
+import { describe, expect, it } from 'vitest';
+import {
+  type RunResult,
+  type RunState,
+  shouldRefireTransientMark,
+  TRANSIENT_REFIRE_CAP,
+} from '../src/client/MarksRegistryPanel';
+
+const STAMP = 'Berakhot/2a/en';
+
+const result = (over: Partial<RunResult> = {}): RunResult =>
+  ({
+    content: '{}',
+    parsed: { instances: [] },
+    parse_error: null,
+    model: 'computed:geography-model',
+    transport: 'computed',
+    attempts: 1,
+    usage: null,
+    elapsed_ms: 1,
+    resolved: { system_prompt: '', user_prompt: '' },
+    total_ms: 1,
+    ...over,
+  }) as RunResult;
+
+const ok = (transient: boolean, stamp = STAMP): RunState => ({
+  kind: 'ok',
+  stamp,
+  at: 0,
+  result: result({ transient }),
+});
+
+const call = (over: Partial<Parameters<typeof shouldRefireTransientMark>[0]>) =>
+  shouldRefireTransientMark({
+    markId: 'geography',
+    stamp: STAMP,
+    runs: {},
+    enabled: new Set(['geography', 'rabbi', 'places']),
+    depMarkIds: ['rabbi', 'places'],
+    refireCount: 0,
+    ...over,
+  });
+
+describe('shouldRefireTransientMark', () => {
+  it('does NOT re-fire while a dependency mark is still loading', () => {
+    // The race the bug describes: geography settled transient, rabbi mid-run.
+    const runs: Record<string, RunState> = {
+      geography: ok(true),
+      rabbi: { kind: 'loading', stamp: STAMP },
+      places: ok(false),
+    };
+    expect(call({ runs })).toBe(false);
+  });
+
+  it('does NOT re-fire while a dependency mark is itself still transient', () => {
+    const runs: Record<string, RunState> = {
+      geography: ok(true),
+      rabbi: ok(true), // not settled yet
+      places: ok(false),
+    };
+    expect(call({ runs })).toBe(false);
+  });
+
+  it('RE-FIRES once every dependency mark reaches a settled non-transient ok', () => {
+    const runs: Record<string, RunState> = {
+      geography: ok(true),
+      rabbi: ok(false),
+      places: ok(false),
+    };
+    expect(call({ runs })).toBe(true);
+  });
+
+  it('does not re-fire a NON-transient result (already final / warm daf)', () => {
+    const runs: Record<string, RunState> = {
+      geography: ok(false), // genuinely-empty daf is non-transient → final
+      rabbi: ok(false),
+      places: ok(false),
+    };
+    expect(call({ runs })).toBe(false);
+  });
+
+  it('a disabled dependency mark does not block the re-fire', () => {
+    // places turned off: it sits idle/absent forever — must not gate geography.
+    const runs: Record<string, RunState> = {
+      geography: ok(true),
+      rabbi: ok(false),
+    };
+    expect(call({ runs, enabled: new Set(['geography', 'rabbi']) })).toBe(true);
+  });
+
+  it('an idle (not-yet-started) dependency does not block', () => {
+    const runs: Record<string, RunState> = {
+      geography: ok(true),
+      rabbi: ok(false),
+      places: { kind: 'idle' },
+    };
+    expect(call({ runs })).toBe(true);
+  });
+
+  it('stops re-firing at the per-(mark, stamp) cap (loop guard)', () => {
+    const runs: Record<string, RunState> = {
+      geography: ok(true),
+      rabbi: ok(false),
+      places: ok(false),
+    };
+    expect(call({ runs, refireCount: TRANSIENT_REFIRE_CAP - 1 })).toBe(true);
+    expect(call({ runs, refireCount: TRANSIENT_REFIRE_CAP })).toBe(false);
+  });
+
+  it('ignores a transient result stamped for a DIFFERENT daf', () => {
+    const runs: Record<string, RunState> = {
+      geography: ok(true, 'Shabbat/2a/en'), // stale daf
+      rabbi: ok(false),
+      places: ok(false),
+    };
+    expect(call({ runs })).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes the Geography panel showing "No rabbis could be placed… yet" both while the rabbi mark is still loading and **permanently** when geography races ahead of it.

**Root cause of the false-empty:** the run loop fires every enabled mark concurrently; geography (a computed mark reading the rabbi/places mark *caches*) could read them before they populated → empty model. The server already returns `transient: true` ("serve-but-don't-write") in that case and the flag rides the run envelope to the client — but the client `RunResult` interface never *declared* it, so the loop settled geography `ok` terminally and never re-ran it.

**Fixes:**
- Surface `transient` on the client; a re-fire effect re-runs a transient mark **once every declared dependency mark has settled non-transient `ok`** (disabled/idle deps don't block), capped at 3 per (mark, stamp). Pure unit-tested gate. First open: rabbi → ok → geography re-runs against warm caches → settles. Zero cost on warm dapim.
- **Server readiness gates on the `rabbi` mark only** — `places` is optional (city-mention dots); gating on it left a places-disabled daf transient forever (Codex finding, fixed).
- Loading copy: `GeographyMapBlock` shows "Mapping this daf's rabbis…" while a dependency resolves; map renders as soon as a non-empty model arrives.

Codex review cleared loop-safety (stable stamp, declared-deps gate, no cross-mark cascade, additive type); its one Medium (places-disabled perpetual transient) is the server-gates-on-rabbi-only fix above. Tests: +11 (re-fire gate, loading-vs-empty-vs-map). Suite talmud 2162 / core 103 / tanach 42; typecheck + biome + build green.