### PR TITLE
Inspector: clearer icon/label language (anchor types + source/computed/generated)

### DIFF
--- a/packages/talmud/src/client/RunTreeDock.tsx
+++ b/packages/talmud/src/client/RunTreeDock.tsx
@@ -40,6 +40,7 @@ import {
 } from './dafRunsStore';
 import { lang } from './i18n';
 import { inspectRequest } from './inspectBridge';
+import { AnchorTypeIcon, anchorTypeOf } from './inspectVocab';
 import {
   ACTIVE_STROKE,
   AuthorityBadge,
@@ -504,7 +505,7 @@ export default function RunTreeDock(props: {
   // Open onto the waterfall; a row's (i) drills into that piece's DAG.
   const [view, setView] = createSignal<'waterfall' | 'dag'>('waterfall');
   const [typeFilter, setTypeFilter] = createSignal<Set<IconVariant>>(
-    new Set(['source', 'mark', 'enrichment']),
+    new Set(['source', 'mark', 'computed', 'enrichment']),
   );
   const toggleType = (v: IconVariant) =>
     setTypeFilter((prev) => {
@@ -863,7 +864,8 @@ export default function RunTreeDock(props: {
                 [
                   { v: 'source', l: 'sources' },
                   { v: 'mark', l: 'marks' },
-                  { v: 'enrichment', l: 'generations' },
+                  { v: 'computed', l: 'computed' },
+                  { v: 'enrichment', l: 'generated' },
                 ] as const
               }
             >
@@ -928,6 +930,7 @@ export default function RunTreeDock(props: {
                     const k = anchorKey(g);
                     const open = () => whole || expandedAnchors().has(k);
                     const cachedN = g.pieces.filter((p) => p.cached).length;
+                    const ty = anchorTypeOf(g.anchor.markId);
                     return (
                       <Show when={pieces().length > 0}>
                         {/* biome-ignore lint/a11y/useSemanticElements: collapsible anchor-group header; a div keeps it consistent with RunRow's clickable rows */}
@@ -952,28 +955,34 @@ export default function RunTreeDock(props: {
                             'font-size': '0.72rem',
                           }}
                         >
-                          <span style={{ width: '0.7rem', color: '#b3a994' }}>
+                          <span style={{ width: '0.7rem', color: '#b3a994', 'flex-shrink': 0 }}>
                             {whole ? '' : open() ? '▾' : '▸'}
                           </span>
+                          <AnchorTypeIcon markId={g.anchor.markId} color={ty.color} />
+                          {/* type chip — the traditional term, colour-coded */}
                           <span
                             style={{
                               'font-weight': 600,
-                              color: '#4a4034',
+                              color: ty.color,
+                              'flex-shrink': 0,
+                              'font-size': '0.7rem',
+                              'letter-spacing': '0.01em',
+                            }}
+                          >
+                            {ty.label}
+                          </span>
+                          {/* the anchor's own label (the verse / section title / sage name) */}
+                          <span
+                            style={{
+                              color: '#6b6358',
                               'white-space': 'nowrap',
                               overflow: 'hidden',
                               'text-overflow': 'ellipsis',
                               flex: 1,
                             }}
                           >
-                            {whole ? 'Whole daf' : g.anchor.label || g.anchor.markId}
+                            {whole ? 'all daf-level notes' : g.anchor.label}
                           </span>
-                          <Show when={!whole}>
-                            <span
-                              style={{ 'font-size': '0.6rem', color: '#a89c86', 'flex-shrink': 0 }}
-                            >
-                              {g.anchor.markId}
-                            </span>
-                          </Show>
                           <span
                             style={{
                               'font-variant-numeric': 'tabular-nums',

--- a/packages/talmud/src/client/inspectVocab.tsx
+++ b/packages/talmud/src/client/inspectVocab.tsx
@@ -1,0 +1,112 @@
+/**
+ * inspectVocab — the visual LANGUAGE of the by-anchor inspector: a human label,
+ * a colour, and a glyph for each anchor TYPE (the kind of place a note sits on),
+ * so you can scan a daf and tell a Sugya from a Pasuk from a Sage at a glance —
+ * instead of raw mark ids ("argument-move", "pesukim") and one generic sparkle
+ * for everything. Traditional terms (the audience is learners). The whole-daf
+ * group reads "Daf"; raw source inputs (gemara/commentaries) are SOURCES, the
+ * third kind, drawn by NodeIcon in the DAG.
+ */
+
+import { type JSX, Match, Switch } from 'solid-js';
+
+export interface AnchorType {
+  /** Human label (traditional term). */
+  label: string;
+  /** Accent colour for the type chip / icon. */
+  color: string;
+}
+
+export const WHOLE_DAF_ANCHOR = '__whole_daf__';
+
+/** mark id → { traditional label, accent colour }. */
+export const ANCHOR_VOCAB: Record<string, AnchorType> = {
+  [WHOLE_DAF_ANCHOR]: { label: 'Daf', color: '#6b6358' },
+  argument: { label: 'Sugya', color: '#7a5ea8' },
+  'argument-move': { label: 'Move', color: '#9a7b4f' },
+  pesukim: { label: 'Pasuk', color: '#3f7cae' },
+  halacha: { label: 'Halacha', color: '#4a8a5f' },
+  aggadata: { label: 'Aggada', color: '#b06a4a' },
+  rabbi: { label: 'Sage', color: '#c08030' },
+  places: { label: 'Place', color: '#5f8a8a' },
+  rishonim: { label: 'Rishonim', color: '#8a7a5a' },
+  yerushalmi: { label: 'Yerushalmi', color: '#a85f7a' },
+  chart: { label: 'Chart', color: '#8a8a8a' },
+};
+
+export function anchorTypeOf(markId: string): AnchorType {
+  return ANCHOR_VOCAB[markId] ?? { label: markId, color: '#6b6358' };
+}
+
+/** A glyph per anchor type, matching NodeIcon's 18px centred monochrome style.
+ *  Daf=page, Sugya=brackets, Move=step-arrow, Pasuk=open book, Halacha=scale,
+ *  Aggada=speech bubble, Sage=person, Place=pin, Rishonim=stacked pages,
+ *  Yerushalmi=parallel columns, Chart=bars. Falls back to a small disc. */
+export function AnchorTypeIcon(props: { markId: string; color: string }): JSX.Element {
+  const s = (w = 1.4) => ({ fill: 'none', stroke: props.color, 'stroke-width': w }) as const;
+  const r = (w = 1.4) =>
+    ({
+      fill: 'none',
+      stroke: props.color,
+      'stroke-width': w,
+      'stroke-linejoin': 'round',
+      'stroke-linecap': 'round',
+    }) as const;
+  return (
+    <svg
+      aria-hidden="true"
+      width="16"
+      height="16"
+      viewBox="-9 -9 18 18"
+      style={{ display: 'block', 'flex-shrink': 0 }}
+    >
+      <Switch fallback={<circle cx={0} cy={0} r={2.2} fill={props.color} />}>
+        <Match when={props.markId === WHOLE_DAF_ANCHOR}>
+          <rect x={-5} y={-6.5} width={10} height={13} rx={1.4} {...r()} />
+          <path d="M -2.5 -2.5 H 2.5 M -2.5 0.5 H 2.5 M -2.5 3.5 H 1" {...r(1.2)} />
+        </Match>
+        <Match when={props.markId === 'argument'}>
+          <path d="M -3 -6.5 H -6 V 6.5 H -3 M 3 -6.5 H 6 V 6.5 H 3" {...r()} />
+        </Match>
+        <Match when={props.markId === 'argument-move'}>
+          <path d="M -4.5 -6 L 3.5 0 L -4.5 6" {...r()} />
+          <path d="M 5.5 -6 V 6" {...r()} />
+        </Match>
+        <Match when={props.markId === 'pesukim'}>
+          <path d="M 0 -5.5 V 5.5" {...r()} />
+          <path d="M 0 -5.5 C -2.5 -7 -6 -6.5 -7 -5.5 V 5.5 C -6 4.5 -2.5 4 0 5.5" {...r()} />
+          <path d="M 0 -5.5 C 2.5 -7 6 -6.5 7 -5.5 V 5.5 C 6 4.5 2.5 4 0 5.5" {...r()} />
+        </Match>
+        <Match when={props.markId === 'halacha'}>
+          <path
+            d="M 0 -7 V 6.5 M -6 -3.5 H 6 M -6 -3.5 L -7.5 1 H -4.5 Z M 6 -3.5 L 4.5 1 H 7.5 Z"
+            {...r(1.2)}
+          />
+          <path d="M -3 6.5 H 3" {...r()} />
+        </Match>
+        <Match when={props.markId === 'aggadata'}>
+          <path d="M -6.5 -5 H 6.5 V 3 H -1 L -4 6 V 3 H -6.5 Z" {...r()} />
+        </Match>
+        <Match when={props.markId === 'rabbi'}>
+          <circle cx={0} cy={-3.5} r={2.6} {...s()} />
+          <path d="M -5.5 6.5 C -5.5 1.5 5.5 1.5 5.5 6.5" {...r()} />
+        </Match>
+        <Match when={props.markId === 'places'}>
+          <path d="M 0 7 C -5 0.5 -5 -2.5 0 -6 C 5 -2.5 5 0.5 0 7 Z" {...r()} />
+          <circle cx={0} cy={-2} r={1.6} fill={props.color} />
+        </Match>
+        <Match when={props.markId === 'rishonim'}>
+          <rect x={-6.5} y={-6.5} width={9} height={9} rx={1.2} {...r(1.2)} />
+          <rect x={-2.5} y={-2.5} width={9} height={9} rx={1.2} {...r()} />
+        </Match>
+        <Match when={props.markId === 'yerushalmi'}>
+          <path d="M -3.5 -6.5 V 6.5 M 3.5 -6.5 V 6.5" {...r()} />
+          <path d="M -3.5 -2 H 3.5" {...r(1.1)} />
+        </Match>
+        <Match when={props.markId === 'chart'}>
+          <path d="M -6 6 V -1 M 0 6 V -6 M 6 6 V 2" {...r()} />
+        </Match>
+      </Switch>
+    </svg>
+  );
+}

--- a/packages/talmud/src/client/runTreeShared.tsx
+++ b/packages/talmud/src/client/runTreeShared.tsx
@@ -208,9 +208,11 @@ export function edgePath(fromRow: number, toRow: number, lane: number): string {
   ].join(' ');
 }
 
-export type IconVariant = 'source' | 'mark' | 'enrichment';
-/** source = database cylinder, mark = stacked layers, enrichment/generation =
- *  sparkle. Inline 18px SVG. */
+export type IconVariant = 'source' | 'mark' | 'enrichment' | 'computed';
+/** source = database cylinder (a fetched INPUT, $0), mark = stacked layers (an
+ *  extractor), computed = hexagon (a DETERMINISTIC note, no model), enrichment =
+ *  sparkle (a GENERATED note). Inline 18px SVG. The computed glyph is what stops
+ *  deterministic notes from masquerading as raw sources. */
 export function NodeIcon(props: { variant: IconVariant; color: string }): JSX.Element {
   return (
     <svg
@@ -261,12 +263,31 @@ export function NodeIcon(props: { variant: IconVariant; color: string }): JSX.El
             fill={props.color}
           />
         </Match>
+        <Match when={props.variant === 'computed'}>
+          <path
+            d="M0 -6.4 L5.6 -3.2 V3.2 L0 6.4 L-5.6 3.2 V-3.2 Z"
+            fill="none"
+            stroke={props.color}
+            stroke-width={1.4}
+            stroke-linejoin="round"
+          />
+          <circle cx={0} cy={0} r={1.5} fill={props.color} />
+        </Match>
       </Switch>
     </svg>
   );
 }
+/** source (fetched input) → database; computed (deterministic, no model) →
+ *  hexagon; llm mark (extractor) → layers; llm enrichment (generated) → sparkle.
+ *  The computed case is the fix: it no longer collapses into the source icon. */
 export const variantOf = (n: { kind: string; producer?: string }): IconVariant =>
-  n.kind !== 'llm' ? 'source' : n.producer === 'mark' ? 'mark' : 'enrichment';
+  n.kind === 'source'
+    ? 'source'
+    : n.kind === 'computed'
+      ? 'computed'
+      : n.producer === 'mark'
+        ? 'mark'
+        : 'enrichment';
 
 // ---------------------------------------------------------------------------
 // Provenance + staleness visuals (Inspect dock only)

--- a/packages/talmud/tests/inspect-vocab.test.ts
+++ b/packages/talmud/tests/inspect-vocab.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { anchorTypeOf } from '../src/client/inspectVocab';
+import { variantOf } from '../src/client/runTreeShared';
+
+describe('anchorTypeOf — traditional labels for the anchor types', () => {
+  it('maps mark ids to the traditional terms (falls back to the id)', () => {
+    expect(anchorTypeOf('argument').label).toBe('Sugya');
+    expect(anchorTypeOf('argument-move').label).toBe('Move');
+    expect(anchorTypeOf('pesukim').label).toBe('Pasuk');
+    expect(anchorTypeOf('halacha').label).toBe('Halacha');
+    expect(anchorTypeOf('aggadata').label).toBe('Aggada');
+    expect(anchorTypeOf('rabbi').label).toBe('Sage');
+    expect(anchorTypeOf('places').label).toBe('Place');
+    expect(anchorTypeOf('rishonim').label).toBe('Rishonim');
+    expect(anchorTypeOf('__whole_daf__').label).toBe('Daf');
+    expect(anchorTypeOf('something-new').label).toBe('something-new');
+  });
+});
+
+describe('variantOf — computed no longer masquerades as a source', () => {
+  it('source / computed / mark / generated are four distinct icons', () => {
+    expect(variantOf({ kind: 'source' })).toBe('source');
+    // the fix: a deterministic note was previously drawn as a source (database)
+    expect(variantOf({ kind: 'computed' })).toBe('computed');
+    expect(variantOf({ kind: 'llm', producer: 'mark' })).toBe('mark');
+    expect(variantOf({ kind: 'llm', producer: 'enrichment' })).toBe('enrichment');
+  });
+});


### PR DESCRIPTION
## Why

The by-anchor inspector still spoke dev jargon — raw mark ids (`argument-move`, `pesukim`) and one sparkle for everything — and `variantOf` drew **every** non-LLM piece as a *source* (database), so deterministic notes masqueraded as raw inputs. This gives it three clear **kinds** and a real vocabulary.

## What (dev-only; no server change)

- **`inspectVocab.tsx`** — `ANCHOR_VOCAB` maps each anchor type to a **traditional label** + accent colour: **Daf / Sugya / Pasuk / Halacha / Aggada / Sage / Move / Place / Rishonim / Yerushalmi / Chart**. `AnchorTypeIcon` draws a distinct glyph per type (book / scale / person / pin / brackets / …) in NodeIcon's monochrome style.
- **Anchor-group header** now reads `[📖] Pasuk  Deuteronomy 6:7   5/6` — a colour-coded type chip + the place's own label — instead of the raw mark id.
- **`NodeIcon`/`variantOf` gain a 4th variant, `computed`** (a hexagon): a deterministic note no longer collapses into the source icon. Piece icons now read **source** (fetched input · $0) / **computed** (no model) / **mark** (extractor) / **generated** (sparkle). The type filter gains a `computed` chip; `generations` → `generated`.
- tests: `anchorTypeOf` labels + `variantOf`'s four distinct variants.

You picked **traditional terms** for the place types. Browser screenshot wasn't possible (a Chrome instance is attached to the MCP profile), but it's typechecked, unit-tested, and dev-only.

`pnpm typecheck` + full `pnpm test` (2257) + `biome ci .` green.