### PR TITLE
Spine UX fixes: badge overlap, clickable coverage pages, expand detail, full render

### DIFF
--- a/packages/talmud/src/client/ArgumentFlowGraph.tsx
+++ b/packages/talmud/src/client/ArgumentFlowGraph.tsx
@@ -162,6 +162,10 @@ export function assignLanes(connections: FlowConnection[]): number[] {
 
 const LINE_H = 15; // px between wrapped title lines
 const TITLE_CHARS = 40; // approx chars per line at NODE_W / 12px system font
+// Narrower budget for a node that carries an exit badge (top-right): the title's
+// first line must clip BEFORE the ⤳N badge (≈ titleX..badge-left ≈ 235px) instead
+// of running under it. wrapTitle already ellipsizes the overflow.
+const TITLE_CHARS_EXIT = 32;
 const TITLE_LINES = 2; // wrap to at most this many lines, then ellipsize
 
 /** Greedy word-wrap to at most `maxLines` lines of ~`maxChars` each, ellipsizing
@@ -382,7 +386,8 @@ export default function ArgumentFlowGraph(props: Props): JSX.Element {
             {(n, i) => {
               const active = () => props.activeIndex === n.index;
               const cy = () => nodeY(i()) + NODE_H / 2;
-              const lines = () => wrapTitle(n.title, TITLE_CHARS, TITLE_LINES);
+              const lines = () =>
+                wrapTitle(n.title, n.exits?.length ? TITLE_CHARS_EXIT : TITLE_CHARS, TITLE_LINES);
               const select = () => props.onSelect(n.index);
               const exits = () => n.exits ?? [];
               const isOpen = () => openExits().has(n.index);

--- a/packages/talmud/src/client/SpineCoveragePage.tsx
+++ b/packages/talmud/src/client/SpineCoveragePage.tsx
@@ -1,4 +1,5 @@
 import { createMemo, createResource, createSignal, For, type JSX, Show } from 'solid-js';
+import { TRACTATE_OPTIONS } from '../lib/sefref/tractates';
 import { connectionKinds, FlowLegend } from './ArgumentFlowGraph';
 import SpineFlowGraph, { type SpineViewDaf } from './SpineFlowGraph';
 
@@ -30,6 +31,15 @@ interface CoverageReport {
   columns: CoverageColumn[];
   rows: CoverageRow[];
   summary: { computed: number; total: number; pct: number };
+}
+/** Minimal slice of a /api/marks row — enough to count instances per mark in an
+ *  expanded coverage row. */
+interface MarkLite {
+  id: string;
+  label: string;
+  kind: string;
+  cached: boolean;
+  instances: unknown[];
 }
 
 // Coverage producer kinds, recoloured off neon onto app-native hues.
@@ -124,6 +134,50 @@ export function SpineCoveragePage(): JSX.Element {
   };
 
   const prettyTractate = () => tractate().replace(/_/g, ' ');
+
+  // Slug ('bava_metzia') -> the canonical TractateOption.value ('Bava Metzia')
+  // the alignment + reader pages match their <select>/param on; falls back to a
+  // title-cased guess. Load-bearing: a lowercase slug leaves the alignment page's
+  // <select> blank (its data still loads — the worker slug-normalises — but the
+  // selection is wrong).
+  const titleOf = (slug: string): string =>
+    TRACTATE_OPTIONS.find((o) => o.value.toLowerCase().replace(/ /g, '_') === slug)?.value ??
+    slug.replace(/_/g, ' ').replace(/\b\w/g, (ch) => ch.toUpperCase());
+  const alignHref = (page: string): string =>
+    `?tractate=${encodeURIComponent(titleOf(tractate()))}&page=${encodeURIComponent(page)}#align`;
+  const readerHref = (page: string): string =>
+    `?tractate=${encodeURIComponent(titleOf(tractate()))}&page=${encodeURIComponent(page)}`;
+  // Open a daf's alignment workbench / reader. A FULL url change is required (App
+  // re-renders only on hashchange; the alignment page reads its query once at
+  // construction), and stopPropagation keeps the row's expand toggle from firing.
+  const goDaf = (e: MouseEvent, page: string, align: boolean) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const u = new URL(window.location.href);
+    u.searchParams.set('tractate', titleOf(tractate()));
+    u.searchParams.set('page', page);
+    u.hash = align ? 'align' : '';
+    window.location.href = u.toString();
+  };
+
+  // Per-piece detail for the OPEN row only: one /api/marks fetch keyed on the
+  // expanded daf, so an expanded row can show which marks (and how many of each)
+  // are actually on the page — richer than the coverage report's booleans.
+  const [openMarks] = createResource(
+    () => (expanded() ? `${tractate()}/${expanded()}` : null),
+    async (key: string): Promise<MarkLite[]> => {
+      const slash = key.lastIndexOf('/');
+      const t = key.slice(0, slash);
+      const p = key.slice(slash + 1);
+      try {
+        const r = await fetch(`/api/marks/${encodeURIComponent(t)}/${encodeURIComponent(p)}`);
+        if (!r.ok) return [];
+        return ((await r.json()) as { marks?: MarkLite[] }).marks ?? [];
+      } catch {
+        return [];
+      }
+    },
+  );
 
   return (
     <main class="page-shell" style={{ '--page-max': '1040px' }}>
@@ -535,19 +589,24 @@ export function SpineCoveragePage(): JSX.Element {
                             background: isOpen() ? '#f2eee4' : 'transparent',
                           }}
                         >
-                          <span
+                          <a
+                            href={alignHref(row.page)}
+                            onClick={(e) => goDaf(e, row.page, true)}
+                            title={`Open ${prettyTractate()} ${row.page} in the alignment workbench`}
                             style={{
                               width: '44px',
                               'flex-shrink': 0,
                               'font-family': MONO,
                               'font-size': '0.78rem',
-                              color: filledCount() ? 'var(--fg)' : 'var(--muted)',
+                              color: filledCount() ? 'var(--accent)' : 'var(--muted)',
                               'font-weight': isOpen() ? 700 : 400,
                               'padding-left': '0.2rem',
+                              'text-decoration': 'none',
+                              cursor: 'pointer',
                             }}
                           >
                             {row.page}
-                          </span>
+                          </a>
                           <For each={r().columns}>
                             {(col) => (
                               <span
@@ -594,6 +653,37 @@ export function SpineCoveragePage(): JSX.Element {
                             >
                               {prettyTractate()} {row.page}
                             </div>
+                            <div
+                              style={{
+                                display: 'flex',
+                                gap: '0.8rem',
+                                'margin-bottom': '0.45rem',
+                                'font-size': '0.78rem',
+                              }}
+                            >
+                              <a
+                                href={alignHref(row.page)}
+                                onClick={(e) => goDaf(e, row.page, true)}
+                                style={{
+                                  color: 'var(--accent)',
+                                  'text-decoration': 'none',
+                                  'font-weight': 600,
+                                }}
+                              >
+                                open in alignment →
+                              </a>
+                              <a
+                                href={readerHref(row.page)}
+                                onClick={(e) => goDaf(e, row.page, false)}
+                                style={{
+                                  color: 'var(--accent)',
+                                  'text-decoration': 'none',
+                                  'font-weight': 600,
+                                }}
+                              >
+                                open in reader →
+                              </a>
+                            </div>
                             <For each={r().columns}>
                               {(col) => (
                                 <div
@@ -619,6 +709,54 @@ export function SpineCoveragePage(): JSX.Element {
                                 </div>
                               )}
                             </For>
+                            {/* Per-mark instance counts on this page (lazy /api/marks for the open row). */}
+                            <Show
+                              when={(openMarks() ?? []).some((m) => m.cached && m.instances.length)}
+                            >
+                              <div
+                                style={{
+                                  'margin-top': '0.45rem',
+                                  'border-top': '1px solid #eee',
+                                  'padding-top': '0.35rem',
+                                }}
+                              >
+                                <div
+                                  style={{
+                                    'font-size': '0.68rem',
+                                    'text-transform': 'uppercase',
+                                    'letter-spacing': '0.05em',
+                                    color: 'var(--muted)',
+                                    'margin-bottom': '0.25rem',
+                                  }}
+                                >
+                                  pieces on the page
+                                </div>
+                                <div
+                                  style={{
+                                    display: 'flex',
+                                    'flex-wrap': 'wrap',
+                                    gap: '0.25rem 0.6rem',
+                                  }}
+                                >
+                                  <For
+                                    each={(openMarks() ?? []).filter(
+                                      (m) => m.cached && m.instances.length,
+                                    )}
+                                  >
+                                    {(m) => (
+                                      <span style={{ 'font-size': '0.76rem', color: 'var(--fg)' }}>
+                                        {m.label}{' '}
+                                        <span
+                                          style={{ color: 'var(--accent)', 'font-weight': 600 }}
+                                        >
+                                          {m.instances.length}
+                                        </span>
+                                      </span>
+                                    )}
+                                  </For>
+                                </div>
+                              </div>
+                            </Show>
                           </div>
                         </Show>
                       </>

--- a/packages/talmud/src/client/SpineCoveragePage.tsx
+++ b/packages/talmud/src/client/SpineCoveragePage.tsx
@@ -99,7 +99,7 @@ async function fetchCoverage(tractate: string): Promise<CoverageReport> {
 
 async function fetchSpineView(
   tractate: string,
-): Promise<{ tractate: string; dapim: SpineViewDaf[] }> {
+): Promise<{ tractate: string; dapim: SpineViewDaf[]; truncated?: boolean }> {
   const r = await fetch(`/api/spine-view/${encodeURIComponent(tractate)}`);
   if (!r.ok) {
     const body = await r.json().catch(() => ({}));
@@ -108,7 +108,9 @@ async function fetchSpineView(
   return r.json();
 }
 
-const FLOW_VIEW_CAP = 40; // keep the stitched render light; note when truncated
+// Render budget for the stitched flow graph. >= the server's SPINE_VIEW_MAX_DAPIM
+// so the client never re-truncates the (already-bounded) server payload.
+const FLOW_VIEW_CAP = 64;
 
 export function SpineCoveragePage(): JSX.Element {
   const [tractate, setTractate] = createSignal(routeTractate());
@@ -408,9 +410,12 @@ export function SpineCoveragePage(): JSX.Element {
                           fallback={`whole tractate — ${v().dapim.length} dapim, one node each; tinted = has cross-daf links. Click a daf for detail.`}
                         >
                           showing {capped().length} of {shown().length} dapim{' '}
-                          {shown().length > FLOW_VIEW_CAP ? '(capped)' : ''} &middot; {crossCount()}{' '}
-                          cross-daf arrows (thicker lines span the page break) &middot;{' '}
-                          {connectivity().done}/{connectivity().total} boundaries connected
+                          {v().truncated || shown().length > FLOW_VIEW_CAP
+                            ? '(bounded — warm more dapim to extend) '
+                            : ''}
+                          &middot; {crossCount()} cross-daf arrows (thicker lines span the page
+                          break) &middot; {connectivity().done}/{connectivity().total} boundaries
+                          connected
                           {connectivity().done < connectivity().total
                             ? ' (dashed = not computed yet)'
                             : ''}{' '}

--- a/packages/talmud/src/client/SpineFlowGraph.tsx
+++ b/packages/talmud/src/client/SpineFlowGraph.tsx
@@ -65,6 +65,9 @@ const LANE_BASE = 14,
   CORNER_R = 16;
 const LINE_H = 15,
   TITLE_CHARS = 44,
+  // Narrower budget for a box that carries an exit badge (top-right), so the
+  // title's first line clips BEFORE the ⤳N badge instead of running under it.
+  TITLE_CHARS_EXIT = 36,
   TITLE_LINES = 2;
 // Exit markers: the click-to-expand band of cross-text parallels under a box.
 const EXIT_H = 21,
@@ -536,7 +539,12 @@ export default function SpineFlowGraph(props: {
                     const h = m.nodeH.get(key)!;
                     const rabbis = m.nodeRabbis.get(key) ?? [];
                     const cyTitle = yTop + NODE_H / 2;
-                    const lines = wrapTitle(m.nodeTitle.get(key) ?? '', TITLE_CHARS, TITLE_LINES);
+                    const hasExits = (m.nodeExits.get(key) ?? []).length > 0;
+                    const lines = wrapTitle(
+                      m.nodeTitle.get(key) ?? '',
+                      hasExits ? TITLE_CHARS_EXIT : TITLE_CHARS,
+                      TITLE_LINES,
+                    );
                     const num = m.nodeNum.get(key) ?? 0;
                     const lit = () => hl() !== null && rabbis.some((r) => r.slug === hl());
                     // Lay rabbi chips left-to-right, keeping each WITHIN the box.

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -1624,6 +1624,13 @@ function canonicalTractateName(slug: string): string {
   return TRACTATE_OPTIONS.find((o) => slugTractate(o.value) === s)?.value ?? slug;
 }
 
+// Hard cap on dapim swept per /api/spine-view request: each warmed daf costs ~a
+// dozen KV reads (sections + per-section voices + flow + cross + bridge +
+// parallels), and Cloudflare caps a request at 1000 subrequests. The fan-out is
+// already gated onto warmed dapim; this bounds the worst case (a fully-warmed
+// tractate). A per-tractate snapshot shelf warmed by cron is the O(1) follow-up.
+const SPINE_VIEW_MAX_DAPIM = 60;
+
 app.get('/api/spine-view/:tractate', async (c) => {
   const tractate = c.req.param('tractate');
   if (!isKnownTractate(tractate)) return c.json({ error: `unknown tractate: ${tractate}` }, 404);
@@ -1634,7 +1641,19 @@ app.get('/api/spine-view/:tractate', async (c) => {
   // the read-only bundle reads cold-miss everything.
   const canonical = canonicalTractateName(tractate);
   const pages = [...iterAmudim(tractate)];
-  const raw = await mapPool(pages, 24, async (page) => {
+  const nextOf = new Map(pages.map((p, i) => [p, pages[i + 1] ?? null] as const));
+  // Gate the per-daf fan-out onto dapim that ACTUALLY have an argument mark
+  // (sections). Reading every cold amud blows the 1000-subrequest limit — the
+  // route 500s and the flow panel never renders. computeCoverage is a cheap
+  // key-presence sweep (a handful of KV `list`s); cold dapim are skipped (they
+  // have no sections and would be dropped below anyway). On a probe failure, fall
+  // back to all pages (best-effort).
+  const cov = await computeCoverage(c.env.CACHE, tractate).catch(() => null);
+  const warmed = cov ? new Set(cov.rows.filter((r) => r.cells.argument).map((r) => r.page)) : null;
+  const withSections = warmed ? pages.filter((p) => warmed.has(p)) : pages;
+  const truncated = withSections.length > SPINE_VIEW_MAX_DAPIM;
+  const sweep = truncated ? withSections.slice(0, SPINE_VIEW_MAX_DAPIM) : withSections;
+  const raw = await mapPool(sweep, 24, async (page) => {
     const secs = await readSectionRabbis(c.env, tractate, page);
     const flow = await readFlowConnections(c.env, tractate, page);
     const cross = await readCachedCrossFlow(c.env, tractate, page);
@@ -1673,11 +1692,12 @@ app.get('/api/spine-view/:tractate', async (c) => {
       continues: bridge?.continues === true,
     };
   });
-  // nextPage = the adjacent amud (iterAmudim order), so cross-daf + continuity
-  // edges have a target daf to point at.
-  const dapim = raw.map((d, i) => ({ ...d, nextPage: pages[i + 1] ?? null }));
-  // Only dapim that actually have sections (a flow graph needs nodes).
-  return c.json({ tractate, dapim: dapim.filter((d) => d.sections.length > 0) });
+  // nextPage = the adjacent amud (iterAmudim order, via nextOf since `sweep` is a
+  // gated subset of `pages`), so cross-daf + continuity edges have a target daf.
+  const dapim = raw.map((d) => ({ ...d, nextPage: nextOf.get(d.page) ?? null }));
+  // Only dapim that actually have sections (a flow graph needs nodes). `truncated`
+  // tells the client the sweep was bounded (more warmed dapim exist than shown).
+  return c.json({ tractate, dapim: dapim.filter((d) => d.sections.length > 0), truncated });
 });
 
 // On-demand compute (or cache hit) of one daf's cross-daf flow, returned both as


### PR DESCRIPTION
Four follow-up fixes to the #spine + exit-marker UX (from screenshots after the spine-single-source cutover).

### 1. Exit-marker badge no longer overlaps the title
`TITLE_CHARS` was sized to the full card width and badge-unaware, so a long first line ran under the top-right ⤳N badge ("⤳ 12" over "Evening Shema"). Use a reduced wrap budget (`TITLE_CHARS_EXIT`) for nodes that carry a badge so line 1 clips before it. Fixed in both `ArgumentFlowGraph` (reader) and `SpineFlowGraph` (#spine).

### 2. Coverage daf labels link to the alignment page
The punchcard daf label is now an anchor to that daf's alignment workbench (`?tractate=<TitleCase>&page=<P>#align`). Slug→`TractateOption.value` so the alignment `<select>` matches; full `window.location.href` nav (the page reads its query at construction); `stopPropagation` so it doesn't also toggle the row.

### 3. Richer expand panel
The expanded row gains **open in alignment** / **open in reader** actions and a lazy `/api/marks` fetch (keyed on the open daf) showing which marks — and how many instances of each — are actually on the page, beyond the per-column ✓cached/·missing list.

### 4. #spine flow panel fully renders
The coverage punchcard rendered fine, but the stitched-flow panel 500'd: `/api/spine-view` fanned out ~a dozen KV reads per amud across the **whole** tractate (sections + per-section voices + flow + cross + bridge + parallels), so even a cold 125-amud tractate (~1375 reads) blew Cloudflare's **1000-subrequest limit** and the route failed. Now the fan-out is gated on dapim that actually have an `argument` mark (a cheap `computeCoverage` key-presence sweep — cold dapim are skipped), bounded at `SPINE_VIEW_MAX_DAPIM=60` as a hard backstop, with a `truncated` flag; the client `FLOW_VIEW_CAP` is lifted to 64. (A cron-warmed per-tractate snapshot shelf is the noted O(1) follow-up.)

Full suite green (core 103 + talmud 2426), `biome ci` clean, typecheck clean across all three packages. Merged current `origin/master`.