### PR TITLE
Spine: Bavli↔Yerushalmi parallels as deterministic cross-corpus links

### DIFF
--- a/packages/talmud/src/lib/context/dafLinks.ts
+++ b/packages/talmud/src/lib/context/dafLinks.ts
@@ -23,15 +23,16 @@ import {
   type LinkRelation,
 } from '@corpus/core/context/link';
 import type { ContextItem } from '@corpus/core/context/types';
-import type { TalmudParallel } from '../sefref/sefaria/client.ts';
-import { talmudParallelsToLinks } from './parallels.ts';
+import type { TalmudParallel, YerushalmiBundle } from '../sefref/sefaria/client.ts';
+import { talmudParallelsToLinks, yerushalmiToLinks } from './parallels.ts';
 
 /** A link on a daf: where it lives (`source`), the `relation`, and what it
  *  points at (`targets`). `via` records which producer it came from, for
  *  display + debugging. ('mesorah' = the Mesorat HaShas parallel-sugya
- *  apparatus — unrelated to the rabbi-transmission `mesorah:` cache namespace.) */
+ *  apparatus — unrelated to the rabbi-transmission `mesorah:` cache namespace;
+ *  'yerushalmi' = the cross-corpus Bavli↔Yerushalmi parallel.) */
 export interface DafLink {
-  via: 'bridge' | 'context' | 'flow' | 'commentary' | 'cross-flow' | 'mesorah';
+  via: 'bridge' | 'context' | 'flow' | 'commentary' | 'cross-flow' | 'mesorah' | 'yerushalmi';
   source: AnchorCoord;
   relation: LinkRelation;
   targets: AnchorCoord[];
@@ -56,6 +57,10 @@ export interface DafLinkInputs {
    *  becomes a 'parallels' link from its anchored segment on this daf to a
    *  passage elsewhere in Shas. Optional/absent contributes nothing. */
   talmudParallels?: readonly TalmudParallel[];
+  /** Jerusalem Talmud parallels (the `yerushalmi` mark's shared-mishnah bundle)
+   *  — each becomes a cross-corpus 'parallels' link to the parallel halacha.
+   *  Optional/absent contributes nothing. */
+  yerushalmi?: YerushalmiBundle;
 }
 
 export function dafLinks(daf: DafRef, input: DafLinkInputs): DafLink[] {
@@ -114,6 +119,10 @@ export function dafLinks(daf: DafRef, input: DafLinkInputs): DafLink[] {
   // 5) Talmud parallels: Mesorat HaShas cross-references to parallel sugyot
   //    elsewhere in Shas (deterministic, from Sefaria's apparatus).
   out.push(...talmudParallelsToLinks(daf, input.talmudParallels ?? []));
+
+  // 6) Yerushalmi parallels: the cross-corpus Bavli↔Yerushalmi parallel sugya,
+  //    via the shared mishnah (deterministic, from the `yerushalmi` mark).
+  out.push(...yerushalmiToLinks(daf, input.yerushalmi ?? []));
 
   return out;
 }

--- a/packages/talmud/src/lib/context/parallels.ts
+++ b/packages/talmud/src/lib/context/parallels.ts
@@ -1,24 +1,25 @@
 /**
- * talmudParallels — project a daf's Talmud↔Talmud cross-references (the
- * "Mesorat HaShas" apparatus: where the same sugya, baraita, or dispute recurs
- * elsewhere in Shas) into the shared Link vocabulary.
+ * parallels — project a daf's "parallel sugya" cross-references into the shared
+ * Link vocabulary (`relation: 'parallels'`), from two deterministic sources:
+ *   - via 'mesorah'    — Sefaria's `category: "Talmud"` apparatus (Mesorat
+ *                        HaShas: the same sugya/baraita/dispute recurring
+ *                        elsewhere in Shas). Same-corpus, Bavli↔Bavli.
+ *   - via 'yerushalmi' — the `yerushalmi` mark's shared-mishnah bundle (the
+ *                        Jerusalem Talmud on a daf's mishnah IS its direct
+ *                        parallel sugya). Cross-corpus, Bavli↔Yerushalmi.
  *
- * The data is Sefaria's `category: "Talmud"` related links — a human-curated
- * apparatus, so the edges are high-precision by construction. Each link carries
- * `anchorRef` (the segment on THIS daf) and `ref` (the parallel passage). This
- * pure module parses those refs to global coordinates and emits one
- * `relation: 'parallels'` DafLink per cross-reference (`via: 'mesorah'`), so a
- * parallel sugya joins the daf/tractate link graph exactly like a flow edge or
- * a citation — no bespoke encoding.
+ * Both are human-curated/deterministic, so the edges are high-precision by
+ * construction, and both emit the SAME `parallels` link shape — a parallel joins
+ * the daf/tractate link graph exactly like a flow edge or a citation, no bespoke
+ * encoding. The `via` distinguishes the producer.
  *
- * PRECISION over recall: a ref that doesn't parse to a Bavli coordinate
- * (Yerushalmi chapter:halacha, a Tanakh verse) is dropped, not guessed, and a
- * parallel that points back onto the same daf carries no cross-daf information
- * so it is dropped too.
+ * PRECISION over recall: a ref that doesn't parse to its expected coordinate is
+ * dropped, not guessed, and a same-daf self-parallel carries no cross-daf
+ * information so it is dropped too.
  */
 
 import { type AnchorCoord, coordForSeg, DAF_SEG, type DafRef } from '@corpus/core/context/coord';
-import type { TalmudParallel } from '../sefref/sefaria/client.ts';
+import type { TalmudParallel, YerushalmiBundle } from '../sefref/sefaria/client.ts';
 import type { DafLink } from './dafLinks.ts';
 
 /**
@@ -77,6 +78,46 @@ export function talmudParallelsToLinks(
     if (seen.has(dedup)) continue;
     seen.add(dedup);
     out.push({ via: 'mesorah', source, relation: 'parallels', targets: [target] });
+  }
+  return out;
+}
+
+/**
+ * Parse a Sefaria Jerusalem Talmud ref ("Jerusalem Talmud Berakhot 1:1", or a
+ * normalized form with a trailing segment / range) into an `AnchorCoord` on the
+ * Yerushalmi spine: `tractate` keeps the full "Jerusalem Talmud <Name>" title
+ * (its own pagination — a distinct spine from the Bavli, hence a `tractate`
+ * value, not the commentary-style `spine` overlay), `page` is the
+ * "<perek>:<halacha>", and it is daf-level ({@link DAF_SEG}) — the parallel is
+ * the halacha-level discussion, not a single segment. Returns null for anything
+ * that isn't a Jerusalem Talmud ref.
+ */
+export function parseYerushalmiRef(ref: string): AnchorCoord | null {
+  const m = (ref ?? '').trim().match(/^(Jerusalem Talmud .+?)\s+(\d+:\d+)(?::\d+)?(?:[-–].*)?$/);
+  if (!m) return null;
+  return { tractate: m[1], page: m[2], seg: DAF_SEG };
+}
+
+/**
+ * Project a daf's Jerusalem Talmud parallels (the `yerushalmi` mark's already
+ * computed shared-mishnah bundle) into DafLinks (`relation: 'parallels'`,
+ * `via: 'yerushalmi'`): source = the Bavli segment the shared mishnah anchors to
+ * on THIS daf (`anchorStartSeg`, already 0-indexed), target = the parallel
+ * Yerushalmi halacha. The cross-corpus sibling of {@link talmudParallelsToLinks}.
+ * Drops snippets whose ref doesn't parse and dedupes identical
+ * (source-segment, target) pairs.
+ */
+export function yerushalmiToLinks(daf: DafRef, bundle: YerushalmiBundle): DafLink[] {
+  const out: DafLink[] = [];
+  const seen = new Set<string>();
+  for (const s of bundle) {
+    const target = parseYerushalmiRef(s.ref);
+    if (!target) continue;
+    const source = coordForSeg(daf, s.anchorStartSeg >= 0 ? s.anchorStartSeg : DAF_SEG);
+    const dedup = `${source.seg}|${target.tractate}:${target.page}`;
+    if (seen.has(dedup)) continue;
+    seen.add(dedup);
+    out.push({ via: 'yerushalmi', source, relation: 'parallels', targets: [target] });
   }
   return out;
 }

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -205,6 +205,7 @@ import {
   getTalmudParallelsCached,
   getYerushalmiCached,
   readCachedTalmudParallels,
+  readCachedYerushalmi,
   type SefariaSegments,
 } from './source-cache';
 import { computeCoverage, isKnownTractate } from './spine-coverage';
@@ -1091,6 +1092,9 @@ app.get('/api/links/:tractate/:page', async (c) => {
   const talmudParallels = await getTalmudParallelsCached(c.env.CACHE, tractate, page).catch(
     () => [],
   );
+  // Jerusalem Talmud parallels (cross-corpus): the `yerushalmi` mark's
+  // shared-mishnah bundle, projected into 'parallels' links. Fetch-on-miss.
+  const yerushalmi = await getYerushalmiCached(c.env.CACHE, tractate, page).catch(() => []);
 
   const links = dafLinks(daf, {
     continuesTo: bridge?.continues ? bridge.to : null,
@@ -1099,6 +1103,7 @@ app.get('/api/links/:tractate/:page', async (c) => {
     sectionStartSegs,
     commentaryWorks,
     talmudParallels,
+    yerushalmi,
   });
   return c.json({ tractate, page, count: links.length, links });
 });
@@ -1305,6 +1310,7 @@ async function readDafParts(env: Bindings, tractate: string, page: string): Prom
   const bridge = await readCachedBridge(env, tractate, page);
   const cross = await readCachedCrossFlow(env, tractate, page);
   const talmudParallels = await readCachedTalmudParallels(env.CACHE, tractate, page);
+  const yerushalmi = await readCachedYerushalmi(env.CACHE, tractate, page);
   const withinLinks = dafLinks(
     { tractate, page },
     {
@@ -1314,6 +1320,7 @@ async function readDafParts(env: Bindings, tractate: string, page: string): Prom
       sectionStartSegs: startSegs,
       commentaryWorks: [],
       talmudParallels,
+      yerushalmi,
     },
   );
   return { withinLinks, startSegs, crossEdges: cross?.edges ?? [] };

--- a/packages/talmud/src/worker/source-cache.ts
+++ b/packages/talmud/src/worker/source-cache.ts
@@ -292,6 +292,19 @@ export async function getYerushalmiCached(
 }
 
 /**
+ * Read-only: this daf's cached Jerusalem Talmud bundle, or [] if not yet
+ * computed. NEVER fetches — the spine sweep reads across a whole tractate and
+ * must not fan out network calls (same contract as readCachedTalmudParallels).
+ */
+export async function readCachedYerushalmi(
+  cache: KVNamespace | undefined,
+  tractate: string,
+  page: string,
+): Promise<YerushalmiBundle> {
+  return (await readCache<YerushalmiBundle>(cache, keyForYerushalmi(tractate, page))) ?? [];
+}
+
+/**
  * Cache this daf's Talmud↔Talmud parallels (the "Mesorat HaShas" apparatus:
  * related gemaras elsewhere in Shas), located via Sefaria's `category: "Talmud"`
  * related links. One getRelated call; daf-keyed since the apparatus doesn't vary

--- a/packages/talmud/tests/parallels.test.ts
+++ b/packages/talmud/tests/parallels.test.ts
@@ -1,6 +1,11 @@
 import { DAF_SEG } from '@corpus/core/context/coord';
 import { describe, expect, it } from 'vitest';
-import { parseTalmudRef, talmudParallelsToLinks } from '../src/lib/context/parallels';
+import {
+  parseTalmudRef,
+  parseYerushalmiRef,
+  talmudParallelsToLinks,
+  yerushalmiToLinks,
+} from '../src/lib/context/parallels';
 
 describe('parseTalmudRef', () => {
   it('parses a bare daf ref to a daf-level coord', () => {
@@ -101,5 +106,69 @@ describe('talmudParallelsToLinks', () => {
       { anchorRef: 'Berakhot 2a:8', targetRef: 'Shabbat 31a:5' },
     ]);
     expect(links).toHaveLength(2);
+  });
+});
+
+describe('parseYerushalmiRef', () => {
+  it('parses a perek:halacha ref to a daf-level coord on the Yerushalmi spine', () => {
+    expect(parseYerushalmiRef('Jerusalem Talmud Berakhot 1:1')).toEqual({
+      tractate: 'Jerusalem Talmud Berakhot',
+      page: '1:1',
+      seg: DAF_SEG,
+    });
+  });
+  it('keeps multi-word tractate names + ignores a trailing segment or range', () => {
+    expect(parseYerushalmiRef('Jerusalem Talmud Bava Metzia 2:3:4')).toEqual({
+      tractate: 'Jerusalem Talmud Bava Metzia',
+      page: '2:3',
+      seg: DAF_SEG,
+    });
+    expect(parseYerushalmiRef('Jerusalem Talmud Berakhot 1:1-3')).toEqual({
+      tractate: 'Jerusalem Talmud Berakhot',
+      page: '1:1',
+      seg: DAF_SEG,
+    });
+  });
+  it('rejects non-Yerushalmi refs (Bavli, Mishnah, empty)', () => {
+    expect(parseYerushalmiRef('Shabbat 31a')).toBeNull();
+    expect(parseYerushalmiRef('Mishnah Berakhot 1:1')).toBeNull();
+    expect(parseYerushalmiRef('')).toBeNull();
+  });
+});
+
+describe('yerushalmiToLinks', () => {
+  const daf = { tractate: 'Berakhot', page: '2a' };
+  const snip = (ref: string, anchorStartSeg: number) => ({
+    ref,
+    heRef: '',
+    mishnahRef: '',
+    anchorStartSeg,
+    anchorEndSeg: anchorStartSeg,
+    hebrew: 'h',
+    english: 'e',
+  });
+
+  it('projects a shared-mishnah snippet to a cross-corpus parallels link', () => {
+    expect(yerushalmiToLinks(daf, [snip('Jerusalem Talmud Berakhot 1:1', 4)])).toEqual([
+      {
+        via: 'yerushalmi',
+        relation: 'parallels',
+        source: { tractate: 'Berakhot', page: '2a', seg: 4 },
+        targets: [{ tractate: 'Jerusalem Talmud Berakhot', page: '1:1', seg: DAF_SEG }],
+      },
+    ]);
+  });
+
+  it('dedupes identical (source-segment, target) pairs', () => {
+    expect(
+      yerushalmiToLinks(daf, [
+        snip('Jerusalem Talmud Berakhot 1:1', 0),
+        snip('Jerusalem Talmud Berakhot 1:1', 0),
+      ]),
+    ).toHaveLength(1);
+  });
+
+  it('drops snippets whose ref does not parse to a Yerushalmi coordinate', () => {
+    expect(yerushalmiToLinks(daf, [snip('Berakhot 2a', 0)])).toEqual([]);
   });
 });


### PR DESCRIPTION
PR2 of the spine connection-expansion (follows #385, related gemaras). Adds the **cross-corpus** parallel: Bavli↔Yerushalmi, as real `parallels` links.

## What & why
The `yerushalmi` mark already computes, per daf, the Jerusalem Talmud passages that parallel it — located via the **shared mishnah** (Bavli and Yerushalmi both expound the same Mishnah, so the Yerushalmi on a daf's mishnah is its direct parallel sugya). That bundle carries a Bavli anchor segment + a canonical Yerushalmi ref, but it was only ever a sidebar card. This lifts it into the shared link vocabulary as `relation:'parallels'`, `via:'yerushalmi'` — additive; the card is unchanged (same pattern as bridge→`continuationLink`).

Deterministic (shared-mishnah grounding), so precision-first; no LLM. Note: Sefaria's `/api/related` carries **no** direct Bavli↔Yerushalmi sugya parallels, which is exactly why this uses the mark's grounding rather than the `category:'Talmud'` apparatus that PR1 used.

## How
- **`parseYerushalmiRef` + `yerushalmiToLinks`** (pure, unit-tested) in `parallels.ts`, alongside the PR1 Bavli projection: source = the shared mishnah's 0-indexed Bavli anchor seg on this daf; target = the parallel Yerushalmi halacha, addressed as a **distinct spine** — `tractate: "Jerusalem Talmud <Name>"`, `page: "<perek>:<halacha>"`, daf-level (a different corpus has its own pagination, so it's a `tractate` value, not the commentary-style `spine` overlay). Drops unparseable refs; dedupes.
- **`readCachedYerushalmi`** (read-only) in source-cache for the spine sweep's no-network invariant; `getYerushalmiCached` already handles fetch-on-miss. **No new cache key** — reuses `keyForYerushalmi` (the mark's existing bundle).
- Wired into `dafLinks` (new `'yerushalmi'` via + optional input), `GET /api/links` (fetch-on-miss), and the `GET /api/spine-links` sweep (read-only).

## Surfacing
- `/api/links` and `/api/spine-links` now include these edges (`byVia.yerushalmi`, `byRelation.parallels`).
- **Follow-ups (out of scope, shared with #385):** cross-corpus targets land as graph nodes + stats but not drawn arrows (the spine-view "exit marker" rendering); a reader-facing "Parallel sugyot" card line; the curated cross-tractate pairs + dafyomi "Yerushalmi to Match" as additional `via:'yerushalmi'` tiers.

## Verification
- `pnpm typecheck` clean; full suite **2202 tests pass** (+ Yerushalmi cases in `parallels.test.ts`).
- `biome check .` clean.
- Codex read-only review run (repo convention).