### PR TITLE
Warm cross-text parallels in the Sefaria warm-cron

### DIFF
--- a/packages/talmud/src/worker/warm-cron.ts
+++ b/packages/talmud/src/worker/warm-cron.ts
@@ -17,6 +17,7 @@ import {
   keyForHebrewBooks,
   keyForSefariaBundle,
   keyForSefariaSegments,
+  keyForTalmudParallels,
 } from './cache-keys';
 import { computeCacheStats, writeCachedCacheStats } from './cache-stats';
 import {
@@ -24,6 +25,8 @@ import {
   getHebrewBooksDafCached,
   getSefariaPageCached,
   getSefariaSegmentsCached,
+  getTalmudParallelsCached,
+  getYerushalmiCached,
 } from './source-cache';
 import type { JobMessage } from './types';
 
@@ -417,7 +420,12 @@ async function runSefariaPhase(env: WarmEnv): Promise<void> {
     const amud = AMUDIM_BY_TRACTATE[tractateIdx][amudIdx];
     const bundleKey = keyForSefariaBundle(tractate, amud); // was sefaria-bundle:v2 — drifted from the reader's v5
     const segKey = keyForSefariaSegments(tractate, amud);
-    const [bundleHit, segHit] = await Promise.all([cache.get(bundleKey), cache.get(segKey)]);
+    const parKey = keyForTalmudParallels(tractate, amud);
+    const [bundleHit, segHit, parHit] = await Promise.all([
+      cache.get(bundleKey),
+      cache.get(segKey),
+      cache.get(parKey),
+    ]);
 
     let didFetch = false;
     if (bundleHit === null) {
@@ -426,6 +434,15 @@ async function runSefariaPhase(env: WarmEnv): Promise<void> {
     }
     if (segHit === null) {
       await getSefariaSegmentsCached(cache, tractate, amud);
+      didFetch = true;
+    }
+    // Cross-text parallels (Mesorat HaShas + the shared-mishnah Yerushalmi) — the
+    // spine's exit markers. Sefaria getRelated only, no LLM; warming here turns
+    // the spine's "⤳?" cold markers into real badges Shas-wide. Both bundles are
+    // written together (also by /api/links), so the parallels key gates both.
+    if (parHit === null) {
+      await getTalmudParallelsCached(cache, tractate, amud);
+      await getYerushalmiCached(cache, tractate, amud);
       didFetch = true;
     }
     if (didFetch) {


### PR DESCRIPTION
Final piece of the spine connection arc (follows #385/#387/#389/#393). The exit markers only show for dapim warmed on-demand (a `/api/links` hit), so most of an un-warmed tractate shows the `⤳?` cold marker from #393. This populates them Shas-wide.

## Change
Fold parallels warming into the **existing always-on Sefaria warm phase** in `warm-cron.ts` — it already walks all of Shas with a cursor, paces (20 dapim/tick, 1s between fetches), and skips already-warmed entries. Per daf, when the `talmud-parallels` key is absent, warm `getTalmudParallelsCached` + `getYerushalmiCached`.

- **Cheap**: Sefaria `getRelated` only — **no LLM, no budget**. (Unlike the LLM-gated `OBSERVATIONS_WARM_SHAS`/`DAFYOMI_WARM_SHAS` phases, this needs no flag.)
- **Idempotent**: the parallels key gates both bundles (they're written together, same as `/api/links`); the wrap refills on TTL expiry like the other source bundles.
- As the cursor sweeps, the spine's `⤳?` markers turn into real `⤳ N` badges across the tractate — no manual warming.

## Verification
- `pnpm typecheck` clean; `biome check .` clean; **2233 tests** pass.
- Post-deploy the warm cron will gradually fill parallels (full pass ≈ the same cadence as the Sefaria bundle warm). The #393 `⤳?`→`⤳ N` transition is the visible signal it's working.