### PR TITLE
Inspector: key per-instance pieces correctly (fix false miss/$0)

### DIFF
--- a/packages/talmud/src/client/RunTreeDock.tsx
+++ b/packages/talmud/src/client/RunTreeDock.tsx
@@ -29,6 +29,7 @@ import {
 import { aiActivity } from './aiActivity';
 import { lang } from './i18n';
 import { inspectRequest } from './inspectBridge';
+import { liveProducerCounts, liveProducerSet } from './runStatus';
 import {
   ACTIVE_STROKE,
   type Authority,
@@ -76,6 +77,9 @@ interface DafRun {
   // additive (older payloads omit them)
   authority?: Authority | null;
   staleness?: Staleness | null;
+  // Per-instance producers report the warmed fraction (e.g. 3/5 pesukim);
+  // absent on whole-daf / single-entry rows.
+  instances?: { total: number; cached: number };
 }
 
 /** One waterfall row — a piece run with a cold-time bar. Used as the collapsed
@@ -86,6 +90,7 @@ function RunRow(props: {
   active?: boolean;
   collapsed?: boolean;
   loading?: boolean;
+  loadingCount?: number;
   onClick?: () => void;
   onInspect?: () => void;
 }): JSX.Element {
@@ -94,6 +99,14 @@ function RunRow(props: {
   const slow = () => (r().cold_ms ?? 0) > 10_000;
   const color = () => (isLLM() ? (r().model?.includes('pro') ? BADGE_PRO : BADGE_LLM) : BADGE_SRC);
   const pct = () => Math.max(2, Math.round(((r().cold_ms ?? 0) / props.maxMs) * 100));
+  // Per-instance fraction (e.g. 3/5 pesukim warmed). `anyCached` keeps the bar
+  // and badge honest for a partially-warmed producer (cost > 0 yet cached=false).
+  const inst = () => r().instances;
+  const frac = () => {
+    const i = inst();
+    return i && i.total > 0 && i.cached < i.total ? `${i.cached}/${i.total}` : null;
+  };
+  const anyCached = () => r().cached || (inst()?.cached ?? 0) > 0;
   return (
     // biome-ignore lint/a11y/useSemanticElements: row contains a nested inspect <button>; a native button cannot contain another button
     <div
@@ -148,7 +161,7 @@ function RunRow(props: {
               style={{
                 width: `${pct()}%`,
                 height: '100%',
-                background: !r().cached
+                background: !anyCached()
                   ? '#ddd7c9'
                   : slow()
                     ? '#a8542e'
@@ -212,12 +225,28 @@ function RunRow(props: {
         <Show
           when={props.loading}
           fallback={
-            <Show when={r().cached} fallback={<span style={{ color: '#a8854a' }}>miss</span>}>
-              <span style={{ color: '#5f8a6f' }}>hit</span>
+            <Show
+              when={frac()}
+              fallback={
+                <Show when={r().cached} fallback={<span style={{ color: '#a8854a' }}>miss</span>}>
+                  <span style={{ color: '#5f8a6f' }}>hit</span>
+                </Show>
+              }
+            >
+              {(f) => (
+                <span
+                  title={`${inst()?.cached} of ${inst()?.total} instances cached`}
+                  style={{ color: '#a8854a' }}
+                >
+                  {f()}
+                </span>
+              )}
             </Show>
           }
         >
-          <span style={{ color: '#9c5a2a' }}>run</span>
+          <span style={{ color: '#9c5a2a' }}>
+            run{props.loadingCount && props.loadingCount > 1 ? ` ${props.loadingCount}` : ''}
+          </span>
         </Show>
       </span>
       <Show when={props.collapsed}>
@@ -517,17 +546,12 @@ export default function RunTreeDock(props: {
       cold_ms: rs.reduce((s, r) => s + (r.cold_ms ?? 0), 0),
     };
   });
-  // Producer ids with a live in-flight run (the activity id is `${id}:${t}:${p}:…`).
-  const liveLoading = createMemo<Set<string>>(() => {
-    const out = new Set<string>();
-    for (const e of Object.values(aiActivity())) {
-      if (e.state.kind === 'loading' || e.state.kind === 'queued') {
-        const pid = e.id.split(':')[0];
-        if (pid) out.add(pid);
-      }
-    }
-    return out;
-  });
+  // Producer ids with a live in-flight run, and the per-producer in-flight count
+  // ("2 warming"). Both derive from the in-memory aiActivity signal — see
+  // runStatus.ts, which also strips the dev panel's `mark:`/`enrichment:` prefix
+  // so those ids map to a real producer instead of a phantom "mark"/"enrichment".
+  const liveLoading = createMemo<Set<string>>(() => liveProducerSet(aiActivity()));
+  const liveCounts = createMemo<Map<string, number>>(() => liveProducerCounts(aiActivity()));
   // The waterfall's telemetry is a snapshot; while anything is loading, re-poll
   // /api/daf-runs so finished pieces flip from "run" to their real hit + time +
   // cost (instead of staying on the stale miss/0ms snapshot). Also refetch once
@@ -898,6 +922,7 @@ export default function RunTreeDock(props: {
                   maxMs={maxCold()}
                   active={r.id === pieceId()}
                   loading={liveLoading().has(r.id)}
+                  loadingCount={liveCounts().get(r.id) ?? 0}
                   onClick={() => openPiece(r.id)}
                   onInspect={() => openPiece(r.id)}
                 />
@@ -1237,6 +1262,24 @@ export default function RunTreeDock(props: {
                         {fmtCost(n().cost)}
                       </span>
                     </Show>
+                    <Show when={n().instances}>
+                      {(i) => (
+                        <span
+                          style={{
+                            'font-size': '0.66rem',
+                            background: '#f1f1f3',
+                            'border-radius': '4px',
+                            padding: '0.05rem 0.4rem',
+                            color:
+                              i().cached === i().total && i().total > 0 ? '#047857' : '#a8854a',
+                            'font-family': 'ui-monospace, Menlo, monospace',
+                          }}
+                          title="instances warmed on this daf"
+                        >
+                          {i().cached}/{i().total} cached
+                        </span>
+                      )}
+                    </Show>
                     <span
                       style={{
                         'font-size': '0.66rem',
@@ -1341,9 +1384,49 @@ export default function RunTreeDock(props: {
                             )}
                           </Show>
                           <Show when={!detail.loading && !detail()}>
-                            <div style={{ color: '#bbb', 'font-size': '0.78rem' }}>
-                              nothing cached for this node on this daf yet.
-                            </div>
+                            <Show
+                              when={
+                                n().id === tree()?.root && (tree()?.rootInstances?.length ?? 0) > 0
+                              }
+                              fallback={
+                                <div style={{ color: '#bbb', 'font-size': '0.78rem' }}>
+                                  nothing cached for this node on this daf yet.
+                                </div>
+                              }
+                            >
+                              <div
+                                style={{
+                                  display: 'flex',
+                                  'flex-wrap': 'wrap',
+                                  gap: '0.3rem',
+                                  'align-items': 'center',
+                                  'font-size': '0.78rem',
+                                }}
+                              >
+                                <span style={{ color: '#999' }}>
+                                  per-instance — pick one to inspect:
+                                </span>
+                                <For each={tree()?.rootInstances ?? []}>
+                                  {(ri) => (
+                                    <button
+                                      type="button"
+                                      onClick={() => openPiece(tree()!.root, ri.instance)}
+                                      style={{
+                                        'font-size': '0.72rem',
+                                        padding: '0.1rem 0.45rem',
+                                        border: '1px solid #d8d2c4',
+                                        'border-radius': '4px',
+                                        background: '#faf8f2',
+                                        cursor: 'pointer',
+                                        color: '#555',
+                                      }}
+                                    >
+                                      {ri.label}
+                                    </button>
+                                  )}
+                                </For>
+                              </div>
+                            </Show>
                           </Show>
                           <ProvenanceSection node={n()} />
                         </>

--- a/packages/talmud/src/client/runStatus.ts
+++ b/packages/talmud/src/client/runStatus.ts
@@ -1,0 +1,63 @@
+/**
+ * runStatus — the pure state-machine the Inspector's waterfall rows use to
+ * reconcile two INDEPENDENT sources: live run state (the in-memory aiActivity
+ * signal) and cached telemetry (the /api/daf-runs snapshot). Extracted from
+ * RunTreeDock so the reconciliation is unit-testable (tests/inspect-row-status)
+ * — the thing that silently drifted before: a finished per-instance producer
+ * would sit on "run" then flip to "miss" (never "hit") because the snapshot
+ * probed the wrong key. With the endpoint fixed, this pins run -> hit.
+ */
+
+/** Minimal shape of one aiActivity entry (avoids importing the Solid store). */
+export interface ActivityLike {
+  id: string;
+  state: { kind: string };
+}
+
+const LIVE_KINDS = new Set(['loading', 'queued']);
+
+/**
+ * The producer id an activity id refers to. Reader warms key activity as
+ * `${producerId}:${tractate}:${page}:${instance}[:lang]` (enrichmentQueue /
+ * MarkEnrichmentCards / QAPanel), so the producer is the first segment — EXCEPT
+ * the dev MarksRegistryPanel, which prefixes `mark:` / `enrichment:`. Strip that
+ * so both map to the real producer id (the bare first segment matched no row).
+ */
+export function producerIdOf(activityId: string): string {
+  const parts = activityId.split(':');
+  if ((parts[0] === 'mark' || parts[0] === 'enrichment') && parts[1]) return parts[1];
+  return parts[0] ?? '';
+}
+
+/** Producer ids with >=1 instance currently loading/queued. Collapsing per
+ *  instance to producer is intentional (a row is one producer) — but the COUNT
+ *  matters for "2 warming", so see liveProducerCounts. */
+export function liveProducerSet(activities: Record<string, ActivityLike>): Set<string> {
+  const out = new Set<string>();
+  for (const e of Object.values(activities)) {
+    if (!LIVE_KINDS.has(e.state.kind)) continue;
+    const pid = producerIdOf(e.id);
+    if (pid) out.add(pid);
+  }
+  return out;
+}
+
+/** How many instances of each producer are loading/queued right now. Lets a row
+ *  show "2 warming" instead of a single binary spinner that hid the fan-out. */
+export function liveProducerCounts(activities: Record<string, ActivityLike>): Map<string, number> {
+  const out = new Map<string, number>();
+  for (const e of Object.values(activities)) {
+    if (!LIVE_KINDS.has(e.state.kind)) continue;
+    const pid = producerIdOf(e.id);
+    if (pid) out.set(pid, (out.get(pid) ?? 0) + 1);
+  }
+  return out;
+}
+
+/** The badge a waterfall row shows: live work wins, else the snapshot's
+ *  hit/miss. (Once the snapshot keys per-instance producers correctly, a warmed
+ *  row settles on 'hit' instead of bouncing back to 'miss'.) */
+export function rowStatus(o: { loading: boolean; cached: boolean }): 'run' | 'hit' | 'miss' {
+  if (o.loading) return 'run';
+  return o.cached ? 'hit' : 'miss';
+}

--- a/packages/talmud/src/client/runTreeShared.tsx
+++ b/packages/talmud/src/client/runTreeShared.tsx
@@ -25,6 +25,9 @@ export interface TreeNode {
   cold_ms: number | null;
   cost: number | null;
   tokens: number | null;
+  /** Per-instance producers report the warmed fraction; absent on whole-daf /
+   *  single-entry nodes (which carry one cached entry, not a per-instance set). */
+  instances?: { total: number; cached: number };
   // additive provenance/staleness fields (absent on older payloads + source
   // leaves; null when nothing is cached) — every consumer must tolerate absence
   authority?: Authority | null;
@@ -41,6 +44,10 @@ export interface RunTree {
   lang: string;
   nodes: Record<string, TreeNode>;
   edges: Array<[string, string]>;
+  /** For a per-instance ROOT opened without a pinned instance: its instance list
+   *  so the dock can offer a picker (each chip re-opens the piece with that
+   *  instance to inspect its content). Absent on whole-daf roots. */
+  rootInstances?: Array<{ label: string; instance: unknown }>;
   totals: {
     count: number;
     llm: number;

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -154,6 +154,14 @@ import { aiMatchToSegments } from './context-match';
 import { collectContext, type SourceTiming } from './context-providers';
 import { dafCostReport } from './daf-cost';
 import { getRabbiEntryOr404, readJsonBody } from './http-helpers';
+import {
+  aggregateProbes,
+  type InspectEntry,
+  inspectorCostOf,
+  type ProbeAggregate,
+  probeInstances,
+  tokensOfEntry,
+} from './inspect';
 import { noteLintAttempt, readLintFailures } from './lint-failures';
 import { ALIGN_MARKS } from './mark-categories';
 import {
@@ -1569,6 +1577,9 @@ app.get('/api/run-tree/:tractate/:page/:id', async (c) => {
     cold_ms: number | null;
     cost: number | null;
     tokens: number | null;
+    // Per-instance producers (one cached entry per pasuk / halacha / rabbi /
+    // move) report the fraction warmed; absent on whole-daf / single-entry nodes.
+    instances?: { total: number; cached: number };
     // --- additive provenance/staleness fields (absent on source leaves; null
     // when nothing is cached). Older clients ignore them. ---
     authority?: Authority | null;
@@ -1593,6 +1604,19 @@ app.get('/api/run-tree/:tractate/:page/:id', async (c) => {
   const currentRecipeOf = new Map<string, string>();
   const depsOf = new Map<string, ReadonlyArray<unknown>>();
   const rootCustomInstance = JSON.stringify(rootInstance) !== JSON.stringify({ fields: {} });
+  // Whole-daf marks key their enrichments under the single {fields:{}} instance;
+  // every other mark is per-instance, so its enrichments live under one key per
+  // instance. Read each target mark's instance list at most once per request.
+  const markAnchorById = new Map(CODE_MARKS.map((m) => [m.id, (m as { anchor?: string }).anchor]));
+  const instCache = new Map<string, Promise<RawInstance[]>>();
+  const instancesForMark = (mid: string): Promise<RawInstance[]> => {
+    let p = instCache.get(mid);
+    if (!p) {
+      p = readMarkInstances(c.env, mid, tractate, page);
+      instCache.set(mid, p);
+    }
+    return p;
+  };
 
   for (const nid of nodeIds) {
     const def = byId.get(nid);
@@ -1618,33 +1642,67 @@ app.get('/api/run-tree/:tractate/:page/:id', async (c) => {
     // Same key derivation (and the same KV def reads) cacheKeyForRunBody
     // performs — inlined so the loaded def also yields the CURRENT recipe hash
     // (enrichments stamp recipe_hash at generation; marks never have).
-    let key: string | null = null;
+    let res: RunResult | null = null;
+    // Per-instance enrichments (target mark is NOT whole-daf) cache one entry per
+    // instance, keyed by the mark_input's identity via instanceIdOf — NOT under
+    // {fields:{}}. Probing {fields:{}} (the old code) always missed them; enumerate
+    // the target mark's real instances and aggregate. The exception is THIS node
+    // being the root with a caller-pinned instance — then it's the one we want.
+    let aggregate: ProbeAggregate | null = null;
     if (isMark) {
       const ldef = await loadMarkDef(c.env, nid);
       if (ldef) {
-        key = store.keyFor(markKeyInfo(ldef), { unit: { work: tractate, unit: page }, lang });
+        const key = store.keyFor(markKeyInfo(ldef), { unit: { work: tractate, unit: page }, lang });
+        res = await readCachedResult(c.env, key);
         depsOf.set(nid, ldef.dependencies ?? []);
       }
     } else {
       const ldef = await loadEnrichmentDef(c.env, nid);
       if (ldef) {
-        const iid = await instanceIdOf(nid === id ? rootInstance : { fields: {} });
-        key = store.keyFor(enrichKeyInfo(ldef), {
-          instanceId: iid,
-          unit: { work: tractate, unit: page },
-          lang,
-        });
         currentRecipeOf.set(nid, await recipeHash(enrichmentRecipe(ldef)));
         depsOf.set(nid, ldef.dependencies ?? []);
+        const targetMark = (def as { target_mark?: string }).target_mark;
+        const perInstance = !!targetMark && markAnchorById.get(targetMark) !== 'whole-daf';
+        const pinnedRoot = nid === id && rootCustomInstance;
+        const keyForIid = (iid: string): string =>
+          store.keyFor(enrichKeyInfo(ldef), {
+            instanceId: iid,
+            unit: { work: tractate, unit: page },
+            lang,
+          });
+        if (perInstance && !pinnedRoot && targetMark) {
+          const insts = await instancesForMark(targetMark);
+          const probed = await Promise.all(
+            insts.map(async (inst) => readCachedResult(c.env, keyForIid(await instanceIdOf(inst)))),
+          );
+          aggregate = aggregateProbes(
+            probed.map((r) => ({
+              cached: !!r,
+              cost: inspectorCostOf(r as InspectEntry | null),
+              cold_ms: typeof r?.elapsed_ms === 'number' ? r.elapsed_ms : null,
+              tokens: tokensOfEntry(r),
+            })),
+          );
+          // A real instance entry stands in for the provenance/staleness pass.
+          res = probed.find((r) => r) ?? null;
+        } else {
+          const iid = await instanceIdOf(pinnedRoot ? rootInstance : { fields: {} });
+          res = await readCachedResult(c.env, keyForIid(iid));
+        }
       }
     }
-    const res = key ? await readCachedResult(c.env, key) : null;
     if (res) entryOf.set(nid, res);
-    const usage = res?.usage as { cost?: number; total_tokens?: number } | undefined;
-    const coldMs = typeof res?.elapsed_ms === 'number' ? res.elapsed_ms : null;
-    const cost = typeof usage?.cost === 'number' ? usage.cost : null;
-    if (res) cachedCount++;
-    if (isLLM && res) {
+    const coldMs = aggregate
+      ? aggregate.cold_ms
+      : typeof res?.elapsed_ms === 'number'
+        ? res.elapsed_ms
+        : null;
+    const cost = aggregate ? aggregate.cost : inspectorCostOf(res as InspectEntry | null);
+    const tokens = aggregate ? aggregate.tokens : tokensOfEntry(res);
+    const cached = aggregate ? aggregate.cached : !!res;
+    const anyCached = aggregate ? aggregate.instances.cached > 0 : !!res;
+    if (cached) cachedCount++;
+    if (isLLM && anyCached) {
       totalColdMs += coldMs ?? 0;
       totalCost += cost ?? 0;
       llmCount++;
@@ -1655,10 +1713,11 @@ app.get('/api/run-tree/:tractate/:page/:id', async (c) => {
       kind: isLLM ? 'llm' : 'computed',
       producer: isMark ? 'mark' : 'enrichment',
       model: isLLM ? ext?.model : undefined,
-      cached: !!res,
+      cached,
       cold_ms: coldMs,
       cost,
-      tokens: typeof usage?.total_tokens === 'number' ? usage.total_tokens : null,
+      tokens,
+      ...(aggregate ? { instances: aggregate.instances } : {}),
     };
   }
 
@@ -1736,6 +1795,22 @@ app.get('/api/run-tree/:tractate/:page/:id', async (c) => {
             : 'unknown';
   }
 
+  // A per-instance root opened WITHOUT a pinned instance shows an aggregate; hand
+  // back the instance list so the dock can offer a picker (each chip re-opens the
+  // piece with ?instance= to inspect that one's content/provenance). Empty for
+  // whole-daf roots and when an instance was already pinned.
+  const rootTarget = (byId.get(id) as { target_mark?: string } | undefined)?.target_mark;
+  const rootInstances =
+    !markIds.has(id) &&
+    rootTarget &&
+    markAnchorById.get(rootTarget) !== 'whole-daf' &&
+    !rootCustomInstance
+      ? (await instancesForMark(rootTarget)).map((inst) => ({
+          label: instanceLabel(inst.fields),
+          instance: inst,
+        }))
+      : [];
+
   return c.json({
     root: id,
     tractate,
@@ -1743,6 +1818,7 @@ app.get('/api/run-tree/:tractate/:page/:id', async (c) => {
     lang,
     nodes: out,
     edges,
+    rootInstances,
     totals: {
       count: nodeIds.length,
       llm: llmCount,
@@ -1765,15 +1841,38 @@ app.get('/api/daf-runs/:tractate/:page', async (c) => {
   const page = c.req.param('page');
   const lang: 'en' | 'he' = c.req.query('lang') === 'he' ? 'he' : 'en';
 
-  const wholeDafEnrichments = CODE_ENRICHMENTS.filter(
+  // Every LOCAL enrichment (the global rabbi/place facets are entity pieces shown
+  // elsewhere) EXCEPT the per-section `argument` facets. Those carry a dual
+  // display/synth mark_input (argumentDisplayInstance drops the seg indices
+  // argumentSynthInstance keys on), so their instance id needs separate
+  // verification before we enumerate them here — every other per-instance mark
+  // (pesukim, aggadata, halacha, argument-move, rabbi, places) round-trips
+  // cleanly (the reader reshape preserves the fields instanceIdOf hashes).
+  const localEnrichments = CODE_ENRICHMENTS.filter(
     (e) => e.scope === 'local' && e.target_mark !== 'argument',
   );
-  // The whole-daf instance id is the same for every enrichment ({fields:{}}),
-  // so hash it ONCE rather than per producer (cacheKeyForRunBody did it per call).
+  // The whole-daf instance id is the same for every whole-daf enrichment
+  // ({fields:{}}), so hash it ONCE rather than per producer.
   const iid = await instanceIdOf({ fields: {} });
+  // Per-instance enrichments (target mark is NOT whole-daf) are keyed one entry
+  // per instance — enumerate the target mark's instances and aggregate, instead
+  // of probing {fields:{}} (which never matched and reported a false miss). Read
+  // each target mark's instance list once.
+  const markAnchorById = new Map(CODE_MARKS.map((m) => [m.id, (m as { anchor?: string }).anchor]));
+  const perInstanceTargets = new Set(
+    localEnrichments
+      .map((e) => e.target_mark)
+      .filter((m): m is string => !!m && markAnchorById.get(m) !== 'whole-daf'),
+  );
+  const instancesByMark = new Map<string, RawInstance[]>();
+  await Promise.all(
+    [...perInstanceTargets].map(async (mid) => {
+      instancesByMark.set(mid, await readMarkInstances(c.env, mid, tractate, page));
+    }),
+  );
   const producers = [
     ...CODE_MARKS.map((def) => ({ def, isMark: true as const })),
-    ...wholeDafEnrichments.map((def) => ({ def, isMark: false as const })),
+    ...localEnrichments.map((def) => ({ def, isMark: false as const })),
   ];
   // KV-overridden defs (Studio-authored, KV wins over code) change BOTH the
   // cache key (cache_version) and the current recipe — read the indexes once
@@ -1800,6 +1899,33 @@ app.get('/api/daf-runs/:tractate/:page', async (c) => {
           | { kind?: string; model?: string; system_prompt_he?: string }
           | undefined)) as { kind?: string; model?: string; system_prompt_he?: string } | undefined;
       const isLLM = kvEnrich || kvMark ? true : ext?.kind === 'llm';
+      // Per-instance enrichment: aggregate across the target mark's instances
+      // (each its own cached entry). One row that reads "3/3 cached · $0.004"
+      // instead of a single {fields:{}} probe that always missed. Provenance dots
+      // (authority/staleness) are per-entry and so left null on the aggregate.
+      const targetMark = isMark ? undefined : (def as { target_mark?: string }).target_mark;
+      if (!isMark && targetMark && markAnchorById.get(targetMark) !== 'whole-daf') {
+        const edef = kvEnrich ?? def;
+        const agg = await probeInstances(
+          async (k) => (await readCachedResult(c.env, k)) as InspectEntry | null,
+          (iidLocal) => keyForEnrichment(edef, iidLocal, { tractate, page }, undefined, lang),
+          instancesByMark.get(targetMark) ?? [],
+        );
+        return {
+          id: def.id,
+          label: def.label,
+          kind: isLLM ? 'llm' : 'computed',
+          producer: 'enrichment' as const,
+          model: isLLM ? ext?.model : undefined,
+          cached: agg.cached,
+          cold_ms: agg.cold_ms,
+          cost: agg.cost,
+          tokens: agg.tokens,
+          instances: agg.instances,
+          authority: null,
+          staleness: null,
+        };
+      }
       const key = isMark
         ? keyForMark(
             kvMark ?? def,
@@ -1809,7 +1935,6 @@ app.get('/api/daf-runs/:tractate/:page', async (c) => {
           )
         : keyForEnrichment(kvEnrich ?? def, iid, { tractate, page }, undefined, lang);
       const res = await readCachedResult(c.env, key);
-      const usage = res?.usage as { cost?: number; total_tokens?: number } | undefined;
       // Additive provenance fields for the waterfall dots — cheap (no extra KV
       // reads; recipe-leg verdict only, the inputs leg needs the DAG's dep
       // reads and stays on /api/run-tree). Marks never stamp a recipe_hash, so
@@ -1839,8 +1964,9 @@ app.get('/api/daf-runs/:tractate/:page', async (c) => {
         model: isLLM ? ext?.model : undefined,
         cached: !!res,
         cold_ms: typeof res?.elapsed_ms === 'number' ? res.elapsed_ms : null,
-        cost: typeof usage?.cost === 'number' ? usage.cost : null,
-        tokens: typeof usage?.total_tokens === 'number' ? usage.total_tokens : null,
+        cost: inspectorCostOf(res as InspectEntry | null),
+        tokens: tokensOfEntry(res),
+        instances: undefined as { total: number; cached: number } | undefined,
         authority: stored ? authorityOf(stored) : null,
         staleness,
       };

--- a/packages/talmud/src/worker/inspect.ts
+++ b/packages/talmud/src/worker/inspect.ts
@@ -1,0 +1,123 @@
+/**
+ * inspect.ts — pure, KV-injectable helpers behind the dev Inspector's two
+ * read-only endpoints (`/api/daf-runs` waterfall + `/api/run-tree` DAG). Kept
+ * separate from index.ts so the cache-status logic is unit-testable without a
+ * worker (see tests/inspect-*.test.ts).
+ *
+ * The bug these fix: both endpoints used to probe EVERY enrichment with the
+ * whole-daf placeholder instance `{fields:{}}`, and read cost from
+ * `usage.cost`. That is correct only for genuinely whole-daf pieces. A
+ * PER-INSTANCE enrichment (one per pasuk / halacha / aggadic unit / rabbi /
+ * argument move) is cached under a key whose instance_id derives — via
+ * instanceIdOf — from the rich mark_input the reader warms with (e.g.
+ * `fields.verseRef`). The `{fields:{}}` probe can never reproduce that id, so
+ * those rows reported a false "miss / $0 / not cached" even when warmed.
+ *
+ * The fix: enumerate the target mark's actual instances and probe each one's
+ * key, exactly the way the warm path keyed them, then aggregate. instanceIdOf
+ * is deliberately shape-tolerant (it reads the same identity fields off either
+ * the stored instance or the reader's reshaped mark_input), so the keys match
+ * by construction — which the round-trip test pins.
+ */
+
+import { instanceIdOf } from './cache-keys';
+import { bestStampUsd } from './daf-cost';
+
+/** The slice of a stored entry the inspector needs to report telemetry. */
+export interface InspectEntry {
+  /** Permanent per-entry cost ledger (CostStamp) stamped at write time. */
+  cost?: { billedUsd: number | null; estimatedUsd: number | null } | null;
+  /** Raw model usage — `cost` here is OpenRouter's reported figure (absent on
+   *  Workers-AI / unpriced models even on a cache hit). */
+  usage?: unknown;
+  elapsed_ms?: number;
+}
+
+/**
+ * Canonical per-entry cost for the inspector: the stamped CostStamp ledger
+ * (billed-or-estimated USD), the SAME figure daf-cost.ts / the budget guard /
+ * the /usage rollup report. Falls back to the raw `usage.cost` for pre-stamp or
+ * OpenRouter-only entries, then null. Reading `usage.cost` alone (the old bug)
+ * returned null on Workers-AI / unpriced hits — making cached rows show "$0".
+ */
+export function inspectorCostOf(res: InspectEntry | null | undefined): number | null {
+  const stamp = res?.cost;
+  if (stamp && (typeof stamp.billedUsd === 'number' || typeof stamp.estimatedUsd === 'number')) {
+    return bestStampUsd(stamp);
+  }
+  const u = res?.usage as { cost?: number } | undefined;
+  return typeof u?.cost === 'number' ? u.cost : null;
+}
+
+/** Total tokens off a stored entry's raw usage, or null. */
+export function tokensOfEntry(res: InspectEntry | null | undefined): number | null {
+  const u = res?.usage as { total_tokens?: number } | undefined;
+  return typeof u?.total_tokens === 'number' ? u.total_tokens : null;
+}
+
+/** One probed instance's telemetry. */
+export interface InstanceProbe {
+  cached: boolean;
+  cost: number | null;
+  cold_ms: number | null;
+  tokens: number | null;
+}
+
+/** A per-instance producer's row, reduced from its instance probes. */
+export interface ProbeAggregate {
+  /** "Fully cached" — every instance present. The honest fraction is in
+   *  `instances`; a partially-warmed producer is cached:false, instances 3/5. */
+  cached: boolean;
+  /** Sum over cached instances (total spend on the daf), null if none priced. */
+  cost: number | null;
+  /** Sum of generation time over cached instances — "where the time went". */
+  cold_ms: number | null;
+  tokens: number | null;
+  instances: { total: number; cached: number };
+}
+
+/** Reduce per-instance probes into one waterfall/DAG row. */
+export function aggregateProbes(probes: InstanceProbe[]): ProbeAggregate {
+  const total = probes.length;
+  const cachedN = probes.filter((p) => p.cached).length;
+  const sum = (xs: (number | null)[]): number | null => {
+    const nums = xs.filter((x): x is number => typeof x === 'number');
+    return nums.length ? nums.reduce((a, b) => a + b, 0) : null;
+  };
+  return {
+    cached: total > 0 && cachedN === total,
+    cost: sum(probes.map((p) => p.cost)),
+    cold_ms: sum(probes.map((p) => p.cold_ms)),
+    tokens: sum(probes.map((p) => p.tokens)),
+    instances: { total, cached: cachedN },
+  };
+}
+
+/**
+ * Probe a per-instance enrichment across all of a mark's instances on a daf and
+ * aggregate. `keyFor(instanceId)` builds the cache key (each endpoint passes its
+ * own scheme so the inspector keys exactly as that endpoint's single-probe path
+ * would — no drift); `get` reads a cached entry (the worker's readCachedResult,
+ * or a fake KV in tests). `instances` are the mark's stored `parsed.instances`
+ * (raw, fields intact) — passed verbatim through instanceIdOf, the same id the
+ * warm path produced from the reader's reshaped mark_input.
+ */
+export async function probeInstances(
+  get: (key: string) => Promise<InspectEntry | null>,
+  keyFor: (instanceId: string) => string,
+  instances: unknown[],
+): Promise<ProbeAggregate> {
+  const probes = await Promise.all(
+    instances.map(async (inst): Promise<InstanceProbe> => {
+      const iid = await instanceIdOf(inst);
+      const res = await get(keyFor(iid));
+      return {
+        cached: !!res,
+        cost: inspectorCostOf(res),
+        cold_ms: typeof res?.elapsed_ms === 'number' ? res.elapsed_ms : null,
+        tokens: tokensOfEntry(res),
+      };
+    }),
+  );
+  return aggregateProbes(probes);
+}

--- a/packages/talmud/tests/inspect-cost.test.ts
+++ b/packages/talmud/tests/inspect-cost.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { aggregateProbes, inspectorCostOf } from '../src/worker/inspect';
+
+// The inspector used to read cost from `usage.cost` — OpenRouter's raw figure,
+// which is null on Workers-AI / unpriced models even on a cache hit, so cached
+// rows showed "$0". The canonical figure is the stamped CostStamp ledger (the
+// same one daf-cost.ts / the budget guard / /usage report). inspectorCostOf
+// reads that, falling back to usage.cost only for pre-stamp / OR-only entries.
+describe('inspectorCostOf — canonical CostStamp, not usage.cost', () => {
+  it('prefers the stamped ledger (billed wins, then estimate)', () => {
+    expect(inspectorCostOf({ cost: { billedUsd: 0.5, estimatedUsd: 0.7 } })).toBe(0.5);
+    expect(inspectorCostOf({ cost: { billedUsd: null, estimatedUsd: 0.7 } })).toBe(0.7);
+  });
+  it('falls back to raw usage.cost only when there is no stamp', () => {
+    expect(inspectorCostOf({ usage: { cost: 0.3 } })).toBe(0.3);
+    expect(inspectorCostOf({ cost: null, usage: { cost: 0.25 } })).toBe(0.25);
+  });
+  it('is null when neither is present (the cached-but-$0 bug surface)', () => {
+    expect(inspectorCostOf({ usage: { total_tokens: 100 } })).toBeNull();
+    expect(inspectorCostOf(null)).toBeNull();
+    expect(inspectorCostOf(undefined)).toBeNull();
+  });
+});
+
+describe('aggregateProbes — per-instance row reduction', () => {
+  it('sums cost/cold/tokens, reports the fraction, cached only when ALL present', () => {
+    const agg = aggregateProbes([
+      { cached: true, cost: 0.001, cold_ms: 100, tokens: 10 },
+      { cached: true, cost: 0.002, cold_ms: 200, tokens: 20 },
+      { cached: false, cost: null, cold_ms: null, tokens: null },
+    ]);
+    expect(agg.instances).toEqual({ total: 3, cached: 2 });
+    expect(agg.cached).toBe(false); // 2/3 — partial, not a green "hit"
+    expect(agg.cost).toBeCloseTo(0.003, 6);
+    expect(agg.cold_ms).toBe(300);
+    expect(agg.tokens).toBe(30);
+  });
+  it('fully cached -> cached:true; empty -> cached:false with null sums', () => {
+    expect(aggregateProbes([{ cached: true, cost: 0.001, cold_ms: 5, tokens: 1 }]).cached).toBe(
+      true,
+    );
+    expect(aggregateProbes([])).toMatchObject({
+      cached: false,
+      cost: null,
+      cold_ms: null,
+      tokens: null,
+      instances: { total: 0, cached: 0 },
+    });
+  });
+});

--- a/packages/talmud/tests/inspect-instance-key.test.ts
+++ b/packages/talmud/tests/inspect-instance-key.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { instanceIdOf, keyForEnrichment } from '../src/worker/cache-keys';
+
+// The root cause of the inspector's false misses: a per-instance enrichment is
+// cached under a key whose instance_id derives — via instanceIdOf — from the
+// rich mark_input the reader warms with (e.g. fields.verseRef). The inspector
+// used the whole-daf placeholder {fields:{}} instead, which can NEVER reproduce
+// that id. These tests pin the invariant the fix relies on: instanceIdOf is
+// shape-tolerant (reader mark_input and stored mark instance agree), and the
+// {fields:{}} probe is provably a different key.
+describe('per-instance key parity — reader mark_input vs stored instance', () => {
+  it('verseRef-bearing instances share an id regardless of surrounding fields', async () => {
+    // What pasukInstance() warms vs what the mark stores (same verseRef, extra fields differ).
+    const reader = {
+      startSegIdx: 7,
+      endSegIdx: 7,
+      fields: { verseRef: 'Deuteronomy 6:7', excerpt: 'x', summary: 'y' },
+    };
+    const stored = { startSegIdx: 7, endSegIdx: 7, fields: { verseRef: 'Deuteronomy 6:7' } };
+    expect(await instanceIdOf(reader)).toBe(await instanceIdOf(stored));
+  });
+  it('the whole-daf probe {fields:{}} computes a DIFFERENT id — the false-miss bug', async () => {
+    const real = await instanceIdOf({ fields: { verseRef: 'Deuteronomy 6:7' } });
+    expect(await instanceIdOf({ fields: {} })).not.toBe(real);
+  });
+  it('rabbi flat shape and stored {fields:{name}} shape share an id', async () => {
+    const flat = await instanceIdOf({ name: 'Abaye', generation: '4' });
+    const stored = await instanceIdOf({ excerpt: '...', fields: { name: 'Abaye' } });
+    expect(flat).toBe(stored);
+  });
+  it('the cache key differs between the real instance and the {fields:{}} probe', async () => {
+    const def = { id: 'pesukim.why-here', cache_version: '2', scope: 'local' as const };
+    const daf = { tractate: 'Berakhot', page: '2a' };
+    const realKey = keyForEnrichment(
+      def,
+      await instanceIdOf({ fields: { verseRef: 'Deuteronomy 6:7' } }),
+      daf,
+      undefined,
+      'en',
+    );
+    const probeKey = keyForEnrichment(
+      def,
+      await instanceIdOf({ fields: {} }),
+      daf,
+      undefined,
+      'en',
+    );
+    expect(realKey).not.toBe(probeKey);
+    expect(realKey).toContain('pesukim.why-here');
+  });
+});

--- a/packages/talmud/tests/inspect-round-trip.test.ts
+++ b/packages/talmud/tests/inspect-round-trip.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { instanceIdOf, keyForEnrichment } from '../src/worker/cache-keys';
+import { type InspectEntry, probeInstances } from '../src/worker/inspect';
+
+// The centerpiece: write a per-instance enrichment to a fake KV under the REAL
+// keys the warm path uses, then assert the inspector's enumeration finds them
+// (cached + correct cost) — and that the OLD whole-daf single-probe does not.
+// This is the guarantee that the waterfall/DAG "reflect the actual state".
+describe('inspector round-trip — enumeration finds per-instance entries', () => {
+  const def = { id: 'pesukim.why-here', cache_version: '2', scope: 'local' as const };
+  const daf = { tractate: 'Berakhot', page: '2a' };
+  // The mark's stored instances (parsed.instances) — fields carry the identity.
+  const instances = [
+    { startSegIdx: 7, endSegIdx: 7, fields: { verseRef: 'Deuteronomy 6:7' } },
+    { startSegIdx: 9, endSegIdx: 9, fields: { verseRef: 'Deuteronomy 11:19' } },
+  ];
+  const realKey = async (inst: unknown) =>
+    keyForEnrichment(def, await instanceIdOf(inst), daf, undefined, 'en');
+  const keyFor = (iid: string) => keyForEnrichment(def, iid, daf, undefined, 'en');
+  const getter = (kv: Map<string, unknown>) => async (k: string) =>
+    (kv.get(k) as InspectEntry | undefined) ?? null;
+
+  it('reports 2/2 cached with summed cost when both instances are warmed', async () => {
+    const kv = new Map<string, unknown>();
+    for (const inst of instances) {
+      kv.set(await realKey(inst), {
+        elapsed_ms: 1000,
+        usage: { total_tokens: 50 },
+        cost: { billedUsd: 0.001, estimatedUsd: 0.001 },
+      });
+    }
+    const agg = await probeInstances(getter(kv), keyFor, instances);
+    expect(agg.instances).toEqual({ total: 2, cached: 2 });
+    expect(agg.cached).toBe(true);
+    expect(agg.cost).toBeCloseTo(0.002, 6);
+    expect(agg.cold_ms).toBe(2000);
+    expect(agg.tokens).toBe(100);
+  });
+
+  it('the OLD {fields:{}} single-probe MISSES those same entries (regression contrast)', async () => {
+    const kv = new Map<string, unknown>();
+    for (const inst of instances) kv.set(await realKey(inst), { elapsed_ms: 1000 });
+    const probeKey = keyForEnrichment(
+      def,
+      await instanceIdOf({ fields: {} }),
+      daf,
+      undefined,
+      'en',
+    );
+    expect(kv.has(probeKey)).toBe(false);
+  });
+
+  it('partial warm -> cached:false, instances 1/2', async () => {
+    const kv = new Map<string, unknown>();
+    kv.set(await realKey(instances[0]), {
+      elapsed_ms: 500,
+      cost: { billedUsd: 0.001, estimatedUsd: 0.001 },
+    });
+    const agg = await probeInstances(getter(kv), keyFor, instances);
+    expect(agg.instances).toEqual({ total: 2, cached: 1 });
+    expect(agg.cached).toBe(false);
+    expect(agg.cost).toBeCloseTo(0.001, 6);
+  });
+});

--- a/packages/talmud/tests/inspect-row-status.test.ts
+++ b/packages/talmud/tests/inspect-row-status.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type ActivityLike,
+  liveProducerCounts,
+  liveProducerSet,
+  producerIdOf,
+  rowStatus,
+} from '../src/client/runStatus';
+
+// The waterfall stitches two INDEPENDENT sources — live run state (aiActivity)
+// and the cached snapshot (/api/daf-runs). These pin the reconciliation so a
+// finished, warmed row settles on 'hit' (not the old run -> miss bounce), and
+// the producer-id extraction tolerates every warm path's id format.
+describe('producerIdOf — id formats from every warm path', () => {
+  it('reader path: producer id is the first segment', () => {
+    expect(producerIdOf('pesukim.why-here:Berakhot:2a:deuteronomy_6_7:en')).toBe(
+      'pesukim.why-here',
+    );
+  });
+  it('dev MarksRegistryPanel path: strips the mark:/enrichment: prefix', () => {
+    expect(producerIdOf('enrichment:pesukim.why-here:Berakhot:2a:en')).toBe('pesukim.why-here');
+    expect(producerIdOf('mark:rabbi:Berakhot:2a:en')).toBe('rabbi');
+  });
+});
+
+describe('liveProducerSet / counts — collapse instances to producer', () => {
+  const acts: Record<string, ActivityLike> = {
+    a: { id: 'pesukim.why-here:Berakhot:2a:i1:en', state: { kind: 'loading' } },
+    b: { id: 'pesukim.why-here:Berakhot:2a:i2:en', state: { kind: 'queued' } },
+    c: { id: 'rabbi.location:Berakhot:2a:abaye:en', state: { kind: 'ok' } },
+    d: { id: 'aggadata.synthesis:Berakhot:2a:i1:en', state: { kind: 'loading' } },
+  };
+  it('only loading/queued count; instances collapse to one producer', () => {
+    const set = liveProducerSet(acts);
+    expect(set.has('pesukim.why-here')).toBe(true);
+    expect(set.has('aggadata.synthesis')).toBe(true);
+    expect(set.has('rabbi.location')).toBe(false); // terminal 'ok' is not live
+    expect(set.size).toBe(2);
+  });
+  it('counts in-flight instances per producer (the "2 warming" signal)', () => {
+    const counts = liveProducerCounts(acts);
+    expect(counts.get('pesukim.why-here')).toBe(2);
+    expect(counts.get('aggadata.synthesis')).toBe(1);
+    expect(counts.has('rabbi.location')).toBe(false);
+  });
+});
+
+describe('rowStatus — the loading <-> cache reconciliation', () => {
+  it('live work wins; else the snapshot hit/miss', () => {
+    expect(rowStatus({ loading: true, cached: false })).toBe('run');
+    expect(rowStatus({ loading: true, cached: true })).toBe('run');
+    expect(rowStatus({ loading: false, cached: true })).toBe('hit');
+    expect(rowStatus({ loading: false, cached: false })).toBe('miss');
+  });
+});


### PR DESCRIPTION
## Problem

The dev Inspector's waterfall and DAG reported **miss / \$0 / "not cached"** for pieces that are actually warmed (the reader renders them). Root cause, proven end-to-end against prod (`berakhot/2a`):

- A **per-instance** enrichment (one cached entry per pasuk / halacha / rabbi / argument-move) is keyed by an `instance_id` that `instanceIdOf` derives from the rich `mark_input` the reader warms with (e.g. `fields.verseRef = "Deuteronomy 6:7"` → `…:deuteronomy_6_7:…`).
- Both inspector endpoints hardcoded the **whole-daf placeholder** `instanceIdOf({fields:{}})`, which can never reproduce that id → guaranteed miss → null telemetry → rendered as `miss` / `$0`.
- Proof: run-tree for `pesukim.why-here` with a `verseRef`-bearing instance flips `cached:false → true, $0.0017`; the `{fields:{}}` probe never matches.
- Secondary: cost was read from `usage.cost` (OpenRouter's raw figure — null on Workers-AI / unpriced models even on a hit) instead of the canonical `CostStamp` ledger the rest of the system uses.
- "So many running": `liveLoading` collapsed every instance to its producer id, and because the snapshot mis-keyed per-instance rows they bounced `run → miss` (never `run → hit`).

## Fix (read-side only — no cache writes, no LLM, no reader-facing change)

- **`/api/daf-runs` + `/api/run-tree`**: enumerate the target mark's real instances (`readMarkInstances` → `instanceIdOf`, the same id the warm path produced) and aggregate → e.g. `pesukim 3/3 cached · $0.004`. New `inspect.ts` holds the pure, KV-injectable helpers.
- **Cost**: `inspectorCostOf` reads the `CostStamp` (`bestStampUsd`) with a `usage.cost` fallback — matches `daf-cost.ts`.
- **run-tree** returns `rootInstances` so a per-instance root offers an instance **picker** instead of a "nothing cached" dead-end; nodes show a `3/5 cached` fraction.
- **`runStatus.ts`**: `liveProducerSet` collapses instances to producer and strips the dev panel's `mark:`/`enrichment:` prefix; `liveProducerCounts` powers a "2 warming" count.
- `argument` (per-section) stays **excluded** from the waterfall — it has a dual `display`/`synth` instance shape that needs separate verification; every other per-instance mark round-trips cleanly (reader reshape preserves the fields `instanceIdOf` hashes).

## Tests (the "in-sync" guarantee)

- `inspect-cost` — canonical cost vs `usage.cost`; aggregate reduction.
- `inspect-instance-key` — `instanceIdOf` parity (reader mark_input ≡ stored instance) and that `{fields:{}}` is a different key (the bug).
- `inspect-round-trip` — write per-instance entries to a fake KV under the real keys; enumeration finds them, the old probe doesn't.
- `inspect-row-status` — `liveProducerSet`/`rowStatus` reconciliation (warmed row settles on `hit`, not `run→miss`).

`pnpm typecheck` + full `pnpm test` (2213) + `biome ci .` all green.