### PR TITLE
Overview map: fix statement-node side-label overflow + latch map readiness

### DIFF
--- a/packages/talmud/src/client/ArgumentFlowGraph.tsx
+++ b/packages/talmud/src/client/ArgumentFlowGraph.tsx
@@ -359,10 +359,16 @@ export function StatementBand(props: {
           const pick = () => props.onSelect?.(s.id);
           const roleLabel = s.role.toUpperCase();
           const roleW = roleLabel.length * 6 + 13;
-          const speakerBudget = Math.max(
-            3,
-            Math.floor((swNode - 14 - roleW - (s.side ? 14 : 8) - 6) / 6),
-          );
+          // `side` is a grouping tag — usually a letter (A/B/…) but legitimately a
+          // word too ("support-A", see STMT_SIDE_COLOR). It used to render CENTRED
+          // on the node's right edge, so a multi-char side spilled past it into the
+          // lane gutter. Fix: right-anchor it INSIDE the node (so it can never
+          // overflow), reserve its REAL width from the speaker budget (so it can't
+          // collide with the speaker), and only ellipsize a pathologically long one.
+          const sideRaw = s.side ?? '';
+          const sideText = sideRaw.length > 12 ? `${sideRaw.slice(0, 11)}…` : sideRaw;
+          const sideW = sideText ? sideText.length * 6 + 12 : 4;
+          const speakerBudget = Math.max(3, Math.floor((swNode - 13 - roleW - sideW - 6) / 6));
           const speakerText =
             (s.speaker || '').length > speakerBudget
               ? `${(s.speaker || '').slice(0, speakerBudget - 1)}…`
@@ -430,18 +436,19 @@ export function StatementBand(props: {
                 <title>{s.speaker || ''}</title>
                 {speakerText}
               </text>
-              <Show when={s.side}>
+              <Show when={sideText}>
                 <text
-                  x={sx + swNode - 9}
+                  x={sx + swNode - 8}
                   y={top() + sh / 2}
-                  text-anchor="middle"
+                  text-anchor="end"
                   dominant-baseline="central"
                   font-size="9.5"
                   font-weight="700"
                   font-family={STMT_FONT}
                   fill={STMT_SIDE_COLOR[s.side ?? ''] ?? '#888'}
                 >
-                  {s.side}
+                  <title>{sideRaw}</title>
+                  {sideText}
                 </text>
               </Show>
             </g>

--- a/packages/talmud/src/client/ArgumentSidebar.tsx
+++ b/packages/talmud/src/client/ArgumentSidebar.tsx
@@ -976,6 +976,23 @@ function ArgumentOverviewMaps(props: SpecialBlockProps): JSX.Element {
   // miss/error) — either way the map should stop waiting and render.
   const flowResolved = (): boolean => flowRun.state === 'ready';
 
+  // Once the maps have rendered for THIS daf, never flicker back to the
+  // "Mapping the discussion…" spinner mid-interaction: a transient resource
+  // refresh (e.g. flowRun briefly leaving 'ready' while the synthesis is still
+  // pending, so the gate momentarily has neither input) must not re-hide a map
+  // the reader is already using. Latch readiness per daf-key; it resets when the
+  // daf or language actually changes (where a fresh load IS wanted).
+  const dafKey = (): string => `${props.tractate}|${props.page}|${lang()}`;
+  const [readyKey, setReadyKey] = createSignal<string | null>(null);
+  createEffect(() => {
+    if (mapsState(sections().length, props.synthesisResolved || flowResolved()) === 'ready') {
+      setReadyKey(dafKey());
+    }
+  });
+  const mapsReady = (): boolean =>
+    readyKey() === dafKey() ||
+    mapsState(sections().length, props.synthesisResolved || flowResolved()) === 'ready';
+
   // The daf-level flow leaf's section connections. Prefer the flow bundled in
   // the synthesis deps (free once the synthesis resolves); otherwise the
   // independently-fetched flow. Empty = a daf that legitimately has no section
@@ -1167,7 +1184,7 @@ function ArgumentOverviewMaps(props: SpecialBlockProps): JSX.Element {
             page break. Until the flow resolves we have no connections, so we
             show a loading state rather than disconnected, link-less nodes. */}
       <Show
-        when={mapsState(sections().length, props.synthesisResolved || flowResolved()) === 'ready'}
+        when={mapsReady()}
         fallback={
           <div
             style={{


### PR DESCRIPTION
Two small map-polish fixes in the statement band (reported on the live site).

## 1. Side-label overflow
A statement node's `side` tag rendered `text-anchor="middle"` at the node's right edge, so a multi-char side — a legitimate value like **`support-A`** (mapped in `STMT_SIDE_COLOR`) — spilled ~18px past the node into the lane gutter, and the speaker budget reserved only 14px for it.

Now: the side is **right-anchored inside** the node (can't overflow the edge), its **real width is reserved** from the speaker budget (can't collide with the speaker), and only a pathologically long side (>12 chars) is ellipsized (full value in a `<title>`).

## 2. Map readiness latch ("stuck reloading")
Once the Overview maps have rendered for a daf, they no longer flicker back to the **"Mapping the discussion…"** spinner mid-interaction. The gate is `synthesisResolved || flowResolved`; when the map showed via the cheap flow alone (synthesis still pending — the common case after #418), any transient that briefly left `flowRun`'s `'ready'` state re-hid the whole map. Now readiness is **latched per daf-key** (`tractate|page|lang`) and only resets when the daf or language actually changes.

(Follow-ups to #418/#419, which decoupled the map from the synthesis prose and fixed click-to-expand.)

## Checks
`pnpm typecheck`, `pnpm lint` (Biome), full suite (2446 tests) — all green.