### PR TITLE
tanach: fix word translation, show Hebrew originals in sources, dismiss gloss popup

### DIFF
--- a/packages/tanach/src/client/App.tsx
+++ b/packages/tanach/src/client/App.tsx
@@ -425,7 +425,23 @@ export function App(): JSX.Element {
   onMount(() => {
     const clear = () => setWordSel(null);
     window.addEventListener('scroll', clear, { passive: true });
-    onCleanup(() => window.removeEventListener('scroll', clear));
+    // Dismiss the gloss popup on click-away or Escape. A fresh selection still
+    // works: the mousedown clears the old popup, the following mouseup
+    // (onTextSelect) opens a new one for the new selection.
+    const onPointerDown = (e: MouseEvent) => {
+      if ((e.target as HTMLElement | null)?.closest('.xlate-pop')) return;
+      setWordSel(null);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setWordSel(null);
+    };
+    window.addEventListener('mousedown', onPointerDown);
+    window.addEventListener('keydown', onKey);
+    onCleanup(() => {
+      window.removeEventListener('scroll', clear);
+      window.removeEventListener('mousedown', onPointerDown);
+      window.removeEventListener('keydown', onKey);
+    });
   });
   createEffect(() => {
     chapterKey();
@@ -796,7 +812,10 @@ export function App(): JSX.Element {
                       fallback={<p class="comm-muted">No commentary on this verse.</p>}
                     >
                       {(cm) => {
-                        const useEn = loc().lang === 'en' && cm.enText.length > 0;
+                        // The rishonim themselves always show in the Hebrew /
+                        // Aramaic original (the English is a weak translation);
+                        // fall back to English only when no Hebrew is available.
+                        const useEn = cm.he.length === 0;
                         return (
                           <section class="comm-entry">
                             <h4 class="comm-name">{loc().lang === 'he' ? cm.heName : cm.en}</h4>
@@ -818,13 +837,7 @@ export function App(): JSX.Element {
                   <p class="comm-muted">Finding Talmud passages…</p>
                 </Show>
                 <Show when={gemara()}>
-                  {(g) => (
-                    <PassageList
-                      passages={g().passages}
-                      lang={loc().lang}
-                      empty="Not cited in the Talmud."
-                    />
-                  )}
+                  {(g) => <PassageList passages={g().passages} empty="Not cited in the Talmud." />}
                 </Show>
               </Show>
 
@@ -849,11 +862,7 @@ export function App(): JSX.Element {
                 </Show>
                 <Show when={midrash()}>
                   {(md) => (
-                    <PassageList
-                      passages={md().passages}
-                      lang={loc().lang}
-                      empty="No midrash on this verse."
-                    />
+                    <PassageList passages={md().passages} empty="No midrash on this verse." />
                   )}
                 </Show>
               </Show>
@@ -867,14 +876,15 @@ export function App(): JSX.Element {
 
 function PassageList(props: {
   passages: { ref: string; he: string; en: string }[];
-  lang: 'en' | 'he';
   empty: string;
 }): JSX.Element {
   return (
     <For each={props.passages} fallback={<p class="comm-muted">{props.empty}</p>}>
       {(p) => {
-        const text = props.lang === 'en' ? p.en || p.he : p.he || p.en;
-        const ltr = props.lang === 'en' && !!p.en;
+        // Source passages (Gemara / Midrash) always show the Hebrew / Aramaic
+        // original; fall back to English only when Sefaria has no Hebrew text.
+        const text = p.he || p.en;
+        const ltr = !p.he && !!p.en;
         return (
           <div class="gem-entry">
             <a

--- a/packages/tanach/src/worker/producers/translate.ts
+++ b/packages/tanach/src/worker/producers/translate.ts
@@ -48,6 +48,38 @@ export const TRANSLATE_SCHEMA = {
   },
 };
 
+/**
+ * The gloss is a single short phrase, so we ask for plain text rather than a
+ * strict json_schema — the cheap Flash model behind this route does not reliably
+ * honour strict structured output and was silently returning unparseable content
+ * (empty -> 502 "No translation" on every lookup). Tolerate every shape we might
+ * still get back: plain text, a markdown code fence, a raw JSON object, or a
+ * quoted string, so a well-formed answer is never dropped on the floor.
+ */
+function extractGloss(raw: string): string {
+  let s = (raw ?? '').trim();
+  if (!s) return '';
+  // Strip a leading/trailing markdown code fence.
+  s = s
+    .replace(/^```(?:json)?\s*/i, '')
+    .replace(/\s*```$/, '')
+    .trim();
+  // If the model wrapped it as {"translation": "..."}, pull the field out.
+  if (s.startsWith('{')) {
+    try {
+      const obj = JSON.parse(s) as { translation?: unknown };
+      if (typeof obj.translation === 'string') s = obj.translation;
+    } catch {
+      /* not JSON after all; fall through to the raw text */
+    }
+  }
+  // Drop surrounding quotes the model sometimes adds, and collapse whitespace.
+  return s
+    .replace(/^["']+|["']+$/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
 export async function translateHebrew(
   env: LLMEnv,
   q: string,
@@ -60,18 +92,10 @@ export async function translateHebrew(
     ],
     max_tokens: 120,
     temperature: 0.2,
-    response_format: { type: 'json_schema', json_schema: TRANSLATE_SCHEMA },
     tag: 'tanach:translate',
   });
 
-  let translation = '';
-  try {
-    translation = String(
-      (JSON.parse(res.content) as { translation?: string }).translation ?? '',
-    ).trim();
-  } catch {
-    /* leave empty */
-  }
+  const translation = extractGloss(res.content);
 
   return {
     translation,


### PR DESCRIPTION
Three reader-facing fixes in the Tanach app (tanach.shaunregenbaum.com).

## 1. Word translation almost always returned nothing
The `/api/translate` producer asked the cheap DeepSeek Flash model for strict `json_schema` output, which that endpoint does not reliably honour. `JSON.parse(res.content)` failed, `translation` came back empty, and the route 502'd with `{"error":"No translation"}` on every lookup (confirmed live).

Fix: request **plain text** (a gloss is one short phrase — no structure to preserve) and parse tolerantly via `extractGloss`, which handles plain text, markdown code fences, a raw `{"translation": "..."}` object, and quoted strings. `TRANSLATE_SCHEMA` stays exported for the registry def.

## 2. Rishonim / Gemara / Midrash source lists showed English
Source texts (the commentators themselves, Talmud and Midrash passages) rendered Sefaria's weak English translation when the UI was in English mode. They now **always show the Hebrew/Aramaic original**, falling back to English only when Sefaria has no Hebrew for that ref. Our own AI synthesis still follows the language toggle. Removed the now-unused `lang` prop from `PassageList`.

## 3. The translation gloss popup never dismissed
Added click-away (`mousedown` outside `.xlate-pop`) and `Escape` handlers. A fresh text selection still opens a new gloss (the mousedown clears the old popup, the following mouseup opens a new one).

## Verification
`pnpm typecheck`, `pnpm lint` (biome), and `pnpm test` (2591 tests) all pass. Translation output will be re-verified live against the prod endpoint after deploy.