### PR TITLE
Daf-yomi warmer: deep-warm the prose surface in Hebrew too (en/he parity)

### DIFF
--- a/packages/talmud/src/worker/yomi-cron.ts
+++ b/packages/talmud/src/worker/yomi-cron.ts
@@ -169,22 +169,42 @@ export async function runYomiWarmCron(env: YomiCronEnv): Promise<void> {
           console.error(`[yomi-cron] enqueue rabbi.observations ${tractate}/${page} failed:`, e);
         }),
     );
-    // Deep-warm the daf so the section-typing views are ready for the daf-yomi
-    // crowd — notably argument.narrative on story sections, which the deep-warm
-    // path pre-warms only for narrative-primary sections (cache-respecting, so
-    // the marks above are reused, not re-paid). One full deep-warm per daily daf.
-    const deepRunId = (await warmRunId('warm-deep', tractate, page))
-      .replace(/[^a-zA-Z0-9._:-]+/g, '_')
-      .slice(0, 200);
-    jobs.push(
-      env.ENRICHMENT_QUEUE.send({ runId: deepRunId, warm_deep: true, tractate, page })
-        .then(() => {
-          console.log(`[yomi-cron] enqueued deep-warm ${tractate}/${page} runId=${deepRunId}`);
-        })
-        .catch((e) => {
-          console.error(`[yomi-cron] enqueue deep-warm ${tractate}/${page} failed:`, e);
-        }),
-    );
+    // Deep-warm the daf so the section-typing views + reader-facing prose are
+    // ready for the daf-yomi crowd — notably argument.narrative on story
+    // sections, which the deep-warm path pre-warms only for narrative-primary
+    // sections (cache-respecting, so the marks above are reused, not re-paid).
+    // Warm BOTH languages: the prose enrichments (synthesis, narrative,
+    // suggested-questions, essays) and, transitively via dependency resolution,
+    // every rabbi-card leaf enrichment (rabbi.synthesis -> rabbi.bio/.geography/
+    // .relationships/...) are language-specific. Without the :he pass a Hebrew
+    // reader regenerates the entire prose surface on first open even though the
+    // structure is warm. One full deep-warm per language per daily daf.
+    for (const lang of ['en', 'he'] as const) {
+      const deepRunId = (await warmRunId('warm-deep', tractate, page, lang))
+        .replace(/[^a-zA-Z0-9._:-]+/g, '_')
+        .slice(0, 200);
+      const deepJob: JobMessage = {
+        runId: deepRunId,
+        warm_deep: true,
+        tractate,
+        page,
+        ...(lang === 'he' ? { lang: 'he' } : {}),
+      };
+      jobs.push(
+        env.ENRICHMENT_QUEUE.send(deepJob)
+          .then(() => {
+            console.log(
+              `[yomi-cron] enqueued deep-warm lang=${lang} ${tractate}/${page} runId=${deepRunId}`,
+            );
+          })
+          .catch((e) => {
+            console.error(
+              `[yomi-cron] enqueue deep-warm lang=${lang} ${tractate}/${page} failed:`,
+              e,
+            );
+          }),
+      );
+    }
   }
   await Promise.allSettled(jobs);
   console.log(`[yomi-cron] enqueued ${jobs.length} warm job(s) for ${tractate} ${daf}`);

--- a/packages/talmud/tests/yomi-cron.test.ts
+++ b/packages/talmud/tests/yomi-cron.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { JobMessage } from '../src/worker/types';
+import { runYomiWarmCron } from '../src/worker/yomi-cron';
+
+// Sefaria's calendar shape for "tomorrow is Berakhot 12".
+const CALENDAR_RESPONSE = {
+  calendar_items: [
+    { title: { en: 'Daf Yomi' }, category: 'Talmud', displayValue: { en: 'Berakhot 12' } },
+  ],
+};
+
+function collectJobs() {
+  const sent: JobMessage[] = [];
+  const queue = {
+    send: async (job: JobMessage) => {
+      sent.push(job);
+    },
+  } as unknown as Queue<JobMessage>;
+  return { sent, queue };
+}
+
+describe('runYomiWarmCron', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(global, 'fetch');
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify(CALENDAR_RESPONSE), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it('deep-warms the prose surface in BOTH languages (en + he parity)', async () => {
+    const { sent, queue } = collectJobs();
+    await runYomiWarmCron({ ENRICHMENT_QUEUE: queue });
+
+    const deep = sent.filter((j) => j.warm_deep);
+    // Two amudim (a + b) x two languages = four deep-warm jobs.
+    expect(deep.length).toBe(4);
+
+    const he = deep.filter((j) => j.lang === 'he');
+    const en = deep.filter((j) => j.lang !== 'he');
+    // Hebrew parity: every amud gets a Hebrew deep-warm, not just English.
+    expect(he.map((j) => j.page).sort()).toEqual(['12a', '12b']);
+    expect(en.map((j) => j.page).sort()).toEqual(['12a', '12b']);
+
+    // Distinct runIds so the queue never dedupes the he pass against the en one.
+    expect(new Set(deep.map((j) => j.runId)).size).toBe(4);
+  });
+
+  it('warms the prose-bearing structural marks in Hebrew but not the language-neutral rabbi mark', async () => {
+    const { sent, queue } = collectJobs();
+    await runYomiWarmCron({ ENRICHMENT_QUEUE: queue });
+
+    const heMarks = new Set(sent.filter((j) => j.mark_id && j.lang === 'he').map((j) => j.mark_id));
+    // rabbi has no _he prompt -> language-neutral structure -> warming it under
+    // :he would just duplicate the en cache, so it is deliberately skipped.
+    expect(heMarks.has('rabbi')).toBe(false);
+    for (const m of ['argument', 'halacha', 'aggadata', 'yerushalmi', 'pesukim']) {
+      expect(heMarks.has(m)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Problem

The daily daf-yomi pre-warm (`yomi-cron.ts`) warmed the 5 structural **marks** in both EN and HE, but enqueued the `warm_deep` job with **no `lang`** — so the entire reader-facing **prose** surface was warmed in English only:

- `argument.synthesis`, `aggadata.synthesis`, `halacha.synthesis`, `pesukim.synthesis`, `rabbi.synthesis`, `places.synthesis`, `rishonim.synthesis`
- `argument.narrative`, `argument-overview.synthesis`, `*.suggested-questions`, `tidbit.essay`, `biyun.essay`

Effect for a Hebrew reader: the **structure** loads instantly (warm `:he` marks), then the page **stalls** while each prose enrichment regenerates cold in Hebrew on first open (~5–15s each). It looks "cached but slow" because the structure genuinely was cached and the prose genuinely wasn't — they live in separate cache entries warmed by different jobs.

## Fix

Enqueue `warm_deep` for **both** languages (distinct runIds). The plumbing already existed:

- `deepWarmDaf` forwards `rc.lang` to every enrichment job it fans out (`index.ts:9398/9443/9491`).
- Dependency resolution persists each resolved dep under its own `:he` cache key (`resolveDependencies` → `runEnrichmentOnce` → `writeCachedResult`; `lang` flows through `RunCtx`).

So one `warm_deep` pass with `lang:'he'` warms the whole prose surface in Hebrew — including, **transitively**, every rabbi-card leaf enrichment (`rabbi.synthesis` → `rabbi.bio`/`.geography`/`.relationships`/`.geography.evidence`/`.location`/…), which is what makes the rabbi card fast in Hebrew. The structural marks warmed earlier in the cron are reused (cache-respecting), so the marginal cost is just the HE prose generation for the two daily amudim.

### Left as-is on purpose
- The `rabbi` **mark** — language-neutral (no `_he` prompt; emits identical names/IDs/Hebrew excerpts). Warming it under `:he` would duplicate the EN cache for no gain.
- `rabbi.observations` — deterministic computed reverse-index, no LLM, no reader card → no Hebrew variant to warm.

## Tests
Adds `tests/yomi-cron.test.ts` locking the EN/HE deep-warm parity (4 deep-warm jobs: 2 amudim × 2 langs, distinct runIds) and the rabbi-mark Hebrew exclusion.

`pnpm typecheck`, `pnpm lint`, and `pnpm test` (2277 tests) all pass.