### PR TITLE
Connect sections the AI flow missed, from the statement dialectic (precision-gated)

### DIFF
--- a/packages/talmud/src/client/ArgumentFlowGraph.tsx
+++ b/packages/talmud/src/client/ArgumentFlowGraph.tsx
@@ -135,7 +135,8 @@ const STMT_REL_AS_LINK: Record<string, FlowConnection['kind']> = {
   cites: 'cites',
   continues: 'continues',
 };
-const stmtRelKind = (rel: string): FlowConnection['kind'] => STMT_REL_AS_LINK[rel] ?? 'continues';
+export const stmtRelKind = (rel: string): FlowConnection['kind'] =>
+  STMT_REL_AS_LINK[rel] ?? 'continues';
 // `supports` (raya / proof) has no section-flow kin — the section vocabulary lacks
 // it (see the deferred note above). So it gets its OWN evidential colour + label
 // rather than the old, direction-REVERSED alias to `depends-on` (evidence-FOR vs

--- a/packages/talmud/src/client/ArgumentSidebar.tsx
+++ b/packages/talmud/src/client/ArgumentSidebar.tsx
@@ -42,7 +42,7 @@ import {
 } from '../lib/typing/statementSpine';
 import type { ArgumentVoicesData } from '../lib/typing/voices';
 import { deriveVoiceEdges } from '../lib/typing/voices';
-import ArgumentFlowGraph, { type FlowConnection } from './ArgumentFlowGraph';
+import ArgumentFlowGraph, { type FlowConnection, stmtRelKind } from './ArgumentFlowGraph';
 import ArgumentNarrative from './ArgumentNarrative';
 import { type BackgroundGroup, orderBackgroundGroups } from './backgroundGroups';
 import { ChartTableView } from './ChartTableView';
@@ -934,6 +934,28 @@ async function fetchOverviewFlow(
   return null;
 }
 
+/** A section→section connection derived deterministically from the statement
+ *  dialectic (GET /api/derived-flow, read-only). Used to CONNECT sections the AI
+ *  flow producer left disconnected — see the endpoint comment. The relation is a
+ *  StatementRelation; the consumer maps it onto a FlowConnection kind. */
+interface DerivedFlowEdge {
+  fromSection: number;
+  toSection: number;
+  relation: string;
+}
+async function fetchDerivedFlow(tractate: string, page: string): Promise<DerivedFlowEdge[]> {
+  try {
+    const r = await fetch(
+      `/api/derived-flow/${encodeURIComponent(tractate)}/${encodeURIComponent(page)}`,
+    );
+    if (!r.ok) return [];
+    const j = (await r.json()) as { derived?: DerivedFlowEdge[] };
+    return Array.isArray(j.derived) ? j.derived : [];
+  } catch {
+    return [];
+  }
+}
+
 // ===========================================================================
 // Whole-daf argument OVERVIEW card — recipe block.
 // ---------------------------------------------------------------------------
@@ -993,16 +1015,39 @@ function ArgumentOverviewMaps(props: SpecialBlockProps): JSX.Element {
     readyKey() === dafKey() ||
     mapsState(sections().length, props.synthesisResolved || flowResolved()) === 'ready';
 
-  // The daf-level flow leaf's section connections. Prefer the flow bundled in
-  // the synthesis deps (free once the synthesis resolves); otherwise the
-  // independently-fetched flow. Empty = a daf that legitimately has no section
-  // edges (see `mapsState`).
+  // Section connections derived from the statement dialectic — they CONNECT the
+  // sections the AI flow producer left disconnected (often all of them on a long
+  // technical sugya). Merged UNDER the AI flow below (AI keeps final say).
+  const [derivedFlow] = createResource(
+    () => `${props.tractate}|${props.page}`,
+    () => fetchDerivedFlow(props.tractate, props.page),
+  );
+
+  // The daf-level flow leaf's section connections. Start from the AI flow — the
+  // bundled-in-synthesis copy (free once it resolves) or the direct fetch — then
+  // ADD the deterministic statement-derived edges for any section pair the AI flow
+  // didn't already cover (AI authoritative; deterministic fills its silence). Empty
+  // = a daf that legitimately has no section edges (see `mapsState`).
   const connections = createMemo<FlowConnection[]>(() => {
     const flow = props.deps['argument-overview.flow'] as
       | { connections?: FlowConnection[] }
       | undefined;
-    if (flow && Array.isArray(flow.connections)) return flow.connections;
-    return flowRun() ?? [];
+    const ai: FlowConnection[] =
+      flow && Array.isArray(flow.connections) ? flow.connections : (flowRun() ?? []);
+    const covered = new Set(ai.map((c) => `${Math.min(c.from, c.to)}|${Math.max(c.from, c.to)}`));
+    const merged = [...ai];
+    for (const d of derivedFlow() ?? []) {
+      const pairKey = `${Math.min(d.fromSection, d.toSection)}|${Math.max(d.fromSection, d.toSection)}`;
+      if (covered.has(pairKey)) continue; // the AI flow already connects this pair
+      covered.add(pairKey);
+      merged.push({
+        from: d.fromSection,
+        to: d.toSection,
+        kind: stmtRelKind(d.relation),
+        note: 'from the statement dialectic',
+      });
+    }
+    return merged;
   });
 
   // The daf's statement spines (one per section), built server-side from the

--- a/packages/talmud/src/lib/typing/statementSpine.ts
+++ b/packages/talmud/src/lib/typing/statementSpine.ts
@@ -30,6 +30,17 @@
  * Pure + DOM-free + env-free → lives in src/lib, unit-tested, and runs on either
  * side (the worker builds it as the canonical artifact the #spine view pulls;
  * the sidebar will later pull the same shape instead of re-deriving three views).
+ *
+ * TWO BUILDERS, same node + link model:
+ *   - `buildStatementSpine`  — PER SECTION (the shipped behaviour). One-slot
+ *     trackers: a move links only to the single most-recent claim / open / question.
+ *   - `buildDafSpine`        — DAF-GLOBAL (the exploration). Walks ALL the daf's
+ *     moves in reading order with a STACK of open moves, so an answer can resolve
+ *     a non-adjacent question and an objection in one section can attach to the
+ *     claim it actually challenges in another. A faint `continues` backbone links
+ *     consecutive moves so nothing floats. This is the render-only ($0) fix for
+ *     technical sugyot whose dialectic is fragmented one-move-per-section, where a
+ *     section-local walk has nothing to connect. See Sandbox/2026-06-16-edge-exploration.
  */
 
 /** The dialectical role of a statement (mirrors the `argument-move` role enum;
@@ -182,19 +193,11 @@ function isOpen(role: string): boolean {
   return role === 'question' || role === 'objection';
 }
 
-/**
- * Fold a section's moves + voices into one statement spine. Pure + deterministic
- * given its inputs (the only non-determinism — the voices graph — is an input,
- * already repaired by `deriveVoiceEdges`). See the file header for the model.
- */
-export function buildStatementSpine(input: {
-  moves: readonly StatementMoveLike[];
-  voices?: VoicesGraphLike | null;
-}): StatementSpine {
-  const { moves, voices } = input;
-
-  // 1. Nodes, in reading order (moveOrder, then segment start, then input order).
-  const nodes: StatementNode[] = moves
+/** Build the statement nodes from a set of moves, in reading order (moveOrder,
+ *  then segment start, then input order). Shared by both builders so they never
+ *  drift on the node shape. */
+function buildStatementNodes(moves: readonly StatementMoveLike[]): StatementNode[] {
+  return moves
     .map((m, i) => {
       const f = m.fields ?? {};
       const order = typeof f.moveOrder === 'number' ? f.moveOrder : i;
@@ -218,59 +221,89 @@ export function buildStatementSpine(input: {
     })
     .sort((a, b) => a.order - b.order || a.startSegIdx - b.startSegIdx || a._i - b._i)
     .map(({ _i, ...n }) => n);
+}
 
-  // 2. Side assignment: a voice's position side ("A"/"B"/…) onto its statements.
-  if (Array.isArray(voices?.voices)) {
-    for (const v of voices.voices) {
-      const name = str(v?.name);
-      const side = str(v?.side);
-      if (!name || !side) continue;
-      for (const n of nodes) if (nodeSpeaksFor(n, name)) n.side = n.side ?? side;
-    }
+/** Assign each voice's position side ("A"/"B"/…) onto the statements it speaks. */
+function applyVoiceSides(nodes: StatementNode[], voices?: VoicesGraphLike | null): void {
+  if (!Array.isArray(voices?.voices)) return;
+  for (const v of voices.voices) {
+    const name = str(v?.name);
+    const side = str(v?.side);
+    if (!name || !side) continue;
+    for (const n of nodes) if (nodeSpeaksFor(n, name)) n.side = n.side ?? side;
   }
+}
 
-  const links: StatementLink[] = [];
+/** Map the voices graph's edges onto statement links via each voice's
+ *  representative statement. `opposes` is gated on BOTH ends being named
+ *  (anti-hallucination). Scoped to `nodes` (the section it belongs to). */
+function applyVoiceEdges(
+  nodes: StatementNode[],
+  voices: VoicesGraphLike | null | undefined,
+  addLink: (l: StatementLink) => void,
+): void {
+  if (!Array.isArray(voices?.edges)) return;
+  for (const e of voices.edges) {
+    const relation = VOICE_TO_STATEMENT[str(e?.kind)];
+    if (!relation) continue;
+    const fromName = str(e?.from);
+    const toName = str(e?.to);
+    if (!fromName || !toName) continue;
+    const fromNode = representativeNode(nodes, fromName);
+    const toNode = representativeNode(nodes, toName);
+    if (!fromNode || !toNode) continue; // voice with no statement here → drop
+    if (relation === 'opposes') {
+      const bothNamed =
+        !isAnonymousVoice(fromName) && !isAnonymousVoice(toName) && fromNode.named && toNode.named;
+      if (!bothNamed) continue;
+    }
+    addLink({ from: fromNode.id, to: toNode.id, relation, source: 'voices' });
+  }
+}
+
+function makeAddLink(links: StatementLink[]): (l: StatementLink) => void {
   const seen = new Set<string>();
-  const addLink = (l: StatementLink): void => {
+  return (l: StatementLink) => {
     if (l.from === l.to) return; // a statement never links to itself
     const key = `${l.from}|${l.to}|${l.relation}`;
     if (seen.has(key)) return;
     seen.add(key);
     links.push(l);
   };
+}
 
-  // 3. Voices overlay FIRST — it is the authoritative signal (the model's actual
-  //    voice analysis), so when it and the deterministic role-rule agree on an
-  //    opposition the voices-sourced link wins the dedup ("AI keeps final say").
-  //    Map each voice edge onto its speakers' representative statements. `opposes`
-  //    is gated on BOTH ends being named (anti-hallucination — a Stam-vs-Stam
-  //    "dispute" is a fabrication and never branches the spine).
-  if (Array.isArray(voices?.edges)) {
-    for (const e of voices.edges) {
-      const relation = VOICE_TO_STATEMENT[str(e?.kind)];
-      if (!relation) continue;
-      const fromName = str(e?.from);
-      const toName = str(e?.to);
-      if (!fromName || !toName) continue;
-      const fromNode = representativeNode(nodes, fromName);
-      const toNode = representativeNode(nodes, toName);
-      if (!fromNode || !toNode) continue; // voice with no statement here → drop
-      if (relation === 'opposes') {
-        const bothNamed =
-          !isAnonymousVoice(fromName) &&
-          !isAnonymousVoice(toName) &&
-          fromNode.named &&
-          toNode.named;
-        if (!bothNamed) continue;
-      }
-      addLink({ from: fromNode.id, to: toNode.id, relation, source: 'voices' });
-    }
-  }
+function computeDispute(nodes: StatementNode[], links: StatementLink[]): boolean {
+  const byId = new Map(nodes.map((n) => [n.id, n]));
+  return links.some(
+    (l) => l.relation === 'opposes' && !!byId.get(l.from)?.named && !!byId.get(l.to)?.named,
+  );
+}
 
-  // 4. Role-derived links (deterministic, no model) fill the gaps the voices
-  //    graph didn't express. Walk in order, tracking the most recent claim and
-  //    the most recent open question/objection. addLink dedupes, so an opposition
-  //    the voices overlay already drew stays voices-sourced.
+/**
+ * Fold a section's moves + voices into one statement spine. Pure + deterministic
+ * given its inputs (the only non-determinism — the voices graph — is an input,
+ * already repaired by `deriveVoiceEdges`). See the file header for the model.
+ *
+ * PER-SECTION (shipped) walk: single-slot trackers — a move links only to the
+ * single most-recent claim / open / question. Unchanged behaviour.
+ */
+export function buildStatementSpine(input: {
+  moves: readonly StatementMoveLike[];
+  voices?: VoicesGraphLike | null;
+}): StatementSpine {
+  const { moves, voices } = input;
+  const nodes = buildStatementNodes(moves);
+  applyVoiceSides(nodes, voices);
+
+  const links: StatementLink[] = [];
+  const addLink = makeAddLink(links);
+
+  // Voices overlay FIRST — the authoritative signal (AI keeps final say); when it
+  // and a deterministic role-rule agree, the voices-sourced link wins the dedup.
+  applyVoiceEdges(nodes, voices, addLink);
+
+  // Role-derived links (deterministic) fill the gaps, tracking the SINGLE most
+  // recent claim / open / question.
   let lastClaim: StatementNode | null = null;
   let lastOpen: StatementNode | null = null;
   let lastQuestion: StatementNode | null = null;
@@ -289,11 +322,206 @@ export function buildStatementSpine(input: {
     if (n.role === 'question') lastQuestion = n;
   }
 
-  // 5. A real מחלוקת = an opposition between two named statements.
-  const byId = new Map(nodes.map((n) => [n.id, n]));
-  const dispute = links.some(
-    (l) => l.relation === 'opposes' && !!byId.get(l.from)?.named && !!byId.get(l.to)?.named,
+  return { nodes, links, dispute: computeDispute(nodes, links) };
+}
+
+/** A daf's section, as `buildDafSpine` consumes it: the section's moves and its
+ *  (already-repaired) voices graph. Voices stay SECTION-scoped — a voice edge only
+ *  maps onto statements within its own section — while the role walk goes global. */
+export interface DafSection {
+  moves: readonly StatementMoveLike[];
+  voices?: VoicesGraphLike | null;
+}
+
+/** Largest segment gap allowed between a move and the antecedent it links to.
+ *  The stack already picks the nearest UNRESOLVED open/claim, which is the real
+ *  precision mechanism; this is a backstop so a long-dead open move on the stack
+ *  can't attract a far-away answer across half the daf (precision over recall —
+ *  a float beats a wrong arrow). Generous: dialectic rarely reaches back further. */
+const MAX_ANTECEDENT_GAP = 14;
+
+/**
+ * DAF-GLOBAL statement spine: the exploration's "whole-page" build. Concatenates
+ * every section's statements into one reading-ordered sequence and walks it with a
+ * STACK of open moves + claims, so:
+ *   - an `answer` responds to the nearest still-open question (possibly several
+ *     moves / sections back), popping it;
+ *   - a `resolution` resolves the nearest still-open question/objection, popping it;
+ *   - an `objection`/`rejection` `opposes` the nearest open claim;
+ *   - `supporting-evidence` `supports` the nearest open claim;
+ *   - a faint `continues` backbone links each move to its predecessor UNLESS a
+ *     typed edge already connects that pair — so nothing floats, but typed edges
+ *     read as the signal.
+ * Voices overlay is applied per section FIRST (authoritative); a typed role edge
+ * never overwrites it. A cross-move antecedent beyond MAX_ANTECEDENT_GAP segments
+ * is skipped (precision backstop). Pure + deterministic.
+ */
+export function buildDafSpine(sections: readonly DafSection[]): StatementSpine {
+  const links: StatementLink[] = [];
+  const addLink = makeAddLink(links);
+
+  // Per-section nodes so the voices overlay scopes correctly, then concatenate.
+  const all: StatementNode[] = [];
+  for (const sec of sections) {
+    const nodes = buildStatementNodes(sec.moves);
+    applyVoiceSides(nodes, sec.voices);
+    applyVoiceEdges(nodes, sec.voices, addLink);
+    all.push(...nodes);
+  }
+  // Global reading order across the whole daf.
+  all.sort(
+    (a, b) => a.startSegIdx - b.startSegIdx || a.endSegIdx - b.endSegIdx || a.order - b.order,
   );
 
-  return { nodes, links, dispute };
+  // The segment gap between two (possibly multi-segment) ranges: 0 if they touch
+  // or overlap, else the distance between their nearest edges. (The earlier
+  // double-Math.abs form was wrong — it rejected adjacent/overlapping ranges.)
+  const withinGap = (a: StatementNode, b: StatementNode): boolean => {
+    const gap =
+      a.startSegIdx > b.endSegIdx
+        ? a.startSegIdx - b.endSegIdx
+        : b.startSegIdx > a.endSegIdx
+          ? b.startSegIdx - a.endSegIdx
+          : 0;
+    return gap <= MAX_ANTECEDENT_GAP;
+  };
+
+  // Stack-based role walk over the whole daf. `openStack` holds unresolved
+  // questions/objections (most-recent last); `claimStack` holds claims.
+  const openStack: StatementNode[] = [];
+  const claimStack: StatementNode[] = [];
+  const popNearest = (
+    stack: StatementNode[],
+    n: StatementNode,
+    pred: (m: StatementNode) => boolean,
+  ): StatementNode | null => {
+    for (let i = stack.length - 1; i >= 0; i--) {
+      if (pred(stack[i]) && withinGap(n, stack[i])) {
+        return stack.splice(i, 1)[0];
+      }
+    }
+    return null;
+  };
+  const peekNearest = (stack: StatementNode[], n: StatementNode): StatementNode | null => {
+    for (let i = stack.length - 1; i >= 0; i--) {
+      if (withinGap(n, stack[i])) return stack[i];
+    }
+    return null;
+  };
+
+  // Abandon any open move OLDER than `kept`: answering/resolving a question means
+  // the discussion has moved past everything before it, so a still-dangling older
+  // question must not be grabbed by a later unit's answer (the parallel-units
+  // false-positive: e.g. bava kamma 3a §5's unanswered "toladah of regel?" question
+  // was being caught by §6's second answer about bor).
+  const dropOlderThan = (kept: StatementNode): void => {
+    for (let i = openStack.length - 1; i >= 0; i--) {
+      if (openStack[i].startSegIdx < kept.startSegIdx) openStack.splice(i, 1);
+    }
+  };
+
+  for (const n of all) {
+    if (n.role === 'answer') {
+      const q = popNearest(openStack, n, (m) => m.role === 'question');
+      if (q) {
+        addLink({ from: n.id, to: q.id, relation: 'responds-to', source: 'role' });
+        dropOlderThan(q);
+      }
+    } else if (n.role === 'resolution') {
+      const o = popNearest(openStack, n, () => true);
+      if (o) addLink({ from: n.id, to: o.id, relation: 'resolves', source: 'role' });
+      // A resolution CLOSES the sub-discussion. Clear both stacks so the next unit
+      // starts fresh — without this, on a "parallel units" sugya (each verse /
+      // category its own objection→answer→resolution) every following objection
+      // mechanically grabbed the PREVIOUS unit's claim and a stale open lingered to
+      // catch a later answer, manufacturing a cascade of false cross-section edges
+      // (the precision audit's dominant failure). Precision over recall.
+      openStack.length = 0;
+      claimStack.length = 0;
+    } else if (n.role === 'objection' || n.role === 'rejection') {
+      const c = peekNearest(claimStack, n);
+      if (c) addLink({ from: n.id, to: c.id, relation: 'opposes', source: 'role' });
+    } else if (n.role === 'supporting-evidence') {
+      const c = peekNearest(claimStack, n);
+      if (c) addLink({ from: n.id, to: c.id, relation: 'supports', source: 'role' });
+    }
+    if (isOpen(n.role)) openStack.push(n);
+    if (isClaim(n.role)) claimStack.push(n);
+  }
+
+  // A typed (non-continues) link already drawn between two nodes, either direction
+  // — so the backbone doesn't double a pair the dialectic already connects. Built
+  // AFTER the role walk so it includes the role-derived links, not just voices.
+  const typedPair = new Set<string>();
+  for (const l of links) {
+    typedPair.add(`${l.from}|${l.to}`);
+    typedPair.add(`${l.to}|${l.from}`);
+  }
+
+  // Continues backbone: consecutive moves, unless a typed edge already links them.
+  for (let i = 1; i < all.length; i++) {
+    const prev = all[i - 1];
+    const cur = all[i];
+    if (typedPair.has(`${cur.id}|${prev.id}`)) continue;
+    addLink({ from: cur.id, to: prev.id, relation: 'continues', source: 'role' });
+  }
+
+  return { nodes: all, links, dispute: computeDispute(all, links) };
+}
+
+/** A daf section with its segment range + index, so cross-section links can be
+ *  attributed back to the sections they connect. */
+export interface DafSectionRanged extends DafSection {
+  index: number;
+  startSegIdx: number;
+  endSegIdx: number;
+}
+
+/** Relations lifted to the section grain. ONLY the question→answer relations
+ *  (`responds-to`) and resolution relations (`resolves`) — these are the ones a
+ *  precision audit found reliable across sections (they consume their antecedent
+ *  off the open-stack, so they can't pile up). Cross-section `opposes` / `supports`
+ *  are DELIBERATELY excluded: on a "parallel units" sugya they fired ~70% false
+ *  (an objection grabbing the previous unit's claim). Revisit once the walk and a
+ *  topical-engagement check make them reliable. `continues` is excluded too (the
+ *  daf order already shows "the next section"). */
+const LIFTED_CROSS_SECTION: ReadonlySet<StatementRelation> = new Set<StatementRelation>([
+  'responds-to',
+  'resolves',
+]);
+
+/** A section→section connection derived from the statement dialectic: a cross-
+ *  section question→answer / resolution link lifted to the section grain. The
+ *  `argument-overview.flow` AI producer often returns NO section edges on a long
+ *  technical sugya even though one section plainly answers/resolves another; these
+ *  deterministic, role-derived edges fill that silence so the map connects the
+ *  boxes instead of showing a disconnected row. Deduped by (fromSection,
+ *  toSection, relation). The consumer maps `relation` onto its FlowConnection kind
+ *  and merges these UNDER the AI flow (AI keeps final say on any pair it covers). */
+export function crossSectionStatementFlow(
+  sections: readonly DafSectionRanged[],
+): { fromSection: number; toSection: number; relation: StatementRelation }[] {
+  const daf = buildDafSpine(sections);
+  const byId = new Map(daf.nodes.map((n) => [n.id, n]));
+  const sectionOf = (id: string): number => {
+    const n = byId.get(id);
+    if (!n) return -1;
+    const hit = sections.find(
+      (s) => n.startSegIdx >= s.startSegIdx && n.startSegIdx <= s.endSegIdx,
+    );
+    return hit ? hit.index : -1;
+  };
+  const out: { fromSection: number; toSection: number; relation: StatementRelation }[] = [];
+  const seen = new Set<string>();
+  for (const l of daf.links) {
+    if (!LIFTED_CROSS_SECTION.has(l.relation)) continue; // only the reliable relations
+    const fromSection = sectionOf(l.from);
+    const toSection = sectionOf(l.to);
+    if (fromSection < 0 || toSection < 0 || fromSection === toSection) continue;
+    const key = `${fromSection}|${toSection}|${l.relation}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ fromSection, toSection, relation: l.relation });
+  }
+  return out;
 }

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -103,7 +103,7 @@ import {
   type TypeProfile,
   type UnitRange,
 } from '../lib/typing/profile';
-import { buildStatementSpine } from '../lib/typing/statementSpine';
+import { buildStatementSpine, crossSectionStatementFlow } from '../lib/typing/statementSpine';
 import { deriveVoiceEdges } from '../lib/typing/voices';
 import {
   alignOutlineToSegments,
@@ -1783,6 +1783,64 @@ app.get('/api/statement-spine/:tractate/:page', async (c) => {
   // every section's spine is empty, show "not computed yet") from a section that
   // legitimately has no sub-statements. Without it an empty band reads as broken.
   return c.json({ tractate, page, sections: out, movesComputed: allMoves.length > 0 });
+});
+
+// Deterministic section→section connections derived from the STATEMENT dialectic
+// (read-only, no compute). The `argument-overview.flow` AI producer frequently
+// returns NO edges on a long technical sugya even when its sections plainly answer
+// / object to one another (e.g. Pesachim 2a: 0 AI edges, yet a 6-link kushya-terutz
+// chain). `crossSectionStatementFlow` lifts the daf-global statement walk's typed
+// cross-section links to the section grain, so the Overview map can connect the
+// boxes the AI flow left disconnected. The client merges these UNDER the AI flow
+// (AI keeps final say on any pair it already covers). Cheap: reads cached
+// argument-move + argument.voices, builds the spine in-process, no LLM, no write.
+app.get('/api/derived-flow/:tractate/:page', async (c) => {
+  const tractate = c.req.param('tractate');
+  const page = c.req.param('page');
+  if (!isKnownTractate(tractate)) return c.json({ error: `unknown tractate: ${tractate}` }, 404);
+  if (!c.env.CACHE) return c.json({ error: 'no CACHE binding in this environment' }, 503);
+
+  const sections = (await readMarkInstances(c.env, 'argument', tractate, page))
+    .filter((s) => typeof s.startSegIdx === 'number' && typeof s.endSegIdx === 'number')
+    .sort((a, b) => (a.startSegIdx as number) - (b.startSegIdx as number));
+  const allMoves: MoveLike[] = (await readMarkInstances(c.env, 'argument-move', tractate, page))
+    .filter((m) => typeof m.startSegIdx === 'number' && typeof m.endSegIdx === 'number')
+    .map((m) => ({
+      startSegIdx: m.startSegIdx as number,
+      endSegIdx: m.endSegIdx as number,
+      fields: m.fields ?? {},
+    }));
+  const voicesDef = findCodeEnrichment('argument.voices');
+
+  // Per-section {index, range, moves, voices} — moves sliced to the section, the
+  // section's voices graph read from cache (same key readSectionRabbis uses).
+  const secData = await Promise.all(
+    sections.map(async (sec, index) => {
+      const startSegIdx = sec.startSegIdx as number;
+      const endSegIdx = sec.endSegIdx as number;
+      const moves = selectSectionMoves(allMoves, { startSegIdx, endSegIdx });
+      let voices: ReturnType<typeof deriveVoiceEdges> | null = null;
+      if (voicesDef) {
+        const vhit = await readCachedResult(
+          c.env,
+          keyForEnrichment(voicesDef, await instanceIdOf(sec), { tractate, page }),
+        );
+        if (vhit?.parsed) voices = deriveVoiceEdges(vhit.parsed);
+      }
+      return {
+        index,
+        startSegIdx,
+        endSegIdx,
+        moves,
+        voices: voices as Parameters<typeof crossSectionStatementFlow>[0][number]['voices'],
+      };
+    }),
+  );
+
+  const derived = crossSectionStatementFlow(secData);
+  // movesComputed false → argument-move marks not warmed yet; the client shouldn't
+  // treat an empty `derived` as "no connections" (it just isn't computed).
+  return c.json({ tractate, page, derived, movesComputed: allMoves.length > 0 });
 });
 
 // Incremental per-tractate spine-view snapshot builder — the cron payoff. A full

--- a/packages/talmud/tests/statement-spine.test.ts
+++ b/packages/talmud/tests/statement-spine.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
+  buildDafSpine,
   buildStatementSpine,
+  crossSectionStatementFlow,
+  type DafSectionRanged,
   type StatementMoveLike,
   type VoicesGraphLike,
 } from '../src/lib/typing/statementSpine';
@@ -224,5 +227,111 @@ describe('buildStatementSpine — edge cases', () => {
       voices: { edges: [{ from: 'Rava', to: 'Rava', kind: 'opposes' }] },
     });
     expect(spine.links.every((l) => l.from !== l.to)).toBe(true);
+  });
+});
+
+// The DAF-GLOBAL builder: walks ALL the daf's moves with a stack of open moves,
+// so an answer/objection in one section attaches to the question/claim it really
+// engages in ANOTHER — the connections the per-section walk structurally can't see
+// (a one-move-per-section technical sugya). A `continues` backbone keeps the rest
+// from floating; a segment-gap guard keeps a far-away open move from over-reaching.
+describe('buildDafSpine — daf-global walk', () => {
+  it('links an answer to a question in an EARLIER section (per-section walk cannot)', () => {
+    const sections = [
+      { moves: [move(0, 'question', 'Stam')] },
+      { moves: [move(5, 'answer', 'Stam')] },
+    ];
+    const daf = buildDafSpine(sections);
+    expect(
+      daf.links.some((l) => l.relation === 'responds-to' && l.from === 's_5' && l.to === 's_0'),
+    ).toBe(true);
+    // Per-section: each section has ONE move, so neither produces a typed link.
+    const perSection = sections.flatMap((s) => buildStatementSpine(s).links);
+    expect(perSection.filter((l) => l.relation !== 'continues')).toHaveLength(0);
+  });
+
+  it('attaches a cross-section objection to the claim it opposes', () => {
+    const daf = buildDafSpine([
+      { moves: [move(0, 'opening', 'Rava', ['Rava'])] },
+      { moves: [move(3, 'objection', 'Abaye', ['Abaye'])] },
+    ]);
+    expect(
+      daf.links.some((l) => l.relation === 'opposes' && l.from === 's_3' && l.to === 's_0'),
+    ).toBe(true);
+  });
+
+  it('lays a continues backbone between consecutive moves, but not over a typed pair', () => {
+    const daf = buildDafSpine([
+      { moves: [move(0, 'question', 'Stam'), move(1, 'answer', 'Stam')] },
+    ]);
+    // The answer responds-to the question, so NO continues doubles that pair…
+    expect(
+      daf.links.some((l) => l.relation === 'responds-to' && l.from === 's_1' && l.to === 's_0'),
+    ).toBe(true);
+    expect(daf.links.some((l) => l.relation === 'continues' && l.from === 's_1')).toBe(false);
+  });
+
+  it('does NOT reach back past the segment-gap guard (precision over recall)', () => {
+    const daf = buildDafSpine([
+      { moves: [move(0, 'question', 'Stam')] },
+      { moves: [move(40, 'answer', 'Stam')] }, // > MAX_ANTECEDENT_GAP segments away
+    ]);
+    expect(daf.links.some((l) => l.relation === 'responds-to')).toBe(false);
+  });
+});
+
+describe('crossSectionStatementFlow — section→section edges from the dialectic', () => {
+  const ranged = (
+    index: number,
+    start: number,
+    end: number,
+    m: StatementMoveLike,
+  ): DafSectionRanged => ({
+    index,
+    startSegIdx: start,
+    endSegIdx: end,
+    moves: [m],
+  });
+
+  it('lifts a cross-section responds-to (a question answered in a later section)', () => {
+    const flow = crossSectionStatementFlow([
+      ranged(0, 0, 2, move(0, 'question', 'Stam')),
+      ranged(1, 3, 5, move(4, 'answer', 'Stam')),
+    ]);
+    expect(flow).toEqual([{ fromSection: 1, toSection: 0, relation: 'responds-to' }]);
+    expect(flow.every((f) => f.relation !== 'continues')).toBe(true);
+  });
+
+  it('does NOT lift cross-section opposes (the audit found it ~70% false)', () => {
+    // An objection opposes an earlier opening across sections; buildDafSpine still
+    // computes that `opposes`, but crossSectionStatementFlow must not surface it.
+    const flow = crossSectionStatementFlow([
+      ranged(0, 0, 2, move(0, 'opening', 'Rava', ['Rava'])),
+      ranged(1, 3, 5, move(4, 'objection', 'Abaye', ['Abaye'])),
+    ]);
+    expect(flow.some((f) => f.relation === 'opposes')).toBe(false);
+    expect(flow).toHaveLength(0);
+  });
+
+  it('does NOT lift cross-section supports either', () => {
+    const flow = crossSectionStatementFlow([
+      ranged(0, 0, 2, move(0, 'opening', 'Rava', ['Rava'])),
+      ranged(1, 3, 5, move(4, 'supporting-evidence', 'Abaye', ['Abaye'])),
+    ]);
+    expect(flow.some((f) => f.relation === 'supports')).toBe(false);
+  });
+
+  it('a resolution clears the stack so a later unit cannot reach back (no false edge)', () => {
+    // §0 question is RESOLVED inside §1; §2's answer must not then "respond-to" the
+    // already-closed §0 question across the boundary (the parallel-units cascade).
+    const flow = crossSectionStatementFlow([
+      ranged(0, 0, 2, move(0, 'question', 'Stam')),
+      ranged(1, 3, 5, move(4, 'resolution', 'Stam')),
+      ranged(2, 6, 8, move(7, 'answer', 'Stam')),
+    ]);
+    // The only legitimate cross-section edge is §1 resolves §0; §2's answer finds
+    // no open question (the stack was cleared), so no §2→§0 responds-to.
+    expect(flow).toContainEqual({ fromSection: 1, toSection: 0, relation: 'resolves' });
+    expect(flow.some((f) => f.fromSection === 2)).toBe(false);
   });
 });


### PR DESCRIPTION
## What

The `argument-overview.flow` AI producer often returns **no** section edges on a long technical sugya even when one section plainly **answers** or **resolves** another — so the Overview map shows a disconnected row of section boxes. This derives section→section connections **deterministically** from the per-statement dialectic and merges them **under** the AI flow (AI keeps final say on any pair it already covers).

## How

- `buildDafSpine` (statementSpine.ts) — a daf-**global** walk over all `argument-move` statements with a stack of open moves: an answer responds-to the nearest open question, a resolution resolves the nearest open, plus a `continues` backbone. The shipped per-section `buildStatementSpine` was refactored onto shared node/voices helpers (behaviour unchanged — the 17 existing tests pass).
- `crossSectionStatementFlow` lifts **only the reliable** cross-section relations (`responds-to`, `resolves`) to the section grain. Read-only `GET /api/derived-flow/:t/:p` serves them — reads cached `argument-move` + `argument.voices`, builds in-process: **no LLM, no cache write, $0**.
- `ArgumentOverviewMaps` fetches them and merges into the map's `connections` (dedupe by unordered section pair; AI flow wins).

## Precision over recall (the whole point)

An adversarial audit of an earlier, broader version found cross-section **`opposes`/`supports` fired ~70% FALSE** on the common "parallel units" shape (each verse/category its own objection→answer) — an unpruned stack let a new objection grab the previous unit's claim. Fixes:
- lift **only** `responds-to`/`resolves` (suppress `opposes`/`supports` pending a better walk + topical check);
- a **resolution clears the stack** (closes its sub-discussion);
- **answering a question abandons older still-open questions** (the daf moved on);
- corrected `withinGap` range math (it had rejected adjacent/overlapping ranges).

After the fixes the benchmark's false cascades are gone (pesachim/eruvin/menachot/bava-kamma 3a → **0** derived edges) and the survivors are hand-verified genuine (chullin 2a §3 answers §1; bava metzia 2a §2 answers §1, §6 resolves §5).

**Honest scope:** intentionally conservative. It adds genuine connections only where the AI flow truly missed a cross-section Q→A/resolution; it does **not** change dapim the AI already connects. Recovering the `opposes`/`supports` connections safely is deferred (needs the harder walk + a re-audit).

## Checks
8 new tests; `pnpm typecheck`, `pnpm lint`, full suite (2454) — all green. Read-only + additive + $0; AI flow keeps final say.