### PR TITLE
Timeline: route region inference through the shared geography matcher

### DIFF
--- a/packages/talmud/src/client/RabbiPlacesTimeline.tsx
+++ b/packages/talmud/src/client/RabbiPlacesTimeline.tsx
@@ -23,6 +23,7 @@
  */
 
 import { createMemo, createSignal, For, type JSX, Show } from 'solid-js';
+import { inferRegionOfPlace } from '../lib/geographyModel';
 import { t } from './i18n';
 import type { BirthPlace, GeographyData, GeographyEvidence } from './RabbiGeographyCard';
 
@@ -79,16 +80,13 @@ interface TimelineEvent {
   evidencePlace: string;
 }
 
+// Region of a place name, mapped onto the timeline's 4-value Region. Routes
+// through the SHARED matcher (geographyModel.inferRegionOfPlace — the same
+// GEO_CITIES table + region-word fallback the whole-daf geography map uses) so
+// the timeline and the map agree on what "Sura" or "Tiberias" is. The canonical
+// matcher returns israel|bavel|null; null becomes the timeline's neutral 'other'.
 function inferRegion(place: string): Region {
-  const p = place.toLowerCase();
-  if (/bavel|babylonia|sura|pumbedita|nehardea|machoza|mata mehasya/.test(p)) return 'bavel';
-  if (
-    /eretz yisrael|israel|tiberias|tiberya|sepphoris|tzipori|yavneh|caesarea|lod|jerusalem|usha|bnei brak/.test(
-      p,
-    )
-  )
-    return 'israel';
-  return 'other';
+  return inferRegionOfPlace(place) ?? 'other';
 }
 
 function regionColor(r: Region): string {


### PR DESCRIPTION
## Why

`RabbiPlacesTimeline` (the per-rabbi "Places — Timeline" card) carried its own hardcoded region regex, duplicating the canonical `inferRegionOfPlace` in `geographyModel.ts` that the new whole-daf geography map/pill uses. Two implementations of "is this place Bavel or Eretz Yisrael?" drift apart — the map and the timeline could disagree on the same place name.

This is **step 1 (foundation)** of unifying the per-rabbi timeline with the whole-daf geography map onto one spatial vocabulary, ahead of the planned drill-down-on-shared-maps integration.

## What

- Delete the bespoke regex; route `inferRegion` through the shared `inferRegionOfPlace` (the `GEO_CITIES` table + region-word fallback both surfaces now share).
- `GeoRegionId` (`israel|bavel|null`) maps onto the timeline's 4-value `Region` with `null -> 'other'`.

**No behavior regression** — strictly broader recognition. `GEO_CITIES` already contains every city the old regex hardcoded (Usha, Yavneh, Jerusalem, Bnei Brak, Caesarea, Lod, Tiberias, Tzipori/Sepphoris, Nehardea, Pumbedita, Sura, Mehoza, Mata Mehasya) with the same aliases, plus the rest of Shas' cities; the region-word fallback covers `bavel|babylon` / `eretz yisrael|israel|...`.

## Test

- `pnpm typecheck`, `pnpm lint`, `pnpm test` (2162 talmud tests) all green.