### PR TITLE
Overview map: expand a section's statement spine on map-node click

### DIFF
--- a/packages/talmud/src/client/ArgumentSidebar.tsx
+++ b/packages/talmud/src/client/ArgumentSidebar.tsx
@@ -1200,23 +1200,31 @@ function ArgumentOverviewMaps(props: SpecialBlockProps): JSX.Element {
           {(grp) => {
             const hasFirst = grp.includes(0);
             const hasLast = grp.includes(sections().length - 1);
-            const grpNodes = grp.map((i) => ({
-              index: i,
-              title: sections()[i].title,
-              exits: sectionExits()?.[sections()[i].startSegIdx ?? -1] ?? [],
-              // The focused section carries its statement spine, rendered as
-              // nested sub-nodes under the node (the in-map drill-in) + its edges
-              // (response threads + opposition bracket) drawn between them.
-              statements: i === focused() ? focusedSpine()?.spine.nodes : undefined,
-              statementLinks: i === focused() ? focusedSpine()?.spine.links : undefined,
-            }));
+            // A MEMO, not a static const: the focused section's `statements`
+            // depend on focused() + focusedSpine(), which change AFTER this group
+            // first renders (a map-node click only changes focus, not groups()).
+            // Baking grpNodes once froze `statements` to the focus at mount, so
+            // clicking a different node highlighted it (activeIndex is reactive)
+            // but never expanded its spine. The memo re-bakes on focus change.
+            const grpNodes = createMemo(() =>
+              grp.map((i) => ({
+                index: i,
+                title: sections()[i].title,
+                exits: sectionExits()?.[sections()[i].startSegIdx ?? -1] ?? [],
+                // The focused section carries its statement spine, rendered as
+                // nested sub-nodes under the node (the in-map drill-in) + its edges
+                // (response threads + opposition bracket) drawn between them.
+                statements: i === focused() ? focusedSpine()?.spine.nodes : undefined,
+                statementLinks: i === focused() ? focusedSpine()?.spine.links : undefined,
+              })),
+            );
             return (
               <div style={{ 'margin-bottom': '0.7rem' }}>
                 <Show when={hasFirst && bridge()?.fromPrev}>
                   {crossLabel(t('overview.continuesFrom', { page: pageRef(bridge()!.prev) }))}
                 </Show>
                 <ArgumentFlowGraph
-                  nodes={grpNodes}
+                  nodes={grpNodes()}
                   connections={connections()}
                   activeIndex={focused()}
                   onSelect={setFocused}


### PR DESCRIPTION
## Bug

In the whole-daf **Overview** map, clicking a section node **highlighted** it (red border) but did **not** expand its statement sub-nodes. The drill-in only worked when arriving via a reader **gutter anchor**, and even then flakily.

## Cause

`grpNodes` (the node array handed to `ArgumentFlowGraph`) was a **static const** computed once when its sugya group first rendered. `activeIndex={focused()}` is a reactive prop — so the node highlighted on click — but `nodes={grpNodes}` was frozen. Each node's `statements` field was baked to whatever `focused()` was at group-render time, so clicking a *different* node never gave it statements.

- The **anchor path "worked"** because focus is already set at mount, so the group bakes statements for that section.
- It was **flaky** because `groups()` recomputing (e.g. when the flow connections load and merge sugyot) re-runs the child and re-bakes `grpNodes` with the *current* focus — so it sometimes caught up.

## Fix

Make `grpNodes` a `createMemo` so it re-bakes whenever `focused()` / `focusedSpine()` change, and pass `nodes={grpNodes()}`. Map-node clicks now expand the right section's spine every time.

(Companion to #418, which decoupled the map's *appearance* from the synthesis prose. This fixes the *drill-in* on click.)

## Checks

`pnpm typecheck`, `pnpm lint` (Biome), full suite (2446 tests) — all green; module transforms clean on the dev server.