### PR TITLE
Load bar + Inspect waterfall share one daf-runs store (sync, step 1)

### DIFF
--- a/packages/talmud/src/client/DafLoadProgress.tsx
+++ b/packages/talmud/src/client/DafLoadProgress.tsx
@@ -14,6 +14,7 @@
 
 import { createEffect, createMemo, createSignal, type JSX, onCleanup, Show } from 'solid-js';
 import { loadNotice, prefetchProgress } from './dafPrefetch';
+import { dafCacheProgress } from './dafRunsStore';
 import { t } from './i18n';
 import { markStatuses } from './MarksRegistryPanel';
 
@@ -46,7 +47,9 @@ export default function DafLoadProgress(props: DafLoadProgressProps = {}): JSX.E
   // anchor extraction then snapping backwards when the prefetch cohort appears.
   // Anchors occupy the first 30%; section prefetch the remaining 70%.
   const ANCHOR_WEIGHT = 30;
-  const percent = createMemo(() => {
+  // The client warm engine (anchors + prefetch) drives the smooth, low-latency
+  // live climb — the part that made this bar more reliable than the waterfall.
+  const enginePercent = createMemo(() => {
     const { m, pf } = combined();
     if (m.total === 0 && pf.total === 0) return 0;
     const anchorFrac = m.total > 0 ? m.done / m.total : 1;
@@ -58,6 +61,13 @@ export default function DafLoadProgress(props: DafLoadProgressProps = {}): JSX.E
     }
     return Math.round(ANCHOR_WEIGHT + (pf.done / pf.total) * (100 - ANCHOR_WEIGHT));
   });
+  // Ground completion in the SHARED daf-runs cache snapshot — the same source the
+  // Inspect waterfall reads — so the two can't disagree about what's loaded (a
+  // warm revisit with a full cache reads ~100% at once). max() so the snapshot
+  // only ever ADVANCES the bar; it never drags the live climb backward on a cold
+  // load, where the snapshot lags the warm. (Stale cross-daf rows are guarded in
+  // the store, so this fraction is always for the current daf.)
+  const percent = createMemo(() => Math.max(enginePercent(), dafCacheProgress().pct));
 
   const label = createMemo(() => {
     const c = combined();

--- a/packages/talmud/src/client/DafViewer.tsx
+++ b/packages/talmud/src/client/DafViewer.tsx
@@ -36,6 +36,7 @@ import { type CommentaryAnchorIndex, fetchCommentaryAnchorIndex } from './commen
 import DafLoadProgress from './DafLoadProgress';
 import { readDevMode, setDevModeActive } from './DevModeShelf';
 import { cancelPrefetch, prefetchDaf } from './dafPrefetch';
+import { setDafRunsTarget } from './dafRunsStore';
 import { ensureMasechetIncipit } from './ensureMasechetIncipit';
 import { GutterIcons, type GutterKind } from './GutterIcons';
 import { GutterOverlay } from './GutterOverlay';
@@ -788,6 +789,10 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
   // signature (daf + per-mark instance counts) guards against re-firing and
   // self-corrects if a daf change briefly leaves stale mark runs visible — the
   // generation-guarded prefetchDaf supersedes any stale cohort.
+  // Point the shared daf-runs store (Inspect waterfall + the load bar's cache
+  // grounding) at the open daf, so both consume one snapshot for this daf/lang.
+  createEffect(() => setDafRunsTarget(tractate(), page(), lang()));
+
   let lastPrefetchSig = '';
   createEffect(() => {
     const t = tractate();

--- a/packages/talmud/src/client/RunTreeDock.tsx
+++ b/packages/talmud/src/client/RunTreeDock.tsx
@@ -26,13 +26,18 @@ import {
   onCleanup,
   Show,
 } from 'solid-js';
-import { aiActivity } from './aiActivity';
+import {
+  type DafRun,
+  dafRunRows,
+  dafRunsLoading,
+  liveCounts,
+  liveLoading,
+  refetchDafRuns,
+} from './dafRunsStore';
 import { lang } from './i18n';
 import { inspectRequest } from './inspectBridge';
-import { liveProducerCounts, liveProducerSet } from './runStatus';
 import {
   ACTIVE_STROKE,
-  type Authority,
   AuthorityBadge,
   BADGE_LLM,
   BADGE_PRO,
@@ -57,30 +62,14 @@ import {
   type RunResult,
   type RunTree,
   STALENESS_COLOR,
-  type Staleness,
   StalenessDot,
   TOP_PAD,
   type TreeNode,
   variantOf,
 } from './runTreeShared';
 
-interface DafRun {
-  id: string;
-  label: string;
-  kind: 'llm' | 'computed';
-  producer: 'mark' | 'enrichment';
-  model?: string;
-  cached: boolean;
-  cold_ms: number | null;
-  cost: number | null;
-  tokens: number | null;
-  // additive (older payloads omit them)
-  authority?: Authority | null;
-  staleness?: Staleness | null;
-  // Per-instance producers report the warmed fraction (e.g. 3/5 pesukim);
-  // absent on whole-daf / single-entry rows.
-  instances?: { total: number; cached: number };
-}
+// DafRun (the shared snapshot row) is imported from dafRunsStore — the load bar
+// reads the same rows, so the two surfaces can't drift.
 
 /** One waterfall row — a piece run with a cold-time bar. Used as the collapsed
  *  header (the selected run) and as each row of the full waterfall list. */
@@ -525,20 +514,14 @@ export default function RunTreeDock(props: {
   const [width, setWidth] = createSignal(Math.min(620, Math.round(window.innerWidth * 0.42)));
   const [detailH, setDetailH] = createSignal(Math.round(window.innerHeight * 0.34));
 
-  // Waterfall feed — every top-level run on this daf with cached telemetry.
-  const [runs, { refetch: refetchRuns }] = createResource(
-    () => (props.open ? `${props.tractate}|${props.page}|${lang()}` : null),
-    async (): Promise<DafRun[]> => {
-      const r = await fetch(
-        `/api/daf-runs/${encodeURIComponent(props.tractate)}/${encodeURIComponent(props.page)}?lang=${lang()}`,
-      );
-      if (!r.ok) return [];
-      return ((await r.json()) as { runs: DafRun[] }).runs;
-    },
-  );
-  const maxCold = createMemo(() => Math.max(1, ...(runs() ?? []).map((r) => r.cold_ms ?? 0)));
+  // Waterfall feed + live overlay come from the SHARED dafRunsStore — the load bar
+  // reads the same snapshot, so the two surfaces can't drift. The store owns the
+  // fetch (keyed by the open daf) and the refetch-while-warming poll; the dock
+  // only reads. `liveLoading`/`liveCounts` are the store's aiActivity overlay.
+  const runs = dafRunRows;
+  const maxCold = createMemo(() => Math.max(1, ...runs().map((r) => r.cold_ms ?? 0)));
   const _dafTotals = createMemo(() => {
-    const rs = runs() ?? [];
+    const rs = runs();
     return {
       count: rs.length,
       cached: rs.filter((r) => r.cached).length,
@@ -546,26 +529,6 @@ export default function RunTreeDock(props: {
       cold_ms: rs.reduce((s, r) => s + (r.cold_ms ?? 0), 0),
     };
   });
-  // Producer ids with a live in-flight run, and the per-producer in-flight count
-  // ("2 warming"). Both derive from the in-memory aiActivity signal — see
-  // runStatus.ts, which also strips the dev panel's `mark:`/`enrichment:` prefix
-  // so those ids map to a real producer instead of a phantom "mark"/"enrichment".
-  const liveLoading = createMemo<Set<string>>(() => liveProducerSet(aiActivity()));
-  const liveCounts = createMemo<Map<string, number>>(() => liveProducerCounts(aiActivity()));
-  // The waterfall's telemetry is a snapshot; while anything is loading, re-poll
-  // /api/daf-runs so finished pieces flip from "run" to their real hit + time +
-  // cost (instead of staying on the stale miss/0ms snapshot). Also refetch once
-  // more right after the live set empties, to capture the final state.
-  createEffect((wasLive: boolean) => {
-    const isLive = props.open && liveLoading().size > 0;
-    if (isLive) {
-      const t = setInterval(() => refetchRuns(), 2500);
-      onCleanup(() => clearInterval(t));
-    } else if (wasLive && props.open) {
-      refetchRuns();
-    }
-    return isLive;
-  }, false);
   // Waterfall rows after the type filter; actively-loading pieces float to the top.
   const visibleRuns = createMemo(() => {
     const live = liveLoading();
@@ -912,7 +875,7 @@ export default function RunTreeDock(props: {
             </span>
           </div>
           <div style={{ flex: 1, 'min-height': 0, overflow: 'auto' }}>
-            <Show when={runs.loading}>
+            <Show when={dafRunsLoading()}>
               <div style={{ padding: '0.6rem', color: '#aaa' }}>loading…</div>
             </Show>
             <For each={visibleRuns()}>
@@ -1166,7 +1129,7 @@ export default function RunTreeDock(props: {
             tractate={props.tractate}
             page={props.page}
             pieceId={pieceId()}
-            onRewarmed={() => refetchRuns()}
+            onRewarmed={() => refetchDafRuns()}
           />
         </Show>
 

--- a/packages/talmud/src/client/dafRunsProgress.ts
+++ b/packages/talmud/src/client/dafRunsProgress.ts
@@ -1,0 +1,51 @@
+/**
+ * dafRunsProgress — the PURE (no Solid) shape + reducers shared by the Inspect
+ * waterfall and the load bar, split out of dafRunsStore so they're unit-testable
+ * without booting the reactive store (whose module-scope createResource trips
+ * Solid's SSR build under vitest). The store re-exports these.
+ */
+
+import type { Authority, Staleness } from './runTreeShared';
+
+export interface DafRun {
+  id: string;
+  label: string;
+  kind: 'llm' | 'computed';
+  producer: 'mark' | 'enrichment';
+  model?: string;
+  cached: boolean;
+  cold_ms: number | null;
+  cost: number | null;
+  tokens: number | null;
+  // additive (older payloads omit them)
+  authority?: Authority | null;
+  staleness?: Staleness | null;
+  /** Per-instance producers report the warmed fraction (e.g. 3/5 pesukim). */
+  instances?: { total: number; cached: number };
+  /** Dev-only / experimental producers (e.g. chart) — excluded from the load
+   *  bar's denominator since the reader never auto-warms them. */
+  experimental?: boolean;
+}
+
+/** A row the reader auto-warms on daf load — the load bar's denominator. Excludes
+ *  experimental (chart) and lazy on-demand leaves (*.qa / *.suggested-questions),
+ *  which only warm when a user opens them, so they'd otherwise peg the bar < 100%. */
+export function isEagerRow(r: Pick<DafRun, 'id' | 'experimental'>): boolean {
+  if (r.experimental) return false;
+  if (r.id.endsWith('.qa') || r.id.endsWith('.suggested-questions')) return false;
+  return true;
+}
+
+/** Reduce the snapshot to a cache-progress fraction over the eager set. Counts
+ *  per-instance producers by their instance units (3/5 pesukim = 5 units, 3 done)
+ *  so a half-warmed per-pasuk producer reads honestly. */
+export function cacheProgressOf(rows: DafRun[]): { total: number; cached: number; pct: number } {
+  let total = 0;
+  let cached = 0;
+  for (const r of rows) {
+    if (!isEagerRow(r)) continue;
+    total += r.instances?.total ?? 1;
+    cached += r.instances?.cached ?? (r.cached ? 1 : 0);
+  }
+  return { total, cached, pct: total > 0 ? Math.round((cached / total) * 100) : 0 };
+}

--- a/packages/talmud/src/client/dafRunsStore.ts
+++ b/packages/talmud/src/client/dafRunsStore.ts
@@ -1,0 +1,100 @@
+/**
+ * dafRunsStore — ONE shared owner of the `/api/daf-runs` snapshot (cache status +
+ * cost per piece) plus the live `aiActivity` overlay, so the Inspect waterfall
+ * (RunTreeDock) and the daf load bar (DafLoadProgress) consume the SAME info and
+ * can't drift. Previously the dock owned this fetch privately and the load bar
+ * had its own counters; this lifts the fetch to module scope (under a long-lived
+ * createRoot) keyed by the active daf, so it runs whether or not the dock is open.
+ *
+ * Two facts, two natures, deliberately kept separate and reconciled downstream:
+ *   - durable "cached + cost"  ← the daf-runs snapshot (this resource)
+ *   - ephemeral "in flight now" ← aiActivity (liveProducerSet/Counts)
+ * The load bar grounds its completion in the cached snapshot but keeps its live
+ * climb on aiActivity, so it never lags a cold load or stalls below 100%.
+ */
+
+import {
+  createEffect,
+  createMemo,
+  createResource,
+  createRoot,
+  createSignal,
+  onCleanup,
+} from 'solid-js';
+import { aiActivity } from './aiActivity';
+import { cacheProgressOf, type DafRun } from './dafRunsProgress';
+import { liveProducerCounts, liveProducerSet } from './runStatus';
+
+// Re-export the pure shape + reducers so consumers keep one import site; the
+// testable definitions live in dafRunsProgress (no Solid → importable in vitest).
+export { cacheProgressOf, type DafRun, isEagerRow } from './dafRunsProgress';
+
+interface Target {
+  tractate: string;
+  page: string;
+  lang: string;
+}
+
+const [target, setTarget] = createSignal<Target | null>(null);
+
+/** Point the store at a daf — called from DafViewer on every daf/lang change.
+ *  Idempotent: a same-value target doesn't refetch (resource keys on the tuple). */
+export function setDafRunsTarget(tractate: string, page: string, lang: string): void {
+  const cur = target();
+  if (cur && cur.tractate === tractate && cur.page === page && cur.lang === lang) return;
+  setTarget({ tractate, page, lang });
+}
+
+const targetKey = (): string | null => {
+  const t = target();
+  return t ? `${t.tractate}|${t.page}|${t.lang}` : null;
+};
+
+const store = createRoot(() => {
+  const [runs, { refetch }] = createResource(
+    targetKey,
+    async (key): Promise<{ key: string; rows: DafRun[] }> => {
+      const t = target();
+      if (!t) return { key, rows: [] };
+      const r = await fetch(
+        `/api/daf-runs/${encodeURIComponent(t.tractate)}/${encodeURIComponent(t.page)}?lang=${t.lang}`,
+      );
+      if (!r.ok) return { key, rows: [] };
+      return { key, rows: ((await r.json()) as { runs: DafRun[] }).runs };
+    },
+  );
+  const liveLoading = createMemo<Set<string>>(() => liveProducerSet(aiActivity()));
+  const liveCounts = createMemo<Map<string, number>>(() => liveProducerCounts(aiActivity()));
+  // The snapshot is point-in-time; while anything is warming, re-poll so finished
+  // pieces flip to their real cached/cost, then once more right after the live set
+  // empties to capture the final state. Bounded — only runs during active warming.
+  createEffect((wasLive: boolean) => {
+    const isLive = !!target() && liveLoading().size > 0;
+    if (isLive) {
+      const h = setInterval(() => refetch(), 2500);
+      onCleanup(() => clearInterval(h));
+    } else if (wasLive && target()) {
+      refetch();
+    }
+    return isLive;
+  }, false);
+  return { runs, refetch, liveLoading, liveCounts };
+});
+
+// Rows for the CURRENT target only. A resource keeps its prior value during a
+// source-change refetch, so without this guard a daf change would briefly serve
+// the previous daf's snapshot — flashing a stale cache fraction on the load bar.
+// [] until the current daf's fetch resolves; persists across same-daf refetches.
+export const dafRunRows = (): DafRun[] => {
+  const r = store.runs();
+  return r && r.key === targetKey() ? r.rows : [];
+};
+export const dafRunsLoading = (): boolean => store.runs.loading;
+export const refetchDafRuns = (): void => {
+  void store.refetch();
+};
+export const liveLoading = store.liveLoading;
+export const liveCounts = store.liveCounts;
+
+/** The shared cache-progress, recomputed as the snapshot updates. */
+export const dafCacheProgress = createRoot(() => createMemo(() => cacheProgressOf(dafRunRows())));

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -2045,6 +2045,7 @@ app.get('/api/daf-runs/:tractate/:page', async (c) => {
           cost: agg.cost,
           tokens: agg.tokens,
           instances: agg.instances,
+          experimental: !!(def as { experimental?: boolean }).experimental,
           authority: null,
           staleness: null,
         };
@@ -2090,6 +2091,7 @@ app.get('/api/daf-runs/:tractate/:page', async (c) => {
         cost: inspectorCostOf(res as InspectEntry | null),
         tokens: tokensOfEntry(res),
         instances: undefined as { total: number; cached: number } | undefined,
+        experimental: !!(def as { experimental?: boolean }).experimental,
         authority: stored ? authorityOf(stored) : null,
         staleness,
       };

--- a/packages/talmud/tests/daf-runs-store.test.ts
+++ b/packages/talmud/tests/daf-runs-store.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { cacheProgressOf, type DafRun, isEagerRow } from '../src/client/dafRunsProgress';
+
+// The load bar and the Inspect waterfall now read ONE snapshot (dafRunsStore).
+// These pin the reducer the load bar grounds its completion in — the shared
+// "what's cached on this daf" fraction — so the two surfaces can't disagree.
+const row = (o: Partial<DafRun> & { id: string }): DafRun => ({
+  id: o.id,
+  label: o.id,
+  kind: 'llm',
+  producer: 'enrichment',
+  cached: false,
+  cold_ms: null,
+  cost: null,
+  tokens: null,
+  ...o,
+});
+
+describe('isEagerRow — the load bar denominator', () => {
+  it('excludes experimental + lazy on-demand leaves (they never auto-warm)', () => {
+    expect(isEagerRow(row({ id: 'pesukim.why-here' }))).toBe(true);
+    expect(isEagerRow(row({ id: 'daf-background.synthesis' }))).toBe(true);
+    expect(isEagerRow(row({ id: 'chart', experimental: true }))).toBe(false);
+    expect(isEagerRow(row({ id: 'pesukim.qa' }))).toBe(false);
+    expect(isEagerRow(row({ id: 'aggadata.suggested-questions' }))).toBe(false);
+  });
+});
+
+describe('cacheProgressOf — shared cache fraction (load bar grounding)', () => {
+  it('counts per-instance producers by instance units, whole-daf as one', () => {
+    const p = cacheProgressOf([
+      row({ id: 'pesukim.why-here', instances: { total: 3, cached: 3 } }),
+      row({ id: 'rabbi.location', instances: { total: 2, cached: 1 } }),
+      row({ id: 'daf-background.synthesis', cached: true }),
+    ]);
+    // (3+2+1) units, (3+1+1) cached -> 5/6
+    expect(p).toEqual({ total: 6, cached: 5, pct: 83 });
+  });
+  it('drops experimental + lazy rows from BOTH numerator and denominator', () => {
+    const p = cacheProgressOf([
+      row({ id: 'pesukim.why-here', instances: { total: 2, cached: 2 } }),
+      row({ id: 'chart', experimental: true, instances: { total: 5, cached: 0 } }),
+      row({ id: 'pesukim.qa', cached: false }),
+    ]);
+    expect(p).toEqual({ total: 2, cached: 2, pct: 100 });
+  });
+  it('empty snapshot -> 0% (load bar then rides the live engine alone)', () => {
+    expect(cacheProgressOf([])).toEqual({ total: 0, cached: 0, pct: 0 });
+  });
+});


### PR DESCRIPTION
## Why

The daf **load bar** (`DafLoadProgress`) and the dev **Inspect waterfall** (`RunTreeDock`) each kept their own accounting of "what's loaded on this daf" — the bar from the live client plan (`markStatuses` + prefetch counters), the waterfall from a private `/api/daf-runs` fetch — so they could drift. This makes them consume **one shared snapshot** (step 1 toward full sync; per the discussion, the load bar is the better-behaved surface, so this protects it rather than degrading it).

## What

- **`dafRunsStore.ts`** — a long-lived store owning the `/api/daf-runs` resource (keyed by the open daf, pointed from `DafViewer` so it runs whether or not the dock is open) + the `aiActivity` live overlay + the refetch-while-warming poll. Guards against serving the previous daf's rows during a source-change refetch (no stale-cache flash on the bar). **`dafRunsProgress.ts`** holds the pure reducer (no Solid → unit-testable without booting the store).
- **`RunTreeDock`** now reads the store — its private resource + `liveLoading` + poll are removed (net smaller).
- **`DafLoadProgress`** grounds completion in the shared cache snapshot via `max(enginePercent, cached)`: the snapshot only ever **advances** the bar, so the live client engine still drives the smooth climb and the bar **never lags a cold load or stalls** — the reliable behavior is preserved, now agreeing with the waterfall on what's cached.
- `daf-runs` rows carry `experimental` so the bar's denominator excludes dev-only producers (chart) and lazy leaves (`*.qa` / `*.suggested-questions`).
- Tests: `cacheProgressOf` / `isEagerRow` (per-instance units, eager filtering).

## Trade-off (accepted, to iterate on)

The store now fetches `daf-runs` on every daf open (previously dock-only). It's read-only (no LLM), and the bar's live climb does **not** depend on it (the `max()` keeps the client engine primary), so a slow/failed snapshot can't regress the bar.

## Follow-ups

Unify the denominator and retire the bar's bespoke counters once this proves out; eventually source from the provenance manifest instead of an always-on `daf-runs` fetch.

`pnpm typecheck` + full `pnpm test` (2223) + `biome ci .` all green.