### PR TITLE
Collapse whole-daf enrichments to one cache key (kill the daf-background.concepts fan-out)

### DIFF
--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -4677,6 +4677,23 @@ function enrichmentRecipe(def: EnrichmentDefinition): { extractor: unknown } {
   };
 }
 
+// Marks whose anchor is the whole daf (one daf-level note, not a per-instance
+// extractor). Their enrichments analyse the whole daf, so they must always run
+// and cache at the single canonical {fields:{}} instance.
+const WHOLE_DAF_MARK_IDS: ReadonlySet<string> = new Set(
+  CODE_MARKS.filter((m) => (m as { anchor?: string }).anchor === 'whole-daf').map((m) => m.id),
+);
+
+/** True for a whole-daf enrichment: a local enrichment whose target mark is a
+ *  whole-daf note (daf-background.concepts, argument-overview.flow, tidbit.essay,
+ *  biyun.essay). Such an enrichment has exactly one instance per daf, so
+ *  runEnrichmentOnce keys it to the canonical {fields:{}} instance for every
+ *  caller. Exported for the regression test that pins this set. */
+export function isWholeDafEnrichment(def: EnrichmentDefinition): boolean {
+  const targetMark = (def as { target_mark?: string }).target_mark;
+  return def.scope === 'local' && !!targetMark && WHOLE_DAF_MARK_IDS.has(targetMark);
+}
+
 async function runEnrichmentOnce(
   rc: RunCtx,
   def: EnrichmentDefinition,
@@ -4691,7 +4708,16 @@ async function runEnrichmentOnce(
    *  template as {{user_question}}. */
   userQuestion?: string,
 ): Promise<RunResultEnrichment> {
-  const res = (await runProducer(RUN_PORTS, rc, 'enrich', def, tractate, page, markInput, {
+  // Collapse whole-daf enrichments to the canonical {fields:{}} instance no
+  // matter who calls them. The dependency walk runs an enrichment dep with the
+  // PARENT's markInput (producer-run.ts), so a whole-daf enrichment pulled in by
+  // a per-section (argument.synthesis) or per-rabbi (rabbi.synthesis) producer
+  // would otherwise re-run and re-cache under a fresh key per section/rabbi —
+  // dozens of redundant runs/daf of the identical whole-daf result (e.g.
+  // daf-background.concepts fired ~22x/daf). Keying every caller to one instance
+  // makes them share one cache entry; idempotent for callers already passing it.
+  const effInput = isWholeDafEnrichment(def) ? { fields: {} } : markInput;
+  const res = (await runProducer(RUN_PORTS, rc, 'enrich', def, tractate, page, effInput, {
     bypassCache,
     lang: rc.lang,
     modelOverride,
@@ -4703,7 +4729,7 @@ async function runEnrichmentOnce(
   if (!res.cache_hit && rc.env.CACHE && def.scope === 'local' && !userQuestion) {
     fireDafIndex(
       rc,
-      recordEnrichmentDafIndex(rc.env.CACHE, def.id, tractate, page, markInput, rc.lang, res),
+      recordEnrichmentDafIndex(rc.env.CACHE, def.id, tractate, page, effInput, rc.lang, res),
     );
   }
   return res;

--- a/packages/talmud/tests/whole-daf-enrichment.test.ts
+++ b/packages/talmud/tests/whole-daf-enrichment.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { CODE_ENRICHMENTS } from '../src/worker/code-marks';
+import { isWholeDafEnrichment } from '../src/worker/index';
+
+// runEnrichmentOnce collapses whole-daf enrichments to the single canonical
+// {fields:{}} instance for every caller. That is correct ONLY for enrichments
+// that genuinely produce one note per daf — so this pins exactly which
+// enrichments get collapsed. If a per-instance enrichment ever lands in the
+// "yes" set (e.g. someone flips a mark's anchor to 'whole-daf'), or a real
+// whole-daf enrichment drops out of it (re-introducing the per-section/per-rabbi
+// cache-key leak that fired daf-background.concepts ~22x/daf), this test fails.
+describe('isWholeDafEnrichment — which enrichments collapse to {fields:{}}', () => {
+  const byId = (id: string) => CODE_ENRICHMENTS.find((e) => e.id === id);
+
+  it('flags exactly the whole-daf enrichments (one note per daf)', () => {
+    const whole = CODE_ENRICHMENTS.filter(isWholeDafEnrichment)
+      .map((e) => e.id)
+      .sort();
+    expect(whole).toEqual(
+      [
+        'argument-overview.flow',
+        'argument-overview.synthesis',
+        'biyun.essay',
+        'daf-background.concepts',
+        'daf-background.synthesis',
+        'tidbit.essay',
+      ].sort(),
+    );
+  });
+
+  it('flags daf-background.concepts (the leak this fix closes)', () => {
+    const def = byId('daf-background.concepts');
+    expect(def).toBeTruthy();
+    expect(isWholeDafEnrichment(def!)).toBe(true);
+  });
+
+  it('does NOT flag the per-section / per-rabbi consumers that pulled it in', () => {
+    for (const id of ['argument.synthesis', 'rabbi.synthesis', 'argument.background']) {
+      const def = byId(id);
+      expect(def, id).toBeTruthy();
+      expect(isWholeDafEnrichment(def!), id).toBe(false);
+    }
+  });
+
+  it('does NOT flag a global-scope per-rabbi enrichment', () => {
+    const def = byId('rabbi.bio');
+    if (def) expect(isWholeDafEnrichment(def)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

A **whole-daf enrichment** produces exactly one note per daf and is meant to run once, keyed to the canonical `{fields:{}}` instance. But the dependency walk runs an enrichment dependency with the **parent producer's** `markInput` (`packages/core/src/run/producer-run.ts`). So when a **per-section** producer (`argument.synthesis`, ~one per section) or a **per-rabbi** producer (`rabbi.synthesis`, ~one per rabbi) pulled `daf-background.concepts` in as a dependency, it re-ran and re-cached the *identical* whole-daf result under a fresh section/rabbi-derived key each time.

Measured on prod KV — `berakhot/2a` held **49** `daf-background.concepts` entries where only **2** (EN + HE canonical) are legitimate; some dapim exceeded **120**:

```
enrich:daf-background.concepts:5:f35cd02cd97b:berakhot:2a          <- canonical (kept)
enrich:daf-background.concepts:5:he:f35cd02cd97b:berakhot:2a       <- canonical HE (kept)
enrich:daf-background.concepts:5:definition_of_nightfall_...:berakhot:2a   <- SECTION leak
enrich:daf-background.concepts:5:dispute_among_tannaim_...:berakhot:2a     <- SECTION leak
enrich:daf-background.concepts:5:rabban_gamliel:berakhot:2a                <- RABBI leak
...
```

That **~22x/daf** fan-out of the priciest enrichment ($0.0110/call, pro model) was the single largest line on the shas-cost projection (~$1.3k full-shas, ~95% waste). It surfaced on `/usage` as `daf-background.concepts` running `22.7×` per amud.

## Fix

At the single chokepoint — `runEnrichmentOnce` — collapse any whole-daf enrichment to `{fields:{}}` regardless of caller, so the dependency walk, prefetch, and warm paths all share one cache entry.

The six affected (genuinely whole-daf) enrichments: `daf-background.concepts`, `argument-overview.flow`, `argument-overview.synthesis`, `daf-background.synthesis`, `tidbit.essay`, `biyun.essay`. The change is a **win** for the two that leaked (`daf-background.concepts` big, `argument-overview.flow` small) and a **safe no-op** for the rest (already canonical — verified against prod KV).

Consumers now receive the whole-daf concept list the reader actually sees rather than a section-scoped recomputation, so this is also more coherent.

## Safety

- Existing `argument.synthesis` / `rabbi.synthesis` cache entries are **unaffected** — their keys derive from their own `markInput` + recipe, not the dependency value — so **no re-warm is forced**.
- Orphaned section/rabbi-keyed entries already in KV are left for a **separate GC pass**; the `/usage` multiplier drops to ~1x once they are evicted (the spend stops immediately regardless).

## Test

`tests/whole-daf-enrichment.test.ts` pins exactly which enrichments collapse, so flipping a mark's anchor or adding a per-instance enrichment under a whole-daf mark can't silently re-open the leak.

`pnpm typecheck` / `pnpm test` (2459 pass) / `pnpm lint` all green.