### PR TITLE
Rabbi card: "Across the Talmud" accumulated-observations panel

### DIFF
--- a/packages/core/src/sidebar/recipe.ts
+++ b/packages/core/src/sidebar/recipe.ts
@@ -267,5 +267,8 @@ export const RABBI_RECIPE: SidebarRecipe = {
       block: 'rabbi-geography',
       deps: ['rabbi.geography', 'rabbi.geography.evidence', 'rabbi.location'],
     },
+    // "Across the Talmud" — accumulated reverse-index. Lazily fetched by slug
+    // (rabbi.identity), so it only needs that dep; nothing per-daf to resolve.
+    { type: 'special', block: 'rabbi-observations', deps: ['rabbi.identity'] },
   ],
 };

--- a/packages/talmud/src/client/ArgumentSidebar.tsx
+++ b/packages/talmud/src/client/ArgumentSidebar.tsx
@@ -55,6 +55,7 @@ import RabbiLineageTree, {
   type RelationshipsData,
   type RelationshipsEvidence,
 } from './RabbiLineageTree';
+import RabbiObservations from './RabbiObservations';
 import RabbiPlacesTimeline, { type LocationInference } from './RabbiPlacesTimeline';
 import { HebraizedWithRabbis, RabbiLinkProvider } from './rabbiLinks';
 import type {
@@ -1789,6 +1790,17 @@ function RabbiGeography(props: SpecialBlockProps): JSX.Element {
   );
 }
 
+// "Across the Talmud" — the accumulated reverse-index (rabbi.observations),
+// fetched lazily by the rabbi's canonical slug. The LIVING counterpart to the
+// static geography biography above it: it grows as more dapim are studied.
+function RabbiObservationsBlock(props: SpecialBlockProps): JSX.Element {
+  const slug = (): string | null => {
+    const i = props.deps['rabbi.identity'] as IdentifiedRabbi | undefined;
+    return i?.slug ?? null;
+  };
+  return <RabbiObservations slug={slug()} />;
+}
+
 /** Display instance ({fields} for the heading + meta). genSource/homonyms are
  *  the grounding stamps RabbiMeta uses to surface homonym uncertainty. */
 export function rabbiDisplayInstance(rabbi: IdentifiedRabbi): { fields: Record<string, unknown> } {
@@ -1827,6 +1839,7 @@ export const RABBI_BLOCKS: Record<string, (p: SpecialBlockProps) => JSX.Element>
   'rabbi-meta': RabbiMeta,
   'rabbi-lineage': RabbiLineage,
   'rabbi-geography': RabbiGeography,
+  'rabbi-observations': RabbiObservationsBlock,
 };
 
 // ===========================================================================

--- a/packages/talmud/src/client/RabbiObservations.tsx
+++ b/packages/talmud/src/client/RabbiObservations.tsx
@@ -1,0 +1,191 @@
+/**
+ * "Across the Talmud" — the rabbi's accumulated reverse-index, the LIVING
+ * counterpart to the static rabbi.geography biography. As more dapim are
+ * studied (and warmed), the `rabbi.observations` collector records where this
+ * rabbi appears, whom they appear with, and the opinions / stories / verse
+ * expositions they feature in — each tagged to a daf. This panel reads the
+ * accumulated view from GET /api/rabbi-observations/:slug and surfaces the
+ * frequency signals (companions + places by how many dapim carry them, plus
+ * encounter counts). It GROWS over time; nothing here is AI-generated.
+ *
+ * Read-only and lazy: fetches once per rabbi (slug), shows a loading line, and
+ * renders nothing until there is accumulated data.
+ */
+
+import { createResource, For, type JSX, Show } from 'solid-js';
+import { t } from './i18n';
+
+interface AggEntry {
+  type: 'place' | 'opinion' | 'story' | 'exegesis' | 'lineage';
+  payload: Record<string, unknown>;
+  dafs: number;
+  confidence: 'high' | 'medium' | 'low';
+}
+
+interface ObsResponse {
+  slug: string;
+  name: string;
+  dafCount: number;
+  byType: Partial<Record<AggEntry['type'], number>>;
+  aggregated: AggEntry[];
+}
+
+interface Props {
+  slug?: string | null;
+}
+
+const PANEL_BG = '#fafaf7';
+const PANEL_BORDER = '#eae8e0';
+
+async function fetchObservations(slug: string): Promise<ObsResponse | null> {
+  // summary=1 drops the (huge) flat observation list; min=2 keeps signals that
+  // recur on at least two dapim (drops one-off noise). Cached server-side.
+  const r = await fetch(`/api/rabbi-observations/${encodeURIComponent(slug)}?min=2&summary=1`);
+  if (!r.ok) return null;
+  return (await r.json()) as ObsResponse;
+}
+
+/** Best display label for an aggregated entry's payload. */
+function labelOf(e: AggEntry): string {
+  const p = e.payload;
+  const pick = (k: string): string | undefined =>
+    typeof p[k] === 'string' && p[k] ? (p[k] as string) : undefined;
+  return pick('name') ?? pick('place') ?? pick('title') ?? pick('verseRef') ?? '';
+}
+
+export default function RabbiObservations(props: Props): JSX.Element {
+  const [data] = createResource(
+    () => props.slug || null,
+    (slug) => fetchObservations(slug),
+  );
+
+  const top = (type: AggEntry['type'], n: number): AggEntry[] =>
+    (data()?.aggregated ?? []).filter((e) => e.type === type && labelOf(e)).slice(0, n);
+
+  const oftenWith = () => top('lineage', 6);
+  const places = () => top('place', 6);
+
+  // Encounter counts (raw byType totals — how many we've seen, daf by daf).
+  const stats = (): Array<{ label: string; n: number }> => {
+    const b = data()?.byType ?? {};
+    return [
+      { label: t('rabbi.observations.opinions'), n: b.opinion ?? 0 },
+      { label: t('rabbi.observations.stories'), n: b.story ?? 0 },
+      { label: t('rabbi.observations.exegesis'), n: b.exegesis ?? 0 },
+    ].filter((s) => s.n > 0);
+  };
+
+  const hasData = () => (data()?.dafCount ?? 0) > 0;
+
+  return (
+    <Show when={props.slug}>
+      <Show when={!data.loading} fallback={<LoadingLine />}>
+        <Show when={hasData()}>
+          <div
+            style={{
+              border: `1px solid ${PANEL_BORDER}`,
+              'border-radius': '6px',
+              background: PANEL_BG,
+              padding: '0.75rem 0.95rem 0.85rem',
+              'margin-top': '0.7rem',
+            }}
+          >
+            <div
+              style={{
+                'font-size': '0.7rem',
+                'text-transform': 'uppercase',
+                'letter-spacing': '0.08em',
+                color: '#888',
+                'margin-bottom': '0.5rem',
+              }}
+            >
+              {t('rabbi.observations.title')}
+            </div>
+
+            <div style={{ 'font-size': '0.82rem', color: '#444', 'margin-bottom': '0.55rem' }}>
+              {t('rabbi.observations.appearsOn', { n: String(data()?.dafCount ?? 0) })}
+              <Show when={stats().length > 0}>
+                {' · '}
+                <For each={stats()}>
+                  {(s, i) => (
+                    <span>
+                      <Show when={i() > 0}>{' · '}</Show>
+                      <strong style={{ color: '#333' }}>{s.n.toLocaleString()}</strong> {s.label}
+                    </span>
+                  )}
+                </For>
+              </Show>
+            </div>
+
+            <Show when={oftenWith().length > 0}>
+              <ChipRow heading={t('rabbi.observations.oftenWith')} entries={oftenWith()} />
+            </Show>
+            <Show when={places().length > 0}>
+              <ChipRow heading={t('rabbi.observations.places')} entries={places()} />
+            </Show>
+          </div>
+        </Show>
+      </Show>
+    </Show>
+  );
+}
+
+function LoadingLine(): JSX.Element {
+  return (
+    <p
+      style={{
+        margin: '0.55rem 0 0',
+        color: '#999',
+        'font-style': 'italic',
+        'font-size': '0.8rem',
+      }}
+    >
+      {t('rabbi.observations.loading')}
+    </p>
+  );
+}
+
+function ChipRow(props: { heading: string; entries: AggEntry[] }): JSX.Element {
+  return (
+    <div style={{ 'margin-top': '0.4rem' }}>
+      <div
+        style={{
+          'font-size': '0.64rem',
+          'text-transform': 'uppercase',
+          'letter-spacing': '0.06em',
+          color: '#999',
+          'margin-bottom': '0.25rem',
+        }}
+      >
+        {props.heading}
+      </div>
+      <div style={{ display: 'flex', 'flex-wrap': 'wrap', gap: '0.3rem' }}>
+        <For each={props.entries}>
+          {(e) => (
+            <span
+              title={t('rabbi.observations.onNDapim', { n: String(e.dafs) })}
+              style={{
+                display: 'inline-flex',
+                'align-items': 'baseline',
+                gap: '0.25rem',
+                padding: '0.12rem 0.4rem',
+                'border-radius': '10px',
+                background: '#fff',
+                border: '1px solid #e5e3dc',
+                'font-size': '0.78rem',
+                color: '#333',
+              }}
+            >
+              {labelOf(e)}
+              <span
+                style={{ color: '#a98', 'font-size': '0.66rem', 'font-variant': 'tabular-nums' }}
+              >
+                {e.dafs}
+              </span>
+            </span>
+          )}
+        </For>
+      </div>
+    </div>
+  );
+}

--- a/packages/talmud/src/client/i18n.ts
+++ b/packages/talmud/src/client/i18n.ts
@@ -1009,6 +1009,16 @@ const CATALOG = {
   'rabbi.places.confidence.high': { en: 'high', he: 'גבוהה' },
   'rabbi.places.confidence.medium': { en: 'medium', he: 'בינונית' },
   'rabbi.places.confidence.low': { en: 'low', he: 'נמוכה' },
+  // — Across the Talmud (accumulated observations) —
+  'rabbi.observations.title': { en: 'Across the Talmud', he: 'לאורך הש"ס' },
+  'rabbi.observations.appearsOn': { en: 'Appears on {n} dapim', he: 'מופיע ב-{n} דפים' },
+  'rabbi.observations.oftenWith': { en: 'Often appears with', he: 'מופיע לעתים קרובות עם' },
+  'rabbi.observations.places': { en: 'Places', he: 'מקומות' },
+  'rabbi.observations.opinions': { en: 'opinions', he: 'דעות' },
+  'rabbi.observations.stories': { en: 'stories', he: 'סיפורים' },
+  'rabbi.observations.exegesis': { en: 'verse expositions', he: 'דרשות פסוקים' },
+  'rabbi.observations.loading': { en: 'Gathering across the Talmud…', he: 'אוסף מכל הש"ס…' },
+  'rabbi.observations.onNDapim': { en: 'on {n} dapim', he: 'ב-{n} דפים' },
 
   // — Commentary picker / strip —
   'commentary.heading': { en: 'Commentaries on this daf', he: 'מפרשים על הדף' },

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -4346,6 +4346,25 @@ app.get('/api/rabbi-observations/:slug', async (c) => {
   const slug = c.req.param('slug');
   const prefix = prefixForRabbiObs(slug);
 
+  const typeFilterEarly = c.req.query('type') ?? '';
+  const minEarly = Math.max(1, parseInt(c.req.query('min') ?? '1', 10) || 1);
+  // `summary=1` omits the (potentially huge — tens of thousands for Rav) flat
+  // observations list, returning only dafCount + byType + aggregated. The
+  // accumulation card uses this; full reads stay available without the flag.
+  const summary = c.req.query('summary') === '1';
+  // Aggregating a prolific rabbi means a KV.list + a get per daf slice (~1600
+  // for Rav) — too slow to run on every card open. Cache the computed view
+  // with a short TTL; the accumulation is a lifetime signal, so minutes-stale
+  // is fine, and the backfill keeps writing slices underneath regardless. Only
+  // `summary` bodies are cached (the full body's flat list can be many MB and
+  // risk the KV value limit); `type` only narrows that flat list, so it drops
+  // out of the summary key.
+  const aggKey = `rabbi-obs-agg:v1:${slug}:${summary ? 'all' : typeFilterEarly || 'all'}:${minEarly}:${summary ? 's' : 'f'}`;
+  if (summary) {
+    const cachedAgg = await cache.get(aggKey);
+    if (cachedAgg) return c.json(JSON.parse(cachedAgg));
+  }
+
   const keys: string[] = [];
   let cursor: string | undefined;
   do {
@@ -4365,8 +4384,8 @@ app.get('/api/rabbi-observations/:slug', async (c) => {
     }
   }
 
-  const typeFilter = c.req.query('type');
-  const minDafs = Math.max(1, parseInt(c.req.query('min') ?? '1', 10) || 1);
+  const typeFilter = typeFilterEarly || undefined;
+  const minDafs = minEarly;
   const RANK: Record<string, number> = { high: 3, medium: 2, low: 1 };
 
   const byType: Record<string, number> = {};
@@ -4388,7 +4407,7 @@ app.get('/api/rabbi-observations/:slug', async (c) => {
       } else {
         freq.set(o.hash, { type: o.type, payload: o.payload, dafs: 1, confidence: o.confidence });
       }
-      if (!typeFilter || o.type === typeFilter) {
+      if (!summary && (!typeFilter || o.type === typeFilter)) {
         observations.push({ ...o, tractate: s.tractate, page: s.page });
       }
     }
@@ -4397,7 +4416,7 @@ app.get('/api/rabbi-observations/:slug', async (c) => {
     .filter((e) => e.dafs >= minDafs)
     .sort((a, b) => b.dafs - a.dafs || (RANK[b.confidence] ?? 0) - (RANK[a.confidence] ?? 0));
 
-  return c.json({
+  const body = {
     slug,
     name: slices[0]?.name ?? slug,
     nameHe: slices[0]?.nameHe ?? '',
@@ -4405,7 +4424,14 @@ app.get('/api/rabbi-observations/:slug', async (c) => {
     byType,
     aggregated,
     observations,
-  });
+  };
+  // 10-minute TTL: fast on repeat opens; the lifetime view tolerates staleness.
+  // summary only (bounded size); best-effort so a failed/oversized put never
+  // turns a good read into a 500.
+  if (summary) {
+    await cache.put(aggKey, JSON.stringify(body), { expirationTtl: 600 }).catch(() => {});
+  }
+  return c.json(body);
 });
 
 /**

--- a/packages/talmud/tests/client/rabbi-body.test.tsx
+++ b/packages/talmud/tests/client/rabbi-body.test.tsx
@@ -72,10 +72,15 @@ describe('Rabbi recipe card — name-flip', () => {
     expect(sub.textContent).toBe('Rabbi Yochanan');
   });
 
-  it('declares the meta + lineage + geography blocks around the synthesis (flip=rabbi)', () => {
+  it('declares the meta + lineage + geography + observations blocks around the synthesis (flip=rabbi)', () => {
     expect(RABBI_RECIPE.flip).toBe('rabbi');
     const blocks = RABBI_RECIPE.sections.flatMap((s) => (s.type === 'special' ? [s.block] : []));
-    expect(blocks).toEqual(['rabbi-meta', 'rabbi-lineage', 'rabbi-geography']);
+    expect(blocks).toEqual([
+      'rabbi-meta',
+      'rabbi-lineage',
+      'rabbi-geography',
+      'rabbi-observations',
+    ]);
     for (const b of blocks) expect(RABBI_BLOCKS[b]).toBeTypeOf('function');
   });
 });


### PR DESCRIPTION
## Why

**Step 4** of the geography/timeline initiative — surfacing the dormant `rabbi.observations` reverse-index. It's been collecting silently in production (`OBSERVATIONS_WARM_SHAS=1`; a pure deterministic join over cached marks, **no LLM cost**), with a working aggregator endpoint — but **nothing rendered it**. This is the consumer.

It's the *living* counterpart to the static AI biography: a rabbi's record that **grows as you study more dapim** (your original "build up over time as we see more rabbis and their opinions/stories" ask).

## What

A new lazy panel in the rabbi card, below the geography timeline:
- **"Across the Talmud"** — *Appears on N dapim*, with encounter counts (*X opinions · Y stories · Z verse expositions*).
- **Often appears with** — lineage co-occurrence, top companions by how many dapim carry them (e.g. Rav → Rava ×794, Shmuel ×636).
- **Places** — accumulated places by daf-frequency.

Fetched by the rabbi's canonical slug; renders nothing until there's data; shows a loading line while fetching.

- New `RabbiObservations.tsx` + `RABBI_BLOCKS['rabbi-observations']` + a `RABBI_RECIPE` section (deps: `rabbi.identity`, for the slug).
- Endpoint `GET /api/rabbi-observations/:slug` gains:
  - `summary=1` — omit the multi-MB flat observation list (the panel only needs `dafCount`/`byType`/`aggregated`).
  - a **10-min TTL cache** (summary bodies only, **best-effort write**) so a prolific rabbi (~1,600 KV reads for Rav) doesn't re-aggregate on every card open.

## Verified on prod

The data is rich: **Rav** — 1,637 dapim (most-with Rava ×794, Shmuel ×636, R. Yochanan ×628); **Rabbi Akiva** — 735 dapim. (Slug-sensitive: a wrong slug returns empty, which is why the panel keys on `rabbi.identity.slug`.)

## Review / test

- Codex read-only pass: 2 findings fixed (don't cache huge full bodies + best-effort write so a failed/oversized `put` can't 500 a read; normalize the cache key so `type` doesn't pollute summary keys). 1 Low declined (the headline + stat counts always render when `dafCount>0`, so the panel is never empty).
- `pnpm typecheck`, `pnpm lint`, `pnpm test` (2178 talmud + 103 core + 42 tanach) green; updated the rabbi-recipe section test.

Read-only feature; no producer or cache-version change.