### PR TITLE
Inspector: cluster places under their extractor type

### DIFF
--- a/packages/talmud/src/client/RunTreeDock.tsx
+++ b/packages/talmud/src/client/RunTreeDock.tsx
@@ -30,6 +30,7 @@ import {
   type AnchorGroup as AnchorGroupT,
   type DafRun,
   dafRunGroups,
+  dafRunMarks,
   dafRunRows,
   dafRunsLoading,
   liveCounts,
@@ -561,6 +562,185 @@ export default function RunTreeDock(props: {
   // wants). A group with none passing is hidden.
   const groupPieces = (g: AnchorGroupT): DafRun[] =>
     g.pieces.map(pieceToRun).filter((r) => typeFilter().has(variantOf(r)));
+  // Cluster the per-place groups by their TYPE (mark id) so a place-type (the
+  // extractor mark) heads its own places, instead of the mark floating in the
+  // "Daf" group apart from its instances. The Daf group (daf-level notes) leads.
+  const typeClusters = createMemo(() => {
+    const groups = groupedRuns();
+    if (!groups) return null;
+    const daf = groups.find((g) => g.anchor.markId === WHOLE_DAF_ANCHOR) ?? null;
+    const clusters: { markId: string; instances: AnchorGroupT[] }[] = [];
+    const byId = new Map<string, { markId: string; instances: AnchorGroupT[] }>();
+    for (const g of groups) {
+      if (g.anchor.markId === WHOLE_DAF_ANCHOR) continue;
+      let c = byId.get(g.anchor.markId);
+      if (!c) {
+        c = { markId: g.anchor.markId, instances: [] };
+        byId.set(g.anchor.markId, c);
+        clusters.push(c);
+      }
+      c.instances.push(g);
+    }
+    return { daf, clusters };
+  });
+  // Type clusters default OPEN; instance groups default closed (`expandedAnchors`).
+  const [collapsedTypes, setCollapsedTypes] = createSignal<Set<string>>(new Set());
+  const typeOpen = (markId: string) => !collapsedTypes().has(markId);
+  const toggleTypeCluster = (markId: string) =>
+    setCollapsedTypes((prev) => {
+      const n = new Set(prev);
+      if (n.has(markId)) n.delete(markId);
+      else n.add(markId);
+      return n;
+    });
+
+  // A place-type cluster header (the extractor mark): icon + traditional label +
+  // count + the mark's own cost. Collapsible — hides the whole cluster.
+  const TypeHeader = (tp: {
+    markId: string;
+    count: number;
+    cachedN: number;
+    daf?: boolean;
+  }): JSX.Element => {
+    const ty = anchorTypeOf(tp.markId);
+    return (
+      // biome-ignore lint/a11y/useSemanticElements: collapsible cluster header, consistent with RunRow
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={() => toggleTypeCluster(tp.markId)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            toggleTypeCluster(tp.markId);
+          }
+        }}
+        style={{
+          display: 'flex',
+          'align-items': 'center',
+          gap: '0.4rem',
+          padding: '0.3rem 0.6rem',
+          cursor: 'pointer',
+          background: '#efe9dc',
+          'border-top': '1px solid #e2dccc',
+          'font-size': '0.72rem',
+        }}
+      >
+        <span style={{ width: '0.7rem', color: '#9a8f78', 'flex-shrink': 0 }}>
+          {typeOpen(tp.markId) ? '▾' : '▸'}
+        </span>
+        <AnchorTypeIcon markId={tp.markId} color={ty.color} />
+        <span
+          style={{
+            'font-weight': 700,
+            color: ty.color,
+            'flex-shrink': 0,
+            'letter-spacing': '0.01em',
+          }}
+        >
+          {ty.label}
+        </span>
+        <span style={{ color: '#a89c86', 'flex-shrink': 0 }}>
+          {tp.daf ? 'daf-level notes' : `· ${tp.count}`}
+        </span>
+        <span style={{ flex: 1 }} />
+        <Show when={dafRunMarks()[tp.markId]?.cost != null}>
+          <span
+            style={{
+              'font-size': '0.66rem',
+              color: '#bcae9a',
+              'font-variant-numeric': 'tabular-nums',
+              'flex-shrink': 0,
+            }}
+          >
+            {fmtCost(dafRunMarks()[tp.markId]?.cost ?? null)}
+          </span>
+        </Show>
+        <span
+          style={{
+            'font-variant-numeric': 'tabular-nums',
+            color: tp.cachedN === tp.count ? '#5f8a6f' : '#a8854a',
+            'flex-shrink': 0,
+          }}
+        >
+          {tp.cachedN}/{tp.count}
+        </span>
+      </div>
+    );
+  };
+
+  // One instance group (a single place): a collapsible row — the anchor's own
+  // label + cached fraction — expanding to its pieces. Indented under its type.
+  const AnchorGroupRow = (gp: { g: AnchorGroupT }): JSX.Element => {
+    const g = gp.g;
+    const pieces = createMemo(() => groupPieces(g));
+    const k = anchorKey(g);
+    const open = () => expandedAnchors().has(k);
+    const cachedN = g.pieces.filter((p) => p.cached).length;
+    return (
+      <Show when={pieces().length > 0}>
+        {/* biome-ignore lint/a11y/useSemanticElements: collapsible instance header, consistent with RunRow */}
+        <div
+          role="button"
+          tabIndex={0}
+          onClick={() => toggleAnchor(k)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              toggleAnchor(k);
+            }
+          }}
+          style={{
+            display: 'flex',
+            'align-items': 'center',
+            gap: '0.4rem',
+            padding: '0.2rem 0.6rem 0.2rem 1.6rem',
+            cursor: 'pointer',
+            'font-size': '0.72rem',
+          }}
+        >
+          <span style={{ width: '0.7rem', color: '#b3a994', 'flex-shrink': 0 }}>
+            {open() ? '▾' : '▸'}
+          </span>
+          <span
+            style={{
+              color: '#6b6358',
+              'white-space': 'nowrap',
+              overflow: 'hidden',
+              'text-overflow': 'ellipsis',
+              flex: 1,
+            }}
+          >
+            {g.anchor.label || g.anchor.markId}
+          </span>
+          <span
+            style={{
+              'font-variant-numeric': 'tabular-nums',
+              color: cachedN === g.pieces.length ? '#5f8a6f' : '#a8854a',
+              'flex-shrink': 0,
+            }}
+          >
+            {cachedN}/{g.pieces.length}
+          </span>
+        </div>
+        <Show when={open()}>
+          <For each={pieces()}>
+            {(r) => (
+              <RunRow
+                run={r}
+                maxMs={maxCold()}
+                active={r.id === pieceId()}
+                loading={liveLoading().has(r.id)}
+                loadingCount={liveCounts().get(r.id) ?? 0}
+                onClick={() => openPiece(r.id, g.anchor.instanceJson)}
+                onInspect={() => openPiece(r.id, g.anchor.instanceJson)}
+              />
+            )}
+          </For>
+        </Show>
+      </Show>
+    );
+  };
   // Per-instance focus (a mark_input) when an (i) inspects e.g. one section's
   // synthesis; null = whole-daf. Cleared when navigating via the waterfall.
   const [focusInstance, setFocusInstance] = createSignal<unknown>(null);
@@ -905,7 +1085,7 @@ export default function RunTreeDock(props: {
               <div style={{ padding: '0.6rem', color: '#aaa' }}>loading…</div>
             </Show>
             <Show
-              when={groupedRuns()}
+              when={typeClusters()}
               fallback={
                 <For each={visibleRuns()}>
                   {(r) => (
@@ -922,96 +1102,57 @@ export default function RunTreeDock(props: {
                 </For>
               }
             >
-              {(groups) => (
-                <For each={groups()}>
-                  {(g) => {
-                    const pieces = createMemo(() => groupPieces(g));
-                    const whole = g.anchor.markId === WHOLE_DAF_ANCHOR;
-                    const k = anchorKey(g);
-                    const open = () => whole || expandedAnchors().has(k);
-                    const cachedN = g.pieces.filter((p) => p.cached).length;
-                    const ty = anchorTypeOf(g.anchor.markId);
-                    return (
-                      <Show when={pieces().length > 0}>
-                        {/* biome-ignore lint/a11y/useSemanticElements: collapsible anchor-group header; a div keeps it consistent with RunRow's clickable rows */}
-                        <div
-                          role="button"
-                          tabIndex={0}
-                          onClick={() => !whole && toggleAnchor(k)}
-                          onKeyDown={(e) => {
-                            if (!whole && (e.key === 'Enter' || e.key === ' ')) {
-                              e.preventDefault();
-                              toggleAnchor(k);
-                            }
-                          }}
-                          style={{
-                            display: 'flex',
-                            'align-items': 'center',
-                            gap: '0.4rem',
-                            padding: '0.25rem 0.6rem',
-                            cursor: whole ? 'default' : 'pointer',
-                            background: '#f6f3ec',
-                            'border-top': '1px solid #ece7da',
-                            'font-size': '0.72rem',
-                          }}
-                        >
-                          <span style={{ width: '0.7rem', color: '#b3a994', 'flex-shrink': 0 }}>
-                            {whole ? '' : open() ? '▾' : '▸'}
-                          </span>
-                          <AnchorTypeIcon markId={g.anchor.markId} color={ty.color} />
-                          {/* type chip — the traditional term, colour-coded */}
-                          <span
-                            style={{
-                              'font-weight': 600,
-                              color: ty.color,
-                              'flex-shrink': 0,
-                              'font-size': '0.7rem',
-                              'letter-spacing': '0.01em',
-                            }}
-                          >
-                            {ty.label}
-                          </span>
-                          {/* the anchor's own label (the verse / section title / sage name) */}
-                          <span
-                            style={{
-                              color: '#6b6358',
-                              'white-space': 'nowrap',
-                              overflow: 'hidden',
-                              'text-overflow': 'ellipsis',
-                              flex: 1,
-                            }}
-                          >
-                            {whole ? 'all daf-level notes' : g.anchor.label}
-                          </span>
-                          <span
-                            style={{
-                              'font-variant-numeric': 'tabular-nums',
-                              color: cachedN === g.pieces.length ? '#5f8a6f' : '#a8854a',
-                              'flex-shrink': 0,
-                            }}
-                          >
-                            {cachedN}/{g.pieces.length}
-                          </span>
-                        </div>
-                        <Show when={open()}>
-                          <For each={pieces()}>
-                            {(r) => (
-                              <RunRow
-                                run={r}
-                                maxMs={maxCold()}
-                                active={r.id === pieceId()}
-                                loading={liveLoading().has(r.id)}
-                                loadingCount={liveCounts().get(r.id) ?? 0}
-                                onClick={() => openPiece(r.id, g.anchor.instanceJson)}
-                                onInspect={() => openPiece(r.id, g.anchor.instanceJson)}
-                              />
-                            )}
-                          </For>
+              {(tc) => (
+                <>
+                  {/* Daf — the daf-level notes, as rows under the header */}
+                  <Show when={tc().daf}>
+                    {(daf) => {
+                      const pcs = createMemo(() => groupPieces(daf()));
+                      return (
+                        <Show when={pcs().length > 0}>
+                          <TypeHeader
+                            markId={WHOLE_DAF_ANCHOR}
+                            count={daf().pieces.length}
+                            cachedN={daf().pieces.filter((p) => p.cached).length}
+                            daf
+                          />
+                          <Show when={typeOpen(WHOLE_DAF_ANCHOR)}>
+                            <For each={pcs()}>
+                              {(r) => (
+                                <RunRow
+                                  run={r}
+                                  maxMs={maxCold()}
+                                  active={r.id === pieceId()}
+                                  loading={liveLoading().has(r.id)}
+                                  loadingCount={liveCounts().get(r.id) ?? 0}
+                                  onClick={() => openPiece(r.id)}
+                                  onInspect={() => openPiece(r.id)}
+                                />
+                              )}
+                            </For>
+                          </Show>
                         </Show>
-                      </Show>
-                    );
-                  }}
-                </For>
+                      );
+                    }}
+                  </Show>
+                  {/* One cluster per place-type — the extractor mark heads its places */}
+                  <For each={tc().clusters}>
+                    {(c) => (
+                      <>
+                        <TypeHeader
+                          markId={c.markId}
+                          count={c.instances.length}
+                          cachedN={
+                            c.instances.filter((g) => g.pieces.every((p) => p.cached)).length
+                          }
+                        />
+                        <Show when={typeOpen(c.markId)}>
+                          <For each={c.instances}>{(g) => <AnchorGroupRow g={g} />}</For>
+                        </Show>
+                      </>
+                    )}
+                  </For>
+                </>
               )}
             </Show>
           </div>

--- a/packages/talmud/src/client/dafRunsStore.ts
+++ b/packages/talmud/src/client/dafRunsStore.ts
@@ -22,7 +22,12 @@ import {
   onCleanup,
 } from 'solid-js';
 import { aiActivity } from './aiActivity';
-import { type AnchorGroup, cacheProgressOf, type DafRun } from './dafRunsProgress';
+import {
+  type AnchorGroup,
+  type AnchorPiece,
+  cacheProgressOf,
+  type DafRun,
+} from './dafRunsProgress';
 import { liveProducerCounts, liveProducerSet } from './runStatus';
 
 // Re-export the pure shape + reducers so consumers keep one import site; the
@@ -62,15 +67,26 @@ const targetKey = (): string | null => {
 const store = createRoot(() => {
   const [runs, { refetch }] = createResource(
     targetKey,
-    async (key): Promise<{ key: string; rows: DafRun[]; groups: AnchorGroup[] }> => {
+    async (
+      key,
+    ): Promise<{
+      key: string;
+      rows: DafRun[];
+      groups: AnchorGroup[];
+      marks: Record<string, AnchorPiece>;
+    }> => {
       const t = target();
-      if (!t) return { key, rows: [], groups: [] };
+      if (!t) return { key, rows: [], groups: [], marks: {} };
       const r = await fetch(
         `/api/daf-runs/${encodeURIComponent(t.tractate)}/${encodeURIComponent(t.page)}?lang=${t.lang}`,
       );
-      if (!r.ok) return { key, rows: [], groups: [] };
-      const j = (await r.json()) as { runs?: DafRun[]; groups?: AnchorGroup[] };
-      return { key, rows: j.runs ?? [], groups: j.groups ?? [] };
+      if (!r.ok) return { key, rows: [], groups: [], marks: {} };
+      const j = (await r.json()) as {
+        runs?: DafRun[];
+        groups?: AnchorGroup[];
+        marks?: Record<string, AnchorPiece>;
+      };
+      return { key, rows: j.runs ?? [], groups: j.groups ?? [], marks: j.marks ?? {} };
     },
   );
   const liveLoading = createMemo<Set<string>>(() => liveProducerSet(aiActivity()));
@@ -101,6 +117,10 @@ export const dafRunRows = (): DafRun[] => {
 };
 /** The by-anchor groups for the current daf (additive; empty when the server is
  *  old or the daf is un-indexed — the dock falls back to the flat `runs` view). */
+export const dafRunMarks = (): Record<string, AnchorPiece> => {
+  const r = store.runs();
+  return r && r.key === targetKey() ? r.marks : {};
+};
 export const dafRunGroups = (): AnchorGroup[] => {
   const r = store.runs();
   return r && r.key === targetKey() ? r.groups : [];

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -2252,7 +2252,7 @@ async function dafGroupsFromIndex(
   tractate: string,
   page: string,
   lang: 'en' | 'he',
-): Promise<AnchorGroup[]> {
+): Promise<{ groups: AnchorGroup[]; marks: Record<string, AnchorPiece> }> {
   const raw = await listDafIndexRaw(env, tractate, page);
   const metas = raw
     .map((e) => e.meta as DafIndexEntryMeta & { l?: string })
@@ -2281,8 +2281,13 @@ async function dafGroupsFromIndex(
     };
   };
   // Per-instance enrichments grouped by target mark; everything else is whole-daf.
+  // Only WHOLE-DAF marks (Overview/Background/Tidbit/Bi'yun) are daf-level notes;
+  // per-instance marks (pesukim/argument/rabbi/…) are EXTRACTORS — not daf-level
+  // pieces — so they go in `marks` (the per-type header), NOT this group.
   const byTarget = new Map<string, Desc[]>();
-  const wholeDafProducers: Desc[] = CODE_MARKS.map((d) => descOf(d, 'mark'));
+  const wholeDafProducers: Desc[] = CODE_MARKS.filter(
+    (m) => (m as { anchor?: string }).anchor === 'whole-daf',
+  ).map((d) => descOf(d, 'mark'));
   for (const def of CODE_ENRICHMENTS.filter((e) => e.scope === 'local')) {
     const targetMark = (def as { target_mark?: string }).target_mark;
     if (targetMark && markAnchorById.get(targetMark) !== 'whole-daf') {
@@ -2321,6 +2326,14 @@ async function dafGroupsFromIndex(
     tokens: meta?.t ?? null,
   });
 
+  // The per-instance marks themselves (the extractors) — one row each, keyed by
+  // mark id (= the anchor type), for the place-type cluster header's telemetry.
+  const marks: Record<string, AnchorPiece> = {};
+  for (const m of CODE_MARKS) {
+    if ((m as { anchor?: string }).anchor === 'whole-daf') continue;
+    marks[m.id] = pieceOf(descOf(m, 'mark'), markMetaByP.get(m.id));
+  }
+
   const placed: Array<{ piece: AnchorPiece; anchor: AnchorRef | null }> = [];
   for (const [mid, anchors] of anchorsByMark) {
     const producers = byTarget.get(mid) ?? [];
@@ -2337,19 +2350,22 @@ async function dafGroupsFromIndex(
   }
 
   const { groups, wholeDaf } = groupByAnchor(placed);
-  return [
-    {
-      anchor: {
-        markId: WHOLE_DAF_ANCHOR,
-        instanceId: '',
-        label: 'Whole daf',
-        segRange: null,
-        instanceJson: { fields: {} },
+  return {
+    groups: [
+      {
+        anchor: {
+          markId: WHOLE_DAF_ANCHOR,
+          instanceId: '',
+          label: 'Whole daf',
+          segRange: null,
+          instanceJson: { fields: {} },
+        },
+        pieces: wholeDaf,
       },
-      pieces: wholeDaf,
-    },
-    ...groups,
-  ];
+      ...groups,
+    ],
+    marks,
+  };
 }
 
 app.get('/api/daf-runs/:tractate/:page', async (c) => {
@@ -2365,15 +2381,24 @@ app.get('/api/daf-runs/:tractate/:page', async (c) => {
   // backfills + writes the sentinel, so the next view takes this branch).
   if (c.env.CACHE && (await c.env.CACHE.get(keyForDafIndexDone(tractate, page, lang)))) {
     try {
-      const [runs, groups] = await Promise.all([
+      const [runs, grouped] = await Promise.all([
         dafRunsFromIndexRows(c.env, tractate, page, lang),
         dafGroupsFromIndex(c.env, tractate, page, lang),
       ]);
       runs.sort((a, b) => (b.cold_ms ?? -1) - (a.cold_ms ?? -1));
-      // `groups` (additive) is the by-anchor view; `runs` stays flat for the load
+      // `groups` (additive) is the by-anchor view, `marks` the per-type extractor
+      // rows (for the place-type cluster headers); `runs` stays flat for the load
       // bar + old clients. The slow path below emits no groups → client falls
       // back to grouping `runs` flatly until the daf backfills.
-      return c.json({ tractate, page, lang, runs, groups, source: 'index' });
+      return c.json({
+        tractate,
+        page,
+        lang,
+        runs,
+        groups: grouped.groups,
+        marks: grouped.marks,
+        source: 'index',
+      });
     } catch {
       /* fall through to the probe path on any index-read error */
     }


### PR DESCRIPTION
## What

The by-anchor inspector view split a producer from its places: the per-instance **marks** (Pesukim, Arguments, Rabbis…) sat as flat rows inside the **Daf** group, while their *output* — the Pasuk / Sugya / Sage place groups — sat separately below. A mark **is** its place-type, so they were one thing shown as two.

## Change

- **Server** (`dafGroupsFromIndex`): only WHOLE-DAF marks + whole-daf enrichments stay in the **Daf** group (the genuine daf-level notes). Per-instance marks move into a new additive `marks: Record<markId, AnchorPiece>` — the extractor's own row, used for its place-type cluster header. The `/api/daf-runs` response gains `marks`; `groups` keeps its shape.
- **Client** (`RunTreeDock`): cluster the place groups by type. Each place-type is now a collapsible **cluster header** (icon + traditional label + place count + the mark's own cost) over its place instances; the **Daf** cluster leads with the daf-level notes. Two small local components (`TypeHeader`, `AnchorGroupRow`); instances stay click-to-expand to their pieces. `dafRunsStore` exposes `dafRunMarks()`.
- Falls back to the flat list when `groups` is absent (old server / un-indexed daf).

## Notes

No index rebuild — the read path just groups the same index entries differently; the load bar still reads the flat `runs`. Existing suite green (2260).