### PR TITLE
Alignment + MCP: surface whole-daf marks (geography etc.) + drift test

### DIFF
--- a/packages/talmud/src/client/AlignPage.tsx
+++ b/packages/talmud/src/client/AlignPage.tsx
@@ -75,7 +75,7 @@ interface MarkRow {
   id: string;
   kind: string;
   label: string;
-  anchorBy: 'segment' | 'name';
+  anchorBy: 'segment' | 'name' | 'whole-daf';
   cached: boolean;
   instances: (SegInst | NameInst)[];
   meta: MarkMeta | null;
@@ -215,9 +215,14 @@ export function AlignPage(): JSX.Element {
   const items = () => ctx()?.items ?? [];
   const timing = () => ctx()?.timing ?? [];
   const allMarks = () =>
-    (marksRes()?.marks ?? []).filter((m) => m.cached && m.instances.length > 0);
+    // whole-daf marks (geography, daf-background, …) anchor to the spine as a
+    // whole, so they carry no instances — keep them on `cached` alone.
+    (marksRes()?.marks ?? []).filter(
+      (m) => m.cached && (m.instances.length > 0 || m.anchorBy === 'whole-daf'),
+    );
   const segMarks = () => allMarks().filter((m) => m.anchorBy === 'segment');
   const nameMarks = () => allMarks().filter((m) => m.anchorBy === 'name');
+  const wholeDafMarks = () => allMarks().filter((m) => m.anchorBy === 'whole-daf');
   const onLine = () => items().filter((i) => i.segs.length > 0);
   const offLine = () => items().filter((i) => i.segs.length === 0);
   const byKey = createMemo(() => new Map(items().map((i) => [i.key, i])));
@@ -310,7 +315,9 @@ export function AlignPage(): JSX.Element {
     ];
     if (onLine().length) c.push({ id: 'line', label: 'On a line', n: onLine().length });
     if (offLine().length) c.push({ id: 'page', label: 'Page-level', n: offLine().length });
-    const nInst = segMarks().reduce((a, m) => a + m.instances.length, 0);
+    // "Marks" covers both segment instances and whole-daf computed marks, so
+    // the chip shows (and counts) even on a daf whose only marks are whole-daf.
+    const nInst = segMarks().reduce((a, m) => a + m.instances.length, 0) + wholeDafMarks().length;
     if (nInst) c.push({ id: 'marks', label: 'Marks', n: nInst });
     for (const m of nameMarks()) {
       const e = entitiesFor(m).length;
@@ -432,6 +439,24 @@ export function AlignPage(): JSX.Element {
       <div class="aw-mkdetail"><span class="aw-label" style="display:block">made from — how it was built (hover to locate · click to inspect)</span>
         <div class="aw-wf"><div class="aw-wfband">collect — sources it drew on</div>${collectRowsHtml(new Set(range))}${gen}</div></div></div>`;
   }
+  // A whole-daf computed mark (geography, daf-background, tidbit, biyun,
+  // argument-overview): no span/name anchor, so it highlights the whole spine
+  // (data-hl="*") and exposes its generation DAG (data-gen) for debugging.
+  function wholeDafRow(m: MarkRow): string {
+    const c = kindColor(m.kind);
+    const usd = m.meta?.cost ? (m.meta.cost.billedUsd ?? m.meta.cost.estimatedUsd) : null;
+    const gen = m.meta
+      ? `<div class="aw-wfband">generate — model run (whole daf)</div>
+         <div class="aw-wfrow" data-gen="${esc(m.id)}" data-hl="*"><div class="aw-wflabel">${markIconHtml(m.kind)}${esc(m.label)} run</div>
+           <div class="aw-wftrack"><div class="aw-wfbar gen" style="width:100%;background:${c}"></div></div>
+           <div class="aw-wfmeta">${fmtMs(m.meta.elapsed_ms)} · ${usd == null ? '<span class="free">unpriced</span>' : `<span class="cost">${fmtUsd(usd)}</span>`}</div></div>`
+      : '';
+    return `<div class="aw-li aw-mkrow" style="--mkc:${c}">
+      <div class="aw-mkhead" data-mkhead data-hl="*">${markIconHtml(m.kind, true)}<span class="aw-nm" style="color:${c}">${esc(m.label)}</span>
+        <span class="aw-range">whole daf</span><span class="aw-chev">▸</span></div>
+      <div class="aw-mkdetail"><span class="aw-label" style="display:block">made from — how it was built (hover to locate · click to inspect)</span>
+        <div class="aw-wf">${gen || '<div class="aw-note">not generated yet</div>'}</div></div></div>`;
+  }
   function scopeRowsHtml(): string {
     const me = meAmud();
     const groups = new Map<
@@ -518,6 +543,11 @@ export function AlignPage(): JSX.Element {
       if (instances.length)
         blocks.push(
           `<div class="aw-grouph">Marks · ${instances.length}</div>${instances.join('')}`,
+        );
+      const wd = wholeDafMarks();
+      if (wd.length)
+        blocks.push(
+          `<div class="aw-grouph">Whole-daf · ${wd.length}</div>${wd.map(wholeDafRow).join('')}`,
         );
     }
     for (const m of nameMarks()) {

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -155,6 +155,7 @@ import { collectContext, type SourceTiming } from './context-providers';
 import { dafCostReport } from './daf-cost';
 import { getRabbiEntryOr404, readJsonBody } from './http-helpers';
 import { noteLintAttempt, readLintFailures } from './lint-failures';
+import { ALIGN_MARKS } from './mark-categories';
 import {
   ARGUMENT_BRIDGE_OUTPUT_SCHEMA,
   ARGUMENT_CROSS_FLOW_OUTPUT_SCHEMA,
@@ -660,21 +661,6 @@ app.delete('/api/marks/:id', async (c) => {
 // uncached mark just reports `cached:false`. Two path params, so it never
 // collides with the single-param `/api/marks/:id` definition route above.
 // Segment-anchored gutter marks (instances carry startSegIdx/endSegIdx).
-const GUTTER_MARKS: { id: string; kind: string }[] = [
-  { id: 'argument', kind: 'argument' },
-  { id: 'halacha', kind: 'halacha' },
-  { id: 'chart', kind: 'chart' },
-  { id: 'aggadata', kind: 'aggadata' },
-  { id: 'yerushalmi', kind: 'yerushalmi' },
-  { id: 'pesukim', kind: 'pesuk' },
-  { id: 'rishonim', kind: 'rishonim' },
-];
-// Name/phrase-anchored marks (markInstances: { excerpt, fields:{name,nameHe,…} }).
-// No segment indices — the workbench locates them by matching nameHe in the text.
-const NAME_MARKS: { id: string; kind: string }[] = [
-  { id: 'rabbi', kind: 'rabbi' },
-  { id: 'places', kind: 'place' },
-];
 function instanceLabel(fields: Record<string, unknown> | undefined): string {
   const f = fields ?? {};
   for (const k of ['title', 'topic', 'theme', 'caption', 'verseRef', 'summary']) {
@@ -699,54 +685,51 @@ app.get('/api/marks/:tractate/:page', async (c) => {
           cost: hit.cost ?? null,
         }
       : null;
-  for (const gm of GUTTER_MARKS) {
-    const def = findCodeMark(gm.id);
+  // One loop over the DERIVED alignment-mark list (ALIGN_MARKS, from CODE_MARKS
+  // by anchor) — segment, name, AND whole-daf computed marks. Deriving it means
+  // a newly added mark can't be silently dropped from the workbench/MCP
+  // (geography once was); the coverage test pins it.
+  for (const am of ALIGN_MARKS) {
+    const def = findCodeMark(am.id);
     if (!def) continue;
     const hit = await readCachedResult(c.env, keyForMark(def, tractate, page, lang));
     const parsed = hit?.parsed as { instances?: unknown } | null;
-    const raw = Array.isArray(parsed?.instances) ? (parsed!.instances as RawInstance[]) : [];
-    const instances = raw
-      .filter((i) => typeof i.startSegIdx === 'number' && typeof i.endSegIdx === 'number')
-      .map((i) => ({
-        startSegIdx: i.startSegIdx as number,
-        endSegIdx: i.endSegIdx as number,
-        label: instanceLabel(i.fields),
-      }));
-    marks.push({
-      id: gm.id,
-      kind: gm.kind,
-      label: def.label ?? gm.id,
-      anchorBy: 'segment',
+    const base = {
+      id: am.id,
+      kind: am.kind,
+      label: def.label ?? am.id,
       cached: !!hit,
-      instances,
       meta: metaOf(hit),
-    });
-  }
-  for (const nm of NAME_MARKS) {
-    const def = findCodeMark(nm.id);
-    if (!def) continue;
-    const hit = await readCachedResult(c.env, keyForMark(def, tractate, page, lang));
-    const parsed = hit?.parsed as { instances?: unknown } | null;
-    const raw = Array.isArray(parsed?.instances)
-      ? (parsed!.instances as { excerpt?: unknown; fields?: Record<string, unknown> }[])
-      : [];
-    const instances = raw
-      .map((i) => ({
-        name: str(i.fields?.name),
-        nameHe: str(i.fields?.nameHe),
-        generation: str(i.fields?.generation),
-        excerpt: str(i.excerpt),
-      }))
-      .filter((x) => x.nameHe || x.name);
-    marks.push({
-      id: nm.id,
-      kind: nm.kind,
-      label: def.label ?? nm.id,
-      anchorBy: 'name',
-      cached: !!hit,
-      instances,
-      meta: metaOf(hit),
-    });
+    };
+    if (am.anchorBy === 'segment') {
+      const raw = Array.isArray(parsed?.instances) ? (parsed!.instances as RawInstance[]) : [];
+      const instances = raw
+        .filter((i) => typeof i.startSegIdx === 'number' && typeof i.endSegIdx === 'number')
+        .map((i) => ({
+          startSegIdx: i.startSegIdx as number,
+          endSegIdx: i.endSegIdx as number,
+          label: instanceLabel(i.fields),
+        }));
+      marks.push({ ...base, anchorBy: 'segment', instances });
+    } else if (am.anchorBy === 'name') {
+      const raw = Array.isArray(parsed?.instances)
+        ? (parsed!.instances as { excerpt?: unknown; fields?: Record<string, unknown> }[])
+        : [];
+      const instances = raw
+        .map((i) => ({
+          name: str(i.fields?.name),
+          nameHe: str(i.fields?.nameHe),
+          generation: str(i.fields?.generation),
+          excerpt: str(i.excerpt),
+        }))
+        .filter((x) => x.nameHe || x.name);
+      marks.push({ ...base, anchorBy: 'name', instances });
+    } else {
+      // whole-daf: a computed daf-level mark (geography, daf-background, tidbit,
+      // biyun, argument-overview). No span/name instances — the workbench
+      // anchors it to the whole spine.
+      marks.push({ ...base, anchorBy: 'whole-daf', instances: [] });
+    }
   }
   return c.json({ tractate, page, lang, marks });
 });

--- a/packages/talmud/src/worker/mark-categories.ts
+++ b/packages/talmud/src/worker/mark-categories.ts
@@ -1,0 +1,45 @@
+/**
+ * Which marks the alignment workbench (`/api/marks` → AlignPage) lists, and how
+ * each anchors. DERIVED from CODE_MARKS by the mark's own `anchor`, so a newly
+ * added mark can never be silently omitted (geography once was). The coverage
+ * test (tests/align-marks-coverage.test.ts) fails if a mark is neither
+ * categorized here nor explicitly excluded below.
+ */
+
+import { CODE_MARKS } from './code-marks';
+
+/** The mark's anchor, projected to the workbench's three display buckets. */
+export type AlignAnchor = 'segment' | 'name' | 'whole-daf';
+
+/** Marks deliberately NOT surfaced in the workbench. Keep tiny + documented —
+ *  the coverage test forces a conscious decision for every new mark. */
+export const ALIGN_EXCLUDED: ReadonlySet<string> = new Set<string>([
+  // The sub-move layer of `argument`; the workbench shows the section layer.
+  'argument-move',
+]);
+
+/** Map a mark's `anchor` onto an alignment bucket; null = unknown anchor type
+ *  (the coverage test flags it so it can't slip through uncategorized). */
+export function alignAnchorOf(anchor: string): AlignAnchor | null {
+  if (anchor === 'segment' || anchor === 'segment-range') return 'segment';
+  if (anchor === 'phrase' || anchor === 'name') return 'name';
+  if (anchor === 'whole-daf') return 'whole-daf';
+  return null;
+}
+
+// `kind` drives the gutter icon/color in the workbench — mostly the id, a few
+// aliases where the icon key differs from the mark id.
+const KIND_ALIAS: Record<string, string> = { pesukim: 'pesuk', places: 'place' };
+
+export interface AlignMarkEntry {
+  id: string;
+  kind: string;
+  anchorBy: AlignAnchor;
+}
+
+/** Every mark the workbench lists, derived from CODE_MARKS by anchor. */
+export const ALIGN_MARKS: AlignMarkEntry[] = CODE_MARKS.flatMap((m) => {
+  if (ALIGN_EXCLUDED.has(m.id)) return [];
+  const anchorBy = alignAnchorOf(m.anchor);
+  return anchorBy ? [{ id: m.id, kind: KIND_ALIAS[m.id] ?? m.id, anchorBy }] : [];
+});

--- a/packages/talmud/src/worker/mcp-openapi.ts
+++ b/packages/talmud/src/worker/mcp-openapi.ts
@@ -215,6 +215,24 @@ export const TALMUD_OPENAPI: Record<string, unknown> = {
         },
       },
     },
+    '/api/marks/{tractate}/{page}': {
+      get: {
+        summary:
+          "What the alignment workbench shows: every cached mark on this daf + where it anchors. Each entry is { id, kind, label, anchorBy: 'segment'|'name'|'whole-daf', cached, instances, meta }. Whole-daf computed marks (geography, daf-background, tidbit, biyun, argument-overview) appear with anchorBy 'whole-daf' and no instances. The fastest way to see which pieces exist on a daf without running anything.",
+        parameters: [
+          tractate,
+          page,
+          {
+            name: 'lang',
+            in: 'query',
+            required: false,
+            schema: { type: 'string', enum: ['en', 'he'] },
+            description: 'Language of the cached marks to read (default en).',
+          },
+        ],
+        responses: { '200': { description: '{ tractate, page, lang, marks: [...] }' } },
+      },
+    },
 
     '/api/enrichments': {
       get: {
@@ -340,8 +358,16 @@ export const TALMUD_OPENAPI: Record<string, unknown> = {
             schema: { type: 'integer' },
             description: 'Minimum daf count to include an aggregated observation.',
           },
+          {
+            name: 'summary',
+            in: 'query',
+            required: false,
+            schema: { type: 'string', enum: ['1'] },
+            description:
+              'summary=1 drops the (large) flat observation list, returning only dafCount + byType + aggregated. Cached server-side (~10 min).',
+          },
         ],
-        responses: { '200': { description: '{ observations, aggregated, byType }' } },
+        responses: { '200': { description: '{ dafCount, byType, aggregated, observations }' } },
       },
     },
 

--- a/packages/talmud/tests/align-marks-coverage.test.ts
+++ b/packages/talmud/tests/align-marks-coverage.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { CODE_MARKS } from '../src/worker/code-marks';
+import { ALIGN_EXCLUDED, ALIGN_MARKS, alignAnchorOf } from '../src/worker/mark-categories';
+
+/**
+ * Guards the alignment workbench / GET /api/marks against silent drift: every
+ * code mark must be either categorized for the workbench (ALIGN_MARKS, derived
+ * by anchor) or explicitly excluded (ALIGN_EXCLUDED). Adding a new mark without
+ * doing one of those fails here — which is how `geography` slipped out of the
+ * workbench before.
+ */
+describe('alignment mark coverage', () => {
+  it('every code mark is categorized for alignment or explicitly excluded', () => {
+    const categorized = new Set(ALIGN_MARKS.map((m) => m.id));
+    const uncovered = CODE_MARKS.map((m) => m.id).filter(
+      (id) => !categorized.has(id) && !ALIGN_EXCLUDED.has(id),
+    );
+    expect(uncovered).toEqual([]);
+  });
+
+  it('every non-excluded mark maps to a known alignment anchor bucket', () => {
+    const unknown = CODE_MARKS.filter(
+      (m) => !ALIGN_EXCLUDED.has(m.id) && alignAnchorOf(m.anchor) === null,
+    ).map((m) => `${m.id}:${m.anchor}`);
+    expect(unknown).toEqual([]);
+  });
+
+  it('exclusions reference real marks (no stale ids)', () => {
+    const ids = new Set(CODE_MARKS.map((m) => m.id));
+    expect([...ALIGN_EXCLUDED].filter((id) => !ids.has(id))).toEqual([]);
+  });
+
+  it('ALIGN_MARKS and ALIGN_EXCLUDED are disjoint', () => {
+    expect(ALIGN_MARKS.filter((m) => ALIGN_EXCLUDED.has(m.id))).toEqual([]);
+  });
+
+  it('whole-daf computed marks (incl. geography) are surfaced', () => {
+    const byId = new Map(ALIGN_MARKS.map((m) => [m.id, m]));
+    for (const id of ['geography', 'daf-background', 'tidbit', 'biyun', 'argument-overview']) {
+      expect(byId.get(id)?.anchorBy).toBe('whole-daf');
+    }
+  });
+});


### PR DESCRIPTION
## Why

The alignment workbench (and `GET /api/marks/:t/:p`) bills itself as "every source," but it only listed **segment-** and **name-anchored** marks. Every **whole-daf computed mark — `geography`, `daf-background`, `tidbit`, `biyun`, `argument-overview` — was silently omitted.** That's why geography wasn't in alignment. Fix the root cause + prevent it ever recurring.

## What

- **`mark-categories.ts`** — `ALIGN_MARKS` is now **derived from `CODE_MARKS`** by each mark's `anchor` (`segment` | `name` | `whole-daf`), minus a tiny explicit `ALIGN_EXCLUDED` (`argument-move`, the sub-move layer of `argument`). A newly added mark can no longer be silently dropped from the workbench.
- **`/api/marks/:t/:p`** iterates `ALIGN_MARKS` and emits whole-daf marks (`anchorBy: 'whole-daf'`, no instances). Segment/name output is byte-for-byte the same.
- **AlignPage** lists a **"Whole-daf"** group — each row highlights the whole spine and exposes its **generation DAG** (debuggable like any other mark); the "Marks" filter chip counts them.
- **MCP / OpenAPI** — documents `GET /api/marks/:t/:p` (the per-daf cached-marks listing, now incl. whole-daf — the fastest way to see what exists on a daf) and the `rabbi-observations` `summary` param.
- **New test (`align-marks-coverage`)** — exactly what you asked for: every `CODE_MARK` is either categorized for alignment or explicitly excluded; every anchor maps to a known bucket; no stale exclusions; whole-daf marks (incl. geography) are surfaced. **Adding/removing a mark without updating alignment now fails CI.**

## Test / review

- `pnpm typecheck`, `pnpm lint`, `pnpm test` (2183 talmud + 103 core + 42 tanach) green.
- Codex read-only: confirmed segment/name shapes preserved, `argument-move` still excluded, anchors map as intended; its one Low (the Marks chip not counting whole-daf rows) is fixed.

Read-only debug surfaces; no producer/cache-version change.