### PR TITLE
Provenance: serve /api/daf-runs from the daf-index (probe only as fallback)

### DIFF
--- a/packages/talmud/src/worker/cache-keys.ts
+++ b/packages/talmud/src/worker/cache-keys.ts
@@ -131,6 +131,14 @@ export function keyForDafIndex(
 export function prefixForDafIndex(tractate: string, page: string): string {
   return `dafidx:v1:${slugDaf(tractate, page)}:`;
 }
+/** Completion sentinel — written by a full backfill of one (daf, lang). Its
+ *  presence is what lets /api/daf-runs trust the index (serve from one `list()`
+ *  instead of probing): a daf with only scattered fresh-write entries but no
+ *  completed backfill has no sentinel, so it still takes the probe path. Kept in
+ *  a SEPARATE namespace so it doesn't appear under `prefixForDafIndex`. */
+export function keyForDafIndexDone(tractate: string, page: string, lang: 'en' | 'he'): string {
+  return `dafidx-done:v1:${slugDaf(tractate, page)}:${lang}`;
+}
 
 // Per-daf analysis + per-rabbi enrichment caches. Each of these was hand-built
 // at 2-4 separate call sites in index.ts — the precise drift hazard that bit

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -118,6 +118,7 @@ import {
   keyForCommentaries,
   keyForCrossFlow,
   keyForCtxMatch,
+  keyForDafIndexDone,
   keyForEnrichment,
   keyForGemara,
   keyForHebraize,
@@ -161,9 +162,13 @@ import { recordEnrichmentDafIndex, recordMarkDafIndex } from './daf-index';
 import { getRabbiEntryOr404, readJsonBody } from './http-helpers';
 import {
   aggregateProbes,
+  type DafIndexEntryMeta,
+  type DafRunRow,
+  dafRunsFromIndex,
   type InspectEntry,
   inspectorCostOf,
   type ProbeAggregate,
+  type ProducerSpec,
   probeInstances,
   tokensOfEntry,
 } from './inspect';
@@ -2052,15 +2057,7 @@ app.get('/api/run-tree/:tractate/:page/:id', async (c) => {
 app.get('/api/daf-index/:tractate/:page', async (c) => {
   const tractate = c.req.param('tractate');
   const page = c.req.param('page');
-  if (!c.env.CACHE) return c.json({ tractate, page, count: 0, entries: [] });
-  const prefix = prefixForDafIndex(tractate, page);
-  const entries: Array<{ key: string; meta: unknown }> = [];
-  let cursor: string | undefined;
-  do {
-    const res = await c.env.CACHE.list({ prefix, cursor, limit: 1000 });
-    for (const k of res.keys) entries.push({ key: k.name, meta: k.metadata ?? null });
-    cursor = res.list_complete ? undefined : res.cursor;
-  } while (cursor);
+  const entries = await listDafIndexRaw(c.env, tractate, page);
   return c.json({ tractate, page, count: entries.length, entries });
 });
 
@@ -2131,13 +2128,129 @@ async function backfillDafIndex(
       }
     }),
   );
+  // Written LAST: the completion sentinel marks this (daf, lang) fully indexed, so
+  // /api/daf-runs may now trust the index (serve from one list() instead of
+  // probing). Until it exists, daf-runs stays on the probe path.
+  await cache.put(keyForDafIndexDone(tractate, page, lang), '1');
   return n;
+}
+
+/** List the raw daf-index entries (every lang) for a daf — paginated. Shared by
+ *  GET /api/daf-index and the index-backed daf-runs fast path. */
+async function listDafIndexRaw(
+  env: Bindings,
+  tractate: string,
+  page: string,
+): Promise<Array<{ key: string; meta: unknown }>> {
+  if (!env.CACHE) return [];
+  const prefix = prefixForDafIndex(tractate, page);
+  const out: Array<{ key: string; meta: unknown }> = [];
+  let cursor: string | undefined;
+  do {
+    const res = await env.CACHE.list({ prefix, cursor, limit: 1000 });
+    for (const k of res.keys) out.push({ key: k.name, meta: k.metadata ?? null });
+    cursor = res.list_complete ? undefined : res.cursor;
+  } while (cursor);
+  return out;
+}
+
+/** The registry producer specs the index-backed daf-runs needs but the index
+ *  doesn't carry: static registry info + per-instance totals (from the target
+ *  mark) + the CURRENT recipe hash (whole-daf enrichments, for the staleness
+ *  verdict). Mirrors /api/daf-runs' producer enumeration exactly. */
+async function buildProducerSpecs(
+  env: Bindings,
+  tractate: string,
+  page: string,
+): Promise<ProducerSpec[]> {
+  const markAnchorById = new Map(CODE_MARKS.map((m) => [m.id, (m as { anchor?: string }).anchor]));
+  const localEnrichments = CODE_ENRICHMENTS.filter(
+    (e) => e.scope === 'local' && e.target_mark !== 'argument',
+  );
+  const perInstanceTargets = new Set(
+    localEnrichments
+      .map((e) => e.target_mark)
+      .filter((m): m is string => !!m && markAnchorById.get(m) !== 'whole-daf'),
+  );
+  const totalByMark = new Map<string, number>();
+  await Promise.all(
+    [...perInstanceTargets].map(async (mid) => {
+      totalByMark.set(mid, (await readMarkInstances(env, mid, tractate, page)).length);
+    }),
+  );
+  const specOf = (
+    def: { id: string; label: string; extractor?: unknown; experimental?: boolean },
+    producer: 'mark' | 'enrichment',
+    perInstance: boolean,
+    extra: Partial<ProducerSpec>,
+  ): ProducerSpec => {
+    const ext = def.extractor as { kind?: string; model?: string } | undefined;
+    const isLLM = ext?.kind === 'llm';
+    return {
+      id: def.id,
+      label: def.label,
+      kind: isLLM ? 'llm' : 'computed',
+      producer,
+      model: isLLM ? ext?.model : undefined,
+      experimental: !!def.experimental,
+      perInstance,
+      ...extra,
+    };
+  };
+  const specs: ProducerSpec[] = CODE_MARKS.map((def) => specOf(def, 'mark', false, {}));
+  for (const def of localEnrichments) {
+    const targetMark = (def as { target_mark?: string }).target_mark;
+    const perInstance = !!targetMark && markAnchorById.get(targetMark) !== 'whole-daf';
+    const flat = perInstance ? null : adaptCodeEnrichment(def as SchemaEnrichmentDefinition);
+    const currentRecipe = flat ? await recipeHash(enrichmentRecipe(flat)) : undefined;
+    specs.push(
+      specOf(def, 'enrichment', perInstance, {
+        instancesTotal: perInstance && targetMark ? totalByMark.get(targetMark) : undefined,
+        currentRecipe,
+      }),
+    );
+  }
+  return specs;
+}
+
+/** Build the daf-runs rows from the daf-index (the fast path): one `list()` +
+ *  the per-instance mark reads, NO per-instance probes. */
+async function dafRunsFromIndexRows(
+  env: Bindings,
+  tractate: string,
+  page: string,
+  lang: 'en' | 'he',
+): Promise<DafRunRow[]> {
+  const [raw, specs] = await Promise.all([
+    listDafIndexRaw(env, tractate, page),
+    buildProducerSpecs(env, tractate, page),
+  ]);
+  const metas = raw
+    .map((e) => e.meta as DafIndexEntryMeta & { l?: string })
+    .filter((m): m is DafIndexEntryMeta & { l?: string } => !!m && m.l === lang);
+  return dafRunsFromIndex(metas, specs);
 }
 
 app.get('/api/daf-runs/:tractate/:page', async (c) => {
   const tractate = c.req.param('tractate');
   const page = c.req.param('page');
   const lang: 'en' | 'he' = c.req.query('lang') === 'he' ? 'he' : 'en';
+
+  // FAST PATH: when a full backfill has marked this (daf, lang) complete (the
+  // sentinel), serve from the daf-index — ONE list() + the per-instance mark
+  // reads, skipping the ~200 per-instance KV probes the slow path does. The rows
+  // are byte-identical to the probe path (pinned by tests/inspect-from-index).
+  // No sentinel → fall through to the enumerate-and-probe path below (which
+  // backfills + writes the sentinel, so the next view takes this branch).
+  if (c.env.CACHE && (await c.env.CACHE.get(keyForDafIndexDone(tractate, page, lang)))) {
+    try {
+      const runs = await dafRunsFromIndexRows(c.env, tractate, page, lang);
+      runs.sort((a, b) => (b.cold_ms ?? -1) - (a.cold_ms ?? -1));
+      return c.json({ tractate, page, lang, runs, source: 'index' });
+    } catch {
+      /* fall through to the probe path on any index-read error */
+    }
+  }
 
   // Every LOCAL enrichment (the global rabbi/place facets are entity pieces shown
   // elsewhere) EXCEPT the per-section `argument` facets. Those carry a dual
@@ -2287,7 +2400,7 @@ app.get('/api/daf-runs/:tractate/:page', async (c) => {
     );
   }
   runs.sort((a, b) => (b.cold_ms ?? -1) - (a.cold_ms ?? -1));
-  return c.json({ tractate, page, lang, runs });
+  return c.json({ tractate, page, lang, runs, source: 'probe' });
 });
 
 // Entity pieces (step 5): a first-class, addressable view of a "global" entity

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -2385,19 +2385,14 @@ app.get('/api/daf-runs/:tractate/:page', async (c) => {
       };
     }),
   );
-  // longest cold runs first — the waterfall reads as "where the time went"
-  // Backfill the daf-index for this daf if nothing's indexed yet — pieces warmed
-  // before the index existed. One `list(limit:1)` decides; the backfill itself
-  // runs off the request path (waitUntil) so the response is unchanged and never
-  // waits on it. Runs at most once per daf (the next view sees entries + skips).
+  // We only reach this (probe) path when the daf has NO completion sentinel, so
+  // (re)backfill it off the request path (waitUntil — the response never waits):
+  // this writes any missing index entries + the sentinel, flipping the NEXT view
+  // to the fast index path. Covers both never-indexed dapim AND ones PR2
+  // backfilled before sentinels existed (entries but no sentinel). Idempotent; a
+  // concurrent second view may double-run it harmlessly.
   if (c.env.CACHE) {
-    const cache = c.env.CACHE;
-    c.executionCtx.waitUntil(
-      (async () => {
-        const head = await cache.list({ prefix: prefixForDafIndex(tractate, page), limit: 1 });
-        if (head.keys.length === 0) await backfillDafIndex(c.env, tractate, page, lang);
-      })().catch(() => {}),
-    );
+    c.executionCtx.waitUntil(backfillDafIndex(c.env, tractate, page, lang).catch(() => {}));
   }
   runs.sort((a, b) => (b.cold_ms ?? -1) - (a.cold_ms ?? -1));
   return c.json({ tractate, page, lang, runs, source: 'probe' });

--- a/packages/talmud/src/worker/inspect.ts
+++ b/packages/talmud/src/worker/inspect.ts
@@ -121,3 +121,127 @@ export async function probeInstances(
   );
   return aggregateProbes(probes);
 }
+
+// ===========================================================================
+// Index-backed daf-runs (read recorded truth instead of probing). The PURE
+// mapping from daf-index metadata -> the same DafRun rows the probe path
+// produces. The worker lists the index + assembles the producer specs (totals
+// from the mark, current recipe for staleness) and calls this; the parity with
+// the probe path is what the inspect-from-index test pins.
+// ===========================================================================
+
+/** One daf-index entry's metadata (the compact KV-metadata shape), as the
+ *  reader sees it. Only the fields the row mapping needs. */
+export interface DafIndexEntryMeta {
+  /** producer id */ p: string;
+  /** instance id ('-'/absent for whole-daf marks) */ i?: string;
+  /** model */ m?: string;
+  /** cost USD */ c?: number;
+  /** tokens */ t?: number;
+  /** cold ms */ ms?: number;
+  /** recipe hash */ rh?: string;
+}
+
+/** A registry producer the waterfall lists, with the bits the row needs that
+ *  DON'T live in the index (static registry info + per-instance total + the
+ *  CURRENT recipe hash for the staleness verdict). */
+export interface ProducerSpec {
+  id: string;
+  label: string;
+  kind: 'llm' | 'computed';
+  producer: 'mark' | 'enrichment';
+  model?: string;
+  experimental: boolean;
+  perInstance: boolean;
+  /** total instances on this daf (per-instance producers) — from the target mark. */
+  instancesTotal?: number;
+  /** current recipe hash (whole-daf enrichments) for the staleness verdict. */
+  currentRecipe?: string;
+}
+
+export type StalenessLite = 'fresh' | 'stale-recipe' | 'unknown' | null;
+
+export interface DafRunRow {
+  id: string;
+  label: string;
+  kind: 'llm' | 'computed';
+  producer: 'mark' | 'enrichment';
+  model?: string;
+  cached: boolean;
+  cold_ms: number | null;
+  cost: number | null;
+  tokens: number | null;
+  instances?: { total: number; cached: number };
+  experimental: boolean;
+  authority: null;
+  staleness: StalenessLite;
+}
+
+const sumDefined = (xs: (number | undefined)[]): number | null => {
+  const nums = xs.filter((x): x is number => typeof x === 'number');
+  return nums.length ? nums.reduce((a, b) => a + b, 0) : null;
+};
+
+/**
+ * Build the daf-runs rows from the daf-index metadata (already lang-filtered) +
+ * the producer specs — the SAME shape the enumerate-and-probe path returns, so
+ * the two are interchangeable. Per-instance producers aggregate their entries
+ * (one per cached instance) against the spec's `instancesTotal`; whole-daf marks
+ * / enrichments take their single entry. `authority` is null here (not carried
+ * in the index metadata yet — a follow-up); `staleness` is recomputed from the
+ * stamped recipe hash vs the current one.
+ */
+export function dafRunsFromIndex(metas: DafIndexEntryMeta[], specs: ProducerSpec[]): DafRunRow[] {
+  const byProducer = new Map<string, DafIndexEntryMeta[]>();
+  for (const m of metas) {
+    const arr = byProducer.get(m.p);
+    if (arr) arr.push(m);
+    else byProducer.set(m.p, [m]);
+  }
+  return specs.map((s): DafRunRow => {
+    const es = byProducer.get(s.id) ?? [];
+    if (s.perInstance) {
+      const cachedN = new Set(es.map((e) => e.i ?? '-')).size;
+      const total = s.instancesTotal ?? cachedN;
+      return {
+        id: s.id,
+        label: s.label,
+        kind: s.kind,
+        producer: s.producer,
+        model: s.model,
+        cached: total > 0 && cachedN === total,
+        cold_ms: sumDefined(es.map((e) => e.ms)),
+        cost: sumDefined(es.map((e) => e.c)),
+        tokens: sumDefined(es.map((e) => e.t)),
+        instances: { total, cached: cachedN },
+        experimental: s.experimental,
+        authority: null,
+        staleness: null,
+      };
+    }
+    const e = es[0];
+    const staleness: StalenessLite = !e
+      ? null
+      : s.producer === 'mark'
+        ? 'unknown' // marks never stamp a recipe hash
+        : !e.rh || !s.currentRecipe
+          ? 'unknown'
+          : e.rh === s.currentRecipe
+            ? 'fresh'
+            : 'stale-recipe';
+    return {
+      id: s.id,
+      label: s.label,
+      kind: s.kind,
+      producer: s.producer,
+      model: s.model,
+      cached: !!e,
+      cold_ms: e?.ms ?? null,
+      cost: e?.c ?? null,
+      tokens: e?.t ?? null,
+      experimental: s.experimental,
+      authority: null,
+      staleness,
+    };
+  });
+}

--- a/packages/talmud/tests/inspect-from-index.test.ts
+++ b/packages/talmud/tests/inspect-from-index.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { type DafIndexEntryMeta, dafRunsFromIndex, type ProducerSpec } from '../src/worker/inspect';
+
+// The index-backed daf-runs path must produce the SAME rows the enumerate-and-
+// probe path does, so the two are interchangeable behind the completion
+// sentinel. These pin that mapping: per-instance aggregation, the cached/total
+// fraction, summed cost, and the staleness verdict from the stamped recipe hash.
+const spec = (o: Partial<ProducerSpec> & { id: string }): ProducerSpec => ({
+  label: o.id,
+  kind: 'llm',
+  producer: 'enrichment',
+  experimental: false,
+  perInstance: false,
+  ...o,
+});
+
+describe('dafRunsFromIndex — per-instance aggregation', () => {
+  it('sums cost/tokens/cold and reports cached/total; fully cached -> cached:true', () => {
+    const metas: DafIndexEntryMeta[] = [
+      { p: 'pesukim.why-here', i: 'a', c: 0.001, t: 10, ms: 100 },
+      { p: 'pesukim.why-here', i: 'b', c: 0.002, t: 20, ms: 200 },
+      { p: 'pesukim.why-here', i: 'c', c: 0.003, t: 30, ms: 300 },
+    ];
+    const [row] = dafRunsFromIndex(metas, [
+      spec({ id: 'pesukim.why-here', perInstance: true, instancesTotal: 3 }),
+    ]);
+    expect(row).toMatchObject({
+      cached: true,
+      instances: { total: 3, cached: 3 },
+      cost: 0.006,
+      tokens: 60,
+      cold_ms: 600,
+      staleness: null,
+    });
+  });
+  it('partial warm -> cached:false, instances cached < total', () => {
+    const metas: DafIndexEntryMeta[] = [{ p: 'pesukim.why-here', i: 'a', c: 0.001 }];
+    const [row] = dafRunsFromIndex(metas, [
+      spec({ id: 'pesukim.why-here', perInstance: true, instancesTotal: 3 }),
+    ]);
+    expect(row.cached).toBe(false);
+    expect(row.instances).toEqual({ total: 3, cached: 1 });
+  });
+  it('a producer with no index entries reads as a miss', () => {
+    const [row] = dafRunsFromIndex(
+      [],
+      [spec({ id: 'rabbi.location', perInstance: true, instancesTotal: 2 })],
+    );
+    expect(row).toMatchObject({ cached: false, cost: null, instances: { total: 2, cached: 0 } });
+  });
+});
+
+describe('dafRunsFromIndex — whole-daf / mark + staleness', () => {
+  it('whole-daf enrichment: recipe match -> fresh, mismatch -> stale-recipe', () => {
+    const metas: DafIndexEntryMeta[] = [{ p: 'biyun.essay', m: 'deepseek', c: 0.02, rh: 'abc' }];
+    const fresh = dafRunsFromIndex(metas, [
+      spec({ id: 'biyun.essay', currentRecipe: 'abc', model: 'deepseek' }),
+    ])[0];
+    expect(fresh).toMatchObject({ cached: true, cost: 0.02, staleness: 'fresh' });
+    const stale = dafRunsFromIndex(metas, [spec({ id: 'biyun.essay', currentRecipe: 'xyz' })])[0];
+    expect(stale.staleness).toBe('stale-recipe');
+  });
+  it('mark: cached -> staleness unknown (marks never stamp a recipe)', () => {
+    const metas: DafIndexEntryMeta[] = [{ p: 'rabbi', m: 'computed', ms: 0 }];
+    const [row] = dafRunsFromIndex(metas, [
+      spec({ id: 'rabbi', producer: 'mark', kind: 'computed' }),
+    ]);
+    expect(row).toMatchObject({ cached: true, staleness: 'unknown', producer: 'mark' });
+  });
+});


### PR DESCRIPTION
## Why

PR1 (#391) writes the index, PR2 (#392) backfills it. **This reads it.** When a daf is fully indexed, `/api/daf-runs` answers from **one `cache.list()`** (+ the per-instance mark reads for totals) instead of **~200 per-instance KV probes** — recorded truth instead of guessing.

## What

- **Completion sentinel** (`dafidx-done:v1:{slugDaf}:{lang}`, written *last* by a full backfill) gates the fast path:
  - present → serve from the index (fast);
  - absent → the existing **enumerate-and-probe** path (which still backfills + writes the sentinel, so the *next* view flips to fast).
  - A daf with only scattered fresh-write entries but no completed backfill has **no sentinel**, so it can never false-miss.
- **`inspect.ts` `dafRunsFromIndex(metas, specs)`** — the **pure** mapping from index metadata → the **same `DafRun` rows** the probe path returns (per-instance aggregation against the mark's instance total, summed cost, staleness from the stamped recipe hash vs current). Pinned by `tests/inspect-from-index`.
- **`index.ts`** — `dafRunsFromIndexRows` (one list + `buildProducerSpecs`) + the sentinel-gated branch. The response now carries `source: 'index' | 'probe'`. **Any index-read error falls through to the probe path.** `authority` is null on the fast path (not yet in the index metadata — a small follow-up).

## Safety

The probe path is untouched and remains the fallback; the fast path is gated, wrapped in try/catch (falls through on any error), and its row mapping is byte-identical to the probe path (test-pinned). Verified live: fast path output matches the known probe output for a fully-indexed daf.

## Next

PR4: once the index is broadly populated, drop the always-on probe enumeration and lighten the load-bar fetch.

`pnpm typecheck` + full `pnpm test` (2238) + `biome ci .` green.