### PR TITLE
Spine: related-gemaras (Mesorat HaShas) parallels as deterministic links

### DIFF
--- a/packages/talmud/src/lib/context/dafLinks.ts
+++ b/packages/talmud/src/lib/context/dafLinks.ts
@@ -23,12 +23,15 @@ import {
   type LinkRelation,
 } from '@corpus/core/context/link';
 import type { ContextItem } from '@corpus/core/context/types';
+import type { TalmudParallel } from '../sefref/sefaria/client.ts';
+import { talmudParallelsToLinks } from './parallels.ts';
 
 /** A link on a daf: where it lives (`source`), the `relation`, and what it
  *  points at (`targets`). `via` records which producer it came from, for
- *  display + debugging. */
+ *  display + debugging. ('mesorah' = the Mesorat HaShas parallel-sugya
+ *  apparatus — unrelated to the rabbi-transmission `mesorah:` cache namespace.) */
 export interface DafLink {
-  via: 'bridge' | 'context' | 'flow' | 'commentary' | 'cross-flow';
+  via: 'bridge' | 'context' | 'flow' | 'commentary' | 'cross-flow' | 'mesorah';
   source: AnchorCoord;
   relation: LinkRelation;
   targets: AnchorCoord[];
@@ -49,6 +52,10 @@ export interface DafLinkInputs {
   /** Commentary works on this daf — each becomes a 'glosses' link from its own
    *  spine to the daf segments it glosses. Optional/absent contributes nothing. */
   commentaryWorks?: readonly CommentaryWorkLike[];
+  /** Talmud↔Talmud parallels (Mesorat HaShas) from Sefaria's apparatus — each
+   *  becomes a 'parallels' link from its anchored segment on this daf to a
+   *  passage elsewhere in Shas. Optional/absent contributes nothing. */
+  talmudParallels?: readonly TalmudParallel[];
 }
 
 export function dafLinks(daf: DafRef, input: DafLinkInputs): DafLink[] {
@@ -103,6 +110,10 @@ export function dafLinks(daf: DafRef, input: DafLinkInputs): DafLink[] {
       note: gl.source.spine,
     });
   }
+
+  // 5) Talmud parallels: Mesorat HaShas cross-references to parallel sugyot
+  //    elsewhere in Shas (deterministic, from Sefaria's apparatus).
+  out.push(...talmudParallelsToLinks(daf, input.talmudParallels ?? []));
 
   return out;
 }

--- a/packages/talmud/src/lib/context/parallels.ts
+++ b/packages/talmud/src/lib/context/parallels.ts
@@ -1,0 +1,82 @@
+/**
+ * talmudParallels — project a daf's Talmud↔Talmud cross-references (the
+ * "Mesorat HaShas" apparatus: where the same sugya, baraita, or dispute recurs
+ * elsewhere in Shas) into the shared Link vocabulary.
+ *
+ * The data is Sefaria's `category: "Talmud"` related links — a human-curated
+ * apparatus, so the edges are high-precision by construction. Each link carries
+ * `anchorRef` (the segment on THIS daf) and `ref` (the parallel passage). This
+ * pure module parses those refs to global coordinates and emits one
+ * `relation: 'parallels'` DafLink per cross-reference (`via: 'mesorah'`), so a
+ * parallel sugya joins the daf/tractate link graph exactly like a flow edge or
+ * a citation — no bespoke encoding.
+ *
+ * PRECISION over recall: a ref that doesn't parse to a Bavli coordinate
+ * (Yerushalmi chapter:halacha, a Tanakh verse) is dropped, not guessed, and a
+ * parallel that points back onto the same daf carries no cross-daf information
+ * so it is dropped too.
+ */
+
+import { type AnchorCoord, coordForSeg, DAF_SEG, type DafRef } from '@corpus/core/context/coord';
+import type { TalmudParallel } from '../sefref/sefaria/client.ts';
+import type { DafLink } from './dafLinks.ts';
+
+/**
+ * Parse a Sefaria Bavli ref into an `AnchorCoord` at its START coordinate.
+ * Handles multi-word tractate names ("Bava Metzia 59a", "Rosh Hashanah 16b:3"),
+ * an optional segment (Sefaria's 1-indexed `:N` → 0-indexed), and ranges of
+ * either form ("31a:5-7" or the cross-daf "59a:12-59b:7") — the trailing range
+ * is ignored and the start coordinate taken. A bare daf ref ("Shabbat 31a") is
+ * daf-level ({@link DAF_SEG}). Returns null for anything that isn't a BAVLI
+ * "<words> <daf>[:seg]" ref: Yerushalmi chapter:halacha + Tanakh verses fail the
+ * shape, and folio-style Yerushalmi ("Jerusalem Talmud Berakhot 2a") — which is
+ * also Sefaria `category:'Talmud'` and DOES match the shape — is rejected by
+ * title, since the Bavli↔Yerushalmi parallel is a separate, richer producer.
+ */
+export function parseTalmudRef(ref: string): AnchorCoord | null {
+  const m = (ref ?? '').trim().match(/^(.+?)\s+(\d+[ab])(?::(\d+))?(?:[-–].*)?$/);
+  if (!m) return null;
+  const tractate = m[1];
+  const page = m[2];
+  // The Yerushalmi shares the category:'Talmud' channel and a folio ref shape,
+  // but it is a different spine/corpus — keep this Bavli-parallels path clean.
+  if (/^(?:Jerusalem Talmud|Yerushalmi)\b/i.test(tractate)) return null;
+  if (!m[3]) return { tractate, page, seg: DAF_SEG };
+  const seg = Number.parseInt(m[3], 10) - 1;
+  if (!Number.isFinite(seg) || seg < 0) return null;
+  return { tractate, page, seg };
+}
+
+/** The 0-indexed source segment a parallel anchors to on the current daf — the
+ *  start segment of the anchorRef, or 0 when the apparatus anchors the whole
+ *  daf. Reuses {@link parseTalmudRef} so ranges resolve to their start. */
+function anchorSeg(anchorRef: string): number {
+  const c = parseTalmudRef(anchorRef);
+  return c && c.seg >= 0 ? c.seg : 0;
+}
+
+/**
+ * Project a daf's Talmud parallels into DafLinks (`relation: 'parallels'`,
+ * `via: 'mesorah'`): source = the anchored segment on THIS daf, target = the
+ * parallel passage elsewhere in Shas. Drops self-links (a parallel onto the same
+ * daf) and refs that don't parse to a Bavli coordinate, and dedupes identical
+ * (source-segment, target) pairs.
+ */
+export function talmudParallelsToLinks(
+  daf: DafRef,
+  parallels: readonly TalmudParallel[],
+): DafLink[] {
+  const out: DafLink[] = [];
+  const seen = new Set<string>();
+  for (const p of parallels) {
+    const target = parseTalmudRef(p.targetRef);
+    if (!target) continue;
+    if (target.tractate === daf.tractate && target.page === daf.page) continue;
+    const source = coordForSeg(daf, anchorSeg(p.anchorRef));
+    const dedup = `${source.seg}|${target.tractate}:${target.page}:${target.seg}`;
+    if (seen.has(dedup)) continue;
+    seen.add(dedup);
+    out.push({ via: 'mesorah', source, relation: 'parallels', targets: [target] });
+  }
+  return out;
+}

--- a/packages/talmud/src/lib/sefref/sefaria/client.ts
+++ b/packages/talmud/src/lib/sefref/sefaria/client.ts
@@ -224,6 +224,16 @@ export function rishonLabel(indexTitle: string, tractate: string): string | null
  *  Sefaria returns it on /api/related links. */
 export const EIN_MISHPAT_LINK_TYPE = 'ein mishpat / ner mitsvah';
 
+/** One Talmud↔Talmud cross-reference from Sefaria's "Mesorat HaShas" apparatus
+ *  (its `category: "Talmud"` related links): `anchorRef` is the segment on the
+ *  queried daf, `targetRef` the parallel passage elsewhere in Shas. The raw
+ *  Sefaria refs — `talmudParallelsToLinks` (src/lib/context/parallels.ts) parses
+ *  them to coordinates. */
+export interface TalmudParallel {
+  anchorRef: string;
+  targetRef: string;
+}
+
 /** Parse the trailing segment range from a Sefaria ref like
  *  "Berakhot 2a:1-5" → { start: 1, end: 5 } or "Shabbat 20b:5" →
  *  { start: 5, end: 5 }. Returns null if no trailing segment is present.
@@ -588,6 +598,34 @@ class SefariaAPI {
         category: l.category,
         einMishpat: l.type === EIN_MISHPAT_LINK_TYPE || undefined,
       }));
+  }
+
+  /**
+   * Forward Talmud↔Talmud parallels for a gemara daf — the "related gemaras"
+   * apparatus (Mesorat HaShas + Sefaria's editorial parallels), surfaced as
+   * `category: "Talmud"` links on /api/related. The inverse direction of
+   * `fetchCodeSources` (which reads the same category from a CODE ref). Each
+   * kept link carries its `anchorRef` (the segment on THIS daf) + `ref` (the
+   * parallel passage); the projection to coordinates lives in parallels.ts.
+   *
+   * Lets `getRelated` throw on failure — the caller's cache wrapper
+   * distinguishes "no parallels" (cache an empty array) from "fetch failed"
+   * (don't cache, retry later).
+   */
+  async fetchTalmudParallels(tractate: string, page: string): Promise<TalmudParallel[]> {
+    const ref = `${tractate}.${page}`;
+    const related = await this.getRelated(ref);
+    const out: TalmudParallel[] = [];
+    const seen = new Set<string>();
+    for (const l of related.links) {
+      if (l.category !== 'Talmud') continue;
+      if (!l.ref || !l.anchorRef) continue;
+      const dedup = `${l.anchorRef}|${l.ref}`;
+      if (seen.has(dedup)) continue;
+      seen.add(dedup);
+      out.push({ anchorRef: l.anchorRef, targetRef: l.ref });
+    }
+    return out;
   }
 
   /**

--- a/packages/talmud/src/worker/cache-keys.ts
+++ b/packages/talmud/src/worker/cache-keys.ts
@@ -95,6 +95,14 @@ export function keyForMishnaBundle(tractate: string, page: string): string {
 export function keyForYerushalmi(tractate: string, page: string): string {
   return `yerushalmi:v1:${tractate}:${page}`;
 }
+/** Talmud↔Talmud parallels on this daf — Sefaria's "Mesorat HaShas" apparatus
+ *  (`category: "Talmud"` related links) projected into the spine link graph as
+ *  `parallels` edges. One getRelated call; daf-keyed since the apparatus doesn't
+ *  vary by argument. Distinct prefix from keyForMesorah (rabbi transmission).
+ *  RAW tractate:page like its source-bundle siblings above. */
+export function keyForTalmudParallels(tractate: string, page: string): string {
+  return `talmud-parallels:v1:${tractate}:${page}`;
+}
 /** Shulchan Aruch commentary, keyed by an already-sanitised Sefaria ref. */
 export function keyForSaCommentary(safeKey: string): string {
   return `sa-commentary:v1:${safeKey}`;

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -201,7 +201,9 @@ import {
   getRishonimCached,
   getSefariaPageCached,
   getSefariaSegmentsCached,
+  getTalmudParallelsCached,
   getYerushalmiCached,
+  readCachedTalmudParallels,
   type SefariaSegments,
 } from './source-cache';
 import { computeCoverage, isKnownTractate } from './spine-coverage';
@@ -1101,6 +1103,11 @@ app.get('/api/links/:tractate/:page', async (c) => {
   // nothing rather than failing the response — same contract as the others.
   const commentary = await fetchCommentaryWorks(c.env, tractate, page).catch(() => null);
   const commentaryWorks = commentary && !('error' in commentary) ? commentary.works : [];
+  // Talmud↔Talmud parallels (Mesorat HaShas): deterministic, from Sefaria's
+  // apparatus. Fetch-on-miss + cache, like the other source bundles above.
+  const talmudParallels = await getTalmudParallelsCached(c.env.CACHE, tractate, page).catch(
+    () => [],
+  );
 
   const links = dafLinks(daf, {
     continuesTo: bridge?.continues ? bridge.to : null,
@@ -1108,6 +1115,7 @@ app.get('/api/links/:tractate/:page', async (c) => {
     flowEdges,
     sectionStartSegs,
     commentaryWorks,
+    talmudParallels,
   });
   return c.json({ tractate, page, count: links.length, links });
 });
@@ -1313,6 +1321,7 @@ async function readDafParts(env: Bindings, tractate: string, page: string): Prom
   const flowEdges = await readFlowConnections(env, tractate, page);
   const bridge = await readCachedBridge(env, tractate, page);
   const cross = await readCachedCrossFlow(env, tractate, page);
+  const talmudParallels = await readCachedTalmudParallels(env.CACHE, tractate, page);
   const withinLinks = dafLinks(
     { tractate, page },
     {
@@ -1321,6 +1330,7 @@ async function readDafParts(env: Bindings, tractate: string, page: string): Prom
       flowEdges,
       sectionStartSegs: startSegs,
       commentaryWorks: [],
+      talmudParallels,
     },
   );
   return { withinLinks, startSegs, crossEdges: cross?.edges ?? [] };

--- a/packages/talmud/src/worker/source-cache.ts
+++ b/packages/talmud/src/worker/source-cache.ts
@@ -27,6 +27,7 @@ import {
   type SefariaTopicBundle,
   sefariaAPI,
   type TalmudPageData,
+  type TalmudParallel,
   type YerushalmiBundle,
 } from '../lib/sefref';
 import type { DafyomiDaf } from '../lib/sefref/dafyomi/schema';
@@ -41,6 +42,7 @@ import {
   keyForSaCommentary,
   keyForSefariaBundle,
   keyForSefariaSegments,
+  keyForTalmudParallels,
   keyForYerushalmi,
 } from './cache-keys';
 import { scrapeDafyomiLive } from './dafyomi-live';
@@ -287,6 +289,45 @@ export async function getYerushalmiCached(
   } catch {
     return [];
   }
+}
+
+/**
+ * Cache this daf's Talmud↔Talmud parallels (the "Mesorat HaShas" apparatus:
+ * related gemaras elsewhere in Shas), located via Sefaria's `category: "Talmud"`
+ * related links. One getRelated call; daf-keyed since the apparatus doesn't vary
+ * by argument. 30-day TTL like the other source bundles. A daf with genuinely no
+ * parallels caches an empty array; a fetch FAILURE (fetchTalmudParallels lets
+ * getRelated throw) returns [] WITHOUT caching, so it retries later.
+ */
+export async function getTalmudParallelsCached(
+  cache: KVNamespace | undefined,
+  tractate: string,
+  page: string,
+): Promise<TalmudParallel[]> {
+  const key = keyForTalmudParallels(tractate, page);
+  const hit = await readCache<TalmudParallel[]>(cache, key);
+  if (hit) return hit;
+  try {
+    const data = await sefariaAPI.fetchTalmudParallels(tractate, page);
+    await writeCache(cache, key, data);
+    return data;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Read-only: this daf's cached Talmud parallels, or [] if not yet computed.
+ * NEVER fetches — the spine sweep reads across a whole tractate and must not fan
+ * out network calls (the same contract as readCachedBridge / readCachedCrossFlow
+ * in index.ts). The apparatus fills into the spine as dapim are warmed.
+ */
+export async function readCachedTalmudParallels(
+  cache: KVNamespace | undefined,
+  tractate: string,
+  page: string,
+): Promise<TalmudParallel[]> {
+  return (await readCache<TalmudParallel[]>(cache, keyForTalmudParallels(tractate, page))) ?? [];
 }
 
 export async function getSaCommentaryCached(

--- a/packages/talmud/tests/parallels.test.ts
+++ b/packages/talmud/tests/parallels.test.ts
@@ -1,0 +1,105 @@
+import { DAF_SEG } from '@corpus/core/context/coord';
+import { describe, expect, it } from 'vitest';
+import { parseTalmudRef, talmudParallelsToLinks } from '../src/lib/context/parallels';
+
+describe('parseTalmudRef', () => {
+  it('parses a bare daf ref to a daf-level coord', () => {
+    expect(parseTalmudRef('Shabbat 31a')).toEqual({
+      tractate: 'Shabbat',
+      page: '31a',
+      seg: DAF_SEG,
+    });
+  });
+  it('parses a segment ref, converting Sefaria 1-indexed to 0-indexed', () => {
+    expect(parseTalmudRef('Shabbat 31a:5')).toEqual({ tractate: 'Shabbat', page: '31a', seg: 4 });
+  });
+  it('takes the start of a same-daf range', () => {
+    expect(parseTalmudRef('Bava Metzia 59a:12-18')).toEqual({
+      tractate: 'Bava Metzia',
+      page: '59a',
+      seg: 11,
+    });
+  });
+  it('takes the start of a cross-daf range', () => {
+    expect(parseTalmudRef('Bava Metzia 59a:12-59b:7')).toEqual({
+      tractate: 'Bava Metzia',
+      page: '59a',
+      seg: 11,
+    });
+  });
+  it('keeps multi-word tractate names intact', () => {
+    expect(parseTalmudRef('Rosh Hashanah 16b:3')).toEqual({
+      tractate: 'Rosh Hashanah',
+      page: '16b',
+      seg: 2,
+    });
+  });
+  it('rejects non-Bavli refs (Yerushalmi chapter:halacha, Tanakh verses)', () => {
+    expect(parseTalmudRef('Jerusalem Talmud Berakhot 2:1')).toBeNull();
+    expect(parseTalmudRef('Genesis 1:1')).toBeNull();
+    expect(parseTalmudRef('')).toBeNull();
+  });
+  it('rejects folio-style Yerushalmi (same category:Talmud channel + daf shape)', () => {
+    // Sefaria surfaces these under category:'Talmud' and they match the Bavli
+    // ref shape — must be excluded so this Bavli-parallels path stays clean.
+    expect(parseTalmudRef('Jerusalem Talmud Berakhot 2a')).toBeNull();
+    expect(parseTalmudRef('Jerusalem Talmud Bava Metzia 1a:3')).toBeNull();
+  });
+});
+
+describe('talmudParallelsToLinks', () => {
+  const daf = { tractate: 'Berakhot', page: '2a' };
+
+  it('projects a cross-tractate parallel to a parallels link sourced on this daf', () => {
+    const links = talmudParallelsToLinks(daf, [
+      { anchorRef: 'Berakhot 2a:3', targetRef: 'Shabbat 31a:5' },
+    ]);
+    expect(links).toEqual([
+      {
+        via: 'mesorah',
+        relation: 'parallels',
+        source: { tractate: 'Berakhot', page: '2a', seg: 2 },
+        targets: [{ tractate: 'Shabbat', page: '31a', seg: 4 }],
+      },
+    ]);
+  });
+
+  it('anchors at seg 0 when the apparatus anchors the whole daf', () => {
+    const [link] = talmudParallelsToLinks(daf, [
+      { anchorRef: 'Berakhot 2a', targetRef: 'Megillah 3a' },
+    ]);
+    expect(link.source.seg).toBe(0);
+    expect(link.targets[0].seg).toBe(DAF_SEG);
+  });
+
+  it('drops self-links (a parallel onto the same daf)', () => {
+    expect(
+      talmudParallelsToLinks(daf, [{ anchorRef: 'Berakhot 2a:1', targetRef: 'Berakhot 2a:7' }]),
+    ).toEqual([]);
+  });
+
+  it('drops targets that do not parse to a Bavli coordinate (incl. Yerushalmi)', () => {
+    expect(
+      talmudParallelsToLinks(daf, [
+        { anchorRef: 'Berakhot 2a:1', targetRef: 'Jerusalem Talmud Berakhot 1:1' },
+        { anchorRef: 'Berakhot 2a:1', targetRef: 'Jerusalem Talmud Berakhot 2a' },
+      ]),
+    ).toEqual([]);
+  });
+
+  it('dedupes identical (source-segment, target) pairs', () => {
+    const links = talmudParallelsToLinks(daf, [
+      { anchorRef: 'Berakhot 2a:3', targetRef: 'Shabbat 31a:5' },
+      { anchorRef: 'Berakhot 2a:3', targetRef: 'Shabbat 31a:5' },
+    ]);
+    expect(links).toHaveLength(1);
+  });
+
+  it('keeps the same target as distinct edges when anchored at different source segments', () => {
+    const links = talmudParallelsToLinks(daf, [
+      { anchorRef: 'Berakhot 2a:3', targetRef: 'Shabbat 31a:5' },
+      { anchorRef: 'Berakhot 2a:8', targetRef: 'Shabbat 31a:5' },
+    ]);
+    expect(links).toHaveLength(2);
+  });
+});

--- a/packages/talmud/tests/source-cache-keys.test.ts
+++ b/packages/talmud/tests/source-cache-keys.test.ts
@@ -29,6 +29,7 @@ import {
   keyForSaCommentary,
   keyForSefariaBundle,
   keyForSefariaSegments,
+  keyForTalmudParallels,
   keyForTranslate,
   keyForYerushalmi,
   prefixForRabbiObs,
@@ -53,6 +54,7 @@ describe('source-cache keys — byte-exact contract', () => {
     expect(keyForDafTopics(t, p)).toBe('daf-topics:v1:Berakhot:2a');
     expect(keyForMishnaBundle(t, p)).toBe('mishna-bundle:v1:Berakhot:2a');
     expect(keyForYerushalmi(t, p)).toBe('yerushalmi:v1:Berakhot:2a');
+    expect(keyForTalmudParallels(t, p)).toBe('talmud-parallels:v1:Berakhot:2a');
     expect(keyForSaCommentary('Mishnah_Berurah_1:1')).toBe('sa-commentary:v1:Mishnah_Berurah_1:1');
   });
   it('keeps a space/upper-case tractate in the key verbatim (the cold-miss trap)', () => {


### PR DESCRIPTION
First step of widening the spine's connection graph beyond same-tractate flow: **"related gemaras"** — the Talmud↔Talmud parallel-sugya apparatus (Mesorat HaShas) — surfaced as real `parallels` links.

## What & why
Sefaria's `/api/related` (already fetched for every daf to feed rishonim/halacha/mishnah) carries `category: 'Talmud'` links — the human-curated cross-references from a daf to parallel sugyot elsewhere in Shas, with **both endpoints at segment granularity** (`anchorRef` on this daf, `ref` on the target). We only consumed those in reverse before (`fetchCodeSources`, for halacha derivation); forward, they were dropped. This lifts them into the existing link vocabulary as `relation: 'parallels'`, `via: 'mesorah'`.

Deterministic apparatus → **precision-first by construction**, no LLM, no budget.

## How
- **`fetchTalmudParallels`** (Sefaria client): filter `category:'Talmud'` from the related response (mirrors `fetchCodeSources`). Lets `getRelated` throw so the cache wrapper can tell "no parallels" from "fetch failed".
- **`getTalmudParallelsCached`** (fetch-on-miss) + read-only **`readCachedTalmudParallels`** (for the spine sweep, which must never fan out network calls). `keyForTalmudParallels` = `talmud-parallels:v1:<tractate>:<page>` — raw `tractate:page` like its source-bundle siblings; distinct prefix from the unrelated rabbi `mesorah:` namespace.
- **`parseTalmudRef` + `talmudParallelsToLinks`** (pure, unit-tested): parse any ref/range to its **start** coordinate; drop self-links and dedupe; **reject non-Bavli targets** — Tanakh, Yerushalmi chapter:halacha, *and* folio-style "Jerusalem Talmud …" (which shares the `category:'Talmud'` channel and the daf shape) — so this Bavli path stays clean and doesn't pre-empt the planned dedicated Bavli↔Yerushalmi producer.
- Wired into `dafLinks` (new `'mesorah'` via + optional `talmudParallels` input), `GET /api/links/:t/:p` (fetch-on-miss), and the `GET /api/spine-links/:tractate` sweep (read-only).

## Surfacing
- `/api/links` and `/api/spine-links` now include these edges (`byRelation.parallels`, `byVia.mesorah`, coverage counts).
- Same-tractate parallels render in the spine graph automatically via the existing `parallels` color.
- **Follow-ups (intentionally out of scope):** cross-tractate targets currently land as graph nodes + stats but not drawn arrows (the spine-view "exit marker" rendering decision); a reader-facing "Parallel sugyot" card line; adding parallels to a warm set (today they fill in on-demand, like cross-flow).

## Verification
- `pnpm typecheck` clean; full suite **2190 tests pass** (+ new `parallels.test.ts`, 11 cases; `source-cache-keys.test.ts` pins the new key).
- `biome check .` clean.
- Codex read-only review run; its one finding (Yerushalmi leaking through the shared `category:'Talmud'` channel) is fixed by the title-based rejection above.