### PR TITLE
Spine polish: badge/title margin, rabbi chip overflow, #spine ?tractate deep-link

### DIFF
--- a/packages/talmud/src/client/ArgumentFlowGraph.tsx
+++ b/packages/talmud/src/client/ArgumentFlowGraph.tsx
@@ -163,9 +163,10 @@ export function assignLanes(connections: FlowConnection[]): number[] {
 const LINE_H = 15; // px between wrapped title lines
 const TITLE_CHARS = 40; // approx chars per line at NODE_W / 12px system font
 // Narrower budget for a node that carries an exit badge (top-right): the title's
-// first line must clip BEFORE the ⤳N badge (≈ titleX..badge-left ≈ 235px) instead
-// of running under it. wrapTitle already ellipsizes the overflow.
-const TITLE_CHARS_EXIT = 32;
+// first line must clip well BEFORE the ⤳N badge instead of kissing it. The char
+// estimate runs generous for proper-name titles, so leave real margin; wrapTitle
+// ellipsizes the overflow and the full title stays in the hover tooltip.
+const TITLE_CHARS_EXIT = 28;
 const TITLE_LINES = 2; // wrap to at most this many lines, then ellipsize
 
 /** Greedy word-wrap to at most `maxLines` lines of ~`maxChars` each, ellipsizing

--- a/packages/talmud/src/client/SpineCoveragePage.tsx
+++ b/packages/talmud/src/client/SpineCoveragePage.tsx
@@ -85,7 +85,14 @@ const PANEL_H: JSX.CSSProperties = {
 function routeTractate(): string {
   const raw = window.location.hash.replace(/^#/, '');
   const parts = raw.split('/');
-  return (parts[1] || 'berakhot').toLowerCase();
+  // The hash route (#spine/<tractate>) wins; otherwise fall back to the
+  // ?tractate= query param so a deep link like ?tractate=Chullin&page=47b#spine
+  // (the form the reader/align pages use) opens that tractate rather than the
+  // berakhot default. Title-case query values are slugged.
+  if (parts[1]) return parts[1].toLowerCase();
+  const q = new URLSearchParams(window.location.search).get('tractate');
+  if (q?.trim()) return q.trim().toLowerCase().replace(/\s+/g, '_');
+  return 'berakhot';
 }
 
 async function fetchCoverage(tractate: string): Promise<CoverageReport> {

--- a/packages/talmud/src/client/SpineFlowGraph.tsx
+++ b/packages/talmud/src/client/SpineFlowGraph.tsx
@@ -66,8 +66,9 @@ const LANE_BASE = 14,
 const LINE_H = 15,
   TITLE_CHARS = 44,
   // Narrower budget for a box that carries an exit badge (top-right), so the
-  // title's first line clips BEFORE the ⤳N badge instead of running under it.
-  TITLE_CHARS_EXIT = 36,
+  // title's first line clips well BEFORE the ⤳N badge instead of kissing it (the
+  // char estimate runs generous for proper-name titles, so leave real margin).
+  TITLE_CHARS_EXIT = 30,
   TITLE_LINES = 2;
 // Exit markers: the click-to-expand band of cross-text parallels under a box.
 const EXIT_H = 21,
@@ -552,23 +553,27 @@ export default function SpineFlowGraph(props: {
                     // "Rabbi Elazar b. Azaryah" — overflowed the right edge.) Stop
                     // at the first that won't fit and show "+N"; truncate a lone
                     // over-long first name.
-                    const RABBI_RIGHT = LEFT_PAD + NODE_W - 12;
+                    // Conservative per-char width: the 9.5px system font renders a
+                    // touch wider than a tight estimate, and an under-estimate let a
+                    // chip (and the trailing "+N") spill past the box edge.
+                    const CHAR_W = 5.9;
+                    const RABBI_RIGHT = LEFT_PAD + NODE_W - 14;
                     let cx = LEFT_PAD + 10;
                     const chips: { name: string; full: string; slug: string; x: number }[] = [];
                     let hiddenRabbis = 0;
                     for (const r of rabbis) {
-                      const w = r.name.length * 5.4;
+                      const w = r.name.length * CHAR_W;
                       if (chips.length > 0 && cx + w > RABBI_RIGHT) {
                         hiddenRabbis = rabbis.length - chips.length;
                         break;
                       }
                       let name = r.name;
                       if (cx + w > RABBI_RIGHT) {
-                        const max = Math.max(4, Math.floor((RABBI_RIGHT - cx) / 5.4) - 1);
+                        const max = Math.max(4, Math.floor((RABBI_RIGHT - cx) / CHAR_W) - 1);
                         name = `${r.name.slice(0, max)}…`;
                       }
                       chips.push({ name, full: r.name, slug: r.slug, x: cx });
-                      cx += name.length * 5.4 + 12;
+                      cx += name.length * CHAR_W + 12;
                     }
                     return (
                       <g>
@@ -654,7 +659,7 @@ export default function SpineFlowGraph(props: {
                           </For>
                           <Show when={hiddenRabbis > 0}>
                             <text
-                              x={cx}
+                              x={Math.min(cx, LEFT_PAD + NODE_W - 26)}
                               y={yTop + h - 8}
                               font-size="9.5"
                               font-weight={500}


### PR DESCRIPTION
Three small follow-ups from screenshots of the live #spine view.

1. **Exit badge still kissed the title.** The reduced wrap budget from the last PR was too generous — a 36/32-char first line ends right at the ⤳N badge (the char estimate runs narrow for proper-name titles). Tightened `TITLE_CHARS_EXIT` to 30 (`SpineFlowGraph`) / 28 (`ArgumentFlowGraph`) for real margin; the full title stays in the hover tooltip.
2. **Rabbi names escaped the box.** The per-char width under-estimated the 9.5px font, so a chip just-fit and the trailing `+N` spilled past the right edge. Bumped the estimate (5.9) and clamped `+N` inside the box.
3. **`#spine` deep-link honors `?tractate`.** `?tractate=Chullin&page=47b#spine` (no tractate in the hash) now opens Chullin instead of defaulting to berakhot — `routeTractate` falls back to the query param (slugged) when the hash carries no tractate.

Typecheck + biome clean; marker/RTL component tests pass.