### PR TITLE
Spine: auto-load + warm cross-daf links, remove Assembled spine

### DIFF
--- a/packages/talmud/src/client/SpineCoveragePage.tsx
+++ b/packages/talmud/src/client/SpineCoveragePage.tsx
@@ -159,11 +159,10 @@ export function SpineCoveragePage(): JSX.Element {
   );
   const [graph] = createResource(graphTrigger, fetchSpineGraph);
   // The stitched flow view (real per-daf flow graphs, connected by cross-daf
-  // edges). Loads on demand; #spine/<tractate>/flow auto-loads it.
-  const [viewTrigger, setViewTrigger] = createSignal<string | null>(
-    thirdSeg() === 'flow' ? routeTractate() : null,
-  );
-  const [flowView] = createResource(viewTrigger, fetchSpineView);
+  // edges). Auto-loads with the tractate (keyed like the coverage report);
+  // the panel button re-fetches. It is read-only over cached pieces — the
+  // sweep reads ~4 KV keys per daf and computes nothing.
+  const [flowView, { refetch: refetchFlow }] = createResource(tractate, fetchSpineView);
   const [trace, setTrace] = createSignal<string | null>(null); // rabbi being traced across the tractate
   // #spine/<tractate>/flow/overview deep-links straight to the overview.
   const fourthSeg = () => window.location.hash.replace(/^#/, '').split('/')[3];
@@ -454,7 +453,7 @@ export function SpineCoveragePage(): JSX.Element {
                   type="button"
                   class="tb-select"
                   disabled={flowView.loading}
-                  onClick={() => setViewTrigger(tractate())}
+                  onClick={() => refetchFlow()}
                 >
                   {flowView.loading ? 'loading…' : flowView() ? 'reload' : 'load'}
                 </button>

--- a/packages/talmud/src/client/SpineCoveragePage.tsx
+++ b/packages/talmud/src/client/SpineCoveragePage.tsx
@@ -1,5 +1,5 @@
 import { createMemo, createResource, createSignal, For, type JSX, Show } from 'solid-js';
-import { connectionKinds, FlowLegend, KIND_COLOR } from './ArgumentFlowGraph';
+import { connectionKinds, FlowLegend } from './ArgumentFlowGraph';
 import SpineFlowGraph, { type SpineViewDaf } from './SpineFlowGraph';
 
 /**
@@ -31,29 +31,6 @@ interface CoverageReport {
   rows: CoverageRow[];
   summary: { computed: number; total: number; pct: number };
 }
-
-interface SpineGraph {
-  tractate: string;
-  nodes: { key: string; coord: { tractate: string; page: string; seg: number } }[];
-  edges: { source: string; target: string; relation: string; via: string; note?: string }[];
-  byRelation: Record<string, number>;
-  byVia: Record<string, number>;
-  continuityRuns: string[][];
-  coverage: { dapimWithLinks: number; dapimTotal: number };
-}
-
-// coordKey "tractate:page:seg" -> compact "page §seg" ("page" when whole-daf).
-function coordLabel(key: string): string {
-  const parts = key.split(':');
-  const seg = Number(parts[parts.length - 1]);
-  const page = parts[parts.length - 2];
-  return seg < 0 ? page : `${page} §${seg}`;
-}
-
-// Relation colors come from the daf reader's own muted KIND_COLOR (imported), so
-// #spine never drifts from the reader. `glosses` isn't a flow kind — fall back.
-const relColor = (rel: string): string =>
-  (KIND_COLOR as Record<string, string>)[rel] ?? 'var(--muted)';
 
 // Coverage producer kinds, recoloured off neon onto app-native hues.
 const COV_COLOR: Record<string, string> = {
@@ -94,18 +71,6 @@ const PANEL_H: JSX.CSSProperties = {
   'font-weight': 700,
   margin: 0,
 };
-const CHIP = (color: string): JSX.CSSProperties => ({
-  display: 'inline-flex',
-  'align-items': 'center',
-  gap: '0.35rem',
-  padding: '0.1rem 0.5rem',
-  background: '#faf8f3',
-  border: '1px solid #ece7db',
-  'border-radius': '999px',
-  'font-size': '0.7rem',
-  color: 'var(--muted)',
-  'border-left': `3px solid ${color}`,
-});
 
 function routeTractate(): string {
   const raw = window.location.hash.replace(/^#/, '');
@@ -115,15 +80,6 @@ function routeTractate(): string {
 
 async function fetchCoverage(tractate: string): Promise<CoverageReport> {
   const r = await fetch(`/api/spine-coverage/${encodeURIComponent(tractate)}`);
-  if (!r.ok) {
-    const body = await r.json().catch(() => ({}));
-    throw new Error((body as { error?: string }).error || `HTTP ${r.status}`);
-  }
-  return r.json();
-}
-
-async function fetchSpineGraph(tractate: string): Promise<SpineGraph> {
-  const r = await fetch(`/api/spine-links/${encodeURIComponent(tractate)}`);
   if (!r.ok) {
     const body = await r.json().catch(() => ({}));
     throw new Error((body as { error?: string }).error || `HTTP ${r.status}`);
@@ -150,14 +106,6 @@ export function SpineCoveragePage(): JSX.Element {
   const [report] = createResource(tractate, fetchCoverage);
   const [expanded, setExpanded] = createSignal<string | null>(null);
   const [input, setInput] = createSignal('');
-  // The assembled spine graph loads on demand (it sweeps the whole tractate).
-  // A non-null trigger (the tractate) activates the resource. A third hash
-  // segment (#spine/<tractate>/assemble) auto-loads it — a shareable deep link.
-  const thirdSeg = () => window.location.hash.replace(/^#/, '').split('/')[2];
-  const [graphTrigger, setGraphTrigger] = createSignal<string | null>(
-    thirdSeg() === 'assemble' ? routeTractate() : null,
-  );
-  const [graph] = createResource(graphTrigger, fetchSpineGraph);
   // The stitched flow view (real per-daf flow graphs, connected by cross-daf
   // edges). Auto-loads with the tractate (keyed like the coverage report);
   // the panel button re-fetches. It is read-only over cached pieces — the
@@ -293,146 +241,6 @@ export function SpineCoveragePage(): JSX.Element {
                 {r().summary.computed} / {r().summary.total} pieces &middot; {r().rows.length} dapim
                 &times; {r().columns.length} producers &middot; to {r().endAmud}
               </span>
-            </div>
-
-            {/* assembled spine graph (loads on demand) */}
-            <div style={PANEL}>
-              <div
-                style={{
-                  display: 'flex',
-                  'align-items': 'center',
-                  'justify-content': 'space-between',
-                  gap: '10px',
-                }}
-              >
-                <span style={PANEL_H}>Assembled spine &mdash; tractate link graph</span>
-                <button
-                  type="button"
-                  class="tb-select"
-                  disabled={graph.loading}
-                  onClick={() => setGraphTrigger(tractate())}
-                >
-                  {graph.loading ? 'assembling…' : graph() ? 'rebuild' : 'assemble'}
-                </button>
-              </div>
-              <Show when={graph.error}>
-                <p style={{ 'font-size': '0.85rem', color: '#b3261e', margin: '6px 0 0' }}>
-                  error: {String(graph.error?.message || graph.error)}
-                </p>
-              </Show>
-              <Show when={graph()}>
-                {(g) => (
-                  <div style={{ 'margin-top': '0.7rem', 'font-size': '0.85rem' }}>
-                    <div style={{ color: 'var(--muted)', 'margin-bottom': '0.5rem' }}>
-                      {g().nodes.length} nodes &middot; {g().edges.length} edges &middot; backbone
-                      from {g().coverage.dapimWithLinks} / {g().coverage.dapimTotal} dapim with
-                      links
-                    </div>
-                    <div
-                      style={{
-                        'font-size': '0.78rem',
-                        color: 'var(--muted)',
-                        'margin-bottom': '0.5rem',
-                      }}
-                    >
-                      by producer:{' '}
-                      {Object.entries(g().byVia)
-                        .map(([v, n]) => `${v} ${n}`)
-                        .join('  ·  ') || '—'}
-                    </div>
-                    {/* relation breakdown */}
-                    <div
-                      style={{
-                        display: 'flex',
-                        'flex-wrap': 'wrap',
-                        gap: '0.35rem',
-                        'margin-bottom': '0.7rem',
-                      }}
-                    >
-                      <For each={Object.entries(g().byRelation).sort((a, b) => b[1] - a[1])}>
-                        {([rel, n]) => (
-                          <span style={CHIP(relColor(rel))}>
-                            {rel} {n}
-                          </span>
-                        )}
-                      </For>
-                    </div>
-                    {/* continuity backbone — sugya chains that carry across daf boundaries */}
-                    <Show
-                      when={g().continuityRuns.length}
-                      fallback={
-                        <div style={{ color: 'var(--muted)', 'font-style': 'italic' }}>
-                          no continuity edges cached yet (warm bridges to grow the backbone)
-                        </div>
-                      }
-                    >
-                      <div
-                        style={{
-                          ...PANEL_H,
-                          'margin-bottom': '0.3rem',
-                          color: relColor('continues'),
-                        }}
-                      >
-                        Continuity backbone &mdash; {g().continuityRuns.length} runs
-                      </div>
-                      <div
-                        style={{
-                          'max-height': '180px',
-                          'overflow-y': 'auto',
-                          'font-family': MONO,
-                          'font-size': '0.8rem',
-                        }}
-                      >
-                        <For each={g().continuityRuns.sort((a, b) => b.length - a.length)}>
-                          {(run) => (
-                            <div style={{ padding: '1px 0', color: 'var(--fg)' }}>
-                              <span style={{ color: 'var(--muted)' }}>
-                                {String(run.length).padStart(2)}{' '}
-                              </span>
-                              {run.join(' → ')}
-                            </div>
-                          )}
-                        </For>
-                      </div>
-                    </Show>
-                    {/* cross-daf edges — the AI Stage 1 layer (section -> section across the page break) */}
-                    <Show when={g().edges.some((e) => e.via === 'cross-flow')}>
-                      <div
-                        style={{
-                          ...PANEL_H,
-                          margin: '0.7rem 0 0.3rem',
-                          color: relColor('parallels'),
-                        }}
-                      >
-                        Cross-daf edges (AI) &mdash;{' '}
-                        {g().edges.filter((e) => e.via === 'cross-flow').length}
-                      </div>
-                      <div
-                        style={{
-                          'max-height': '200px',
-                          'overflow-y': 'auto',
-                          'font-size': '0.83rem',
-                        }}
-                      >
-                        <For each={g().edges.filter((e) => e.via === 'cross-flow')}>
-                          {(e) => (
-                            <div style={{ padding: '1px 0' }}>
-                              <span style={{ 'font-family': MONO }}>{coordLabel(e.source)}</span>
-                              <span style={{ color: relColor(e.relation), margin: '0 0.4rem' }}>
-                                &mdash;{e.relation}&rarr;
-                              </span>
-                              <span style={{ 'font-family': MONO }}>{coordLabel(e.target)}</span>
-                              <Show when={e.note}>
-                                <span style={{ color: 'var(--muted)' }}> {e.note}</span>
-                              </Show>
-                            </div>
-                          )}
-                        </For>
-                      </div>
-                    </Show>
-                  </div>
-                )}
-              </Show>
             </div>
 
             {/* stitched flow view — real per-daf flow graphs down the tractate,

--- a/packages/talmud/src/client/SpineCoveragePage.tsx
+++ b/packages/talmud/src/client/SpineCoveragePage.tsx
@@ -294,6 +294,19 @@ export function SpineCoveragePage(): JSX.Element {
                   const crossCount = createMemo(() =>
                     capped().reduce((n, d) => n + d.cross.length, 0),
                   );
+                  // Cross-daf warming progress across the whole tractate: a
+                  // boundary = a daf with a next daf; connected = its cross-daf
+                  // link has been computed (warmer/sweep reached it).
+                  const connectivity = createMemo(() => {
+                    let total = 0;
+                    let done = 0;
+                    for (const d of v().dapim) {
+                      if (!d.nextPage) continue;
+                      total++;
+                      if (d.crossComputed) done++;
+                    }
+                    return { total, done };
+                  });
                   const segChip = (active: boolean): JSX.CSSProperties => ({
                     font: 'inherit',
                     'font-size': '0.78rem',
@@ -342,8 +355,12 @@ export function SpineCoveragePage(): JSX.Element {
                         >
                           showing {capped().length} of {shown().length} dapim{' '}
                           {shown().length > FLOW_VIEW_CAP ? '(capped)' : ''} &middot; {crossCount()}{' '}
-                          cross-daf arrows (thicker lines span the page break) &middot; click a
-                          rabbi to trace
+                          cross-daf arrows (thicker lines span the page break) &middot;{' '}
+                          {connectivity().done}/{connectivity().total} boundaries connected
+                          {connectivity().done < connectivity().total
+                            ? ' (dashed = not computed yet)'
+                            : ''}{' '}
+                          &middot; click a rabbi to trace
                         </Show>
                       </div>
                       <FlowLegend kinds={allKinds()} />

--- a/packages/talmud/src/client/SpineFlowGraph.tsx
+++ b/packages/talmud/src/client/SpineFlowGraph.tsx
@@ -29,6 +29,10 @@ export interface SpineViewDaf {
   cross: { fromSection: number; toSection: number; relation: string; note?: string }[];
   /** deterministic daf-continuity bridge: does the sugya carry into the next daf? */
   continues?: boolean;
+  /** has this daf's cross-daf link been computed yet? false = still cold (the
+   *  warmer/sweep hasn't connected this boundary). Drawn as a dashed "not yet
+   *  connected" divider so gaps in the map are visible, not silent. */
+  crossComputed?: boolean;
 }
 
 const NODE_W = 330,
@@ -95,10 +99,13 @@ export default function SpineFlowGraph(props: {
     const nodeTitle = new Map<string, string>();
     const nodeNum = new Map<string, number>();
     const nodeRabbis = new Map<string, SectionRabbi[]>();
-    const dafHeaders: { page: string; y: number }[] = [];
+    const dafHeaders: { page: string; y: number; pending: boolean }[] = [];
     let y = TOP_PAD;
     for (const d of props.dapim) {
-      dafHeaders.push({ page: d.page, y });
+      // pending = this daf has a next daf but its cross-daf link is still cold
+      // (not computed). Genuinely-no-link boundaries (computed, 0 edges) are NOT
+      // pending — crossComputed distinguishes them.
+      dafHeaders.push({ page: d.page, y, pending: !!d.nextPage && d.crossComputed === false });
       y += DAF_HEADER_H;
       d.sections.forEach((s, pos) => {
         const key = `${d.page}#${s.index}`;
@@ -376,8 +383,9 @@ export default function SpineFlowGraph(props: {
                         y1={h.y + DAF_HEADER_H - 6}
                         x2={m.width}
                         y2={h.y + DAF_HEADER_H - 6}
-                        stroke="#efece2"
+                        stroke={h.pending ? '#d8d2c4' : '#efece2'}
                         stroke-width={1}
+                        stroke-dasharray={h.pending ? '4 3' : undefined}
                       />
                       <text
                         x={6}
@@ -389,6 +397,19 @@ export default function SpineFlowGraph(props: {
                       >
                         {h.page}
                       </text>
+                      <Show when={h.pending}>
+                        <text
+                          x={m.width - 6}
+                          y={h.y + 15}
+                          text-anchor="end"
+                          font-size="10.5"
+                          font-style="italic"
+                          font-family="system-ui, -apple-system, sans-serif"
+                          fill="#b0a894"
+                        >
+                          cross-daf link not computed yet
+                        </text>
+                      </Show>
                     </>
                   )}
                 </For>

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -71,7 +71,7 @@ import {
 } from '../lib/rabbi/types';
 import type { EntityPiece } from '../lib/registry/entity';
 import { adjacentAmud, sefariaAPI, type TalmudPageData } from '../lib/sefref';
-import { iterAmudim } from '../lib/sefref/amudim';
+import { iterAmudim, TRACTATE_END_AMUD } from '../lib/sefref/amudim';
 import { getDafyomiMasechet } from '../lib/sefref/dafyomi/masechtos';
 import { fetchHebrewBooksDaf } from '../lib/sefref/hebrewbooks/client';
 import {
@@ -1387,6 +1387,117 @@ async function computeCrossFlow(env: Bindings, tractate: string, page: string): 
   return result;
 }
 
+// Connect ONE daf boundary (page -> next daf): compute + pin BOTH the
+// daf-continuity bridge and the section-level cross-flow. Both compute fns are
+// cache-respecting and never pin a no-data verdict, so this is idempotent and
+// self-healing — a boundary whose two dapim aren't both warm yet stays unpinned
+// and retries on a later call. The single shared step behind the read-triggered
+// deep warm (deepWarmDaf) and the cron connect sweep (runConnectSweep), so the
+// cross-daf layer fills in the same way the within-daf flow already does.
+// Budget-gated at the runLLM chokepoint; best-effort (a failure connects
+// nothing rather than throwing).
+async function connectBoundary(
+  env: Bindings,
+  tractate: string,
+  page: string,
+): Promise<{ bridge: boolean; cross: boolean }> {
+  let bridge = false;
+  let cross = false;
+  try {
+    const b = await computeDafBridge(env, tractate, page);
+    bridge = b.via !== 'no-data';
+  } catch {
+    /* best-effort */
+  }
+  try {
+    const cf = await computeCrossFlow(env, tractate, page);
+    cross = cf.via === 'llm'; // 'llm' = computed/cached; 'no-data'/'edge-of-tractate' = not linked
+  } catch {
+    /* best-effort */
+  }
+  return { bridge, cross };
+}
+
+// Completeness backstop for the cross-daf layer: walk every daf boundary across
+// Shas and CONNECT (bridge + cross-flow) any where both dapim are already warm
+// but the link is still cold. Connect-ONLY — it never warms the underlying
+// argument marks (that happens on read / deep-warm); it just links what is
+// already linkable, so a tick is mostly cheap KV existence checks plus a couple
+// of flash LLM calls per genuinely-new boundary. Cursor-driven and PERPETUAL: a
+// full pass wraps back to the start rather than latching done, so boundaries
+// whose dapim warm up *after* a pass (or that failed on a budget cap / transient
+// error) are picked up on the next lap. Once everything is connected, each tick
+// is pure cheap skips. Best-effort per boundary.
+const CONNECT_CURSOR_KEY = 'connect-cursor:v1';
+const CONNECT_BATCH = 16; // boundaries examined per tick (most are cheap skips)
+interface ConnectCursor {
+  tractateIdx: number;
+  amudIdx: number;
+  connected: number;
+}
+async function runConnectSweep(env: Bindings): Promise<void> {
+  const cache = env.CACHE;
+  if (!cache) return;
+  const tractates = Object.keys(TRACTATE_END_AMUD);
+  if (tractates.length === 0) return;
+  let cur: ConnectCursor = { tractateIdx: 0, amudIdx: 0, connected: 0 };
+  const raw = await cache.get(CONNECT_CURSOR_KEY);
+  if (raw) {
+    try {
+      cur = JSON.parse(raw) as ConnectCursor;
+    } catch {
+      /* reset */
+    }
+  }
+  let { tractateIdx, amudIdx, connected } = cur;
+  if (tractateIdx >= tractates.length) tractateIdx = 0; // tractate list shrank
+  let examined = 0;
+  while (examined < CONNECT_BATCH) {
+    if (tractateIdx >= tractates.length) {
+      // End of Shas — wrap to the start so newly-connectable boundaries get
+      // picked up on the next lap (skips are cheap once already connected).
+      tractateIdx = 0;
+      amudIdx = 0;
+    }
+    const tractate = tractates[tractateIdx];
+    const pages = [...iterAmudim(tractate)];
+    if (amudIdx >= pages.length) {
+      tractateIdx++;
+      amudIdx = 0;
+      continue;
+    }
+    const page = pages[amudIdx];
+    amudIdx++;
+    examined++;
+    const next = adjacentAmud(tractate, page, 1);
+    if (!next) continue; // last daf of the tractate — no boundary
+    // Fully connected? Skip only when BOTH the cross-flow AND the bridge are
+    // cached — `/api/cross-flow` can write the cross key without the bridge, so
+    // a cross-only check would skip a boundary whose continuity is still cold.
+    const [haveCross, haveBridge] = await Promise.all([
+      cache.get(keyForCrossFlow(tractate, page)),
+      cache.get(keyForBridge(tractate, page)),
+    ]);
+    if (haveCross && haveBridge) continue;
+    // Only connect when BOTH sides already have argument sections cached; else
+    // the compute would no-data (not pin) — skip rather than waste the call.
+    const a = await readSortedSections(env, tractate, page);
+    if (a.sections.length === 0) continue;
+    const b = await readSortedSections(env, tractate, next);
+    if (b.sections.length === 0) continue;
+    // connectBoundary computes both; the already-cached side is a cheap hit.
+    const r = await connectBoundary(env, tractate, page).catch(() => ({
+      bridge: false,
+      cross: false,
+    }));
+    if (r.cross) connected++;
+  }
+  await cache.put(CONNECT_CURSOR_KEY, JSON.stringify({ tractateIdx, amudIdx, connected }));
+  console.log(
+    `[connect-sweep] examined=${examined} connected=${connected} cursor=${tractateIdx}:${amudIdx}`,
+  );
+}
+
 // The STITCHED flow view: per-daf argument flow graphs (the same nodes +
 // connections the daf reader's ArgumentFlowGraph renders) plus each daf's
 // cross-daf edges into the next, for the whole tractate. Read-only over cached
@@ -1411,6 +1522,11 @@ app.get('/api/spine-view/:tractate', async (c) => {
       })),
       flow,
       cross: cross?.edges ?? [],
+      // Has this daf's cross-daf link been computed yet? A cached cross-flow
+      // (even with zero edges = genuinely no link) means computed; null means
+      // still cold (not yet warmed). Lets the client distinguish "no link" from
+      // "not connected yet" and surface the gaps.
+      crossComputed: cross != null,
       // deterministic daf-continuity: does the sugya carry into the next daf?
       continues: bridge?.continues === true,
     };
@@ -9435,10 +9551,10 @@ async function deepWarmDaf(
    *  cache-skip below finds them missing and regenerates them; unchanged
    *  (non-cascade) dependencies are not evicted and cache-hit. */
   only?: ReadonlySet<string>,
-): Promise<{ marks: number; enqueued: number; skipped: number; bridges: number }> {
+): Promise<{ marks: number; enqueued: number; skipped: number; bridges: number; cross: number }> {
   const queue = rc.env.ENRICHMENT_QUEUE;
   const cache = rc.env.CACHE;
-  if (!queue) return { marks: 0, enqueued: 0, skipped: 0, bridges: 0 };
+  if (!queue) return { marks: 0, enqueued: 0, skipped: 0, bridges: 0, cross: 0 };
   // Keys derive through the store (one derivation chokepoint); the probes
   // below stay raw `cache.get` EXISTENCE checks on purpose — store.get would
   // treat a corrupt entry as a miss and re-enqueue it, where today's probe
@@ -9587,25 +9703,30 @@ async function deepWarmDaf(
     }
   }
 
-  // Cross-daf bridges (the reader Overview's sugya map): compute + pin this
-  // daf's forward bridge and the previous daf's bridge into this one. Both
-  // dapim's argument sections are warm (run above / globally), so the bridge
-  // verdict resolves and caches instead of leaving the first reader to pay the
-  // cold bridge LLM calls. Best-effort — a bridge failure never fails the warm.
+  // Cross-daf links (the reader Overview's sugya map + the spine stitched view):
+  // connect this daf's forward boundary and the previous daf's boundary into
+  // this one — computing + pinning BOTH the continuity bridge and the
+  // section-level cross-flow. Both dapim's argument sections are warm (run above
+  // / globally), so the verdicts resolve and cache instead of leaving the first
+  // reader to pay the cold LLM calls. Best-effort — a failure never fails the
+  // warm.
   let bridges = 0;
+  let cross = 0;
   try {
-    const fwd = await computeDafBridge(rc.env, tractate, page);
-    if (fwd.via !== 'no-data') bridges++;
+    const fwd = await connectBoundary(rc.env, tractate, page);
+    if (fwd.bridge) bridges++;
+    if (fwd.cross) cross++;
     const prev = adjacentAmud(tractate, page, -1);
     if (prev) {
-      const back = await computeDafBridge(rc.env, tractate, prev);
-      if (back.via !== 'no-data') bridges++;
+      const back = await connectBoundary(rc.env, tractate, prev);
+      if (back.bridge) bridges++;
+      if (back.cross) cross++;
     }
   } catch {
-    /* bridges are best-effort */
+    /* cross-daf links are best-effort */
   }
 
-  return { marks, enqueued, skipped, bridges };
+  return { marks, enqueued, skipped, bridges, cross };
 }
 
 /**
@@ -9668,7 +9789,7 @@ async function processEnrichmentJob(
         result: { kind: 'warm', ...stats, total_ms: Date.now() - t0 },
       });
       console.log(
-        `[queue] deep-warm ${job.tractate}/${job.page} lang=${rc.lang} marks=${stats.marks} enqueued=${stats.enqueued} skipped=${stats.skipped} bridges=${stats.bridges}`,
+        `[queue] deep-warm ${job.tractate}/${job.page} lang=${rc.lang} marks=${stats.marks} enqueued=${stats.enqueued} skipped=${stats.skipped} bridges=${stats.bridges} cross=${stats.cross}`,
       );
       return;
     }
@@ -9787,7 +9908,13 @@ export default {
       // ~nothing when disabled (the common case).
       ctx.waitUntil(
         runBacklogBackfill(wrapped, (n, nHe, g) => enrichRabbi(n, nHe, g as GenerationId)).then(
-          (r) => (r ? undefined : runWarmCron(wrapped)),
+          async (r) => {
+            if (r) return; // backfill ran this tick — give it the full budget
+            // Connect-only cross-daf sweep first (bounded + cheap, so it always
+            // makes a little progress), then the source warm cron uses the rest.
+            await runConnectSweep(wrapped).catch(() => {});
+            await runWarmCron(wrapped);
+          },
         ),
       );
     }


### PR DESCRIPTION
Three things for the #spine page and the cross-daf argument map.

## 1. Auto-load the Stitched flow view
It used to wait for a manual *load* click; now its resource is keyed on the tractate (like the coverage report) so the argument map renders on page open. The button becomes a refetch.

## 2. Remove the Assembled spine panel
The numeric/scoreboard view of the same link data the Stitched flow draws visually — redundant. Drops the panel + its now-unused helpers.

## 3. Warm the cross-daf links (the real fix) + show what is still cold
The cross-daf layer (`bridge` + `cross-flow`) was almost never warmed — nothing in the reader or warm path computed cross-flow — so the stitched map was mostly within-daf flow with disconnected dapim. Now:

- **`connectBoundary()`** — one shared 'connect this boundary' step: computes + pins both the continuity bridge and the section-level cross-flow for a `daf -> next` boundary. Idempotent + self-healing (no-data verdicts are never pinned, so a boundary retries once both dapim are warm).
- **Lazy / read path** — `deepWarmDaf` (fired by `/api/warm-daf` for adjacent dapim on navigation) now connects its boundaries, alongside the bridges it already warmed. Every daf a reader touches links up.
- **Completeness path** — `runConnectSweep`: a perpetual, cursor-driven cron sweep that connects any boundary whose two dapim are already warm but whose link is still cold. Connect-only (never warms the underlying marks); wraps around rather than latching, so newly-warmable boundaries are caught on later laps. Runs before the source warm cron each tick, bounded to 16 boundaries; skips only when BOTH cross-flow and bridge are cached.
- **UI** — `/api/spine-view` reports per-daf `crossComputed`; `SpineFlowGraph` draws a dashed *cross-daf link not computed yet* divider for cold boundaries, and the caption shows *N/M boundaries connected*.

## Cost
Cross-flow warming is real LLM spend — one cheap flash call per boundary (~2,700 across Shas), under the existing budget caps. The sweep fills gradually (16 boundaries/tick) rather than all at once.

typecheck + lint + 2196 tests pass. Reviewed read-only with Codex; two correctness fixes folded in (perpetual wrap-around so the sweep never permanently latches; skip only when both cross + bridge are cached so the bridge/continuity fallback isn't lost).

The `/api/spine-links` endpoint + `spineLinks()` builder are left in place (now unused by the client) — can be retired in a follow-up.