### PR TITLE
Provenance: write a daf -> cached-pieces index at the fresh-write chokepoint

### DIFF
--- a/packages/talmud/src/worker/cache-keys.ts
+++ b/packages/talmud/src/worker/cache-keys.ts
@@ -108,6 +108,30 @@ export function keyForSaCommentary(safeKey: string): string {
   return `sa-commentary:v1:${safeKey}`;
 }
 
+/** daf -> cached pieces reverse index (the "build manifest" read side). One KV
+ *  entry PER (daf, producer, instance, lang), written at every fresh mark/
+ *  enrichment write (best-effort, off the request critical path). The daf is the
+ *  PREFIX — the content `mark:`/`enrich:` keys carry it as a SUFFIX, so they
+ *  can't be listed by daf — so `prefixForDafIndex(t,p)` + one `cache.list()`
+ *  returns the whole daf's pieces, with per-piece telemetry in each entry's KV
+ *  METADATA (cost/model/tokens/cold_ms/recipeHash). The value is empty: the
+ *  inspector needs only the key + metadata, and skipping the content key avoids
+ *  re-deriving it (the mark he-collapse makes that ambiguous). `instanceToken` is
+ *  the enrichment instance_id, or '-' for a whole-daf mark. */
+export function keyForDafIndex(
+  tractate: string,
+  page: string,
+  producerId: string,
+  instanceToken: string,
+  lang: 'en' | 'he',
+): string {
+  return `dafidx:v1:${slugDaf(tractate, page)}:${producerId}:${instanceToken}:${lang}`;
+}
+/** List every daf-index entry for one daf (`cache.list({ prefix })`). */
+export function prefixForDafIndex(tractate: string, page: string): string {
+  return `dafidx:v1:${slugDaf(tractate, page)}:`;
+}
+
 // Per-daf analysis + per-rabbi enrichment caches. Each of these was hand-built
 // at 2-4 separate call sites in index.ts — the precise drift hazard that bit
 // `sefaria-bundle` (warm-cron probed v2 while the reader used v5). Centralising

--- a/packages/talmud/src/worker/daf-index.ts
+++ b/packages/talmud/src/worker/daf-index.ts
@@ -1,0 +1,124 @@
+/**
+ * daf-index — WRITE side of the `daf -> cached pieces` reverse index (the read
+ * side of the provenance build manifest). On every FRESH mark/enrichment write
+ * the run shims stamp one tiny KV entry per (daf, producer, instance, lang) under
+ * a daf-PREFIXED key, with per-piece telemetry in the entry's KV metadata. A
+ * later reader then answers "what's cached on this daf" with ONE `cache.list()`
+ * instead of re-deriving keys and probing each — which is the whole point: the
+ * inspector reads recorded truth instead of guessing.
+ *
+ * ADDITIVE + best-effort: a brand-new `dafidx:v1:` namespace (never touches the
+ * frozen `mark:`/`enrich:` keys), written off the request critical path
+ * (`ctx.waitUntil`) and swallowing its own errors, so it can never affect a run.
+ *
+ * Scope (v1): marks (always per-daf) + LOCAL enrichments. Skips global/spine
+ * (daf-agnostic) and qualified `.qa` runs (lazy, not in the eager set). Already-
+ * warmed entries written before this aren't indexed — the reader falls back to
+ * the enumerate-and-probe path for an un-indexed daf.
+ */
+
+import { instanceIdOf, keyForDafIndex } from './cache-keys';
+import { type InspectEntry, inspectorCostOf, tokensOfEntry } from './inspect';
+
+/** Minimal KV surface the recorder needs (so tests pass a fake). */
+export interface DafIndexCache {
+  put(key: string, value: string, opts?: { metadata?: unknown }): Promise<void>;
+}
+
+/** Per-piece telemetry carried in the index entry's KV metadata. Compact keys to
+ *  stay well under KV's 1024-byte metadata cap; null/absent fields are dropped. */
+export interface DafIndexMeta {
+  /** producer id */ p: string;
+  /** kind */ k: 'mark' | 'enrichment';
+  /** lang */ l: 'en' | 'he';
+  /** instance_id (omitted for whole-daf marks) */ i?: string;
+  /** model */ m?: string;
+  /** cost USD (billed-or-estimated) */ c?: number;
+  /** total tokens */ t?: number;
+  /** cold generation time (ms) */ ms?: number;
+  /** recipe hash */ rh?: string;
+  /** computedAt (epoch ms) */ at?: number;
+}
+
+/** Build the compact metadata, dropping empty fields. */
+export function dafIndexMetaOf(o: {
+  producerId: string;
+  kind: 'mark' | 'enrichment';
+  lang: 'en' | 'he';
+  instanceId?: string;
+  model?: string;
+  cost?: number | null;
+  tokens?: number | null;
+  coldMs?: number | null;
+  recipeHash?: string | null;
+  at?: number | null;
+}): DafIndexMeta {
+  const meta: DafIndexMeta = { p: o.producerId, k: o.kind, l: o.lang };
+  if (o.instanceId && o.instanceId !== '-') meta.i = o.instanceId;
+  if (o.model) meta.m = o.model;
+  if (typeof o.cost === 'number') meta.c = o.cost;
+  if (typeof o.tokens === 'number') meta.t = o.tokens;
+  if (typeof o.coldMs === 'number') meta.ms = o.coldMs;
+  if (o.recipeHash) meta.rh = o.recipeHash;
+  if (typeof o.at === 'number') meta.at = o.at;
+  return meta;
+}
+
+/** Telemetry the recorder reads off a fresh RunResult (a superset of the cost/
+ *  usage InspectEntry needs, plus model/recipe_hash and the stamp's computedAt). */
+interface IndexableResult extends Omit<InspectEntry, 'cost'> {
+  model?: string;
+  recipe_hash?: string;
+  cost?: { billedUsd: number | null; estimatedUsd: number | null; computedAt?: number } | null;
+}
+
+/** Record a fresh MARK write: one entry per (daf, mark, lang). */
+export async function recordMarkDafIndex(
+  cache: DafIndexCache,
+  producerId: string,
+  tractate: string,
+  page: string,
+  lang: 'en' | 'he',
+  res: IndexableResult,
+): Promise<void> {
+  const meta = dafIndexMetaOf({
+    producerId,
+    kind: 'mark',
+    lang,
+    model: res.model,
+    cost: inspectorCostOf(res),
+    tokens: tokensOfEntry(res),
+    coldMs: res.elapsed_ms,
+    recipeHash: res.recipe_hash,
+    at: res.cost?.computedAt ?? null,
+  });
+  await cache.put(keyForDafIndex(tractate, page, producerId, '-', lang), '', { metadata: meta });
+}
+
+/** Record a fresh LOCAL ENRICHMENT write: one entry per (daf, enrichment, instance, lang). */
+export async function recordEnrichmentDafIndex(
+  cache: DafIndexCache,
+  producerId: string,
+  tractate: string,
+  page: string,
+  markInput: unknown,
+  lang: 'en' | 'he',
+  res: IndexableResult,
+): Promise<void> {
+  const instanceId = await instanceIdOf(markInput);
+  const meta = dafIndexMetaOf({
+    producerId,
+    kind: 'enrichment',
+    lang,
+    instanceId,
+    model: res.model,
+    cost: inspectorCostOf(res),
+    tokens: tokensOfEntry(res),
+    coldMs: res.elapsed_ms,
+    recipeHash: res.recipe_hash,
+    at: res.cost?.computedAt ?? null,
+  });
+  await cache.put(keyForDafIndex(tractate, page, producerId, instanceId, lang), '', {
+    metadata: meta,
+  });
+}

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -136,6 +136,7 @@ import {
   keyForRegion,
   keyForSpineLinks,
   keyForTranslate,
+  prefixForDafIndex,
   prefixForRabbiObs,
   qualifierHash,
   recipeHash,
@@ -153,6 +154,7 @@ import { fetchCommentaryWorks, registerCommentaryRoutes } from './commentary';
 import { aiMatchToSegments } from './context-match';
 import { collectContext, type SourceTiming } from './context-providers';
 import { dafCostReport } from './daf-cost';
+import { recordEnrichmentDafIndex, recordMarkDafIndex } from './daf-index';
 import { getRabbiEntryOr404, readJsonBody } from './http-helpers';
 import {
   aggregateProbes,
@@ -1959,6 +1961,28 @@ app.get('/api/run-tree/:tractate/:page/:id', async (c) => {
 // waterfall; clicking one drills into its dependency DAG via /api/run-tree.
 // Whole-daf enrichments only (scope=local, not the per-section `argument`
 // enrichments and not the global rabbi/place facets) so each row is one run.
+// GET /api/daf-index/:tractate/:page — read the daf-index (the `dafidx:v1`
+// reverse index written at each fresh mark/enrichment write). ONE cache.list()
+// over the daf PREFIX returns every cached piece for the daf with its telemetry
+// in KV metadata — no per-entry reads, no key re-derivation. Read-only. The
+// inspector + load bar move onto this in a follow-up (with a fallback to the
+// enumerate-and-probe /api/daf-runs for dapim warmed before the index existed);
+// surfaced now to verify the index populates.
+app.get('/api/daf-index/:tractate/:page', async (c) => {
+  const tractate = c.req.param('tractate');
+  const page = c.req.param('page');
+  if (!c.env.CACHE) return c.json({ tractate, page, count: 0, entries: [] });
+  const prefix = prefixForDafIndex(tractate, page);
+  const entries: Array<{ key: string; meta: unknown }> = [];
+  let cursor: string | undefined;
+  do {
+    const res = await c.env.CACHE.list({ prefix, cursor, limit: 1000 });
+    for (const k of res.keys) entries.push({ key: k.name, meta: k.metadata ?? null });
+    cursor = res.list_complete ? undefined : res.cursor;
+  } while (cursor);
+  return c.json({ tractate, page, count: entries.length, entries });
+});
+
 app.get('/api/daf-runs/:tractate/:page', async (c) => {
   const tractate = c.req.param('tractate');
   const page = c.req.param('page');
@@ -3816,6 +3840,15 @@ const RUN_PORTS: RunProducerPorts<RunCtx, EnrichmentDefinition, SchemaMarkDefini
   },
 };
 
+/** Fire a best-effort daf-index write off the request critical path. Errors are
+ *  swallowed (the index is additive — a miss just falls back to enumerate-probe);
+ *  `waitUntil` lets it finish after the response without adding run latency. */
+function fireDafIndex(rc: RunCtx, p: Promise<void>): void {
+  const done = p.catch(() => {});
+  if (rc.ctx?.waitUntil) rc.ctx.waitUntil(done);
+  else void done;
+}
+
 async function runMarkOnce(
   rc: RunCtx,
   def: SchemaMarkDefinition,
@@ -3823,10 +3856,15 @@ async function runMarkOnce(
   page: string,
   bypassCache: boolean,
 ): Promise<RunResult> {
-  return (await runProducer(RUN_PORTS, rc, 'mark', def, tractate, page, undefined, {
+  const res = (await runProducer(RUN_PORTS, rc, 'mark', def, tractate, page, undefined, {
     bypassCache,
     lang: rc.lang,
   })) as RunResult;
+  // Stamp the daf-index on a FRESH write only (a cache hit is already indexed).
+  if (!res.cache_hit && rc.env.CACHE) {
+    fireDafIndex(rc, recordMarkDafIndex(rc.env.CACHE, def.id, tractate, page, rc.lang, res));
+  }
+  return res;
 }
 
 /** The segment range a section-level argument enrichment is being computed for,
@@ -3881,13 +3919,22 @@ async function runEnrichmentOnce(
    *  template as {{user_question}}. */
   userQuestion?: string,
 ): Promise<RunResultEnrichment> {
-  return (await runProducer(RUN_PORTS, rc, 'enrich', def, tractate, page, markInput, {
+  const res = (await runProducer(RUN_PORTS, rc, 'enrich', def, tractate, page, markInput, {
     bypassCache,
     lang: rc.lang,
     modelOverride,
     parentChain,
     userQuestion,
   })) as RunResultEnrichment;
+  // Daf-index on a fresh write of a daf-scoped (local) enrichment. Skip global/
+  // spine (daf-agnostic) and qualified .qa runs (lazy, not in the eager set).
+  if (!res.cache_hit && rc.env.CACHE && def.scope === 'local' && !userQuestion) {
+    fireDafIndex(
+      rc,
+      recordEnrichmentDafIndex(rc.env.CACHE, def.id, tractate, page, markInput, rc.lang, res),
+    );
+  }
+  return res;
 }
 
 // ===========================================================================

--- a/packages/talmud/tests/daf-index.test.ts
+++ b/packages/talmud/tests/daf-index.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import { instanceIdOf, keyForDafIndex, prefixForDafIndex } from '../src/worker/cache-keys';
+import {
+  dafIndexMetaOf,
+  recordEnrichmentDafIndex,
+  recordMarkDafIndex,
+} from '../src/worker/daf-index';
+
+// New `dafidx:v1:` namespace — the daf is the PREFIX (content keys carry it as a
+// SUFFIX, so they can't be listed by daf). Pin the bytes: this is a fresh
+// contract a reader will `list()` against, so a separator/order change is a
+// deliberate, reviewed edit, not a silent regression.
+describe('daf-index key contract', () => {
+  it('byte-exact key + prefix', () => {
+    expect(keyForDafIndex('Berakhot', '2a', 'pesukim.why-here', 'deuteronomy_6_7', 'en')).toBe(
+      'dafidx:v1:berakhot:2a:pesukim.why-here:deuteronomy_6_7:en',
+    );
+    expect(keyForDafIndex('Bava Kamma', '117b', 'rabbi', '-', 'he')).toBe(
+      'dafidx:v1:bava_kamma:117b:rabbi:-:he',
+    );
+    expect(prefixForDafIndex('Berakhot', '2a')).toBe('dafidx:v1:berakhot:2a:');
+  });
+  it('every entry for a daf falls under that daf prefix (so one list() finds them all)', () => {
+    const k = keyForDafIndex('Berakhot', '2a', 'aggadata.interpretation', 'abc123', 'en');
+    expect(k.startsWith(prefixForDafIndex('Berakhot', '2a'))).toBe(true);
+    // a different daf does NOT
+    expect(k.startsWith(prefixForDafIndex('Shabbat', '2a'))).toBe(false);
+  });
+});
+
+describe('dafIndexMetaOf — compact metadata (< KV 1024b cap)', () => {
+  it('keeps present fields, drops nulls + the mark "-" instance sentinel', () => {
+    expect(
+      dafIndexMetaOf({
+        producerId: 'pesukim.why-here',
+        kind: 'enrichment',
+        lang: 'en',
+        instanceId: 'deuteronomy_6_7',
+        model: 'deepseek',
+        cost: 0.0012,
+        tokens: 50,
+        coldMs: 1000,
+        recipeHash: 'abc',
+        at: 123,
+      }),
+    ).toEqual({
+      p: 'pesukim.why-here',
+      k: 'enrichment',
+      l: 'en',
+      i: 'deuteronomy_6_7',
+      m: 'deepseek',
+      c: 0.0012,
+      t: 50,
+      ms: 1000,
+      rh: 'abc',
+      at: 123,
+    });
+    // computed mark: no cost/tokens, '-' instance dropped
+    expect(
+      dafIndexMetaOf({
+        producerId: 'rabbi',
+        kind: 'mark',
+        lang: 'he',
+        instanceId: '-',
+        cost: null,
+        tokens: null,
+        coldMs: null,
+        recipeHash: null,
+        at: null,
+      }),
+    ).toEqual({ p: 'rabbi', k: 'mark', l: 'he' });
+  });
+});
+
+describe('record*DafIndex — writes to KV (empty value, telemetry in metadata)', () => {
+  const makeFake = () => {
+    const store = new Map<string, { value: string; metadata: unknown }>();
+    return {
+      store,
+      put: async (key: string, value: string, opts?: { metadata?: unknown }) => {
+        store.set(key, { value, metadata: opts?.metadata });
+      },
+    };
+  };
+
+  it('mark: one entry per (daf, mark, lang)', async () => {
+    const kv = makeFake();
+    await recordMarkDafIndex(kv, 'pesukim', 'Berakhot', '2a', 'en', {
+      model: 'computed',
+      elapsed_ms: 5,
+      recipe_hash: 'rh1',
+      cost: { billedUsd: null, estimatedUsd: null },
+      usage: {},
+    });
+    const e = kv.store.get(keyForDafIndex('Berakhot', '2a', 'pesukim', '-', 'en'));
+    expect(e?.value).toBe('');
+    expect(e?.metadata).toMatchObject({
+      p: 'pesukim',
+      k: 'mark',
+      l: 'en',
+      m: 'computed',
+      ms: 5,
+      rh: 'rh1',
+    });
+  });
+
+  it('enrichment: key uses instanceIdOf(markInput), cost from the stamp', async () => {
+    const kv = makeFake();
+    const inst = { fields: { verseRef: 'Deuteronomy 6:7' } };
+    await recordEnrichmentDafIndex(kv, 'pesukim.why-here', 'Berakhot', '2a', inst, 'en', {
+      model: 'deepseek',
+      elapsed_ms: 1000,
+      recipe_hash: 'rh2',
+      cost: { billedUsd: 0.0012, estimatedUsd: 0.0012, computedAt: 999 },
+      usage: { total_tokens: 50 },
+    });
+    const iid = await instanceIdOf(inst);
+    const e = kv.store.get(keyForDafIndex('Berakhot', '2a', 'pesukim.why-here', iid, 'en'));
+    expect(e?.value).toBe('');
+    expect(e?.metadata).toMatchObject({
+      p: 'pesukim.why-here',
+      k: 'enrichment',
+      i: iid,
+      c: 0.0012,
+      t: 50,
+      at: 999,
+    });
+  });
+});


### PR DESCRIPTION
## Why (the durable fix, step 1 of 3)

The inspector and load bar **re-derive** cache keys to learn what's cached on a daf — guessing `instanceIdOf(...)` and enumerating instances. That's the root cause of the per-instance misses (#388) and why `/api/daf-runs` is an always-on enumerate-and-probe. This starts the fix the right way: at every **fresh** write, record what was written, so a reader can later enumerate from **recorded truth** instead of guessing.

## What (write side only — additive, off-path)

- **`dafidx:v1:{slugDaf}:{producer}:{instance}:{lang}`** namespace (`cache-keys.ts`): the **daf is the PREFIX** (content `mark:`/`enrich:` keys carry it as a *suffix*, so they can't be listed by daf), so one `cache.list({prefix})` returns the whole daf. Per-piece telemetry (cost/model/tokens/cold_ms/recipeHash) rides in each entry's **KV metadata** → the list needs **no per-entry reads**. Value is empty (skipping the content key sidesteps the mark `:he`-collapse ambiguity).
- **`daf-index.ts`** — the write recorders + compact metadata builder.
- **`runMarkOnce` / `runEnrichmentOnce`** stamp the index on a **fresh write only** (not cache hits) via `ctx.waitUntil` — off the request critical path, errors swallowed. **Additive**: brand-new namespace, never touches the byte-frozen `mark:`/`enrich:` keys, so it cannot affect a run. v1 scope: marks + **local** enrichments (skips global/spine + qualified `.qa`).
- **`GET /api/daf-index/:t/:p`** — read-only, one `list()` over the prefix, to verify the index populates.
- Tests: byte-exact key/prefix contract, metadata compaction, recorder writes.

## Safety

Per-(daf,piece) entries → **no read-modify-write races** under concurrent warms. The extra write is best-effort and `waitUntil`-deferred, so it adds no run latency and can't fail a generation. Already-warmed entries (written before this) simply aren't indexed yet — the follow-up reader falls back to enumerate-and-probe for an un-indexed daf, and the index fills in as dapim re-warm.

## Next

PR2: serve `/api/daf-runs` from the index (fallback to enumerate-and-probe), then point the load bar at it. PR3: lighten/remove the always-on enumerate fetch.

`pnpm typecheck` + full `pnpm test` (2228) + `biome ci .` green.