### PR TITLE
Spine flow: cross-text exit markers (off-tractate / Yerushalmi parallels)

### DIFF
--- a/packages/talmud/src/client/ArgumentSidebar.tsx
+++ b/packages/talmud/src/client/ArgumentSidebar.tsx
@@ -1258,28 +1258,39 @@ function ArgumentOverviewMaps(props: SpecialBlockProps): JSX.Element {
                   {relLabel(grp.relation)}
                 </span>
                 <For each={grp.pages}>
-                  {(p) => (
-                    <a
-                      href={dafHref({ tractate: p.tractate, page: p.page })}
-                      onClick={(e) => {
-                        e.preventDefault();
-                        goToDaf(p.tractate, p.page);
-                      }}
-                      title={t('overview.goToDaf', { daf: p.label })}
-                      style={{
-                        'font-size': '0.72rem',
-                        color: '#1d4ed8',
-                        'text-decoration': 'none',
-                        background: '#eff6ff',
-                        border: '1px solid #dbeafe',
-                        'border-radius': '5px',
-                        padding: '0.12rem 0.4rem',
-                        'white-space': 'nowrap',
-                      }}
-                    >
-                      {p.label}
-                    </a>
-                  )}
+                  {(p) => {
+                    // A Bavli daf (page like "31a") opens in our reader; a non-daf
+                    // target (Yerushalmi perek:halacha, e.g. "1:1") has no reader
+                    // here, so show it but leave it non-clickable.
+                    const nav = /^\d+[ab]$/.test(p.page);
+                    const chip = {
+                      'font-size': '0.72rem',
+                      'text-decoration': 'none',
+                      color: nav ? '#1d4ed8' : '#6b7280',
+                      background: nav ? '#eff6ff' : '#f3f4f6',
+                      border: `1px solid ${nav ? '#dbeafe' : '#e5e7eb'}`,
+                      'border-radius': '5px',
+                      padding: '0.12rem 0.4rem',
+                      'white-space': 'nowrap',
+                    };
+                    return nav ? (
+                      <a
+                        href={dafHref({ tractate: p.tractate, page: p.page })}
+                        onClick={(e) => {
+                          e.preventDefault();
+                          goToDaf(p.tractate, p.page);
+                        }}
+                        title={t('overview.goToDaf', { daf: p.label })}
+                        style={chip}
+                      >
+                        {p.label}
+                      </a>
+                    ) : (
+                      <span title={p.label} style={chip}>
+                        {p.label}
+                      </span>
+                    );
+                  }}
                 </For>
               </div>
             )}

--- a/packages/talmud/src/client/SpineFlowGraph.tsx
+++ b/packages/talmud/src/client/SpineFlowGraph.tsx
@@ -21,10 +21,20 @@ export interface SectionRabbi {
   slug: string;
   name: string;
 }
+/** A cross-text parallel that leaves the visible tractate (another tractate, or
+ *  the Yerushalmi) — rendered as a click-to-expand "exit marker" on its section
+ *  box rather than an in-graph arrow to an off-screen node. */
+export interface ExitMark {
+  ref: string;
+  relation: string;
+  corpus: 'yeru' | 'bavli' | 'here';
+  tractate: string;
+  page: string;
+}
 export interface SpineViewDaf {
   page: string;
   nextPage: string | null;
-  sections: { index: number; title: string; rabbis: SectionRabbi[] }[];
+  sections: { index: number; title: string; rabbis: SectionRabbi[]; exits?: ExitMark[] }[];
   flow: FlowConnection[];
   cross: { fromSection: number; toSection: number; relation: string; note?: string }[];
   /** deterministic daf-continuity bridge: does the sugya carry into the next daf? */
@@ -49,7 +59,26 @@ const LANE_BASE = 14,
 const LINE_H = 15,
   TITLE_CHARS = 44,
   TITLE_LINES = 2;
+// Exit markers: the click-to-expand band of cross-text parallels under a box.
+const EXIT_H = 21,
+  EXIT_TOP = 5,
+  EXIT_INDENT = 26,
+  BADGE_W = 30,
+  BADGE_H = 15;
+const PARALLEL = KIND_COLOR.parallels ?? '#7c3aed';
 const HILITE = '#b8860b';
+
+/** The Sefaria URL for an exit's target (Bavli or Yerushalmi) — "Berakhot 13a"
+ *  → …/Berakhot.13a, "Jerusalem Talmud Berakhot 1:1" → …/Jerusalem_Talmud_Berakhot.1.1. */
+function sefariaUrl(ex: { tractate: string; page: string }): string {
+  const ref = `${ex.tractate.replace(/ /g, '_')}.${ex.page.replace(/:/g, '.')}`;
+  return `https://www.sefaria.org/${ref}`;
+}
+const corpusTag = (c: ExitMark['corpus']): string =>
+  c === 'yeru' ? 'ירושלמי' : c === 'bavli' ? 'Bavli' : 'this tractate';
+const corpusFill = (c: ExitMark['corpus']): string =>
+  c === 'yeru' ? '#0e7490' : c === 'bavli' ? '#ece9e1' : '#f3f1ea';
+const corpusInk = (c: ExitMark['corpus']): string => (c === 'yeru' ? '#ffffff' : '#57534e');
 // Overview mode: one compact node per daf so the WHOLE tractate fits a screen.
 const OV_NODE_H = 22,
   OV_NODE_W = 132,
@@ -92,13 +121,33 @@ export default function SpineFlowGraph(props: {
   onRabbi?: (name: string) => void;
   mode?: 'detail' | 'overview';
   onPickDaf?: (page: string) => void;
+  /** Click handler for a cross-text exit chip. Defaults to opening the target on
+   *  Sefaria in a new tab. */
+  onPickExit?: (ex: ExitMark) => void;
 }): JSX.Element {
+  const pickExit = (ex: ExitMark) => {
+    if (props.onPickExit) props.onPickExit(ex);
+    else window.open(sefariaUrl(ex), '_blank', 'noopener');
+  };
+  // Which section boxes have their cross-text exits expanded. Collapsed is the
+  // default — a box shows only a small "⤳ N" badge until clicked.
+  const [openExits, setOpenExits] = createSignal(new Set<string>());
+  const toggleExits = (key: string) =>
+    setOpenExits((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+
   const model = createMemo(() => {
     const nodeY = new Map<string, number>();
     const nodeH = new Map<string, number>();
     const nodeTitle = new Map<string, string>();
     const nodeNum = new Map<string, number>();
     const nodeRabbis = new Map<string, SectionRabbi[]>();
+    const nodeExits = new Map<string, ExitMark[]>();
+    const nodeBand = new Map<string, number>(); // reserved height for an open exits band
     const dafHeaders: { page: string; y: number; pending: boolean }[] = [];
     let y = TOP_PAD;
     for (const d of props.dapim) {
@@ -115,7 +164,13 @@ export default function SpineFlowGraph(props: {
         nodeTitle.set(key, s.title);
         nodeNum.set(key, pos + 1);
         nodeRabbis.set(key, s.rabbis);
-        y += h + ROW_GAP;
+        const exits = s.exits ?? [];
+        nodeExits.set(key, exits);
+        // Reflow: an expanded box reserves a vertical band for its chips, so they
+        // never overlap the next box (reading openExits() makes this reactive).
+        const band = exits.length && openExits().has(key) ? EXIT_TOP + exits.length * EXIT_H : 0;
+        nodeBand.set(key, band);
+        y += h + band + ROW_GAP;
       });
       y += DAF_GAP;
     }
@@ -194,6 +249,8 @@ export default function SpineFlowGraph(props: {
       nodeTitle,
       nodeNum,
       nodeRabbis,
+      nodeExits,
+      nodeBand,
       dafHeaders,
       height,
       edges,
@@ -532,6 +589,154 @@ export default function SpineFlowGraph(props: {
                               );
                             }}
                           </For>
+                        </Show>
+                        {/* cross-text exits: collapsed ⤳N badge → click to expand a chip per parallel */}
+                        <Show when={(m.nodeExits.get(key) ?? []).length}>
+                          {(() => {
+                            const exits = m.nodeExits.get(key) ?? [];
+                            const isOpen = () => openExits().has(key);
+                            const bx = LEFT_PAD + NODE_W - BADGE_W - 7;
+                            const by = yTop + 6;
+                            return (
+                              <>
+                                {/* biome-ignore lint/a11y/useSemanticElements: native <button> cannot be used inside an SVG diagram */}
+                                <g
+                                  role="button"
+                                  tabindex={0}
+                                  style={{ cursor: 'pointer' }}
+                                  onClick={() => toggleExits(key)}
+                                  onKeyDown={(e) => {
+                                    if (e.key === 'Enter' || e.key === ' ') {
+                                      e.preventDefault();
+                                      toggleExits(key);
+                                    }
+                                  }}
+                                >
+                                  <title>{`${exits.length} parallel${exits.length > 1 ? 's' : ''} elsewhere — click to ${isOpen() ? 'hide' : 'show'}`}</title>
+                                  <rect
+                                    x={bx}
+                                    y={by}
+                                    width={BADGE_W}
+                                    height={BADGE_H}
+                                    rx={7}
+                                    ry={7}
+                                    fill={isOpen() ? PARALLEL : '#ffffff'}
+                                    stroke={PARALLEL}
+                                    stroke-width={1.5}
+                                  />
+                                  <text
+                                    x={bx + BADGE_W / 2}
+                                    y={by + BADGE_H / 2 + 0.5}
+                                    text-anchor="middle"
+                                    dominant-baseline="central"
+                                    font-size="10"
+                                    font-weight="700"
+                                    font-family="system-ui, sans-serif"
+                                    fill={isOpen() ? '#ffffff' : PARALLEL}
+                                  >
+                                    {`⤳ ${exits.length}`}
+                                  </text>
+                                </g>
+                                <Show when={isOpen()}>
+                                  <For each={exits}>
+                                    {(ex, j) => {
+                                      const top = yTop + h + EXIT_TOP + j() * EXIT_H;
+                                      const ch = EXIT_H - 3;
+                                      const cy = top + ch / 2;
+                                      const chipX = LEFT_PAD + EXIT_INDENT;
+                                      const chipW = NODE_W - EXIT_INDENT - 6;
+                                      const tag = corpusTag(ex.corpus);
+                                      const tagW = tag.length * 5.4 + 12;
+                                      const refMax = Math.max(
+                                        8,
+                                        Math.floor((chipW - tagW - 32) / 5.4),
+                                      );
+                                      const refText =
+                                        ex.ref.length > refMax
+                                          ? `${ex.ref.slice(0, refMax - 1)}…`
+                                          : ex.ref;
+                                      return (
+                                        // biome-ignore lint/a11y/useSemanticElements: native <button> cannot be used inside an SVG diagram
+                                        <g
+                                          role="button"
+                                          tabindex={0}
+                                          style={{ cursor: 'pointer' }}
+                                          onClick={() => pickExit(ex)}
+                                          onKeyDown={(e) => {
+                                            if (e.key === 'Enter' || e.key === ' ') {
+                                              e.preventDefault();
+                                              pickExit(ex);
+                                            }
+                                          }}
+                                        >
+                                          <title>{`${ex.relation} — ${ex.ref} (open on Sefaria)`}</title>
+                                          <rect
+                                            x={chipX}
+                                            y={top}
+                                            width={chipW}
+                                            height={ch}
+                                            rx={6}
+                                            ry={6}
+                                            fill="#ffffff"
+                                            stroke="#e4e0d4"
+                                            stroke-width={1}
+                                          />
+                                          <rect
+                                            x={chipX}
+                                            y={top}
+                                            width={3}
+                                            height={ch}
+                                            fill={PARALLEL}
+                                          />
+                                          <text
+                                            x={chipX + 11}
+                                            y={cy}
+                                            dominant-baseline="central"
+                                            font-size="10"
+                                            fill="#9a948a"
+                                          >
+                                            ↗
+                                          </text>
+                                          <text
+                                            x={chipX + 22}
+                                            y={cy}
+                                            dominant-baseline="central"
+                                            font-size="10.5"
+                                            font-weight="500"
+                                            font-family="system-ui, sans-serif"
+                                            fill="#2a2723"
+                                          >
+                                            {refText}
+                                          </text>
+                                          <rect
+                                            x={chipX + chipW - tagW - 5}
+                                            y={top + 2.5}
+                                            width={tagW}
+                                            height={ch - 5}
+                                            rx={5}
+                                            ry={5}
+                                            fill={corpusFill(ex.corpus)}
+                                          />
+                                          <text
+                                            x={chipX + chipW - tagW / 2 - 5}
+                                            y={cy}
+                                            text-anchor="middle"
+                                            dominant-baseline="central"
+                                            font-size="8.5"
+                                            font-weight="650"
+                                            font-family="system-ui, sans-serif"
+                                            fill={corpusInk(ex.corpus)}
+                                          >
+                                            {tag}
+                                          </text>
+                                        </g>
+                                      );
+                                    }}
+                                  </For>
+                                </Show>
+                              </>
+                            );
+                          })()}
                         </Show>
                       </g>
                     );

--- a/packages/talmud/src/client/SpineFlowGraph.tsx
+++ b/packages/talmud/src/client/SpineFlowGraph.tsx
@@ -68,12 +68,19 @@ const EXIT_H = 21,
 const PARALLEL = KIND_COLOR.parallels ?? '#7c3aed';
 const HILITE = '#b8860b';
 
-/** The Sefaria URL for an exit's target (Bavli or Yerushalmi) — "Berakhot 13a"
- *  → …/Berakhot.13a, "Jerusalem Talmud Berakhot 1:1" → …/Jerusalem_Talmud_Berakhot.1.1. */
-function sefariaUrl(ex: { tractate: string; page: string }): string {
-  const ref = `${ex.tractate.replace(/ /g, '_')}.${ex.page.replace(/:/g, '.')}`;
-  return `https://www.sefaria.org/${ref}`;
+/** In-app reader URL for an exit's target — the same `?tractate=&page=` contract
+ *  the daf reader + overview cross-references use (hash cleared). */
+function dafHref(ex: { tractate: string; page: string }): string {
+  const u = new URL(window.location.href);
+  u.searchParams.set('tractate', ex.tractate);
+  u.searchParams.set('page', ex.page);
+  u.hash = '';
+  return u.pathname + u.search;
 }
+/** Whether an exit opens in our reader (a Bavli daf). The Yerushalmi (corpus
+ *  'yeru') has no reader page here, so its chip is informative but not clickable
+ *  — consistent with the overview, which leaves non-Bavli refs non-clickable. */
+const navigableExit = (ex: ExitMark): boolean => ex.corpus !== 'yeru';
 const corpusTag = (c: ExitMark['corpus']): string =>
   c === 'yeru' ? 'ירושלמי' : c === 'bavli' ? 'Bavli' : 'this tractate';
 const corpusFill = (c: ExitMark['corpus']): string =>
@@ -121,13 +128,17 @@ export default function SpineFlowGraph(props: {
   onRabbi?: (name: string) => void;
   mode?: 'detail' | 'overview';
   onPickDaf?: (page: string) => void;
-  /** Click handler for a cross-text exit chip. Defaults to opening the target on
-   *  Sefaria in a new tab. */
+  /** Click handler for a cross-text exit chip. Defaults to opening the target daf
+   *  in our reader (`?tractate=&page=`); a non-Bavli target (Yerushalmi) is
+   *  non-navigable. */
   onPickExit?: (ex: ExitMark) => void;
 }): JSX.Element {
   const pickExit = (ex: ExitMark) => {
-    if (props.onPickExit) props.onPickExit(ex);
-    else window.open(sefariaUrl(ex), '_blank', 'noopener');
+    if (props.onPickExit) {
+      props.onPickExit(ex);
+      return;
+    }
+    if (navigableExit(ex)) window.location.href = dafHref(ex);
   };
   // Which section boxes have their cross-text exits expanded. Collapsed is the
   // default — a box shows only a small "⤳ N" badge until clicked.
@@ -498,15 +509,29 @@ export default function SpineFlowGraph(props: {
                     const lines = wrapTitle(m.nodeTitle.get(key) ?? '', TITLE_CHARS, TITLE_LINES);
                     const num = m.nodeNum.get(key) ?? 0;
                     const lit = () => hl() !== null && rabbis.some((r) => r.slug === hl());
-                    // lay rabbi chips left-to-right with approx text width
+                    // Lay rabbi chips left-to-right, keeping each WITHIN the box.
+                    // (The old filter only checked the START x, so a long name —
+                    // "Rabbi Elazar b. Azaryah" — overflowed the right edge.) Stop
+                    // at the first that won't fit and show "+N"; truncate a lone
+                    // over-long first name.
+                    const RABBI_RIGHT = LEFT_PAD + NODE_W - 12;
                     let cx = LEFT_PAD + 10;
-                    const chips = rabbis
-                      .map((r) => {
-                        const x = cx;
-                        cx += r.name.length * 5.4 + 12;
-                        return { name: r.name, slug: r.slug, x };
-                      })
-                      .filter((c) => c.x < LEFT_PAD + NODE_W - 16);
+                    const chips: { name: string; full: string; slug: string; x: number }[] = [];
+                    let hiddenRabbis = 0;
+                    for (const r of rabbis) {
+                      const w = r.name.length * 5.4;
+                      if (chips.length > 0 && cx + w > RABBI_RIGHT) {
+                        hiddenRabbis = rabbis.length - chips.length;
+                        break;
+                      }
+                      let name = r.name;
+                      if (cx + w > RABBI_RIGHT) {
+                        const max = Math.max(4, Math.floor((RABBI_RIGHT - cx) / 5.4) - 1);
+                        name = `${r.name.slice(0, max)}…`;
+                      }
+                      chips.push({ name, full: r.name, slug: r.slug, x: cx });
+                      cx += name.length * 5.4 + 12;
+                    }
                     return (
                       <g>
                         <title>{`${num}. ${m.nodeTitle.get(key) ?? ''}`}</title>
@@ -583,12 +608,24 @@ export default function SpineFlowGraph(props: {
                                     }
                                   }}
                                 >
-                                  <title>{`trace ${c.name} across the tractate`}</title>
+                                  <title>{`trace ${c.full} across the tractate`}</title>
                                   {c.name}
                                 </text>
                               );
                             }}
                           </For>
+                          <Show when={hiddenRabbis > 0}>
+                            <text
+                              x={cx}
+                              y={yTop + h - 8}
+                              font-size="9.5"
+                              font-weight={500}
+                              font-family="system-ui, sans-serif"
+                              fill="#b0a894"
+                            >
+                              {`+${hiddenRabbis}`}
+                            </text>
+                          </Show>
                         </Show>
                         {/* cross-text exits: collapsed ⤳N badge → click to expand a chip per parallel */}
                         <Show when={(m.nodeExits.get(key) ?? []).length}>
@@ -655,21 +692,10 @@ export default function SpineFlowGraph(props: {
                                         ex.ref.length > refMax
                                           ? `${ex.ref.slice(0, refMax - 1)}…`
                                           : ex.ref;
-                                      return (
-                                        // biome-ignore lint/a11y/useSemanticElements: native <button> cannot be used inside an SVG diagram
-                                        <g
-                                          role="button"
-                                          tabindex={0}
-                                          style={{ cursor: 'pointer' }}
-                                          onClick={() => pickExit(ex)}
-                                          onKeyDown={(e) => {
-                                            if (e.key === 'Enter' || e.key === ' ') {
-                                              e.preventDefault();
-                                              pickExit(ex);
-                                            }
-                                          }}
-                                        >
-                                          <title>{`${ex.relation} — ${ex.ref} (open on Sefaria)`}</title>
+                                      const nav = navigableExit(ex);
+                                      const inner = (
+                                        <>
+                                          <title>{`${ex.relation} — ${ex.ref}${nav ? ' (open in reader)' : ' (Yerushalmi — see the daf’s Yerushalmi card)'}`}</title>
                                           <rect
                                             x={chipX}
                                             y={top}
@@ -729,6 +755,25 @@ export default function SpineFlowGraph(props: {
                                           >
                                             {tag}
                                           </text>
+                                        </>
+                                      );
+                                      // Bavli → clickable (opens in our reader); Yerushalmi → informative only.
+                                      if (!nav) return <g>{inner}</g>;
+                                      return (
+                                        // biome-ignore lint/a11y/useSemanticElements: native <button> cannot be used inside an SVG diagram
+                                        <g
+                                          role="button"
+                                          tabindex={0}
+                                          style={{ cursor: 'pointer' }}
+                                          onClick={() => pickExit(ex)}
+                                          onKeyDown={(e) => {
+                                            if (e.key === 'Enter' || e.key === ' ') {
+                                              e.preventDefault();
+                                              pickExit(ex);
+                                            }
+                                          }}
+                                        >
+                                          {inner}
                                         </g>
                                       );
                                     }}

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -1,3 +1,4 @@
+import { slugTractate } from '@corpus/core/cache/keys';
 import { continuationLink, type FlowEdge } from '@corpus/core/context/link';
 import { coordLabel } from '@corpus/core/context/types';
 import { gatewayActive, gatewayStatus, wrapEnv } from '@corpus/core/llm/ai-gateway';
@@ -72,7 +73,7 @@ import {
   validateLLMRabbiOutput,
 } from '../lib/rabbi/types';
 import type { EntityPiece } from '../lib/registry/entity';
-import { adjacentAmud, sefariaAPI, type TalmudPageData } from '../lib/sefref';
+import { adjacentAmud, sefariaAPI, type TalmudPageData, TRACTATE_OPTIONS } from '../lib/sefref';
 import { iterAmudim, TRACTATE_END_AMUD } from '../lib/sefref/amudim';
 import { getDafyomiMasechet } from '../lib/sefref/dafyomi/masechtos';
 import { fetchHebrewBooksDaf } from '../lib/sefref/hebrewbooks/client';
@@ -1569,10 +1570,23 @@ function sectionExitMarks(
   return out;
 }
 
+/** Resolve a tractate slug ('berakhot', 'bava_kamma') to its Sefaria-canonical
+ *  name ('Berakhot', 'Bava Kamma') — the case the parallel/yerushalmi bundles are
+ *  keyed under. Falls back to the input when unknown. */
+function canonicalTractateName(slug: string): string {
+  const s = slugTractate(slug);
+  return TRACTATE_OPTIONS.find((o) => slugTractate(o.value) === s)?.value ?? slug;
+}
+
 app.get('/api/spine-view/:tractate', async (c) => {
   const tractate = c.req.param('tractate');
   if (!isKnownTractate(tractate)) return c.json({ error: `unknown tractate: ${tractate}` }, 404);
   if (!c.env.CACHE) return c.json({ error: 'no CACHE binding in this environment' }, 503);
+  // The route param is a lowercase slug; the parallel / yerushalmi bundles are
+  // keyed by the Sefaria-canonical tractate name the reader/API wrote them under
+  // (raw case, unlike the slugDaf-folded mark/flow/bridge keys), so resolve it or
+  // the read-only bundle reads cold-miss everything.
+  const canonical = canonicalTractateName(tractate);
   const pages = [...iterAmudim(tractate)];
   const raw = await mapPool(pages, 24, async (page) => {
     const secs = await readSectionRabbis(c.env, tractate, page);
@@ -1581,10 +1595,10 @@ app.get('/api/spine-view/:tractate', async (c) => {
     const bridge = await readCachedBridge(c.env, tractate, page);
     // Cross-text parallels (off-tractate / Yerushalmi), read-only, grouped to the
     // section they leave from — rendered as exit markers in the flow graph.
-    const tp = await readCachedTalmudParallels(c.env.CACHE, tractate, page);
-    const yeru = await readCachedYerushalmi(c.env.CACHE, tractate, page);
+    const tp = await readCachedTalmudParallels(c.env.CACHE, canonical, page);
+    const yeru = await readCachedYerushalmi(c.env.CACHE, canonical, page);
     const exits = sectionExitMarks(
-      tractate,
+      canonical,
       page,
       secs.map((s) => s.start),
       tp,

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -1,4 +1,5 @@
 import { continuationLink, type FlowEdge } from '@corpus/core/context/link';
+import { coordLabel } from '@corpus/core/context/types';
 import { gatewayActive, gatewayStatus, wrapEnv } from '@corpus/core/llm/ai-gateway';
 import {
   type BudgetScope,
@@ -53,6 +54,7 @@ import { dedupeBy, dedupeByRange, type MoveLike, selectSectionMoves } from '../l
 import { runPasses } from '../lib/check/passes';
 import type { MatchInput } from '../lib/context/anchor/ai-prompt';
 import { type DafLink, dafLinks } from '../lib/context/dafLinks';
+import { talmudParallelsToLinks, yerushalmiToLinks } from '../lib/context/parallels';
 import { dafSpine } from '../lib/context/spine';
 import { spineLinks } from '../lib/context/spineLinks';
 import { buildGeoModel, type GeoEnrichment, type RabbiGeoSource } from '../lib/geographyModel';
@@ -1518,6 +1520,55 @@ async function runConnectSweep(env: Bindings): Promise<void> {
 // cross-daf edges into the next, for the whole tractate. Read-only over cached
 // pieces — nothing is computed. The client stacks these into one continuous
 // argument map down the tractate. (Hidden #spine page only.)
+/** A cross-text "exit" on a section: a parallel link whose target is off the
+ *  visible tractate (another tractate, or the Yerushalmi) and so can't be drawn
+ *  as an in-graph arrow — the spine flow graph renders these as click-to-expand
+ *  markers beside the section box. `corpus` distinguishes the badge. */
+interface SpineExit {
+  ref: string;
+  relation: string;
+  corpus: 'yeru' | 'bavli' | 'here';
+  tractate: string;
+  page: string;
+}
+/** Group a daf's cached parallels (Mesorat HaShas + Yerushalmi) into per-section
+ *  exit marks, keyed to the argument section their source segment sits in. Pure
+ *  over already-read bundles — no network. */
+function sectionExitMarks(
+  tractate: string,
+  page: string,
+  sectionStarts: readonly number[],
+  tp: Awaited<ReturnType<typeof readCachedTalmudParallels>>,
+  yeru: Awaited<ReturnType<typeof readCachedYerushalmi>>,
+): SpineExit[][] {
+  const daf = { tractate, page };
+  const links = [...talmudParallelsToLinks(daf, tp), ...yerushalmiToLinks(daf, yeru)];
+  const out: SpineExit[][] = sectionStarts.map(() => []);
+  if (out.length === 0) return out;
+  for (const l of links) {
+    const t = l.targets[0];
+    if (!t) continue;
+    // the section whose start is the greatest not exceeding the source segment
+    // (robust to section array order).
+    let idx = 0;
+    let best = -1;
+    for (let i = 0; i < sectionStarts.length; i++) {
+      if (sectionStarts[i] <= l.source.seg && sectionStarts[i] >= best) {
+        best = sectionStarts[i];
+        idx = i;
+      }
+    }
+    out[idx].push({
+      ref: coordLabel(t),
+      relation: l.relation,
+      corpus: l.via === 'yerushalmi' ? 'yeru' : t.tractate === tractate ? 'here' : 'bavli',
+      tractate: t.tractate,
+      page: t.page,
+    });
+  }
+  return out;
+}
+
 app.get('/api/spine-view/:tractate', async (c) => {
   const tractate = c.req.param('tractate');
   if (!isKnownTractate(tractate)) return c.json({ error: `unknown tractate: ${tractate}` }, 404);
@@ -1528,12 +1579,24 @@ app.get('/api/spine-view/:tractate', async (c) => {
     const flow = await readFlowConnections(c.env, tractate, page);
     const cross = await readCachedCrossFlow(c.env, tractate, page);
     const bridge = await readCachedBridge(c.env, tractate, page);
+    // Cross-text parallels (off-tractate / Yerushalmi), read-only, grouped to the
+    // section they leave from — rendered as exit markers in the flow graph.
+    const tp = await readCachedTalmudParallels(c.env.CACHE, tractate, page);
+    const yeru = await readCachedYerushalmi(c.env.CACHE, tractate, page);
+    const exits = sectionExitMarks(
+      tractate,
+      page,
+      secs.map((s) => s.start),
+      tp,
+      yeru,
+    );
     return {
       page,
       sections: secs.map((s, i) => ({
         index: i,
         title: s.title || `Section ${i + 1}`,
         rabbis: s.rabbis,
+        exits: exits[i] ?? [],
       })),
       flow,
       cross: cross?.edges ?? [],

--- a/packages/talmud/tests/client/spine-exit-markers.test.tsx
+++ b/packages/talmud/tests/client/spine-exit-markers.test.tsx
@@ -69,6 +69,12 @@ describe('SpineFlowGraph — cross-text exit markers', () => {
     expect(texts(container, 'Jerusalem Talmud Berakhot 1:1').length).toBeGreaterThan(0);
     expect(texts(container, 'Bavli').length).toBeGreaterThan(0);
     expect(texts(container, 'ירושלמי').length).toBeGreaterThan(0);
+    // a Bavli chip is navigable (opens in our reader); the Yerushalmi chip is
+    // informative only — no in-app reader, so not a button.
+    const bavliChip = texts(container, 'Shabbat 31a')[0]?.closest('g');
+    const yeruChip = texts(container, 'Jerusalem Talmud Berakhot 1:1')[0]?.closest('g');
+    expect(bavliChip?.getAttribute('role')).toBe('button');
+    expect(yeruChip?.getAttribute('role')).toBeNull();
   });
 
   it('renders no badge for a section without parallels', () => {

--- a/packages/talmud/tests/client/spine-exit-markers.test.tsx
+++ b/packages/talmud/tests/client/spine-exit-markers.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+//
+// Cross-text "exit markers" on the spine flow graph: a section with parallels
+// elsewhere in Shas / the Yerushalmi shows a small ⤳N badge (collapsed default);
+// clicking it expands a chip per parallel. Verifies the badge renders, chips are
+// hidden until expansion, and a click reveals them (incl. the corpus badge).
+import { fireEvent, render } from '@solidjs/testing-library';
+import { describe, expect, it } from 'vitest';
+import SpineFlowGraph, { type SpineViewDaf } from '../../src/client/SpineFlowGraph';
+
+function texts(container: HTMLElement, needle: string): SVGTextElement[] {
+  return Array.from(container.querySelectorAll('text')).filter((t) =>
+    (t.textContent ?? '').includes(needle),
+  ) as unknown as SVGTextElement[];
+}
+
+const dapim: SpineViewDaf[] = [
+  {
+    page: '2a',
+    nextPage: '2b',
+    sections: [
+      {
+        index: 0,
+        title: 'Evening Shema',
+        rabbis: [],
+        exits: [
+          {
+            ref: 'Shabbat 31a',
+            relation: 'parallels',
+            corpus: 'bavli',
+            tractate: 'Shabbat',
+            page: '31a',
+          },
+          {
+            ref: 'Jerusalem Talmud Berakhot 1:1',
+            relation: 'parallels',
+            corpus: 'yeru',
+            tractate: 'Jerusalem Talmud Berakhot',
+            page: '1:1',
+          },
+        ],
+      },
+      { index: 1, title: 'Gemara source', rabbis: [], exits: [] },
+    ],
+    flow: [],
+    cross: [],
+  },
+];
+
+describe('SpineFlowGraph — cross-text exit markers', () => {
+  it('shows a ⤳N badge for a section with parallels, collapsed by default', () => {
+    const { container } = render(() => <SpineFlowGraph dapim={dapim} />);
+    // badge present with the count
+    expect(texts(container, '⤳').some((t) => (t.textContent ?? '').includes('2'))).toBe(true);
+    // chips are hidden until expanded
+    expect(texts(container, 'Shabbat 31a')).toHaveLength(0);
+    expect(texts(container, 'Jerusalem Talmud Berakhot 1:1')).toHaveLength(0);
+  });
+
+  it('expands the chips (with corpus badges) when the badge is clicked', () => {
+    const { container } = render(() => <SpineFlowGraph dapim={dapim} />);
+    const badge = texts(container, '⤳')
+      .find((t) => (t.textContent ?? '').includes('2'))
+      ?.closest('[role="button"]');
+    expect(badge).toBeTruthy();
+    fireEvent.click(badge as Element);
+    // both parallel chips now render, with their corpus tags
+    expect(texts(container, 'Shabbat 31a').length).toBeGreaterThan(0);
+    expect(texts(container, 'Jerusalem Talmud Berakhot 1:1').length).toBeGreaterThan(0);
+    expect(texts(container, 'Bavli').length).toBeGreaterThan(0);
+    expect(texts(container, 'ירושלמי').length).toBeGreaterThan(0);
+  });
+
+  it('renders no badge for a section without parallels', () => {
+    const noExits: SpineViewDaf[] = [
+      {
+        page: '5a',
+        nextPage: null,
+        sections: [{ index: 0, title: 'Lone section', rabbis: [], exits: [] }],
+        flow: [],
+        cross: [],
+      },
+    ];
+    const { container } = render(() => <SpineFlowGraph dapim={noExits} />);
+    expect(texts(container, '⤳')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
PR3 of the spine connection-expansion (follows #385 related gemaras, #387 Yerushalmi). The parallel *links* already ship; this is the **rendering** — surfacing them in the stitched flow view.

## Problem
`SpineFlowGraph` only draws edges whose endpoints are laid-out section nodes in the visible tractate (the `nodeY.has(target)` guard). A `parallels` link to **another tractate** or the **Yerushalmi** has no node to point at, so it was silently dropped — the `byVia.mesorah` / `byVia.yerushalmi` edges existed in the data but were invisible in the map.

## Solution — collapsible exit markers
A section with parallels shows a small **`⤳ N` badge** in its corner, **collapsed by default** so the map stays clean. Click it (or Enter/Space) to expand a chip per parallel in a **reserved layout band** under the box — the layout reflows so chips never overlap the next box. Click again to collapse.

- Chips are **colored by relation** (`parallels` = the same `KIND_COLOR` purple as every other edge) with a small **corpus badge**: `ירושלמי` (teal) / `Bavli` (other tractate) / `this tractate` (long-range).
- Chip click opens the target on **Sefaria** (uniform for Bavli + Yerushalmi; overridable via a new `onPickExit` prop).
- Keyboard-accessible (`role=button` + Enter/Space), consistent with the existing rabbi chips.

## Wiring
- **`/api/spine-view`**: per daf, read the cached parallels (`readCachedTalmudParallels` + `readCachedYerushalmi` — read-only, no network, same contract as the rest of the sweep), group each to the argument section its source segment sits in, and attach `exits` to that section (`sectionExitMarks`).
- **`SpineFlowGraph.tsx`**: `ExitMark` type + an `openExits` signal; the layout memo reserves a band for an expanded box; badge + chips drawn in SVG (scales with the existing zoom, no overlay).

No producer/data changes — this consumes what #385/#387 already cache.

## Verification
- `pnpm typecheck` clean; **2222 tests** pass incl. a new jsdom render+interaction test (`spine-exit-markers.test.tsx`: badge collapsed by default → click reveals chips + corpus tags → no badge when a section has no parallels); `biome check .` clean; `vite build` clean.
- Visual: matches the approved HTML mockup. Recommend a look on the hidden `#spine/<tractate>/flow` page post-merge (it's a dev-only page).

Note: a parallel local branch (`spine-autoload-flow`) also edits `SpineFlowGraph`/`index.ts`; it isn't on the remote yet, so no conflict at time of writing — may need a `git merge origin/master` if it lands first.