### PR TITLE
Inspector by-anchor (client): render collapsible per-place groups

### DIFF
--- a/packages/talmud/src/client/RunTreeDock.tsx
+++ b/packages/talmud/src/client/RunTreeDock.tsx
@@ -27,12 +27,16 @@ import {
   Show,
 } from 'solid-js';
 import {
+  type AnchorGroup as AnchorGroupT,
   type DafRun,
+  dafRunGroups,
   dafRunRows,
   dafRunsLoading,
   liveCounts,
   liveLoading,
+  pieceToRun,
   refetchDafRuns,
+  WHOLE_DAF_ANCHOR,
 } from './dafRunsStore';
 import { lang } from './i18n';
 import { inspectRequest } from './inspectBridge';
@@ -536,6 +540,26 @@ export default function RunTreeDock(props: {
       .filter((r) => typeFilter().has(variantOf(r)))
       .sort((a, b) => (live.has(b.id) ? 1 : 0) - (live.has(a.id) ? 1 : 0));
   });
+  // BY-ANCHOR view: the server's per-place groups (each anchored instance + its
+  // pieces). Null when absent (old server / un-indexed daf) → the flat
+  // `visibleRuns` fallback renders instead.
+  const groupedRuns = createMemo<AnchorGroupT[] | null>(() => {
+    const g = dafRunGroups();
+    return g.length ? g : null;
+  });
+  const anchorKey = (g: AnchorGroupT) => `${g.anchor.markId}:${g.anchor.instanceId}`;
+  const [expandedAnchors, setExpandedAnchors] = createSignal<Set<string>>(new Set());
+  const toggleAnchor = (k: string) =>
+    setExpandedAnchors((prev) => {
+      const n = new Set(prev);
+      if (n.has(k)) n.delete(k);
+      else n.add(k);
+      return n;
+    });
+  // Pieces in a group passing the type filter (mapped to the DafRun shape RunRow
+  // wants). A group with none passing is hidden.
+  const groupPieces = (g: AnchorGroupT): DafRun[] =>
+    g.pieces.map(pieceToRun).filter((r) => typeFilter().has(variantOf(r)));
   // Per-instance focus (a mark_input) when an (i) inspects e.g. one section's
   // synthesis; null = whole-daf. Cleared when navigating via the waterfall.
   const [focusInstance, setFocusInstance] = createSignal<unknown>(null);
@@ -878,19 +902,108 @@ export default function RunTreeDock(props: {
             <Show when={dafRunsLoading()}>
               <div style={{ padding: '0.6rem', color: '#aaa' }}>loading…</div>
             </Show>
-            <For each={visibleRuns()}>
-              {(r) => (
-                <RunRow
-                  run={r}
-                  maxMs={maxCold()}
-                  active={r.id === pieceId()}
-                  loading={liveLoading().has(r.id)}
-                  loadingCount={liveCounts().get(r.id) ?? 0}
-                  onClick={() => openPiece(r.id)}
-                  onInspect={() => openPiece(r.id)}
-                />
+            <Show
+              when={groupedRuns()}
+              fallback={
+                <For each={visibleRuns()}>
+                  {(r) => (
+                    <RunRow
+                      run={r}
+                      maxMs={maxCold()}
+                      active={r.id === pieceId()}
+                      loading={liveLoading().has(r.id)}
+                      loadingCount={liveCounts().get(r.id) ?? 0}
+                      onClick={() => openPiece(r.id)}
+                      onInspect={() => openPiece(r.id)}
+                    />
+                  )}
+                </For>
+              }
+            >
+              {(groups) => (
+                <For each={groups()}>
+                  {(g) => {
+                    const pieces = createMemo(() => groupPieces(g));
+                    const whole = g.anchor.markId === WHOLE_DAF_ANCHOR;
+                    const k = anchorKey(g);
+                    const open = () => whole || expandedAnchors().has(k);
+                    const cachedN = g.pieces.filter((p) => p.cached).length;
+                    return (
+                      <Show when={pieces().length > 0}>
+                        <div
+                          role="button"
+                          tabIndex={0}
+                          onClick={() => !whole && toggleAnchor(k)}
+                          onKeyDown={(e) => {
+                            if (!whole && (e.key === 'Enter' || e.key === ' ')) {
+                              e.preventDefault();
+                              toggleAnchor(k);
+                            }
+                          }}
+                          style={{
+                            display: 'flex',
+                            'align-items': 'center',
+                            gap: '0.4rem',
+                            padding: '0.25rem 0.6rem',
+                            cursor: whole ? 'default' : 'pointer',
+                            background: '#f6f3ec',
+                            'border-top': '1px solid #ece7da',
+                            'font-size': '0.72rem',
+                          }}
+                        >
+                          <span style={{ width: '0.7rem', color: '#b3a994' }}>
+                            {whole ? '' : open() ? '▾' : '▸'}
+                          </span>
+                          <span
+                            style={{
+                              'font-weight': 600,
+                              color: '#4a4034',
+                              'white-space': 'nowrap',
+                              overflow: 'hidden',
+                              'text-overflow': 'ellipsis',
+                              flex: 1,
+                            }}
+                          >
+                            {whole ? 'Whole daf' : g.anchor.label || g.anchor.markId}
+                          </span>
+                          <Show when={!whole}>
+                            <span
+                              style={{ 'font-size': '0.6rem', color: '#a89c86', 'flex-shrink': 0 }}
+                            >
+                              {g.anchor.markId}
+                            </span>
+                          </Show>
+                          <span
+                            style={{
+                              'font-variant-numeric': 'tabular-nums',
+                              color: cachedN === g.pieces.length ? '#5f8a6f' : '#a8854a',
+                              'flex-shrink': 0,
+                            }}
+                          >
+                            {cachedN}/{g.pieces.length}
+                          </span>
+                        </div>
+                        <Show when={open()}>
+                          <For each={pieces()}>
+                            {(r) => (
+                              <RunRow
+                                run={r}
+                                maxMs={maxCold()}
+                                active={r.id === pieceId()}
+                                loading={liveLoading().has(r.id)}
+                                loadingCount={liveCounts().get(r.id) ?? 0}
+                                onClick={() => openPiece(r.id, g.anchor.instanceJson)}
+                                onInspect={() => openPiece(r.id, g.anchor.instanceJson)}
+                              />
+                            )}
+                          </For>
+                        </Show>
+                      </Show>
+                    );
+                  }}
+                </For>
               )}
-            </For>
+            </Show>
           </div>
         </Show>
 

--- a/packages/talmud/src/client/RunTreeDock.tsx
+++ b/packages/talmud/src/client/RunTreeDock.tsx
@@ -930,6 +930,7 @@ export default function RunTreeDock(props: {
                     const cachedN = g.pieces.filter((p) => p.cached).length;
                     return (
                       <Show when={pieces().length > 0}>
+                        {/* biome-ignore lint/a11y/useSemanticElements: collapsible anchor-group header; a div keeps it consistent with RunRow's clickable rows */}
                         <div
                           role="button"
                           tabIndex={0}

--- a/packages/talmud/src/client/dafRunsProgress.ts
+++ b/packages/talmud/src/client/dafRunsProgress.ts
@@ -27,6 +27,51 @@ export interface DafRun {
   experimental?: boolean;
 }
 
+// --- BY-ANCHOR view (additive; the server's /api/daf-runs `groups`) ----------
+/** One producer's result for one anchor (or for the whole daf). */
+export interface AnchorPiece {
+  producerId: string;
+  label: string;
+  kind: 'llm' | 'computed';
+  model?: string;
+  cached: boolean;
+  cost: number | null;
+  cold_ms: number | null;
+  tokens: number | null;
+}
+/** Where a group of pieces sits — the join id + label + range + the raw instance
+ *  (passed back as ?instance= to root the DAG on this anchor). */
+export interface AnchorRef {
+  markId: string;
+  instanceId: string;
+  label: string;
+  segRange: [number, number] | null;
+  instanceJson: unknown;
+}
+export interface AnchorGroup {
+  anchor: AnchorRef;
+  pieces: AnchorPiece[];
+}
+/** The sentinel anchor markId for the leading daf-level group. */
+export const WHOLE_DAF_ANCHOR = '__whole_daf__';
+
+/** Adapt an anchor piece to the DafRun shape RunRow renders. `producer` is
+ *  derived from the id (mark ids have no dot; enrichment ids do — e.g.
+ *  `pesukim.why-here`), which only drives the icon/dot, not behaviour. */
+export function pieceToRun(p: AnchorPiece): DafRun {
+  return {
+    id: p.producerId,
+    label: p.label,
+    kind: p.kind,
+    producer: p.producerId.includes('.') ? 'enrichment' : 'mark',
+    model: p.model,
+    cached: p.cached,
+    cold_ms: p.cold_ms,
+    cost: p.cost,
+    tokens: p.tokens,
+  };
+}
+
 /** A row the reader auto-warms on daf load — the load bar's denominator. Excludes
  *  experimental (chart) and lazy on-demand leaves (*.qa / *.suggested-questions),
  *  which only warm when a user opens them, so they'd otherwise peg the bar < 100%. */

--- a/packages/talmud/src/client/dafRunsStore.ts
+++ b/packages/talmud/src/client/dafRunsStore.ts
@@ -22,12 +22,21 @@ import {
   onCleanup,
 } from 'solid-js';
 import { aiActivity } from './aiActivity';
-import { cacheProgressOf, type DafRun } from './dafRunsProgress';
+import { type AnchorGroup, cacheProgressOf, type DafRun } from './dafRunsProgress';
 import { liveProducerCounts, liveProducerSet } from './runStatus';
 
 // Re-export the pure shape + reducers so consumers keep one import site; the
 // testable definitions live in dafRunsProgress (no Solid → importable in vitest).
-export { cacheProgressOf, type DafRun, isEagerRow } from './dafRunsProgress';
+export {
+  type AnchorGroup,
+  type AnchorPiece,
+  type AnchorRef,
+  cacheProgressOf,
+  type DafRun,
+  isEagerRow,
+  pieceToRun,
+  WHOLE_DAF_ANCHOR,
+} from './dafRunsProgress';
 
 interface Target {
   tractate: string;
@@ -53,14 +62,15 @@ const targetKey = (): string | null => {
 const store = createRoot(() => {
   const [runs, { refetch }] = createResource(
     targetKey,
-    async (key): Promise<{ key: string; rows: DafRun[] }> => {
+    async (key): Promise<{ key: string; rows: DafRun[]; groups: AnchorGroup[] }> => {
       const t = target();
-      if (!t) return { key, rows: [] };
+      if (!t) return { key, rows: [], groups: [] };
       const r = await fetch(
         `/api/daf-runs/${encodeURIComponent(t.tractate)}/${encodeURIComponent(t.page)}?lang=${t.lang}`,
       );
-      if (!r.ok) return { key, rows: [] };
-      return { key, rows: ((await r.json()) as { runs: DafRun[] }).runs };
+      if (!r.ok) return { key, rows: [], groups: [] };
+      const j = (await r.json()) as { runs?: DafRun[]; groups?: AnchorGroup[] };
+      return { key, rows: j.runs ?? [], groups: j.groups ?? [] };
     },
   );
   const liveLoading = createMemo<Set<string>>(() => liveProducerSet(aiActivity()));
@@ -88,6 +98,12 @@ const store = createRoot(() => {
 export const dafRunRows = (): DafRun[] => {
   const r = store.runs();
   return r && r.key === targetKey() ? r.rows : [];
+};
+/** The by-anchor groups for the current daf (additive; empty when the server is
+ *  old or the daf is un-indexed — the dock falls back to the flat `runs` view). */
+export const dafRunGroups = (): AnchorGroup[] => {
+  const r = store.runs();
+  return r && r.key === targetKey() ? r.groups : [];
 };
 export const dafRunsLoading = (): boolean => store.runs.loading;
 export const refetchDafRuns = (): void => {

--- a/packages/talmud/tests/daf-runs-store.test.ts
+++ b/packages/talmud/tests/daf-runs-store.test.ts
@@ -1,5 +1,33 @@
 import { describe, expect, it } from 'vitest';
-import { cacheProgressOf, type DafRun, isEagerRow } from '../src/client/dafRunsProgress';
+import {
+  type AnchorPiece,
+  cacheProgressOf,
+  type DafRun,
+  isEagerRow,
+  pieceToRun,
+} from '../src/client/dafRunsProgress';
+
+describe('pieceToRun — adapt an anchor piece to the RunRow shape', () => {
+  const piece = (o: Partial<AnchorPiece> & { producerId: string }): AnchorPiece => ({
+    label: o.producerId,
+    kind: 'llm',
+    cached: true,
+    cost: null,
+    cold_ms: null,
+    tokens: null,
+    ...o,
+  });
+  it('maps producerId->id and derives producer from the dot in the id', () => {
+    expect(pieceToRun(piece({ producerId: 'pesukim.why-here', cost: 0.001 }))).toMatchObject({
+      id: 'pesukim.why-here',
+      producer: 'enrichment',
+      cached: true,
+      cost: 0.001,
+    });
+    // a bare mark id (no dot) -> 'mark'
+    expect(pieceToRun(piece({ producerId: 'rabbi' })).producer).toBe('mark');
+  });
+});
 
 // The load bar and the Inspect waterfall now read ONE snapshot (dafRunsStore).
 // These pin the reducer the load bar grounds its completion in — the shared


### PR DESCRIPTION
## What

The **visible** half of the by-anchor inspector. The waterfall now lists each **anchor** (section / pasuk / move / rabbi / …) as a **collapsible group** with its producer-pieces under it, instead of one aggregated row per producer — mirroring the reader's per-section/per-pasuk cards.

- **`dafRunsProgress.ts`** (pure): `AnchorGroup`/`AnchorPiece`/`AnchorRef` types + `pieceToRun` (adapt a piece to the `DafRun` shape `RunRow` renders; `producer` derived from the id dot). `dafRunsStore` captures the additive `groups` field and exposes `dafRunGroups()`.
- **`RunTreeDock`**: a `groupedRuns()` memo (the server groups, or **null → the existing FLAT waterfall fallback** for old servers / un-indexed dapim). Each group is a clickable anchor header (chevron + label + cached n/total) over a collapsed `<For>` of the **same `RunRow`**. The leading **"Whole daf"** group is always open. The type filter applies per-piece (a group with none passing is hidden). Clicking a piece roots the DAG on its anchor via `openPiece(id, anchor.instanceJson)` — the per-instance drill-in becomes the primary navigation. **One reused component, no new `RunRow`.**
- tests: `pieceToRun` adapter.

## Safety

Dev-only surface (the inspector dock). The **load bar is untouched** (reads the flat `runs`). Falls back to the flat list whenever `groups` is absent, so nothing breaks during the index migration. Verified live next (the grouped view renders for a warmed daf).

`pnpm typecheck` + full `pnpm test` (2255) + `biome ci .` green.