### PR TITLE
Spine: surface "parallels not computed yet" (no silent cold dapim)

### DIFF
--- a/packages/talmud/src/client/SpineFlowGraph.tsx
+++ b/packages/talmud/src/client/SpineFlowGraph.tsx
@@ -43,6 +43,10 @@ export interface SpineViewDaf {
    *  warmer/sweep hasn't connected this boundary). Drawn as a dashed "not yet
    *  connected" divider so gaps in the map are visible, not silent. */
   crossComputed?: boolean;
+  /** have this daf's cross-text parallels been computed yet? false = still cold
+   *  (no `⤳ N` badge would be ambiguous — "none" vs "not checked"); drawn as a
+   *  muted `⤳?` marker on the daf header so the gap is visible, not silent. */
+  parallelsComputed?: boolean;
 }
 
 const NODE_W = 330,
@@ -159,13 +163,19 @@ export default function SpineFlowGraph(props: {
     const nodeRabbis = new Map<string, SectionRabbi[]>();
     const nodeExits = new Map<string, ExitMark[]>();
     const nodeBand = new Map<string, number>(); // reserved height for an open exits band
-    const dafHeaders: { page: string; y: number; pending: boolean }[] = [];
+    const dafHeaders: { page: string; y: number; pending: boolean; parallelsCold: boolean }[] = [];
     let y = TOP_PAD;
     for (const d of props.dapim) {
       // pending = this daf has a next daf but its cross-daf link is still cold
       // (not computed). Genuinely-no-link boundaries (computed, 0 edges) are NOT
-      // pending — crossComputed distinguishes them.
-      dafHeaders.push({ page: d.page, y, pending: !!d.nextPage && d.crossComputed === false });
+      // pending — crossComputed distinguishes them. parallelsCold = the daf's
+      // cross-text parallels have never been computed (vs computed-and-none).
+      dafHeaders.push({
+        page: d.page,
+        y,
+        pending: !!d.nextPage && d.crossComputed === false,
+        parallelsCold: d.parallelsComputed === false,
+      });
       y += DAF_HEADER_H;
       d.sections.forEach((s, pos) => {
         const key = `${d.page}#${s.index}`;
@@ -465,6 +475,22 @@ export default function SpineFlowGraph(props: {
                       >
                         {h.page}
                       </text>
+                      <Show when={h.parallelsCold}>
+                        <text
+                          x={44}
+                          y={h.y + 15}
+                          font-size="10.5"
+                          font-family="system-ui, -apple-system, sans-serif"
+                          fill="#c4bdab"
+                          style={{ cursor: 'default' }}
+                        >
+                          <title>
+                            parallels not computed yet for this daf (warm it to see its cross-text
+                            links)
+                          </title>
+                          ⤳?
+                        </text>
+                      </Show>
                       <Show when={h.pending}>
                         <text
                           x={m.width - 6}

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -1322,7 +1322,7 @@ async function readDafParts(env: Bindings, tractate: string, page: string): Prom
   const flowEdges = await readFlowConnections(env, tractate, page);
   const bridge = await readCachedBridge(env, tractate, page);
   const cross = await readCachedCrossFlow(env, tractate, page);
-  const talmudParallels = await readCachedTalmudParallels(env.CACHE, tractate, page);
+  const talmudParallels = (await readCachedTalmudParallels(env.CACHE, tractate, page)) ?? [];
   const yerushalmi = await readCachedYerushalmi(env.CACHE, tractate, page);
   const withinLinks = dafLinks(
     { tractate, page },
@@ -1545,7 +1545,7 @@ function sectionExitMarks(
   yeru: Awaited<ReturnType<typeof readCachedYerushalmi>>,
 ): SpineExit[][] {
   const daf = { tractate, page };
-  const links = [...talmudParallelsToLinks(daf, tp), ...yerushalmiToLinks(daf, yeru)];
+  const links = [...talmudParallelsToLinks(daf, tp ?? []), ...yerushalmiToLinks(daf, yeru)];
   const out: SpineExit[][] = sectionStarts.map(() => []);
   if (out.length === 0) return out;
   for (const l of links) {
@@ -1621,6 +1621,10 @@ app.get('/api/spine-view/:tractate', async (c) => {
       // still cold (not yet warmed). Lets the client distinguish "no link" from
       // "not connected yet" and surface the gaps.
       crossComputed: cross != null,
+      // Same distinction for cross-text parallels: the bundle is cached (an array,
+      // even empty = checked-and-none) vs never computed (null). false → the spine
+      // shows a "parallels not computed yet" marker instead of silently nothing.
+      parallelsComputed: tp != null,
       // deterministic daf-continuity: does the sugya carry into the next daf?
       continues: bridge?.continues === true,
     };

--- a/packages/talmud/src/worker/source-cache.ts
+++ b/packages/talmud/src/worker/source-cache.ts
@@ -330,17 +330,18 @@ export async function getTalmudParallelsCached(
 }
 
 /**
- * Read-only: this daf's cached Talmud parallels, or [] if not yet computed.
- * NEVER fetches — the spine sweep reads across a whole tractate and must not fan
- * out network calls (the same contract as readCachedBridge / readCachedCrossFlow
- * in index.ts). The apparatus fills into the spine as dapim are warmed.
+ * Read-only: this daf's cached Talmud parallels — the ARRAY if computed (even
+ * `[]` = computed and genuinely none), or `null` if NEVER computed (no KV key).
+ * That distinction drives the spine's "not computed yet" indicator. NEVER
+ * fetches — the spine sweep reads across a whole tractate and must not fan out
+ * network calls (same contract as readCachedBridge / readCachedCrossFlow).
  */
 export async function readCachedTalmudParallels(
   cache: KVNamespace | undefined,
   tractate: string,
   page: string,
-): Promise<TalmudParallel[]> {
-  return (await readCache<TalmudParallel[]>(cache, keyForTalmudParallels(tractate, page))) ?? [];
+): Promise<TalmudParallel[] | null> {
+  return (await readCache<TalmudParallel[]>(cache, keyForTalmudParallels(tractate, page))) ?? null;
 }
 
 export async function getSaCommentaryCached(

--- a/packages/talmud/tests/client/spine-exit-markers.test.tsx
+++ b/packages/talmud/tests/client/spine-exit-markers.test.tsx
@@ -90,4 +90,34 @@ describe('SpineFlowGraph — cross-text exit markers', () => {
     const { container } = render(() => <SpineFlowGraph dapim={noExits} />);
     expect(texts(container, '⤳')).toHaveLength(0);
   });
+
+  it('shows a ⤳? marker on a daf whose parallels are not computed yet', () => {
+    const cold: SpineViewDaf[] = [
+      {
+        page: '7a',
+        nextPage: '7b',
+        parallelsComputed: false,
+        sections: [{ index: 0, title: 'X', rabbis: [], exits: [] }],
+        flow: [],
+        cross: [],
+      },
+    ];
+    const { container } = render(() => <SpineFlowGraph dapim={cold} />);
+    expect(texts(container, '⤳?').length).toBeGreaterThan(0);
+  });
+
+  it('shows no ⤳? marker once the daf is computed (even with zero parallels)', () => {
+    const warm: SpineViewDaf[] = [
+      {
+        page: '7a',
+        nextPage: '7b',
+        parallelsComputed: true,
+        sections: [{ index: 0, title: 'X', rabbis: [], exits: [] }],
+        flow: [],
+        cross: [],
+      },
+    ];
+    const { container } = render(() => <SpineFlowGraph dapim={warm} />);
+    expect(texts(container, '⤳?')).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
Follows #389. A section with no `⤳ N` badge was **ambiguous** — "genuinely no parallels here" and "never warmed for this daf" looked identical (the read returned `[]` for both). This makes coldness visible, mirroring how cross-flow already handles it (`crossComputed` → the dashed "cross-daf link not computed yet" divider).

## Change
- **`readCachedTalmudParallels`** now returns `null` on a true KV miss (vs `[]` = computed and genuinely none). The KV key's existence is the warmth signal. The spine-links sweep caller coerces `?? []` (it doesn't need the distinction).
- **`/api/spine-view`** adds a per-daf `parallelsComputed` flag (`tp != null`), beside the existing `crossComputed`.
- **`SpineFlowGraph`** draws a muted `⤳?` marker on a daf header whose parallels aren't computed yet — distinct from the solid `⤳ N` section badges — so the gap reads as "not checked," not "none." It disappears once the daf is warmed.

## Why a marker (not just empty)
Parallels cache **on-demand** (only when a daf's `/api/links` is hit), so most of an un-warmed tractate currently shows nothing. The marker keeps that honest ("no silent gaps") and pairs with the warm-set pass (next) — the `⤳?` markers show exactly what's left to warm, and vanish as warming fills in.

## Verification
- `pnpm typecheck` clean; **2233 tests** (+2: a `parallelsComputed:false` daf shows `⤳?`, a computed one doesn't even with zero parallels); Biome clean.