### PR TITLE
Backlog write-time filters: drop non-geographic places + collective rabbi attributions

### DIFF
--- a/packages/talmud/src/worker/unknown-registry.ts
+++ b/packages/talmud/src/worker/unknown-registry.ts
@@ -98,6 +98,88 @@ const ETHNONYMS_HE = new Set([
 ]);
 const PATRONYMIC_RE = /\s(בר|בן|ברה)\s|\sבריה/; // "X bar/ben Y", "X בריה ד..." (son of) — boundary-anchored so it doesn't fire inside טבריה (Tiberias)
 
+// The `places` mark also tags non-geographic referents as "places": institutions
+// and structures (בית המדרש a study hall, מזבח the altar, בית ריש גלותא the
+// Exilarch's household), halachic land *categories* (בית הפרס a plowed grave-
+// field — an impurity status, not a town), and generic words (מתא "the town",
+// כרכים "cities"). None belong in a gazetteer of missing places. Matched EXACTLY
+// (normalized) — never as a substring — so real towns that merely share a letter
+// (בי חוזאי Bei Ḥozai, מחוזא Mehoza) are untouched. Seeded from the 2026-06 Shas
+// backlog research (see Sandbox/2026-06-16-backlog-research/findings.md).
+const NON_PLACE_HE = new Set([
+  // study halls / academies-as-institution (not a located town)
+  'בית המדרש',
+  'בית מדרש',
+  'בי מדרשא',
+  'בי רב',
+  'בית רבי',
+  'מתיבתא דרקיעא',
+  // synagogues / courts / households (institutions, not points)
+  'בית הכנסת',
+  'בית כנסת',
+  'בתי כנסיות',
+  'בית דין',
+  'בית ריש גלותא',
+  'בית נשיאה',
+  // Temple precinct structures (subsumed by Jerusalem; not gazetteer points)
+  'בית המקדש',
+  'המקדש',
+  'מקדש',
+  'מזבח',
+  'עזרה',
+  'היכל',
+  'לשכת הגזית',
+  'שער נקנור',
+  // halachic land categories / generic terms / cemeteries / bathhouses
+  'בית הפרס',
+  'בית הסאה',
+  'בית סאה',
+  'בית כור',
+  'בית הקברות',
+  'בית המרחץ',
+  'מתא',
+  'מקום',
+  'כרך',
+  'כרכים',
+  'מדבר',
+  'גולה',
+  'שדה',
+  'גורן',
+]);
+const NON_PLACE_EN =
+  /^(beit ?ha?-?(midrash|knesset|din|mikdash)|beit din|study hall|academy of|synagogues?|bathhouse|altar|the temple|chamber of|gate of nicanor|heavenly|exilarch'?s? (household|court)|house of the nasi|cities|a certain place|threshing floor|cemetery)\b/i;
+
+// Anonymous / collective / paired attributions the rabbi mark surfaces as if they
+// were people: אחרים "Others", חכמים "the Sages", תנא קמא the anonymous first
+// opinion, ריש גלותא the Exilarch (an office), דבי רבי ישמעאל "the school of...",
+// and paired speakers ("X and Y", ...דאמרי תרוייהו "who both said"). They resolve
+// to slug=null and so flood the missing-RABBI backlog, but none is a single
+// person to research. Matched exactly (HE) or by shape (schools / pairs).
+const COLLECTIVE_HE = new Set([
+  'אחרים',
+  'חכמים',
+  'רבנן',
+  'רבותינו',
+  'תנא קמא',
+  'תנו רבנן',
+  'תנא',
+  'תנאי',
+  'אמוראי',
+  'יש אומרים',
+  'ויש אומרים',
+  'ריש גלותא',
+  'בית הלל',
+  'בית שמאי',
+  'חכם',
+  'חכמי',
+]);
+const COLLECTIVE_EN =
+  /^(others|the sages|sages|rabbanan|our rabbis|the rabbis|some say|(the )?first tanna|tanna kamma|school of|academy of|the (academy|school)|beit (hillel|shammai))\b/i;
+// The Exilarch is an OFFICE only when bare; a *named* exilarch ("Exilarch Mar
+// Ukva", "Mar Ukva") is a real person — so match the title exactly, never as a
+// prefix (the Hebrew office ריש גלותא is already exact in COLLECTIVE_HE).
+const EXILARCH_OFFICE_EN = /^(the )?exilarch$/i;
+
 function stripNiqqud(s?: string): string {
   return (s || '').replace(/[֑-ׇ]/g, '').trim();
 }
@@ -123,10 +205,38 @@ function isEthnonym(name?: string, nameHe?: string): boolean {
   );
 }
 
+/** True when the emitted "place" is an institution, structure, halachic land
+ *  category, or generic term rather than a located settlement. */
+function isNonGeographic(name?: string, nameHe?: string): boolean {
+  if (NON_PLACE_HE.has(stripNiqqud(nameHe))) return true;
+  return NON_PLACE_EN.test((name || '').trim());
+}
+
 /** True when an emitted "place" is a real geographic location — i.e. not a
- *  rabbi/sage misclassified as a city, and not a people/nation. */
+ *  rabbi/sage misclassified as a city, not a people/nation, and not a
+ *  non-geographic referent (institution / structure / halachic land category /
+ *  generic term). */
 export function isRealPlace(name?: string, nameHe?: string): boolean {
-  return !looksLikePerson(name, nameHe) && !isEthnonym(name, nameHe);
+  return (
+    !looksLikePerson(name, nameHe) && !isEthnonym(name, nameHe) && !isNonGeographic(name, nameHe)
+  );
+}
+
+/** True when an emitted "unknown rabbi" is a single named sage worth tracking —
+ *  i.e. not an anonymous/collective attribution (אחרים, חכמים, תנא קמא), an
+ *  office (ריש גלותא), a school (דבי רבי...), or a paired speaker ("X and Y",
+ *  ...דאמרי תרוייהו). Those resolve to slug=null but are not people to research. */
+export function isNamedSage(name?: string, nameHe?: string): boolean {
+  const he = stripNiqqud(nameHe);
+  if (he) {
+    if (COLLECTIVE_HE.has(he)) return false;
+    if (he.includes('תרוייהו')) return false; // "...who both said" — a pair
+    if (he.startsWith('דבי ')) return false; // "the school of ..."
+  }
+  const en = (name || '').trim();
+  if (COLLECTIVE_EN.test(en) || EXILARCH_OFFICE_EN.test(en)) return false;
+  if (/\band\b/i.test(en)) return false; // "Abaye and Rava" — a pair, not a person
+  return true;
 }
 
 // `count` is a best-effort APPROXIMATION, not an exact tally. This read-modify-
@@ -161,6 +271,7 @@ export async function putUnknownRabbi(
   cache: KVNamespace,
   r: { name?: string; nameHe?: string; generation?: string; tractate: string; page: string },
 ): Promise<void> {
+  if (!isNamedSage(r.name, r.nameHe)) return; // collectives / schools / pairs aren't people to research
   const keyPart = norm(r.name || '') || norm(r.nameHe || '');
   if (!keyPart) return;
   const daf = `${r.tractate} ${r.page}`.trim();
@@ -370,6 +481,7 @@ export function putUnknownRabbisBatch(
   return bumpBatch<UnknownRabbi>(
     cache,
     items.flatMap((r) => {
+      if (!isNamedSage(r.name, r.nameHe)) return []; // skip collectives / schools / pairs
       const keyPart = norm(r.name || '') || norm(r.nameHe || '');
       if (!keyPart) return [];
       return [
@@ -529,7 +641,11 @@ export function listUnknownRabbis(
   cache: KVNamespace,
   sample = 50,
 ): Promise<UnknownSummary<UnknownRabbi>> {
-  return listPrefix<UnknownRabbi>(cache, RABBI_PREFIX, sample);
+  // Hide collective/school/paired attributions already in KV (recorded before
+  // the isNamedSage gate) without a destructive purge — they age out via TTL.
+  return listPrefix<UnknownRabbi>(cache, RABBI_PREFIX, sample, (r) =>
+    isNamedSage(r.name, r.nameHe),
+  );
 }
 
 export function listObservedPlaces(

--- a/packages/talmud/tests/observed-place-filter.test.ts
+++ b/packages/talmud/tests/observed-place-filter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isRealPlace } from '../src/worker/unknown-registry';
+import { isRealPlace, listObservedPlaces, putObservedPlace } from '../src/worker/unknown-registry';
 
 // Regression guard for the `places` mark over-extracting people/peoples as
 // locations. On rabbi-heavy dafim the LLM tagged every `רב X` as a Bavel city,
@@ -58,6 +58,42 @@ describe('isRealPlace — rejects peoples / ethnonyms', () => {
   });
 });
 
+describe('isRealPlace — rejects non-geographic referents (institutions / structures / categories)', () => {
+  // [nameHe, nameEn] pairs the codex place-research flagged as gazetteer
+  // false-positives (Sandbox/2026-06-16-backlog-research/findings.md): study
+  // halls, courts, the Exilarch's household, Temple precinct structures, a
+  // halachic land *category*, and generic words.
+  const nonPlaces: Array<[string, string]> = [
+    ['בית המדרש', 'Beit HaMidrash'],
+    ['בית מדרש', 'Beit Midrash'],
+    ['בי רב', 'Bei Rav'],
+    ['בית הכנסת', 'Beit HaKnesset'],
+    ['בתי כנסיות', 'Synagogues'],
+    ['בית דין', 'Beit Din'],
+    ['בית ריש גלותא', "Exilarch's household"],
+    ['בית נשיאה', 'House of the Nasi'],
+    ['מתיבתא דרקיעא', 'Heavenly study hall'],
+    ['בית המקדש', 'Beit HaMikdash'],
+    ['מזבח', 'Altar'],
+    ['עזרה', 'Azara'],
+    ['בית הפרס', 'beit haperas'], // a plowed grave-field: an impurity STATUS, not a town
+    ['בית המרחץ', 'Bathhouse'],
+    ['כרכים', 'Cities'],
+    ['מתא', 'the town'],
+    ['מקום', 'a certain place'],
+  ];
+
+  it.each(nonPlaces)('drops non-place %s / %s', (nameHe, name) => {
+    expect(isRealPlace(name, nameHe)).toBe(false);
+  });
+
+  it('matches the Hebrew stop-list EXACTLY — a real town sharing a prefix is kept', () => {
+    expect(isRealPlace('Bei Ḥozai', 'בי חוזאי')).toBe(true); // not "בי רב"
+    expect(isRealPlace('Mehoza', 'מחוזא')).toBe(true);
+    expect(isRealPlace('Mata Mehasya', 'מתא מחסיא')).toBe(true); // not bare "מתא"
+  });
+});
+
 describe('isRealPlace — keeps genuine geography (no false positives)', () => {
   const places: Array<[string, string]> = [
     ['דפתי', 'Difti'], // a real Bavel city — a rabbi (Rav Yirmeya) is named after it
@@ -80,5 +116,69 @@ describe('isRealPlace — keeps genuine geography (no false positives)', () => {
 
   it.each(places)('keeps place %s / %s', (nameHe, name) => {
     expect(isRealPlace(name, nameHe)).toBe(true);
+  });
+});
+
+// Minimal in-memory KVNamespace covering the get/put/list surface the registry
+// uses (mirrors observed-concept.test.ts).
+function fakeKV(): KVNamespace {
+  const store = new Map<string, string>();
+  return {
+    async get(key: string) {
+      return store.get(key) ?? null;
+    },
+    async put(key: string, value: string) {
+      store.set(key, value);
+    },
+    async list({
+      prefix = '',
+      limit = 1000,
+      cursor,
+    }: {
+      prefix?: string;
+      limit?: number;
+      cursor?: string;
+    } = {}) {
+      const all = [...store.keys()].filter((k) => k.startsWith(prefix)).sort();
+      const start = cursor ? Number(cursor) : 0;
+      const slice = all.slice(start, start + limit);
+      const next = start + limit;
+      const complete = next >= all.length;
+      return {
+        keys: slice.map((name) => ({ name })),
+        list_complete: complete,
+        cursor: complete ? undefined : String(next),
+      };
+    },
+  } as unknown as KVNamespace;
+}
+
+describe('putObservedPlace — the filter is enforced at write time', () => {
+  it('records a real settlement but never a non-geographic referent', async () => {
+    const kv = fakeKV();
+    await putObservedPlace(kv, {
+      name: 'Hagronya',
+      nameHe: 'הגרוניא',
+      tractate: 'Bava Batra',
+      page: '46a',
+    });
+    await putObservedPlace(kv, {
+      name: 'Beit Din',
+      nameHe: 'בית דין',
+      tractate: 'Sanhedrin',
+      page: '2a',
+    });
+    await putObservedPlace(kv, {
+      name: 'Heavenly study hall',
+      nameHe: 'מתיבתא דרקיעא',
+      tractate: 'Bava Metzia',
+      page: '86a',
+    });
+
+    const { sample } = await listObservedPlaces(kv);
+    const names = sample.map((p) => p.name);
+    expect(names).toContain('Hagronya');
+    expect(names).not.toContain('Beit Din');
+    expect(names).not.toContain('Heavenly study hall');
   });
 });

--- a/packages/talmud/tests/unknown-rabbi-filter.test.ts
+++ b/packages/talmud/tests/unknown-rabbi-filter.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import { isNamedSage, listUnknownRabbis, putUnknownRabbi } from '../src/worker/unknown-registry';
+
+// Regression guard for the unknown-rabbi backlog collecting attributions that
+// resolve to slug=null but are NOT a single person to research: anonymous /
+// collective opinions (אחרים "Others", חכמים "the Sages", תנא קמא the anonymous
+// first opinion), offices (ריש גלותא the Exilarch), schools (דבי רבי ישמעאל),
+// and paired speakers ("Abaye and Rava", ...דאמרי תרוייהו). `isNamedSage` is the
+// deterministic net, applied at record time and when listing the backlog (so
+// collectives already in KV stop showing without a destructive purge). Seeded
+// from the 2026-06 Shas backlog research (Sandbox/2026-06-16-backlog-research/).
+
+describe('isNamedSage — rejects collective / anonymous / school / paired attributions', () => {
+  const collectives: Array<[string, string]> = [
+    ['אחרים', 'Acherim'],
+    ['חכמים', 'Chachamim'],
+    ['רבנן', 'Rabbanan'],
+    ['תנא קמא', 'First Tanna'],
+    ['תנו רבנן', 'Tanu Rabbanan'],
+    ['יש אומרים', 'Some say'],
+    ['ריש גלותא', 'Exilarch'],
+    ['בית הלל', 'Beit Hillel'],
+    ['בית שמאי', 'Beit Shammai'],
+    ['דבי רבי ישמעאל', 'School of Rabbi Yishmael'],
+    ['אביי ורבא דאמרי תרוייהו', 'Abaye and Rava'],
+  ];
+
+  it.each(collectives)('drops collective %s / %s', (nameHe, name) => {
+    expect(isNamedSage(name, nameHe)).toBe(false);
+  });
+});
+
+describe('isNamedSage — keeps genuine missing sages (no false positives)', () => {
+  // Real, genuinely-absent sages surfaced by the research — must NOT be dropped.
+  const sages: Array<[string, string]> = [
+    ['בן בתירא', 'Ben Beteira'],
+    ['רב שישא בריה דרב אידי', 'Rav Shisha son of Rav Idi'],
+    ['רב עוירא', 'Rav Avira'],
+    ['רב זוטרא בר טוביה', 'Rav Zutra bar Tovia'],
+    ['רחבה', 'Rachba'],
+    ['רב טביומי', 'Rav Tavyomi'],
+    ['אבא חנן', 'Abba Chanan'],
+    ['ריש לקיש', 'Reish Lakish'], // starts with ריש but is a person, NOT ריש גלותא
+    ['רבי חנינא', 'Rabbi Chanina'],
+  ];
+
+  it.each(sages)('keeps sage %s / %s', (nameHe, name) => {
+    expect(isNamedSage(name, nameHe)).toBe(true);
+  });
+
+  it('drops the bare Exilarch office but keeps a named exilarch', () => {
+    expect(isNamedSage('Exilarch', 'ריש גלותא')).toBe(false); // bare office
+    expect(isNamedSage('The Exilarch', undefined)).toBe(false);
+    expect(isNamedSage('Mar Ukva', 'מר עוקבא')).toBe(true); // a specific exilarch — a person
+    expect(isNamedSage('Exilarch Mar Ukva', undefined)).toBe(true); // named, not the bare office
+  });
+});
+
+function fakeKV(): KVNamespace {
+  const store = new Map<string, string>();
+  return {
+    async get(key: string) {
+      return store.get(key) ?? null;
+    },
+    async put(key: string, value: string) {
+      store.set(key, value);
+    },
+    async list({
+      prefix = '',
+      limit = 1000,
+      cursor,
+    }: {
+      prefix?: string;
+      limit?: number;
+      cursor?: string;
+    } = {}) {
+      const all = [...store.keys()].filter((k) => k.startsWith(prefix)).sort();
+      const start = cursor ? Number(cursor) : 0;
+      const slice = all.slice(start, start + limit);
+      const next = start + limit;
+      const complete = next >= all.length;
+      return {
+        keys: slice.map((name) => ({ name })),
+        list_complete: complete,
+        cursor: complete ? undefined : String(next),
+      };
+    },
+  } as unknown as KVNamespace;
+}
+
+describe('putUnknownRabbi — the filter is enforced at write time', () => {
+  it('records a real missing sage but never a collective attribution', async () => {
+    const kv = fakeKV();
+    await putUnknownRabbi(kv, {
+      name: 'Ben Beteira',
+      nameHe: 'בן בתירא',
+      tractate: 'Pesachim',
+      page: '66a',
+    });
+    await putUnknownRabbi(kv, {
+      name: 'Acherim',
+      nameHe: 'אחרים',
+      tractate: 'Berakhot',
+      page: '9a',
+    });
+    await putUnknownRabbi(kv, {
+      name: 'Abaye and Rava',
+      nameHe: 'אביי ורבא דאמרי תרוייהו',
+      tractate: 'Shabbat',
+      page: '67a',
+    });
+
+    const { sample } = await listUnknownRabbis(kv);
+    const names = sample.map((r) => r.name);
+    expect(names).toContain('Ben Beteira');
+    expect(names).not.toContain('Acherim');
+    expect(names).not.toContain('Abaye and Rava');
+  });
+});


### PR DESCRIPTION
## What

The unknown-entity backlog (`unknown-registry.ts`) records entities detected on dapim but missing from our datasets. A full-Shas review of the live backlog (1,942 unknown rabbis + 1,539 observed places) found two recurring classes of noise that aren't research targets at all:

- **Places:** institutions/structures (`בית המדרש` study hall, `מזבח` altar, `בית ריש גלותא` the Exilarch's household), halachic land *categories* (`בית הפרס` — a plowed grave-field, an impurity status, **not a town**), and generic words (`מתא` "the town", `כרכים` "cities").
- **Rabbis:** anonymous/collective attributions (`אחרים` Others, `חכמים` the Sages, `תנא קמא` the anonymous first opinion), the office `ריש גלותא`, schools (`דבי רבי...`), and paired speakers (`...דאמרי תרוייהו`, "Abaye and Rava") — all resolve to `slug=null` and flood the missing-**rabbi** backlog.

## How

Two deterministic nets, extending the existing `isRealPlace` person/ethnonym filter and matching its design exactly — **applied at both record time and list time**, so junk already in KV stops surfacing and ages out via TTL (no destructive purge), and in the batch-backfill path:

- `isNonGeographic` (folded into `isRealPlace`) — `NON_PLACE_HE` (exact, normalized) + `NON_PLACE_EN`.
- `isNamedSage` — `COLLECTIVE_HE`/`COLLECTIVE_EN` + school/pair shape heuristics; the Exilarch office matched **exactly** so a *named* exilarch (Mar Ukva) is kept.

Hebrew is matched **exactly** (normalized), never as a substring, so real towns that merely share a prefix (`בי חוזאי` Bei Ḥozai, `מחוזא` Mehoza, `מתא מחסיא` Mata Mehasya) are untouched.

## Tests

`observed-place-filter.test.ts` + new `unknown-rabbi-filter.test.ts`: institution/generic place rejection, collective/school/paired/office rabbi rejection, no-false-positive keep-lists for real towns and real missing sages, the exact-match prefix guard, and write-time enforcement integration tests for both buckets. Full suite green (talmud 2364), typecheck + biome clean.

Reviewed read-only with Codex (caught the bare-Exilarch precision case, fixed).

Seeded from the 2026-06 Shas backlog research; the de-noise taxonomy is now encoded in code rather than living only in a Sandbox doc.