### PR TITLE
LinkRef: one shared cross-reference chip; adopt it in the overview

### DIFF
--- a/packages/talmud/src/client/ArgumentSidebar.tsx
+++ b/packages/talmud/src/client/ArgumentSidebar.tsx
@@ -1,6 +1,8 @@
 // Recipes now live in the shared lib (carried on the worker mark def too).
 // Re-exported so existing importers (CARD_DEFS, tests) keep their `from
 // './ArgumentSidebar'` path.
+
+import type { AnchorCoord } from '@corpus/core/context/coord';
 import {
   AGGADATA_RECIPE,
   ARGUMENT_OVERVIEW_RECIPE,
@@ -49,6 +51,7 @@ import { GeographyMap } from './GeographyMap';
 import { GENERATION_BY_ID, type GenerationId, generationLabelHe } from './generations';
 import { Hebraized } from './Hebraized';
 import { lang, t } from './i18n';
+import { LinkRef } from './LinkRef';
 import { InspectDot, registerMarkRenderer } from './MarkEnrichmentCards';
 import type { GeographyData, GeographyEvidence } from './RabbiGeographyCard';
 import RabbiLineageTree, {
@@ -1083,11 +1086,8 @@ function ArgumentOverviewMaps(props: SpecialBlockProps): JSX.Element {
   // relation as navigable chips, plus a compact count of the within-daf flow
   // (whose detailed view is the maps above). Retires the old cites-only list.
   const relLabel = (rel: string): string => t(`link.rel.${rel}` as Parameters<typeof t>[0]);
-  const crossDafByRelation = (): {
-    relation: string;
-    pages: { tractate: string; page: string; label: string }[];
-  }[] => {
-    const byRel = new Map<string, { tractate: string; page: string; label: string }[]>();
+  const crossDafByRelation = (): { relation: string; targets: AnchorCoord[] }[] => {
+    const byRel = new Map<string, AnchorCoord[]>();
     const seen = new Set<string>();
     for (const l of links() ?? []) {
       for (const tgt of l.targets) {
@@ -1095,14 +1095,12 @@ function ArgumentOverviewMaps(props: SpecialBlockProps): JSX.Element {
         const k = `${l.relation}|${tgt.tractate}|${tgt.page}`;
         if (seen.has(k)) continue;
         seen.add(k);
-        const label =
-          tgt.seg >= 0 ? `${tgt.tractate} ${tgt.page}:${tgt.seg}` : `${tgt.tractate} ${tgt.page}`;
         const arr = byRel.get(l.relation) ?? [];
-        arr.push({ tractate: tgt.tractate, page: tgt.page, label });
+        arr.push(tgt);
         byRel.set(l.relation, arr);
       }
     }
-    return [...byRel.entries()].map(([relation, pages]) => ({ relation, pages }));
+    return [...byRel.entries()].map(([relation, targets]) => ({ relation, targets }));
   };
   const withinFlowCounts = (): { relation: string; count: number }[] => {
     const byRel = new Map<string, number>();
@@ -1117,13 +1115,6 @@ function ArgumentOverviewMaps(props: SpecialBlockProps): JSX.Element {
   };
   const hasConnections = (): boolean =>
     crossDafByRelation().length > 0 || withinFlowCounts().length > 0;
-  const goToDaf = (tractate: string, page: string): void => {
-    const u = new URL(window.location.href);
-    u.searchParams.set('tractate', tractate);
-    u.searchParams.set('page', page);
-    u.hash = '';
-    window.location.href = u.toString();
-  };
 
   // Adjacent-amud page label for the continuation caption: Hebrew daf form
   // ('ב.') in he mode, the raw '2a' slug in en.
@@ -1257,41 +1248,7 @@ function ArgumentOverviewMaps(props: SpecialBlockProps): JSX.Element {
                 >
                   {relLabel(grp.relation)}
                 </span>
-                <For each={grp.pages}>
-                  {(p) => {
-                    // A Bavli daf (page like "31a") opens in our reader; a non-daf
-                    // target (Yerushalmi perek:halacha, e.g. "1:1") has no reader
-                    // here, so show it but leave it non-clickable.
-                    const nav = /^\d+[ab]$/.test(p.page);
-                    const chip = {
-                      'font-size': '0.72rem',
-                      'text-decoration': 'none',
-                      color: nav ? '#1d4ed8' : '#6b7280',
-                      background: nav ? '#eff6ff' : '#f3f4f6',
-                      border: `1px solid ${nav ? '#dbeafe' : '#e5e7eb'}`,
-                      'border-radius': '5px',
-                      padding: '0.12rem 0.4rem',
-                      'white-space': 'nowrap',
-                    };
-                    return nav ? (
-                      <a
-                        href={dafHref({ tractate: p.tractate, page: p.page })}
-                        onClick={(e) => {
-                          e.preventDefault();
-                          goToDaf(p.tractate, p.page);
-                        }}
-                        title={t('overview.goToDaf', { daf: p.label })}
-                        style={chip}
-                      >
-                        {p.label}
-                      </a>
-                    ) : (
-                      <span title={p.label} style={chip}>
-                        {p.label}
-                      </span>
-                    );
-                  }}
-                </For>
+                <For each={grp.targets}>{(c) => <LinkRef coord={c} />}</For>
               </div>
             )}
           </For>

--- a/packages/talmud/src/client/LinkRef.tsx
+++ b/packages/talmud/src/client/LinkRef.tsx
@@ -1,0 +1,93 @@
+/**
+ * LinkRef — one cross-text reference, rendered the same way everywhere.
+ *
+ * Every surface that points at another text (overview cross-references, the
+ * Yerushalmi card header, the halacha derivation, …) used to draw its own chip.
+ * This is the shared atom: the target's label, a small corpus badge when the
+ * label alone doesn't say which corpus it is, clickable into our reader when the
+ * target is a Bavli daf and inert otherwise. Corpus + navigation come from the
+ * one `linkTarget` resolver, so every chip agrees.
+ *
+ * It is just the chip — views own their own layout (a list, a card header, a
+ * map) and drop this in.
+ */
+
+import type { AnchorCoord } from '@corpus/core/context/coord';
+import { type JSX, Show } from 'solid-js';
+import { type LinkCorpus, linkTarget } from '../lib/context/linkTarget';
+import { t } from './i18n';
+
+/** Corpus badge — only for corpora the label alone doesn't make obvious. A Bavli
+ *  daf ("Berakhot 13a") and a Tanakh verse ("Genesis 1:1") read for themselves,
+ *  so they get none; the Yerushalmi + commentary spines get a tag. */
+const CORPUS_BADGE: Partial<Record<LinkCorpus, { label: string; bg: string; fg: string }>> = {
+  yerushalmi: { label: 'ירושלמי', bg: '#0e7490', fg: '#ffffff' },
+  commentary: { label: 'commentary', bg: '#ece9e1', fg: '#57534e' },
+};
+
+const BASE: JSX.CSSProperties = {
+  display: 'inline-flex',
+  'align-items': 'center',
+  gap: '0.28rem',
+  'font-size': '0.72rem',
+  'text-decoration': 'none',
+  'border-radius': '5px',
+  padding: '0.12rem 0.4rem',
+  'white-space': 'nowrap',
+};
+const NAV: JSX.CSSProperties = {
+  ...BASE,
+  color: '#1d4ed8',
+  background: '#eff6ff',
+  border: '1px solid #dbeafe',
+};
+const INERT: JSX.CSSProperties = {
+  ...BASE,
+  color: '#6b7280',
+  background: '#f3f4f6',
+  border: '1px solid #e5e7eb',
+};
+
+export function LinkRef(props: { coord: AnchorCoord }): JSX.Element {
+  const target = () => linkTarget(props.coord);
+  const badge = (): { label: string; bg: string; fg: string } | undefined =>
+    CORPUS_BADGE[target().corpus];
+  const Badge = (): JSX.Element => (
+    <Show when={badge()}>
+      {(b) => (
+        <span
+          style={{
+            'font-size': '0.6rem',
+            'font-weight': 650,
+            'border-radius': '999px',
+            padding: '0 0.32rem',
+            background: b().bg,
+            color: b().fg,
+          }}
+        >
+          {b().label}
+        </span>
+      )}
+    </Show>
+  );
+  return (
+    <Show
+      when={target().navigable && target().href}
+      fallback={
+        // Inert: no in-app reader for this corpus (Yerushalmi, a verse, …).
+        <span style={INERT} title={target().label}>
+          {target().label}
+          <Badge />
+        </span>
+      }
+    >
+      {(href) => (
+        // A real href (relative `?tractate=&page=`) so middle-click / open-in-new-tab work.
+        <a style={NAV} href={href()} title={t('overview.goToDaf', { daf: target().label })}>
+          {target().label}
+          <Badge />
+        </a>
+      )}
+    </Show>
+  );
+}

--- a/packages/talmud/tests/client/link-ref.test.tsx
+++ b/packages/talmud/tests/client/link-ref.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { render } from '@solidjs/testing-library';
+import { describe, expect, it } from 'vitest';
+import { LinkRef } from '../../src/client/LinkRef';
+
+describe('LinkRef', () => {
+  it('renders a Bavli daf as a clickable reader link, no badge', () => {
+    const { container } = render(() => (
+      <LinkRef coord={{ tractate: 'Berakhot', page: '13a', seg: -1 }} />
+    ));
+    const a = container.querySelector('a');
+    expect(a).toBeTruthy();
+    expect(a?.getAttribute('href')).toBe('?tractate=Berakhot&page=13a');
+    expect(a?.textContent).toContain('Berakhot 13a');
+    expect(container.textContent).not.toContain('ירושלמי');
+  });
+
+  it('renders a Yerushalmi target inert (no link) with a corpus badge', () => {
+    const { container } = render(() => (
+      <LinkRef coord={{ tractate: 'Jerusalem Talmud Berakhot', page: '1:1', seg: -1 }} />
+    ));
+    expect(container.querySelector('a')).toBeNull();
+    expect(container.textContent).toContain('Jerusalem Talmud Berakhot 1:1');
+    expect(container.textContent).toContain('ירושלמי');
+  });
+
+  it('renders a commentary-spine target inert with a "commentary" badge', () => {
+    const { container } = render(() => (
+      <LinkRef coord={{ tractate: 'Berakhot', page: '2a', seg: -1, spine: 'Rashi' }} />
+    ));
+    expect(container.querySelector('a')).toBeNull();
+    expect(container.textContent).toContain('Rashi · Berakhot 2a');
+    expect(container.textContent).toContain('commentary');
+  });
+});


### PR DESCRIPTION
Piece #2 of standardizing parallels/connections (follows #396's `linkTarget` resolver). The shared **atom** — not a unified panel, just one consistent chip each view drops into its own layout.

## `LinkRef`
`<LinkRef coord={…} />` → the target's label + a corpus badge *only* where the label isn't self-evident (Yerushalmi, commentary; a Bavli daf and a Tanakh verse read for themselves). Clickable into our reader when the target is a Bavli daf, **inert otherwise** (the "inert for now" call — no per-view action yet). Corpus + navigation both come from `linkTarget`, so every chip agrees. Real `<a href>` so middle-click / open-in-new-tab work; nav tooltip reuses the existing `overview.goToDaf` key (keeps the Hebrew tooltip).

## First adopter: the overview cross-references
`ArgumentSidebar`'s `crossDafByRelation` now carries target coords and renders `<LinkRef>`. Retires the bespoke per-chip nav/style + the dead `goToDaf` helper.

**Minor visible change:** a small corpus badge now appears on non-Bavli targets (e.g. a Yerushalmi parallel shows `ירושלמי`); Bavli chips look the same as before. That's the standardization showing — the overview and the spine now speak the same chip vocabulary.

## Not in this PR
The Yerushalmi card + halacha derivation adopting `LinkRef` as their cross-ref header (their rich bodies stay). The spine already shares the `linkTarget` resolver (its SVG chip can't reuse the HTML component).

## Verification
`pnpm typecheck` clean; **2251 tests** (+3 `link-ref` render tests: Bavli=link, Yerushalmi/commentary=inert+badge); Biome clean.