### PR TITLE
Fix double-Hebrew gloss leaks (a טרפה (טריפה)) across the tokenize boundary

### DIFF
--- a/packages/talmud/src/client/conceptLinks.tsx
+++ b/packages/talmud/src/client/conceptLinks.tsx
@@ -31,6 +31,7 @@ import {
 import { Portal } from 'solid-js/web';
 import type { Term } from '../lib/terms/registry';
 import { Hebraized } from './Hebraized';
+import { stripEchoParens } from './hebraize';
 
 /** The surfaces a reader might actually SEE for a term in prose: the Hebrew
  *  script (the dominant form after hebraization) and the English label, if any.
@@ -371,10 +372,15 @@ export function ConceptText(props: {
   text: string | undefined | null;
   matcher: ConceptMatcher | null;
 }): JSX.Element {
-  // Strip every-but-first inline gloss before tokenizing, then tokenize the
-  // cleaned text so each remaining mention still gets its tooltip.
+  // Strip every-but-first inline gloss, then collapse redundant Hebrew echoes
+  // (e.g. "a טרפה (טריפה)" — a double-Hebrew gloss), THEN tokenize so each
+  // remaining mention still gets its tooltip. stripEchoParens must run on the
+  // whole contiguous string here, not just per-fragment in Hebraized below: when
+  // the parenthetical restates a term whose Hebrew matches a registry surface,
+  // tokenizeWithMatcher pulls that paren out as its own concept mention, so the
+  // "term (term)" pair would never reach Hebraized's echo strip intact.
   const parts = createMemo(() => {
-    const cleaned = firstMentionGloss(props.text ?? '', props.matcher);
+    const cleaned = stripEchoParens(firstMentionGloss(props.text ?? '', props.matcher));
     return tokenizeWithMatcher(cleaned, props.matcher);
   });
   return (

--- a/packages/talmud/src/client/hebraize.ts
+++ b/packages/talmud/src/client/hebraize.ts
@@ -547,20 +547,59 @@ const HE_GLOSS_PAREN_RE = new RegExp(
   'g',
 );
 
+/** Hebrew final-form letters → their medial form, so a word at the end of a
+ *  parenthetical (final kaf/mem/nun/pe/tsadi) compares equal to the same word
+ *  used mid-phrase. */
+const HEBREW_FINAL_FORMS: Record<string, string> = {
+  ך: 'כ',
+  ם: 'מ',
+  ן: 'נ',
+  ף: 'פ',
+  ץ: 'צ',
+};
+
+/** A spelling-invariant skeleton of a Hebrew word: drop the optional matres
+ *  lectionis (vav and yud — the letters that vary between male/plene and
+ *  chaser/defective spelling, e.g. טריפה vs טרפה) and fold final-form letters to
+ *  their medial form. Two spellings of the SAME word collapse to one skeleton.
+ *  Lossy: vav/yud are often consonantal, so two DIFFERENT short words can share
+ *  a skeleton (בית→בת, מום→ממ, דין→דנ) — the caller gates skeleton matching on a
+ *  minimum length so only long, low-collision skeletons are trusted. */
+function hebrewSpellingSkeleton(word: string): string {
+  return word.replace(/[וי]/g, '').replace(/[ךםןףץ]/g, (c) => HEBREW_FINAL_FORMS[c] ?? c);
+}
+
+/** Minimum skeleton length for a male/chaser match to count. Below this, the
+ *  matres-stripping is too lossy — distinct short words collide (בית vs בת, מום
+ *  vs מים, דין vs דן) — so short paren words must restate the term EXACTLY. The
+ *  reported leaks (טרפה/טריפה, skeleton "טרפה") are well above this. */
+const MIN_SKELETON_MATCH_LEN = 3;
+
 /** Drop an all-Hebrew parenthetical that merely restates the Hebrew term before
  *  it (a redundant/duplicated gloss). Conservative: drop only when EVERY word in
- *  the paren already appears in the preceding term — i.e. it adds no new
- *  information (the observed failures are exact or padded repetitions like
- *  "מלא צואר (מלא צואר וחוץ לצואר)"). A paren that introduces even one new word
- *  is a real clarification and is kept. Any closing quote in the gap is kept (it
- *  belongs to the term); only the paren and the whitespace that separated it
- *  are dropped. */
+ *  the paren already appears in the preceding term — exactly, OR (for long
+ *  enough words) as a male/chaser spelling variant (same skeleton, e.g.
+ *  "a טרפה (טריפה)" — defective inline, full in the paren). The observed failures
+ *  are exact, spelling-variant, or padded repetitions like
+ *  "מלא צואר (מלא צואר וחוץ לצואר)". A paren that introduces even one genuinely
+ *  new word is a real clarification and is kept. Any closing quote in the gap is
+ *  kept (it belongs to the term); only the paren and the whitespace that
+ *  separated it are dropped. */
 function dropHebrewGlossEchoes(text: string): string {
   return text.replace(HE_GLOSS_PAREN_RE, (m: string, term: string, gap: string, paren: string) => {
-    const termWords = new Set(term.trim().split(/\s+/).filter(Boolean));
+    const termWords = term.trim().split(/\s+/).filter(Boolean);
     const parenWords = paren.trim().split(/\s+/).filter(Boolean);
     if (parenWords.length === 0) return m;
-    const addsNewWord = parenWords.some((w: string) => !termWords.has(w));
+    const termSet = new Set(termWords);
+    // Only long skeletons are trusted for variant matching (see MIN_… above).
+    const termSkeletons = new Set(
+      termWords.map(hebrewSpellingSkeleton).filter((s) => s.length >= MIN_SKELETON_MATCH_LEN),
+    );
+    const addsNewWord = parenWords.some((w: string) => {
+      if (termSet.has(w)) return false;
+      const skel = hebrewSpellingSkeleton(w);
+      return !(skel.length >= MIN_SKELETON_MATCH_LEN && termSkeletons.has(skel));
+    });
     if (addsNewWord) return m;
     return term + gap.replace(/\s+/g, '');
   });

--- a/packages/talmud/tests/first-mention-gloss.test.ts
+++ b/packages/talmud/tests/first-mention-gloss.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { buildConceptMatcher, firstMentionGloss, glossKey } from '../src/client/conceptLinks';
+import {
+  buildConceptMatcher,
+  firstMentionGloss,
+  glossKey,
+  tokenizeWithMatcher,
+} from '../src/client/conceptLinks';
+import { hebraize, stripEchoParens } from '../src/client/hebraize';
 import { globalTerms, type Term } from '../src/lib/terms/registry';
 
 // A glossary term is glossed inline on its FIRST mention in a prose unit and
@@ -130,5 +136,49 @@ describe('firstMentionGloss', () => {
       buildConceptMatcher(globalTerms()),
     );
     expect(out).toBe('A הלכה (binding law) here; another הלכה there.');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ConceptText render path — the contiguous prose must have its Hebrew echoes
+// collapsed BEFORE tokenization. Reproduces the reported "double Hebrew" bug:
+// "a טרפה (טריפה)". The parenthetical טריפה matches the registry surface for
+// treif, so tokenizeWithMatcher would pull it out as its own concept mention —
+// meaning the "term (term)" pair never reaches the per-fragment echo strip in
+// Hebraized. ConceptText therefore runs stripEchoParens on the whole string
+// first. This mirrors ConceptText's parts() memo exactly.
+// ---------------------------------------------------------------------------
+
+function renderLikeConceptText(text: string): string {
+  const matcher = buildConceptMatcher(globalTerms());
+  const cleaned = stripEchoParens(firstMentionGloss(text, matcher));
+  // Text parts go through Hebraized (hebraize); concept parts render raw.
+  return tokenizeWithMatcher(cleaned, matcher)
+    .map((p) => (p.kind === 'text' ? hebraize(p.value) : p.value))
+    .join('');
+}
+
+describe('ConceptText render path — collapses double-Hebrew across the tokenize boundary', () => {
+  it('collapses male/chaser echo whose paren matches a registry surface', () => {
+    // טרפה (defective) inline, טריפה (full) in the paren — the reported leak.
+    expect(renderLikeConceptText('renders the animal a טרפה (טריפה).')).toBe(
+      'renders the animal a טרפה.',
+    );
+  });
+
+  it('collapses an identical Hebrew echo where both sides match a surface', () => {
+    // Both spell טריפה fully; both tokenize as concepts, so only a whole-string
+    // pass can collapse them.
+    expect(renderLikeConceptText('a טריפה (טריפה).')).toBe('a טריפה.');
+  });
+
+  it('keeps a genuine Hebrew clarification that adds new words', () => {
+    expect(renderLikeConceptText('the מלא צואר (מלא צואר וחוץ לצואר) case')).toBe(
+      'the מלא צואר (מלא צואר וחוץ לצואר) case',
+    );
+  });
+
+  it('keeps a Form B English→Hebrew gloss', () => {
+    expect(renderLikeConceptText('the court (בית דין) ruled.')).toBe('the court (בית דין) ruled.');
   });
 });

--- a/packages/talmud/tests/hebraize.test.ts
+++ b/packages/talmud/tests/hebraize.test.ts
@@ -37,6 +37,13 @@ const ECHO_STRIP: Array<[string, string]> = [
   ['cited by חז״ל (חז״ל) as', 'cited by חז״ל as'],
   // Place names also echo.
   ['at יבנה (יבנה) the council met', 'at יבנה the council met'],
+  // Male/chaser (plene vs defective) echoes — the term and its paren restatement
+  // differ only by a matres-lectionis yud/vav, so a char-for-char backref misses
+  // them. These are the reported "double Hebrew" leaks (Chullin extra-lobe daf).
+  ['renders the animal a טרפה (טריפה).', 'renders the animal a טרפה.'],
+  ['the animal a טריפה (טרפה).', 'the animal a טריפה.'],
+  // Same word, defective vs full vav (skeleton "שלמ", long enough to trust).
+  ['ends with שלום (שלם) upon', 'ends with שלום upon'],
   // English-on-both-sides echoes (rarer but same bug class).
   ['the Mishnah (Mishnah) records', 'the Mishnah records'],
   // Multiple echoes in one string.
@@ -105,6 +112,12 @@ const ECHO_PRESERVE: string[] = [
   // Two ADJACENT but DIFFERENT parentheticals — not a doubled echo, leave both.
   'compare (ביאת השמש) (צאת הכוכבים) here',
   'a (sunset) (nightfall) distinction',
+  // Short-word skeleton collisions — distinct words that share a matres-stripped
+  // skeleton (בית/בת, מום/מים, דין/דן). The male/chaser match is gated on a
+  // minimum skeleton length precisely so these genuine clarifications survive.
+  'a בית (בת) here',
+  'a מום (מים) blemish',
+  'the דין (דן) ruling',
 ];
 
 describe('stripEchoParens — preserves non-echo parens', () => {


### PR DESCRIPTION
## Problem

Prose still occasionally rendered a Hebrew term immediately followed by a near-duplicate Hebrew parenthetical — e.g. **"renders the animal a טרפה (טריפה)"** — where the inline term and the paren are the *same word* in two spellings (defective טרפה vs full טריפה).

## Root cause — two gaps

1. **`dropHebrewGlossEchoes` (hebraize.ts)** compared the parenthetical's words to the term's words *exactly*. A male/chaser (plene vs defective) difference — an extra matres-lectionis yud/vav — read as a brand-new word, so the echo was kept.

2. **`ConceptText` (conceptLinks.tsx)** only ran the echo strip *per text fragment*, inside `Hebraized`, **after** tokenization. When the parenthetical's Hebrew matches a registry term surface (e.g. `טריפה`), `tokenizeWithMatcher` pulls it out as its own concept mention — so the contiguous `term (term)` pair never reached the echo strip. This also leaked *identical* Hebrew echoes, not just spelling variants.

## Fix

- `dropHebrewGlossEchoes` now also matches words on a **spelling skeleton** (strip vav/yud matres + fold final-form letters). Gated on a **minimum skeleton length** so distinct short words that share a stripped skeleton (`בית`/`בת`, `מום`/`מים`, `דין`/`דן`) still survive as genuine clarifications — precision over recall.
- `ConceptText` runs `stripEchoParens` on the **whole contiguous string before tokenizing** (covers both the direct path and `RabbiText` → `ConceptAwareText`).

## Verification

- Regression tests added: male/chaser + final-form echoes collapse; short-word skeleton collisions and Form B `English (Hebrew)` glosses are preserved; render-path tests reproduce the tokenize-boundary leak.
- `pnpm typecheck`, `pnpm lint` (biome), full suite (**2270 talmud + 103 core + 42 tanach**) all green.
- Reviewed read-only with Codex; its one finding (over-aggressive matres stripping for short words) is addressed by the minimum-skeleton-length gate.