### PR TITLE
Spine-view snapshot shelf: O(1), un-bounded #spine flow render (cron-warmed)

### DIFF
--- a/packages/talmud/src/client/SpineCoveragePage.tsx
+++ b/packages/talmud/src/client/SpineCoveragePage.tsx
@@ -104,10 +104,16 @@ async function fetchCoverage(tractate: string): Promise<CoverageReport> {
   return r.json();
 }
 
-async function fetchSpineView(
-  tractate: string,
-): Promise<{ tractate: string; dapim: SpineViewDaf[]; truncated?: boolean }> {
-  const r = await fetch(`/api/spine-view/${encodeURIComponent(tractate)}`);
+async function fetchSpineView(tractate: string): Promise<{
+  tractate: string;
+  dapim: SpineViewDaf[];
+  truncated?: boolean;
+  fromShelf?: boolean;
+  builtAt?: number;
+}> {
+  // Prefer the cron-built snapshot shelf (O(1), un-bounded); on a miss the server
+  // falls back to the bounded live build (truncated:true past 60 warmed dapim).
+  const r = await fetch(`/api/spine-view/${encodeURIComponent(tractate)}?cached=1`);
   if (!r.ok) {
     const body = await r.json().catch(() => ({}));
     throw new Error((body as { error?: string }).error || `HTTP ${r.status}`);
@@ -419,6 +425,9 @@ export function SpineCoveragePage(): JSX.Element {
                           showing {capped().length} of {shown().length} dapim{' '}
                           {v().truncated || shown().length > FLOW_VIEW_CAP
                             ? '(bounded — warm more dapim to extend) '
+                            : ''}
+                          {v().fromShelf && v().builtAt
+                            ? `· snapshot ${Math.max(0, Math.round((Date.now() - (v().builtAt ?? 0)) / 60000))}m old `
                             : ''}
                           &middot; {crossCount()} cross-daf arrows (thicker lines span the page
                           break) &middot; {connectivity().done}/{connectivity().total} boundaries

--- a/packages/talmud/src/worker/cache-keys.ts
+++ b/packages/talmud/src/worker/cache-keys.ts
@@ -293,3 +293,19 @@ export function keyForCrossFlow(tractate: string, page: string): string {
 export function keyForSpineLinks(tractate: string): string {
   return `spine-links:v1:${slugTractate(tractate)}`;
 }
+
+/** Per-tractate spine-VIEW snapshot SHELF — the materialized whole-tractate flow
+ *  graph the warm-cron builds incrementally, served O(1) (no fan-out, no 60-daf
+ *  bound) by `GET /api/spine-view/:t?cached=1`. Tractate-only, slug-normalised,
+ *  mirroring {@link keyForSpineLinks}. */
+export function keyForSpineView(tractate: string): string {
+  return `spine-view:v1:${slugTractate(tractate)}`;
+}
+
+/** The cron's per-tractate ACCUMULATOR for the spine-view shelf — a
+ *  `Record<page, node>` map RMW-merged one window of dapim at a time, then
+ *  projected onto {@link keyForSpineView} at end-of-tractate-pass. Internal to the
+ *  builder; never served. */
+export function keyForSpineViewAcc(tractate: string): string {
+  return `spine-view-acc:v1:${slugTractate(tractate)}`;
+}

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -140,6 +140,8 @@ import {
   keyForReferences,
   keyForRegion,
   keyForSpineLinks,
+  keyForSpineView,
+  keyForSpineViewAcc,
   keyForTranslate,
   prefixForDafIndex,
   prefixForRabbiObs,
@@ -1624,81 +1626,195 @@ function canonicalTractateName(slug: string): string {
   return TRACTATE_OPTIONS.find((o) => slugTractate(o.value) === s)?.value ?? slug;
 }
 
-// Hard cap on dapim swept per /api/spine-view request: each warmed daf costs ~a
-// dozen KV reads (sections + per-section voices + flow + cross + bridge +
+// Hard cap on dapim swept per LIVE /api/spine-view build: each warmed daf costs
+// ~a dozen KV reads (sections + per-section voices + flow + cross + bridge +
 // parallels), and Cloudflare caps a request at 1000 subrequests. The fan-out is
-// already gated onto warmed dapim; this bounds the worst case (a fully-warmed
-// tractate). A per-tractate snapshot shelf warmed by cron is the O(1) follow-up.
+// already gated onto warmed dapim; this bounds the worst case. The cron snapshot
+// shelf (below) removes the bound entirely for tractates it has warmed.
 const SPINE_VIEW_MAX_DAPIM = 60;
+
+// One daf's whole-tractate-flow node: its sections (+ rabbis + cross-text exit
+// markers), within-daf flow, cross-daf edges, and the cold/computed flags. Field
+// names are load-bearing for SpineFlowGraph / SpineCoveragePage — preserve them.
+// `canonical` is the Sefaria raw-case name, passed ONLY to the parallels/yerushalmi
+// reads (their bundle keys are raw, unlike the slug-folded mark/flow/bridge keys).
+async function buildSpineViewDaf(
+  env: Bindings,
+  tractate: string,
+  page: string,
+  canonical: string,
+  nextPage: string | null,
+) {
+  const cache = env.CACHE;
+  if (!cache) throw new Error('buildSpineViewDaf: no CACHE');
+  const secs = await readSectionRabbis(env, tractate, page);
+  const flow = await readFlowConnections(env, tractate, page);
+  const cross = await readCachedCrossFlow(env, tractate, page);
+  const bridge = await readCachedBridge(env, tractate, page);
+  const tp = await readCachedTalmudParallels(cache, canonical, page);
+  const yeru = await readCachedYerushalmi(cache, canonical, page);
+  const exits = sectionExitMarks(
+    canonical,
+    page,
+    secs.map((s) => s.start),
+    tp,
+    yeru,
+  );
+  return {
+    page,
+    nextPage,
+    sections: secs.map((s, i) => ({
+      index: i,
+      title: s.title || `Section ${i + 1}`,
+      rabbis: s.rabbis,
+      exits: exits[i] ?? [],
+    })),
+    flow,
+    cross: cross?.edges ?? [],
+    // A cached cross-flow (even zero edges = genuinely no link) means computed;
+    // null = still cold. Lets the client show "not connected yet" vs "no link".
+    crossComputed: cross != null,
+    parallelsComputed: tp != null,
+    continues: bridge?.continues === true,
+  };
+}
+type SpineViewDaf = Awaited<ReturnType<typeof buildSpineViewDaf>>;
+
+// The LIVE (un-shelved) whole-tractate spine view: gate the per-daf fan-out onto
+// dapim that have an argument mark (cheap computeCoverage key-presence sweep),
+// bound at SPINE_VIEW_MAX_DAPIM so a fully-warmed tractate can't blow the
+// subrequest limit, and assemble. The fallback path when the cron shelf isn't
+// warmed yet; the cron's incremental builder shares buildSpineViewDaf.
+async function buildSpineView(
+  env: Bindings,
+  tractate: string,
+): Promise<{ tractate: string; dapim: SpineViewDaf[]; truncated: boolean }> {
+  const cache = env.CACHE;
+  if (!cache) return { tractate, dapim: [], truncated: false };
+  const canonical = canonicalTractateName(tractate);
+  const pages = [...iterAmudim(tractate)];
+  const nextOf = new Map(pages.map((p, i) => [p, pages[i + 1] ?? null] as const));
+  const cov = await computeCoverage(cache, tractate).catch(() => null);
+  const warmed = cov ? new Set(cov.rows.filter((r) => r.cells.argument).map((r) => r.page)) : null;
+  const withSections = warmed ? pages.filter((p) => warmed.has(p)) : pages;
+  const truncated = withSections.length > SPINE_VIEW_MAX_DAPIM;
+  const sweep = truncated ? withSections.slice(0, SPINE_VIEW_MAX_DAPIM) : withSections;
+  const dapim = await mapPool(sweep, 24, (page) =>
+    buildSpineViewDaf(env, tractate, page, canonical, nextOf.get(page) ?? null),
+  );
+  return { tractate, dapim: dapim.filter((d) => d.sections.length > 0), truncated };
+}
 
 app.get('/api/spine-view/:tractate', async (c) => {
   const tractate = c.req.param('tractate');
   if (!isKnownTractate(tractate)) return c.json({ error: `unknown tractate: ${tractate}` }, 404);
   if (!c.env.CACHE) return c.json({ error: 'no CACHE binding in this environment' }, 503);
-  // The route param is a lowercase slug; the parallel / yerushalmi bundles are
-  // keyed by the Sefaria-canonical tractate name the reader/API wrote them under
-  // (raw case, unlike the slugDaf-folded mark/flow/bridge keys), so resolve it or
-  // the read-only bundle reads cold-miss everything.
-  const canonical = canonicalTractateName(tractate);
-  const pages = [...iterAmudim(tractate)];
-  const nextOf = new Map(pages.map((p, i) => [p, pages[i + 1] ?? null] as const));
-  // Gate the per-daf fan-out onto dapim that ACTUALLY have an argument mark
-  // (sections). Reading every cold amud blows the 1000-subrequest limit — the
-  // route 500s and the flow panel never renders. computeCoverage is a cheap
-  // key-presence sweep (a handful of KV `list`s); cold dapim are skipped (they
-  // have no sections and would be dropped below anyway). On a probe failure, fall
-  // back to all pages (best-effort).
-  const cov = await computeCoverage(c.env.CACHE, tractate).catch(() => null);
-  const warmed = cov ? new Set(cov.rows.filter((r) => r.cells.argument).map((r) => r.page)) : null;
-  const withSections = warmed ? pages.filter((p) => warmed.has(p)) : pages;
-  const truncated = withSections.length > SPINE_VIEW_MAX_DAPIM;
-  const sweep = truncated ? withSections.slice(0, SPINE_VIEW_MAX_DAPIM) : withSections;
-  const raw = await mapPool(sweep, 24, async (page) => {
-    const secs = await readSectionRabbis(c.env, tractate, page);
-    const flow = await readFlowConnections(c.env, tractate, page);
-    const cross = await readCachedCrossFlow(c.env, tractate, page);
-    const bridge = await readCachedBridge(c.env, tractate, page);
-    // Cross-text parallels (off-tractate / Yerushalmi), read-only, grouped to the
-    // section they leave from — rendered as exit markers in the flow graph.
-    const tp = await readCachedTalmudParallels(c.env.CACHE, canonical, page);
-    const yeru = await readCachedYerushalmi(c.env.CACHE, canonical, page);
-    const exits = sectionExitMarks(
-      canonical,
-      page,
-      secs.map((s) => s.start),
-      tp,
-      yeru,
-    );
-    return {
-      page,
-      sections: secs.map((s, i) => ({
-        index: i,
-        title: s.title || `Section ${i + 1}`,
-        rabbis: s.rabbis,
-        exits: exits[i] ?? [],
-      })),
-      flow,
-      cross: cross?.edges ?? [],
-      // Has this daf's cross-daf link been computed yet? A cached cross-flow
-      // (even with zero edges = genuinely no link) means computed; null means
-      // still cold (not yet warmed). Lets the client distinguish "no link" from
-      // "not connected yet" and surface the gaps.
-      crossComputed: cross != null,
-      // Same distinction for cross-text parallels: the bundle is cached (an array,
-      // even empty = checked-and-none) vs never computed (null). false → the spine
-      // shows a "parallels not computed yet" marker instead of silently nothing.
-      parallelsComputed: tp != null,
-      // deterministic daf-continuity: does the sugya carry into the next daf?
-      continues: bridge?.continues === true,
-    };
-  });
-  // nextPage = the adjacent amud (iterAmudim order, via nextOf since `sweep` is a
-  // gated subset of `pages`), so cross-daf + continuity edges have a target daf.
-  const dapim = raw.map((d) => ({ ...d, nextPage: nextOf.get(d.page) ?? null }));
-  // Only dapim that actually have sections (a flow graph needs nodes). `truncated`
-  // tells the client the sweep was bounded (more warmed dapim exist than shown).
-  return c.json({ tractate, dapim: dapim.filter((d) => d.sections.length > 0), truncated });
+  // The cron materializes a per-tractate snapshot shelf (O(1), un-bounded). The
+  // client requests ?cached=1; serve the shelf on a hit, else fall back to the
+  // bounded live build (correct before the shelf is first warmed).
+  if (c.req.query('cached') === '1') {
+    const snap = await c.env.CACHE.get(keyForSpineView(tractate));
+    if (snap) return c.json({ ...JSON.parse(snap), fromShelf: true });
+  }
+  return c.json(await buildSpineView(c.env, tractate));
 });
+
+// Incremental per-tractate spine-view snapshot builder — the cron payoff. A full
+// warm of a large tractate (~170 amudim × ~12 KV reads) exceeds the 1000-subrequest
+// cap, so each tick builds a WINDOW of warmed dapim, RMW-merges it into a
+// per-tractate accumulator (overwrite-by-page → idempotent; cron ticks are serial,
+// so the RMW is safe), and PUBLISHES the sorted snapshot to the shelf at
+// end-of-tractate-pass. A perpetual wrapping cursor re-derives every tractate each
+// pass, so newly-warmed dapim + human edits flow in on the next lap. Gated by
+// SPINE_VIEW_WARM_SHAS.
+const SPINE_VIEW_CURSOR_KEY = 'spine-view-cursor:v1';
+const SPINE_VIEW_WINDOW = 20; // warmed dapim built per tick (~240 KV reads)
+interface SpineViewCursor {
+  tractateIdx: number;
+  amudIdx: number; // index into the WARMED-pages list of the current tractate
+  wraps: number;
+}
+async function runSpineViewSnapshot(env: Bindings): Promise<void> {
+  const cache = env.CACHE;
+  if (!cache || env.SPINE_VIEW_WARM_SHAS !== '1') return;
+  const tractates = Object.keys(TRACTATE_END_AMUD);
+  if (tractates.length === 0) return;
+  try {
+    let cur: SpineViewCursor = { tractateIdx: 0, amudIdx: 0, wraps: 0 };
+    const raw = await cache.get(SPINE_VIEW_CURSOR_KEY);
+    if (raw) {
+      try {
+        cur = JSON.parse(raw) as SpineViewCursor;
+      } catch {
+        /* reset */
+      }
+    }
+    let { tractateIdx, amudIdx, wraps } = cur;
+    if (tractateIdx >= tractates.length) {
+      tractateIdx = 0;
+      amudIdx = 0;
+    }
+    const tractate = tractates[tractateIdx];
+    const pages = [...iterAmudim(tractate)];
+    const order = new Map(pages.map((p, i) => [p, i] as const));
+    const nextOf = new Map(pages.map((p, i) => [p, pages[i + 1] ?? null] as const));
+    const canonical = canonicalTractateName(tractate);
+    const cov = await computeCoverage(cache, tractate).catch(() => null);
+    const warmed = cov
+      ? new Set(cov.rows.filter((r) => r.cells.argument).map((r) => r.page))
+      : null;
+    const warmedPages = warmed ? pages.filter((p) => warmed.has(p)) : [];
+
+    const accKey = keyForSpineViewAcc(tractate);
+    let acc: Record<string, SpineViewDaf> = {};
+    const accRaw = await cache.get(accKey);
+    if (accRaw) {
+      try {
+        acc = JSON.parse(accRaw) as Record<string, SpineViewDaf>;
+      } catch {
+        acc = {};
+      }
+    }
+
+    const window = warmedPages.slice(amudIdx, amudIdx + SPINE_VIEW_WINDOW);
+    if (window.length > 0) {
+      const built = await mapPool(window, 24, (page) =>
+        buildSpineViewDaf(env, tractate, page, canonical, nextOf.get(page) ?? null),
+      );
+      for (const d of built) if (d.sections.length > 0) acc[d.page] = d;
+      await cache.put(accKey, JSON.stringify(acc));
+      amudIdx += window.length;
+    }
+
+    if (amudIdx >= warmedPages.length) {
+      // Tractate pass complete → publish the shelf (only when there is content),
+      // clear the accumulator, advance to the next tractate (wrap at end-of-Shas).
+      const dapim = Object.values(acc).sort(
+        (a, b) => (order.get(a.page) ?? 0) - (order.get(b.page) ?? 0),
+      );
+      if (dapim.length > 0) {
+        const shelf = {
+          tractate,
+          dapim,
+          truncated: false,
+          builtAt: Date.now(),
+          coverage: { dapimWithSections: dapim.length, dapimTotal: pages.length },
+        };
+        await cache.put(keyForSpineView(tractate), JSON.stringify(shelf));
+      }
+      await cache.delete(accKey).catch(() => {});
+      tractateIdx++;
+      amudIdx = 0;
+      if (tractateIdx >= tractates.length) {
+        tractateIdx = 0;
+        wraps++;
+      }
+    }
+    await cache.put(SPINE_VIEW_CURSOR_KEY, JSON.stringify({ tractateIdx, amudIdx, wraps }));
+  } catch (err) {
+    console.error('[spine-view-snapshot] tick failed:', err);
+  }
+}
 
 // On-demand compute (or cache hit) of one daf's cross-daf flow, returned both as
 // the raw verdict and projected to coordinate-resolved links. Mirrors /api/bridge.
@@ -10571,6 +10687,9 @@ export default {
             // makes a little progress), then the source warm cron uses the rest.
             await runConnectSweep(wrapped).catch(() => {});
             await runWarmCron(wrapped);
+            // Last (and self-gated by SPINE_VIEW_WARM_SHAS): build a window of the
+            // per-tractate spine-view snapshot shelf from the now-warmed pieces.
+            await runSpineViewSnapshot(wrapped);
           },
         ),
       );

--- a/packages/talmud/src/worker/types.ts
+++ b/packages/talmud/src/worker/types.ts
@@ -65,6 +65,9 @@ export interface Bindings {
   // When '1', the background Sefaria Shas walk also enqueues rabbi.observations
   // per amud (full reverse-index backfill). OFF by default — see WarmEnv.
   OBSERVATIONS_WARM_SHAS?: string;
+  // When '1', the warm-cron incrementally builds the per-tractate spine-view
+  // snapshot shelf (a window of warmed dapim per tick). OFF by default.
+  SPINE_VIEW_WARM_SHAS?: string;
   // Dynamic Worker Loader binding (wrangler.toml `worker_loaders`). Spins up the
   // isolated sandbox the code-mode MCP `execute` tool runs in. Optional: when
   // unset, GET/POST /mcp returns 503 and the rest of the worker is unaffected.

--- a/packages/talmud/tests/source-cache-keys.test.ts
+++ b/packages/talmud/tests/source-cache-keys.test.ts
@@ -29,6 +29,9 @@ import {
   keyForSaCommentary,
   keyForSefariaBundle,
   keyForSefariaSegments,
+  keyForSpineLinks,
+  keyForSpineView,
+  keyForSpineViewAcc,
   keyForTalmudParallels,
   keyForTranslate,
   keyForYerushalmi,
@@ -127,5 +130,11 @@ describe('content + rabbi caches — byte-exact contract', () => {
     expect(keyForRabbiObs('abaye', 'berakhot:2a')).toBe('rabbi-obs:v1:abaye:berakhot:2a');
     expect(keyForRabbiObsDirty('abaye')).toBe('rabbi-obs-dirty:v1:abaye');
     expect(prefixForRabbiObs('abaye')).toBe('rabbi-obs:v1:abaye:');
+  });
+  it('spine tractate shelves: slug-normalised, tractate-only', () => {
+    expect(keyForSpineLinks('Berakhot')).toBe('spine-links:v1:berakhot');
+    expect(keyForSpineView('Berakhot')).toBe('spine-view:v1:berakhot');
+    expect(keyForSpineView('Bava Kamma')).toBe('spine-view:v1:bava_kamma');
+    expect(keyForSpineViewAcc('Bava Kamma')).toBe('spine-view-acc:v1:bava_kamma');
   });
 });

--- a/packages/talmud/wrangler.toml
+++ b/packages/talmud/wrangler.toml
@@ -74,6 +74,12 @@ OBSERVATIONS_WARM_SHAS = "1"
 # emails. A no-op once latched. To re-run, delete the dafyomi-warm-cursor:v1 KV
 # key. Feeds study notes + poskim into the halacha cards Shas-wide.
 DAFYOMI_WARM_SHAS = "1"
+# When "1", the warm cron incrementally materializes the per-tractate spine-view
+# snapshot shelf (spine-view:v1:{tractate}) — a window of warmed dapim per tick,
+# published at end-of-tractate-pass — so GET /api/spine-view?cached=1 serves the
+# whole tractate's flow graph in one KV get (O(1), no 60-daf bound). Perpetual:
+# each pass re-derives from current pieces. To reset, delete spine-view-cursor:v1.
+SPINE_VIEW_WARM_SHAS = "1"
 # Zone ids for the Usage-page activity tracker. Not secret. COMMA-SEPARATED:
 # the app is served on two zones (shaunregenbaum.com + talmud.dev) and
 # src/worker/cf-zone-analytics.ts queries each, then merges the daily rows so


### PR DESCRIPTION
The #spine flow panel rebuilt the whole-tractate graph **live on every load** (~700 KV reads, ~7s) and was **bounded to 60 dapim**. This makes it a precomputed per-tractate snapshot served in **one KV get** — the deferred follow-up from the last spine PR.

### Design (two-layer, incremental)
A full warm of a large tractate (~170 amudim × ~12 KV reads) exceeds Cloudflare's 1000-subrequest cap, so the build is incremental:
- **Accumulator** (`spine-view-acc:v1:{slug}`, a `Record<page, node>`) the cron RMW-merges one window at a time — idempotent overwrite-by-page; cron ticks are serial, so the RMW is safe.
- **Shelf** (`spine-view:v1:{slug}`) published atomically at end-of-tractate-pass, so readers never see a half-built tractate.

### Changes
- `keyForSpineView` / `keyForSpineViewAcc` (mirroring `keyForSpineLinks`), **locked byte-exact** in `source-cache-keys.test.ts` (+ backfilled the missing `keyForSpineLinks` assertion).
- Extracted `buildSpineViewDaf` + `buildSpineView` so the live route and the cron share **one** code path. The route gains a `?cached=1` branch: hit → O(1) un-bounded shelf; miss → today's bounded live build (correct before the shelf is first warmed).
- `runSpineViewSnapshot`: a perpetual-cursor warm-cron phase (gated `SPINE_VIEW_WARM_SHAS`, ~W=20 dapim/tick) hooked into the scheduled handler after `runWarmCron`, try/catch-isolated. The wrapping cursor re-derives every tractate each pass, so newly-warmed dapim + human edits flow in automatically (no content-hash needed).
- Client requests `?cached=1` and shows a "snapshot Nm old" caption.

`SPINE_VIEW_WARM_SHAS="1"` is set, so the shelf starts building on deploy; each tractate's shelf publishes once the cursor finishes its warmed dapim (berakhot ≈ a handful of ticks). The budget is safe (W=20 ≈ 240 reads, shared with the Sefaria phase ~60-120 + connect ~100, well under 1000); I'll confirm on prod logs post-deploy.

Full suite green (core 103 + talmud 2427), `biome ci` clean, typecheck clean across all three packages.