### PR TITLE
Halacha sources: shared CorpusBadge so Yerushalmi reads distinctly

### DIFF
--- a/packages/talmud/src/client/ArgumentSidebar.tsx
+++ b/packages/talmud/src/client/ArgumentSidebar.tsx
@@ -51,7 +51,7 @@ import { GeographyMap } from './GeographyMap';
 import { GENERATION_BY_ID, type GenerationId, generationLabelHe } from './generations';
 import { Hebraized } from './Hebraized';
 import { lang, t } from './i18n';
-import { LinkRef } from './LinkRef';
+import { CorpusBadge, LinkRef } from './LinkRef';
 import { InspectDot, registerMarkRenderer } from './MarkEnrichmentCards';
 import type { GeographyData, GeographyEvidence } from './RabbiGeographyCard';
 import RabbiLineageTree, {
@@ -2297,6 +2297,9 @@ function HalachaDerivation(props: SpecialBlockProps): JSX.Element {
                   >
                     {s.ref}
                   </span>
+                  {/* Corpus badge — shared with the overview chips. Only the
+                      Yerushalmi shows one; Bavli + Tanakh read for themselves. */}
+                  <CorpusBadge corpus={s.kind === 'tanakh' ? 'other' : s.kind} />
                   <span
                     style={{
                       'font-family': 'system-ui, -apple-system, sans-serif',

--- a/packages/talmud/src/client/LinkRef.tsx
+++ b/packages/talmud/src/client/LinkRef.tsx
@@ -48,28 +48,33 @@ const INERT: JSX.CSSProperties = {
   border: '1px solid #e5e7eb',
 };
 
-export function LinkRef(props: { coord: AnchorCoord }): JSX.Element {
-  const target = () => linkTarget(props.coord);
-  const badge = (): { label: string; bg: string; fg: string } | undefined =>
-    CORPUS_BADGE[target().corpus];
-  const Badge = (): JSX.Element => (
-    <Show when={badge()}>
-      {(b) => (
+/** The corpus tag shown beside a cross-text reference — only for corpora whose
+ *  label isn't self-evident (Yerushalmi, commentary). Shared so the overview
+ *  chip, the halacha sources, and any other ref list badge the same way. */
+export function CorpusBadge(props: { corpus: LinkCorpus }): JSX.Element {
+  const b = (): { label: string; bg: string; fg: string } | undefined => CORPUS_BADGE[props.corpus];
+  return (
+    <Show when={b()}>
+      {(badge) => (
         <span
           style={{
             'font-size': '0.6rem',
             'font-weight': 650,
             'border-radius': '999px',
             padding: '0 0.32rem',
-            background: b().bg,
-            color: b().fg,
+            background: badge().bg,
+            color: badge().fg,
           }}
         >
-          {b().label}
+          {badge().label}
         </span>
       )}
     </Show>
   );
+}
+
+export function LinkRef(props: { coord: AnchorCoord }): JSX.Element {
+  const target = () => linkTarget(props.coord);
   return (
     <Show
       when={target().navigable && target().href}
@@ -77,7 +82,7 @@ export function LinkRef(props: { coord: AnchorCoord }): JSX.Element {
         // Inert: no in-app reader for this corpus (Yerushalmi, a verse, …).
         <span style={INERT} title={target().label}>
           {target().label}
-          <Badge />
+          <CorpusBadge corpus={target().corpus} />
         </span>
       }
     >
@@ -85,7 +90,7 @@ export function LinkRef(props: { coord: AnchorCoord }): JSX.Element {
         // A real href (relative `?tractate=&page=`) so middle-click / open-in-new-tab work.
         <a style={NAV} href={href()} title={t('overview.goToDaf', { daf: target().label })}>
           {target().label}
-          <Badge />
+          <CorpusBadge corpus={target().corpus} />
         </a>
       )}
     </Show>


### PR DESCRIPTION
Standardizing the next ref-rendering surface — the halacha **"Talmudic Sources"** derivation card (the one we looked at: Bavli primary sources + Yerushalmi `RELATED` rows that previously looked identical).

## Change
- Extract **`CorpusBadge`** from `LinkRef` (exported) — the shared corpus tag (only Yerushalmi/commentary show one; Bavli + Tanakh read for themselves).
- Render it on each derivation row. `SourceKind` maps 1:1 to `LinkCorpus` (`tanakh → other`). The full-row layout, role labels (`PRIMARY SOURCE`/`RELATED`/`YOU ARE HERE`), and the existing nav (Bavli clickable, others inert) are **unchanged** — only the corpus badge is added.

Holds the boundary we agreed: **standardize the pointer** (corpus vocabulary, shared component), **leave the card's own layout + semantics**.

## Verified live
Local dev against the real cache, Berakhot 2a halacha card: the `Jerusalem Talmud Berakhot 1:1:x` rows now show the `ירושלמי` badge; Bavli sources stay clean. (Screenshot shared in the working session.)

## Verification
`pnpm typecheck` clean; **2260 tests** (the `link-ref` render tests cover `CorpusBadge` via `LinkRef`); Biome clean.

Next standardization targets (same pattern): the `SOURCES` list, and the rishonim ref/header (pointer only).