### PR TITLE
linkTarget: one resolver for a link's corpus + navigation

### DIFF
--- a/packages/talmud/src/client/SpineFlowGraph.tsx
+++ b/packages/talmud/src/client/SpineFlowGraph.tsx
@@ -13,6 +13,7 @@
  * Hidden #spine page only.
  */
 import { createMemo, createSignal, For, type JSX, Show } from 'solid-js';
+import { dafTarget } from '../lib/context/linkTarget';
 import { type FlowConnection, KIND_COLOR, KIND_DASH, wrapTitle } from './ArgumentFlowGraph';
 
 type Kind = FlowConnection['kind'];
@@ -72,19 +73,10 @@ const EXIT_H = 21,
 const PARALLEL = KIND_COLOR.parallels ?? '#7c3aed';
 const HILITE = '#b8860b';
 
-/** In-app reader URL for an exit's target — the same `?tractate=&page=` contract
- *  the daf reader + overview cross-references use (hash cleared). */
-function dafHref(ex: { tractate: string; page: string }): string {
-  const u = new URL(window.location.href);
-  u.searchParams.set('tractate', ex.tractate);
-  u.searchParams.set('page', ex.page);
-  u.hash = '';
-  return u.pathname + u.search;
-}
-/** Whether an exit opens in our reader (a Bavli daf). The Yerushalmi (corpus
- *  'yeru') has no reader page here, so its chip is informative but not clickable
- *  — consistent with the overview, which leaves non-Bavli refs non-clickable. */
-const navigableExit = (ex: ExitMark): boolean => ex.corpus !== 'yeru';
+// Navigation (is this a Bavli daf we can open + at what URL) comes from the
+// shared `linkTarget` resolver — see ../lib/context/linkTarget. The corpus BADGE
+// stays here: it carries 'here' (same tractate as the daf in view), a view-local
+// distinction the context-free resolver doesn't make.
 const corpusTag = (c: ExitMark['corpus']): string =>
   c === 'yeru' ? 'ירושלמי' : c === 'bavli' ? 'Bavli' : 'this tractate';
 const corpusFill = (c: ExitMark['corpus']): string =>
@@ -142,7 +134,8 @@ export default function SpineFlowGraph(props: {
       props.onPickExit(ex);
       return;
     }
-    if (navigableExit(ex)) window.location.href = dafHref(ex);
+    const href = dafTarget(ex).href;
+    if (href) window.location.href = href;
   };
   // Which section boxes have their cross-text exits expanded. Collapsed is the
   // default — a box shows only a small "⤳ N" badge until clicked.
@@ -718,7 +711,7 @@ export default function SpineFlowGraph(props: {
                                         ex.ref.length > refMax
                                           ? `${ex.ref.slice(0, refMax - 1)}…`
                                           : ex.ref;
-                                      const nav = navigableExit(ex);
+                                      const nav = dafTarget(ex).navigable;
                                       const inner = (
                                         <>
                                           <title>{`${ex.relation} — ${ex.ref}${nav ? ' (open in reader)' : ' (Yerushalmi — see the daf’s Yerushalmi card)'}`}</title>

--- a/packages/talmud/src/lib/context/linkTarget.ts
+++ b/packages/talmud/src/lib/context/linkTarget.ts
@@ -1,0 +1,62 @@
+/**
+ * linkTarget — the ONE place that answers, for any coordinate a piece links to:
+ * what corpus is it, can we open it in our reader, and at what URL.
+ *
+ * Every "connection" in the app (a parallel sugya, the Yerushalmi, a cited daf,
+ * a verse, a commentary) is a `Link` pointing at an `AnchorCoord`. Each surface
+ * that renders one (the spine exit chips, the overview cross-references, the
+ * halacha derivation, …) used to re-implement "is this a Bavli daf / how do I
+ * navigate there" — several copies of `dafHref` + ref-shape regexes. This pure
+ * resolver centralizes that so they all agree; the chip/view layers build on it.
+ *
+ * Pure + DOM-free: returns a RELATIVE reader href (`?tractate=&page=`, which the
+ * browser resolves against the SPA root and which drops any hash), so it needs
+ * no `window` and is unit-testable.
+ */
+
+import type { AnchorCoord } from '@corpus/core/context/coord';
+import { coordLabel } from '@corpus/core/context/types';
+
+/** Which text family a target belongs to. Context-free (a function of the coord
+ *  alone) — "same tractate as the daf in view" is a view concern, not here. */
+export type LinkCorpus = 'bavli' | 'yerushalmi' | 'commentary' | 'other';
+
+export interface LinkTarget {
+  /** Human label, e.g. "Berakhot 13a" / "Jerusalem Talmud Berakhot 1:1". */
+  label: string;
+  corpus: LinkCorpus;
+  /** Whether we have an in-app reader for this target (only the Bavli daf today). */
+  navigable: boolean;
+  /** Relative reader URL when navigable (`?tractate=&page=`, hash cleared); else
+   *  null. Used directly as an `<a href>` or assigned to `window.location.href`. */
+  href: string | null;
+}
+
+/** A Bavli daf page is "<number><a|b>" (2a, 117b); the Yerushalmi + Tanakh use
+ *  "<chapter>:<verse|halacha>", so the page shape disambiguates them. */
+const BAVLI_PAGE = /^\d+[ab]$/;
+
+export function linkCorpus(c: AnchorCoord): LinkCorpus {
+  // A commentary spine (Rashi / Tosafot / a rishon) pinned over the daf.
+  if (c.spine) return 'commentary';
+  // The Yerushalmi is Sefaria `category:'Talmud'` with a distinct title.
+  if (/^(?:Jerusalem Talmud|Yerushalmi)\b/i.test(c.tractate)) return 'yerushalmi';
+  if (BAVLI_PAGE.test(c.page)) return 'bavli';
+  // Tanakh verses, Tosefta, etc. — no in-app reader yet.
+  return 'other';
+}
+
+export function linkTarget(c: AnchorCoord): LinkTarget {
+  const corpus = linkCorpus(c);
+  const navigable = corpus === 'bavli';
+  const href = navigable
+    ? `?tractate=${encodeURIComponent(c.tractate)}&page=${encodeURIComponent(c.page)}`
+    : null;
+  return { label: coordLabel(c), corpus, navigable, href };
+}
+
+/** Convenience for the common `{ tractate, page }` (daf-level) case — callers
+ *  that hold a daf reference rather than a full coord. */
+export function dafTarget(daf: { tractate: string; page: string }): LinkTarget {
+  return linkTarget({ tractate: daf.tractate, page: daf.page, seg: -1 });
+}

--- a/packages/talmud/tests/link-target.test.ts
+++ b/packages/talmud/tests/link-target.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { dafTarget, linkCorpus, linkTarget } from '../src/lib/context/linkTarget';
+
+describe('linkCorpus', () => {
+  it('classifies a Bavli daf by its page shape', () => {
+    expect(linkCorpus({ tractate: 'Berakhot', page: '13a', seg: -1 })).toBe('bavli');
+    expect(linkCorpus({ tractate: 'Bava Metzia', page: '59b', seg: 4 })).toBe('bavli');
+  });
+  it('classifies the Yerushalmi by title (its page shape collides with Tanakh)', () => {
+    expect(linkCorpus({ tractate: 'Jerusalem Talmud Berakhot', page: '1:1', seg: -1 })).toBe(
+      'yerushalmi',
+    );
+  });
+  it('classifies a commentary spine', () => {
+    expect(linkCorpus({ tractate: 'Berakhot', page: '2a', seg: -1, spine: 'Rashi' })).toBe(
+      'commentary',
+    );
+  });
+  it('falls back to other for Tanakh verses / unknown corpora', () => {
+    expect(linkCorpus({ tractate: 'Genesis', page: '1:1', seg: -1 })).toBe('other');
+  });
+});
+
+describe('linkTarget', () => {
+  it('makes a Bavli daf navigable with a relative reader href', () => {
+    expect(linkTarget({ tractate: 'Berakhot', page: '13a', seg: -1 })).toEqual({
+      label: 'Berakhot 13a',
+      corpus: 'bavli',
+      navigable: true,
+      href: '?tractate=Berakhot&page=13a',
+    });
+  });
+  it('url-encodes a multi-word tractate', () => {
+    expect(linkTarget({ tractate: 'Bava Metzia', page: '59a', seg: -1 }).href).toBe(
+      '?tractate=Bava%20Metzia&page=59a',
+    );
+  });
+  it('labels a segment coord', () => {
+    expect(linkTarget({ tractate: 'Shabbat', page: '31a', seg: 5 }).label).toBe('Shabbat 31a:5');
+  });
+  it('leaves a Yerushalmi target non-navigable (no in-app reader)', () => {
+    const t = linkTarget({ tractate: 'Jerusalem Talmud Berakhot', page: '1:1', seg: -1 });
+    expect(t.corpus).toBe('yerushalmi');
+    expect(t.navigable).toBe(false);
+    expect(t.href).toBeNull();
+  });
+  it('leaves a commentary-spine target non-navigable + labels with the spine', () => {
+    const t = linkTarget({ tractate: 'Berakhot', page: '2a', seg: -1, spine: 'Rashi' });
+    expect(t.corpus).toBe('commentary');
+    expect(t.navigable).toBe(false);
+    expect(t.label).toBe('Rashi · Berakhot 2a');
+  });
+});
+
+describe('dafTarget', () => {
+  it('resolves a bare daf reference', () => {
+    expect(dafTarget({ tractate: 'Pesachim', page: '50a' })).toEqual({
+      label: 'Pesachim 50a',
+      corpus: 'bavli',
+      navigable: true,
+      href: '?tractate=Pesachim&page=50a',
+    });
+  });
+});


### PR DESCRIPTION
Piece #1 of standardizing how parallels/connections are presented (data is already unified as `Link`; this starts unifying the *presentation* foundation).

Every connection points at an `AnchorCoord`, and each surface re-implemented "is this a Bavli daf / how do I navigate there" — **three `dafHref` copies** + ref-shape regexes. This is the one resolver they'll all share.

## What
- **`linkTarget(coord) → { label, corpus, navigable, href }`** (+ `linkCorpus`, `dafTarget`) — pure, DOM-free, unit-tested.
  - `corpus` = `bavli | yerushalmi | commentary | other` (from the coord alone — "same tractate" is a view concern, kept out).
  - `navigable` = we have an in-app reader (Bavli today).
  - `href` = a relative `?tractate=&page=` reader URL (resolves against the SPA root, drops the hash) — pure, no `window`.
- **`SpineFlowGraph`** drops its local `dafHref` + `navigableExit` and uses `linkTarget`. The corpus *badge* stays local (it carries `'here'` = same tractate). Behavior-identical → **invisible**.

## Not in this PR (the discussion continues)
The shared chip component (piece #2) and migrating the remaining surfaces (overview cross-refs, halacha derivation, Yerushalmi card) onto `linkTarget` + the chip. Doing one at a time so each view keeps its own layout and just adopts the shared atom.

## Verification
`pnpm typecheck` clean; **2248 tests** (+10 `link-target`; the 5 spine render tests confirm the migration is invisible); Biome clean.