### PR TITLE
build-rabbi-places.py: preserve provenance-stamped entries across regen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ Thumbs.db
 .idea/
 *.swp
 *.swo
+__pycache__/

--- a/packages/talmud/scripts/build-rabbi-places.py
+++ b/packages/talmud/scripts/build-rabbi-places.py
@@ -238,6 +238,33 @@ def main() -> int:
         else:
             print(f'  [warn] GENERATION_OVERRIDES: slug {slug!r} not in dataset, skipping')
 
+    # Preserve manual / AI-researched additions across regens. Any entry in the
+    # PREVIOUS output that carries a `provenance` field did NOT come from this
+    # Sefaria scrape (e.g. sages absent from Sefaria's PersonTopic export, added
+    # by the 2026-06 backlog research). Without this, `rebuild-rabbi-places`
+    # would silently drop them. Re-merge such entries (and their aliases) unless
+    # the scrape now produces the same slug. `add_alias` is first-wins, so a
+    # scraped alias mapping is never clobbered.
+    if OUT_PATH.exists():
+        try:
+            prev = json.loads(OUT_PATH.read_text())
+        except (json.JSONDecodeError, OSError):
+            prev = None
+        if isinstance(prev, dict) and isinstance(prev.get('rabbis'), dict):
+            kept = 0
+            for slug, entry in prev['rabbis'].items():
+                if not isinstance(entry, dict) or not entry.get('provenance'):
+                    continue  # only preserve non-scrape (provenance-stamped) entries
+                if slug in entries:
+                    continue  # the scrape now covers this slug — let it win
+                entries[slug] = entry
+                for a in entry.get('aliases', []):
+                    add_alias(a, slug)
+                add_alias(slug.replace('-', ' '), slug)
+                kept += 1
+            if kept:
+                print(f'  preserved {kept} provenance-stamped (manual/AI-researched) entries from the previous build')
+
     out = {
         'generatedAt': time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime()),
         'source': 'https://www.sefaria.org/api/topics?type=person',


### PR DESCRIPTION
## What

Closes the regen risk flagged in #415. That PR added 33 AI-researched sages to `rabbi-places.json`, but `build-rabbi-places.py` regenerates the file from Sefaria with no manual-additions hook — so the next `rebuild-rabbi-places` would silently drop them.

## Fix

Before writing the output, re-merge any entry from the **previous** output that carries a `provenance` field (i.e. did not come from this Sefaria scrape) — unless the scrape now produces the same slug, in which case the fresh scrape wins. Aliases are re-added via the first-wins `add_alias`, so a scraped mapping is never clobbered. Keyed entirely off the `provenance` field, so it generalizes to any future manual/AI additions.

## Verification

Simulated a fresh scrape missing the 33 → ran the preserve step → all 33 restored with provenance + aliases intact (`1301 → 1334`). `py_compile` clean; biome clean. (Couldn't run the live Sefaria scrape here — network — but the merge logic is pure and tested by simulation.)

Codex review skipped (workspace out of credits).