### PR TITLE
Inspector by-anchor (server): emit additive groups + index argument

### DIFF
--- a/packages/talmud/src/worker/cache-keys.ts
+++ b/packages/talmud/src/worker/cache-keys.ts
@@ -137,7 +137,10 @@ export function prefixForDafIndex(tractate: string, page: string): string {
  *  completed backfill has no sentinel, so it still takes the probe path. Kept in
  *  a SEPARATE namespace so it doesn't appear under `prefixForDafIndex`. */
 export function keyForDafIndexDone(tractate: string, page: string, lang: 'en' | 'he'): string {
-  return `dafidx-done:v1:${slugDaf(tractate, page)}:${lang}`;
+  // v2: the backfill now also indexes the per-section `argument` facets, so a v1
+  // "complete" is stale. Bumping forces one re-backfill per daf (off the request
+  // path) that adds the argument entries, then writes v2.
+  return `dafidx-done:v2:${slugDaf(tractate, page)}:${lang}`;
 }
 
 // Per-daf analysis + per-rabbi enrichment caches. Each of these was hand-built

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -172,6 +172,14 @@ import {
   probeInstances,
   tokensOfEntry,
 } from './inspect';
+import {
+  type AnchorGroup,
+  type AnchorPiece,
+  type AnchorRef,
+  anchorRefOf,
+  groupByAnchor,
+  WHOLE_DAF_ANCHOR,
+} from './inspect-anchors';
 import { noteLintAttempt, readLintFailures } from './lint-failures';
 import { ALIGN_MARKS } from './mark-categories';
 import {
@@ -2095,9 +2103,11 @@ async function backfillDafIndex(
     }),
   );
   const markAnchorById = new Map(CODE_MARKS.map((m) => [m.id, (m as { anchor?: string }).anchor]));
-  const localEnrichments = CODE_ENRICHMENTS.filter(
-    (e) => e.scope === 'local' && e.target_mark !== 'argument',
-  );
+  // Index ALL local enrichments — including the per-section `argument` facets,
+  // which were held out of the flat `runs`/load-bar path but are a first-class
+  // anchor in the by-anchor view. Their leaves key by slug(title), which matches
+  // the argument mark instance (pinned by tests/inspect-anchors).
+  const localEnrichments = CODE_ENRICHMENTS.filter((e) => e.scope === 'local');
   const wholeDafIid = await instanceIdOf({ fields: {} });
   await Promise.all(
     localEnrichments.map(async (def) => {
@@ -2231,6 +2241,117 @@ async function dafRunsFromIndexRows(
   return dafRunsFromIndex(metas, specs);
 }
 
+/** Build the BY-ANCHOR groups for the fast (index) path: join the per-instance
+ *  index entries to the mark instances (the anchors), enumerating EVERY expected
+ *  piece per anchor (cached from the index, else a miss) so a group shows the
+ *  full set. Whole-daf marks + whole-daf enrichments lead in a `__whole_daf__`
+ *  group. Includes the per-section `argument` facets (a first-class anchor here,
+ *  even though they stay out of the flat `runs`/load-bar path). */
+async function dafGroupsFromIndex(
+  env: Bindings,
+  tractate: string,
+  page: string,
+  lang: 'en' | 'he',
+): Promise<AnchorGroup[]> {
+  const raw = await listDafIndexRaw(env, tractate, page);
+  const metas = raw
+    .map((e) => e.meta as DafIndexEntryMeta & { l?: string })
+    .filter((m): m is DafIndexEntryMeta & { l?: string } => !!m && m.l === lang);
+
+  const markAnchorById = new Map(CODE_MARKS.map((m) => [m.id, (m as { anchor?: string }).anchor]));
+  interface Desc {
+    id: string;
+    label: string;
+    kind: 'llm' | 'computed';
+    model?: string;
+    producer: 'mark' | 'enrichment';
+  }
+  const descOf = (
+    def: { id: string; label: string; extractor?: unknown },
+    producer: 'mark' | 'enrichment',
+  ): Desc => {
+    const ext = def.extractor as { kind?: string; model?: string } | undefined;
+    const isLLM = ext?.kind === 'llm';
+    return {
+      id: def.id,
+      label: def.label,
+      kind: isLLM ? 'llm' : 'computed',
+      model: isLLM ? ext?.model : undefined,
+      producer,
+    };
+  };
+  // Per-instance enrichments grouped by target mark; everything else is whole-daf.
+  const byTarget = new Map<string, Desc[]>();
+  const wholeDafProducers: Desc[] = CODE_MARKS.map((d) => descOf(d, 'mark'));
+  for (const def of CODE_ENRICHMENTS.filter((e) => e.scope === 'local')) {
+    const targetMark = (def as { target_mark?: string }).target_mark;
+    if (targetMark && markAnchorById.get(targetMark) !== 'whole-daf') {
+      const arr = byTarget.get(targetMark) ?? [];
+      arr.push(descOf(def, 'enrichment'));
+      byTarget.set(targetMark, arr);
+    } else {
+      wholeDafProducers.push(descOf(def, 'enrichment'));
+    }
+  }
+  // Anchors for each per-instance target mark (instanceIdOf = the join key).
+  const anchorsByMark = new Map<string, AnchorRef[]>();
+  await Promise.all(
+    [...byTarget.keys()].map(async (mid) => {
+      const insts = await readMarkInstances(env, mid, tractate, page);
+      anchorsByMark.set(mid, await Promise.all(insts.map((inst) => anchorRefOf(mid, inst))));
+    }),
+  );
+  // Index lookups: per-instance entries by (producer:instance); mark entries (no
+  // instance id) by producer; whole-daf enrichment entries by the {fields:{}} id.
+  const metaByPK = new Map<string, DafIndexEntryMeta>();
+  const markMetaByP = new Map<string, DafIndexEntryMeta>();
+  for (const m of metas) {
+    if (m.i) metaByPK.set(`${m.p}:${m.i}`, m);
+    else markMetaByP.set(m.p, m);
+  }
+  const wholeIid = await instanceIdOf({ fields: {} });
+  const pieceOf = (d: Desc, meta: DafIndexEntryMeta | undefined): AnchorPiece => ({
+    producerId: d.id,
+    label: d.label,
+    kind: d.kind,
+    model: d.model,
+    cached: !!meta,
+    cost: meta?.c ?? null,
+    cold_ms: meta?.ms ?? null,
+    tokens: meta?.t ?? null,
+  });
+
+  const placed: Array<{ piece: AnchorPiece; anchor: AnchorRef | null }> = [];
+  for (const [mid, anchors] of anchorsByMark) {
+    const producers = byTarget.get(mid) ?? [];
+    for (const anchor of anchors) {
+      for (const d of producers) {
+        placed.push({ piece: pieceOf(d, metaByPK.get(`${d.id}:${anchor.instanceId}`)), anchor });
+      }
+    }
+  }
+  for (const d of wholeDafProducers) {
+    const meta =
+      d.producer === 'mark' ? markMetaByP.get(d.id) : metaByPK.get(`${d.id}:${wholeIid}`);
+    placed.push({ piece: pieceOf(d, meta), anchor: null });
+  }
+
+  const { groups, wholeDaf } = groupByAnchor(placed);
+  return [
+    {
+      anchor: {
+        markId: WHOLE_DAF_ANCHOR,
+        instanceId: '',
+        label: 'Whole daf',
+        segRange: null,
+        instanceJson: { fields: {} },
+      },
+      pieces: wholeDaf,
+    },
+    ...groups,
+  ];
+}
+
 app.get('/api/daf-runs/:tractate/:page', async (c) => {
   const tractate = c.req.param('tractate');
   const page = c.req.param('page');
@@ -2244,9 +2365,15 @@ app.get('/api/daf-runs/:tractate/:page', async (c) => {
   // backfills + writes the sentinel, so the next view takes this branch).
   if (c.env.CACHE && (await c.env.CACHE.get(keyForDafIndexDone(tractate, page, lang)))) {
     try {
-      const runs = await dafRunsFromIndexRows(c.env, tractate, page, lang);
+      const [runs, groups] = await Promise.all([
+        dafRunsFromIndexRows(c.env, tractate, page, lang),
+        dafGroupsFromIndex(c.env, tractate, page, lang),
+      ]);
       runs.sort((a, b) => (b.cold_ms ?? -1) - (a.cold_ms ?? -1));
-      return c.json({ tractate, page, lang, runs, source: 'index' });
+      // `groups` (additive) is the by-anchor view; `runs` stays flat for the load
+      // bar + old clients. The slow path below emits no groups → client falls
+      // back to grouping `runs` flatly until the daf backfills.
+      return c.json({ tractate, page, lang, runs, groups, source: 'index' });
     } catch {
       /* fall through to the probe path on any index-read error */
     }

--- a/packages/talmud/src/worker/inspect-anchors.ts
+++ b/packages/talmud/src/worker/inspect-anchors.ts
@@ -1,0 +1,123 @@
+/**
+ * inspect-anchors — pure helpers for the BY-ANCHOR inspector view.
+ *
+ * Today the inspector lists one aggregated row per PRODUCER ("argument.synthesis
+ * 5/5"). But each instance is a distinct PIECE pinned to a distinct ANCHOR (a
+ * pasuk / section / move / rabbi / ...). This reorganizes the daf into ANCHOR
+ * GROUPS: each anchored instance, with the producer-pieces that sit on it.
+ *
+ * The join: a daf-index entry carries the instance id `i` but no label; the
+ * mark's stored instance carries the label + segment range. They join on
+ * `instanceIdOf(markInstance) === meta.i` — the SAME id the warm path and the
+ * index writer used, so it matches by construction (no label needed to join; the
+ * label is cosmetic and can be empty, e.g. rishonim).
+ */
+
+import { instanceIdOf } from './cache-keys';
+
+export const WHOLE_DAF_ANCHOR = '__whole_daf__';
+
+/** The bits of a stored mark instance (parsed.instances[i]) the anchor needs. */
+export interface RawInstanceLike {
+  startSegIdx?: unknown;
+  endSegIdx?: unknown;
+  segIdx?: unknown;
+  fields?: Record<string, unknown>;
+}
+
+/** Where a piece sits — the join key (instanceId) + a human label + the range,
+ *  plus the raw instance so the client can pass it as ?instance= to drill into
+ *  that anchor's build-tree. */
+export interface AnchorRef {
+  markId: string;
+  instanceId: string;
+  label: string;
+  segRange: [number, number] | null;
+  instanceJson: unknown;
+}
+
+/** One producer's result for one anchor (or for the whole daf). */
+export interface AnchorPiece {
+  producerId: string;
+  label: string;
+  kind: 'llm' | 'computed';
+  model?: string;
+  cached: boolean;
+  cost: number | null;
+  cold_ms: number | null;
+  tokens: number | null;
+}
+
+export interface AnchorGroup {
+  anchor: AnchorRef;
+  pieces: AnchorPiece[];
+}
+
+const num = (v: unknown): number | null => (typeof v === 'number' ? v : null);
+
+/** Human label for an anchor: the same identity fields instanceLabel uses, plus
+ *  `name` (rabbi/places) and `yerushalmiRef`, then a `seg N` fallback (rishonim
+ *  carries no label field), then the mark id. Cosmetic — never the join key. */
+export function anchorLabelOf(markId: string, inst: RawInstanceLike): string {
+  const f = inst.fields ?? {};
+  for (const k of [
+    'title',
+    'topic',
+    'theme',
+    'caption',
+    'verseRef',
+    'yerushalmiRef',
+    'name',
+    'summary',
+  ]) {
+    const v = f[k];
+    if (typeof v === 'string' && v.trim()) return v.trim();
+  }
+  const seg = num(inst.startSegIdx) ?? num(inst.segIdx);
+  return seg != null ? `seg ${seg}` : markId;
+}
+
+function segRangeOf(inst: RawInstanceLike): [number, number] | null {
+  const s = num(inst.startSegIdx) ?? num(inst.segIdx);
+  if (s == null) return null;
+  return [s, num(inst.endSegIdx) ?? s];
+}
+
+/** Build the anchor ref for one mark instance (id via instanceIdOf — THE join
+ *  key — plus label, range, and the raw instance for drill-in). */
+export async function anchorRefOf(markId: string, inst: RawInstanceLike): Promise<AnchorRef> {
+  return {
+    markId,
+    instanceId: await instanceIdOf(inst),
+    label: anchorLabelOf(markId, inst),
+    segRange: segRangeOf(inst),
+    instanceJson: inst,
+  };
+}
+
+/** Partition placed pieces into anchor groups (+ the whole-daf pieces, anchor =
+ *  null). Groups are ordered by mark id, then segment start, then label. */
+export function groupByAnchor(placed: Array<{ piece: AnchorPiece; anchor: AnchorRef | null }>): {
+  groups: AnchorGroup[];
+  wholeDaf: AnchorPiece[];
+} {
+  const byKey = new Map<string, AnchorGroup>();
+  const wholeDaf: AnchorPiece[] = [];
+  for (const { piece, anchor } of placed) {
+    if (!anchor) {
+      wholeDaf.push(piece);
+      continue;
+    }
+    const key = `${anchor.markId}:${anchor.instanceId}`;
+    const g = byKey.get(key);
+    if (g) g.pieces.push(piece);
+    else byKey.set(key, { anchor, pieces: [piece] });
+  }
+  const groups = [...byKey.values()].sort((a, b) => {
+    if (a.anchor.markId !== b.anchor.markId) return a.anchor.markId.localeCompare(b.anchor.markId);
+    const as = a.anchor.segRange?.[0] ?? Number.MAX_SAFE_INTEGER;
+    const bs = b.anchor.segRange?.[0] ?? Number.MAX_SAFE_INTEGER;
+    return as !== bs ? as - bs : a.anchor.label.localeCompare(b.anchor.label);
+  });
+  return { groups, wholeDaf };
+}

--- a/packages/talmud/tests/inspect-anchors.test.ts
+++ b/packages/talmud/tests/inspect-anchors.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import { instanceIdOf } from '../src/worker/cache-keys';
+import {
+  type AnchorPiece,
+  type AnchorRef,
+  anchorLabelOf,
+  anchorRefOf,
+  groupByAnchor,
+} from '../src/worker/inspect-anchors';
+
+describe('anchorLabelOf — human label per mark', () => {
+  it('reads the identity field per mark, with a seg-N fallback', () => {
+    expect(anchorLabelOf('pesukim', { fields: { verseRef: 'Deuteronomy 6:7' } })).toBe(
+      'Deuteronomy 6:7',
+    );
+    expect(anchorLabelOf('argument', { fields: { title: 'The opening Mishnah' } })).toBe(
+      'The opening Mishnah',
+    );
+    expect(anchorLabelOf('rabbi', { fields: { name: 'Abaye' } })).toBe('Abaye');
+    expect(anchorLabelOf('yerushalmi', { fields: { yerushalmiRef: 'Berakhot 1:1' } })).toBe(
+      'Berakhot 1:1',
+    );
+    // rishonim carries no label field -> fall back to the segment number
+    expect(anchorLabelOf('rishonim', { segIdx: 5 })).toBe('seg 5');
+    expect(anchorLabelOf('rishonim', { startSegIdx: 3, endSegIdx: 3 })).toBe('seg 3');
+    // nothing usable -> the mark id
+    expect(anchorLabelOf('whatever', {})).toBe('whatever');
+  });
+});
+
+describe('anchorRefOf — id (the join key) + range + label', () => {
+  it('id is instanceIdOf(inst); segRange + instanceJson pass through', async () => {
+    const inst = { startSegIdx: 7, endSegIdx: 9, fields: { verseRef: 'Deuteronomy 6:7' } };
+    const ref = await anchorRefOf('pesukim', inst);
+    expect(ref.instanceId).toBe(await instanceIdOf(inst));
+    expect(ref.label).toBe('Deuteronomy 6:7');
+    expect(ref.segRange).toEqual([7, 9]);
+    expect(ref.instanceJson).toBe(inst);
+  });
+  it('phrase marks (no seg range) -> segRange null', async () => {
+    const ref = await anchorRefOf('rabbi', { fields: { name: 'Rava' } });
+    expect(ref.segRange).toBeNull();
+    expect(ref.label).toBe('Rava');
+  });
+});
+
+describe('groupByAnchor — partition pieces into anchor groups + whole-daf', () => {
+  const piece = (id: string): AnchorPiece => ({
+    producerId: id,
+    label: id,
+    kind: 'llm',
+    cached: true,
+    cost: null,
+    cold_ms: null,
+    tokens: null,
+  });
+  const anchor = (markId: string, instanceId: string, seg: number): AnchorRef => ({
+    markId,
+    instanceId,
+    label: instanceId,
+    segRange: [seg, seg],
+    instanceJson: {},
+  });
+  it('groups by (markId, instanceId); null anchor -> whole-daf; ordered by seg', () => {
+    const a2 = anchor('pesukim', 'b', 9);
+    const a1 = anchor('pesukim', 'a', 7);
+    const { groups, wholeDaf } = groupByAnchor([
+      { piece: piece('pesukim.why-here'), anchor: a2 },
+      { piece: piece('pesukim.mechanism'), anchor: a2 },
+      { piece: piece('daf-background'), anchor: null },
+      { piece: piece('pesukim.why-here'), anchor: a1 },
+    ]);
+    expect(wholeDaf.map((p) => p.producerId)).toEqual(['daf-background']);
+    // a1 (seg 7) before a2 (seg 9)
+    expect(groups.map((g) => g.anchor.instanceId)).toEqual(['a', 'b']);
+    expect(groups[1].pieces.map((p) => p.producerId)).toEqual([
+      'pesukim.why-here',
+      'pesukim.mechanism',
+    ]);
+  });
+});
+
+// The long-deferred argument gate: argumentDisplayInstance (no seg idx) and
+// argumentSynthInstance (with seg idx) + the stored argument mark instance must
+// share an instance id, else the argument leaves false-miss. They DO for an
+// English title (it slugs to alphanumerics, so instanceIdOf returns slug(title)
+// for all three). A Hebrew title falls to the structural hash, where the two
+// shapes diverge — the documented HE-only edge.
+describe('argument anchor join (the held-back dual display/synth shape)', () => {
+  const title = 'Rava objects to Abaye';
+  const display = { fields: { title, summary: 's', excerpt: 'e', rabbiNames: ['Rava'] } };
+  const synth = {
+    startSegIdx: 7,
+    endSegIdx: 9,
+    fields: { title, summary: 's', excerpt: 'e', rabbiNames: ['Rava'] },
+  };
+  const stored = { startSegIdx: 7, endSegIdx: 9, fields: { title, excerpt: 'e', summary: 's' } };
+  it('English title: display, synth, and stored instance share one id (join works)', async () => {
+    const id = await instanceIdOf(display);
+    expect(await instanceIdOf(synth)).toBe(id);
+    expect(await instanceIdOf(stored)).toBe(id);
+  });
+  it('Hebrew title: display and synth diverge (structural hash) — the HE edge', async () => {
+    const he = 'פתיחה';
+    const d = await instanceIdOf({ fields: { title: he, excerpt: 'e' } });
+    const s = await instanceIdOf({
+      startSegIdx: 7,
+      endSegIdx: 9,
+      fields: { title: he, excerpt: 'e' },
+    });
+    expect(d).not.toBe(s);
+  });
+});


### PR DESCRIPTION
## Why

The inspector lists one aggregated row per **producer** ("argument.synthesis 5/5"), hiding that each instance is a distinct **piece pinned to a distinct anchor** (a pasuk / section / move / rabbi). This is the server half of reorganizing the inspector **by anchor**: each anchored instance, with its producer-pieces under it (mirrors the reader's per-section/per-pasuk cards).

## What (additive, invisible until the client PR)

- **`inspect-anchors.ts`** (pure, tested): `anchorRefOf` (instanceId via `instanceIdOf` — **the join key** — + label + segRange + the raw instance for drill-in), `anchorLabelOf` (per-mark label, `seg N` fallback), `groupByAnchor` (partition pieces into anchor groups + a whole-daf bucket).
- **`/api/daf-runs` fast path** now also returns **`groups: AnchorGroup[]`** (additive). `dafGroupsFromIndex` joins the per-instance daf-index entries to the mark instances (the anchors) and enumerates **every** expected piece per anchor (cached from the index, else a miss), with whole-daf marks/enrichments in a leading `__whole_daf__` group. **`runs` is unchanged → the load bar + old clients are untouched.** The client renders `groups` next; until then it falls back to flat `runs`.
- **The held-back `argument` sections fold in.** Their leaves key by `slug(title)`, which matches the argument mark instance for English titles — **pinned by `tests/inspect-anchors`** (with the Hebrew-title divergence documented as the one edge). The backfill now indexes all local enrichments incl. argument; the completion sentinel bumps **v1→v2** so every daf re-indexes once (off-path) to add the argument entries.

## Safety

No `mark:`/`enrich:` key shape changed. The sentinel bump only re-triggers the **derived** index backfill (cheap to rebuild). `groups` is additive; `runs` is byte-identical; the probe path is the fallback. Verified live next (the `groups` field appears and includes argument anchors).

`pnpm typecheck` + full `pnpm test` (2254) + `biome ci .` green.