### PR TITLE
Tanach: perek Overview pill (whole-chapter orienting smart-note)

### DIFF
--- a/packages/tanach/src/client/App.tsx
+++ b/packages/tanach/src/client/App.tsx
@@ -180,6 +180,8 @@ interface SectionNote {
  *  'overview' exists today; 'geography' and 'tidbit' join it as siblings. */
 type PerekPill = 'overview';
 interface Overview {
+  book: string;
+  chapter: number;
   titleEn: string;
   titleHe: string;
   en: string;
@@ -569,6 +571,14 @@ export function App(): JSX.Element {
       return res.ok ? ((await res.json()) as Overview) : null;
     },
   );
+  // createResource keeps the PREVIOUS chapter's value during a refetch, so the
+  // drawer must not render it: only show the overview once it has loaded AND
+  // its echoed book/chapter match the chapter on screen (else show loading).
+  const currentOverview = createMemo(() => {
+    if (overview.loading) return null;
+    const o = overview();
+    return o && o.book === loc().book && o.chapter === loc().chapter ? o : null;
+  });
   // Opening a verse-source drawer closes any open pill (one right panel).
   createEffect(() => {
     if (source()) setPerekPill(null);
@@ -844,7 +854,7 @@ export function App(): JSX.Element {
                 <Show when={overview.loading}>
                   <p class="comm-muted">Reading the chapter…</p>
                 </Show>
-                <Show when={overview()}>
+                <Show when={currentOverview()}>
                   {(o) => {
                     const he = loc().lang === 'he';
                     const title = he ? o().titleHe || o().titleEn : o().titleEn || o().titleHe;
@@ -860,6 +870,10 @@ export function App(): JSX.Element {
                       </section>
                     );
                   }}
+                </Show>
+                {/* fetched but failed (overview() is null, not undefined) */}
+                <Show when={!overview.loading && overview() === null}>
+                  <p class="comm-muted">Couldn't load the overview — try reopening.</p>
                 </Show>
               </Show>
             </div>

--- a/packages/tanach/src/client/App.tsx
+++ b/packages/tanach/src/client/App.tsx
@@ -176,6 +176,19 @@ interface SectionNote {
   en: string;
   he: string;
 }
+/** A whole-chapter pill the reader can open from the perek-pills row. Only
+ *  'overview' exists today; 'geography' and 'tidbit' join it as siblings. */
+type PerekPill = 'overview';
+interface Overview {
+  titleEn: string;
+  titleHe: string;
+  en: string;
+  he: string;
+}
+/** The perek-pills, in display order. Adding geography/tidbit is a one-line
+ *  edit here plus their resource + drawer body. */
+const PEREK_PILLS: { id: PerekPill; label: string }[] = [{ id: 'overview', label: 'Overview' }];
+const PILL_KIND: Record<PerekPill, string> = { overview: 'Overview' };
 interface CommentaryEntry {
   key: string;
   en: string;
@@ -539,6 +552,32 @@ export function App(): JSX.Element {
     setSource(null);
   });
 
+  // Perek-level pills (Overview, …): a chapter-scoped drawer, mutually
+  // exclusive with the verse-source drawer (both are the same fixed right
+  // panel). Opening a pill lazily fetches its enrichment (warm in KV after the
+  // first reader); the resource only fires while its pill is open.
+  const [perekPill, setPerekPill] = createSignal<PerekPill | null>(null);
+  const openPill = (id: PerekPill) => {
+    setSource(null);
+    setSelected(null);
+    setPerekPill((cur) => (cur === id ? null : id));
+  };
+  const [overview] = createResource(
+    () => (perekPill() === 'overview' ? chapterKey() : undefined),
+    async (k) => {
+      const res = await fetch(`/api/overview/${encodeURIComponent(k.book)}/${k.chapter}`);
+      return res.ok ? ((await res.json()) as Overview) : null;
+    },
+  );
+  // Opening a verse-source drawer closes any open pill (one right panel).
+  createEffect(() => {
+    if (source()) setPerekPill(null);
+  });
+  createEffect(() => {
+    chapterKey();
+    setPerekPill(null);
+  });
+
   return (
     <div
       class="app"
@@ -658,6 +697,20 @@ export function App(): JSX.Element {
       <Show when={loc().view === 'scroll' && data()}>
         {(ch) => (
           <main class="scroll-main" ref={(el) => (scrollMain = el)}>
+            <div class="perek-pills">
+              <For each={PEREK_PILLS}>
+                {(p) => (
+                  <button
+                    type="button"
+                    class="perek-pill"
+                    classList={{ active: perekPill() === p.id }}
+                    onClick={() => openPill(p.id)}
+                  >
+                    {p.label}
+                  </button>
+                )}
+              </For>
+            </div>
             {/* biome-ignore lint/a11y/noStaticElementInteractions: scripture prose surface; onMouseUp is text-selection word lookup and onClick is a pointer convenience delegated to verse-number spans inside innerHTML — a role would mis-announce running text */}
             {/* biome-ignore lint/a11y/useKeyWithClickEvents: the click target (.vnum spans inside innerHTML) is not focusable; the same verse drawers are keyboard-reachable via the gutter <button>s (evt-margin / vgutter) */}
             <div
@@ -762,6 +815,55 @@ export function App(): JSX.Element {
               <span class="xlate-en">{translation() ?? '—'}</span>
             </Show>
           </div>
+        )}
+      </Show>
+
+      {/* Perek-level pill drawer (Overview, …) — same fixed right panel as the
+          verse-source drawer, mutually exclusive with it */}
+      <Show when={perekPill()} keyed>
+        {(pill) => (
+          <aside class="comm-drawer perek-drawer" dir={loc().lang === 'he' ? 'rtl' : 'ltr'}>
+            <header class="comm-head">
+              <span class="comm-ref">
+                {loc().lang === 'he'
+                  ? `${heBook(loc().book)} ${hebrewNumeral(loc().chapter)}`
+                  : `${loc().book} ${loc().chapter}`}
+              </span>
+              <span class="comm-kind">{PILL_KIND[pill]}</span>
+              <button
+                type="button"
+                class="comm-close"
+                onClick={() => setPerekPill(null)}
+                aria-label="Close"
+              >
+                ×
+              </button>
+            </header>
+            <div class="comm-body">
+              <Show when={pill === 'overview'}>
+                <Show when={overview.loading}>
+                  <p class="comm-muted">Reading the chapter…</p>
+                </Show>
+                <Show when={overview()}>
+                  {(o) => {
+                    const he = loc().lang === 'he';
+                    const title = he ? o().titleHe || o().titleEn : o().titleEn || o().titleHe;
+                    const body = he ? o().he || o().en : o().en || o().he;
+                    return (
+                      <section class="perek-overview">
+                        <Show when={title}>
+                          <h3 class="perek-title">{title}</h3>
+                        </Show>
+                        <p class="perek-prose" dir={he ? 'rtl' : 'ltr'}>
+                          {body}
+                        </p>
+                      </section>
+                    );
+                  }}
+                </Show>
+              </Show>
+            </div>
+          </aside>
         )}
       </Show>
 

--- a/packages/tanach/src/client/styles.css
+++ b/packages/tanach/src/client/styles.css
@@ -502,6 +502,74 @@ body {
   font-style: italic;
 }
 
+/* perek-level pills (Overview, …): a centered row of chips at the top of the
+   chapter, each opening the perek drawer. The chapter analogue of the Talmud
+   reader's whole-daf header chips. */
+.perek-pills {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+  max-width: 900px;
+  margin: 0 auto 18px;
+}
+@media (max-width: 1240px) {
+  .perek-pills {
+    max-width: 620px;
+  }
+}
+.perek-pill {
+  font-family: inherit;
+  font-size: 12px;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  padding: 5px 14px;
+  border: 1px solid var(--parchment-edge);
+  border-radius: 999px;
+  background: var(--parchment);
+  color: var(--accent);
+  cursor: pointer;
+  transition:
+    background-color 0.12s ease,
+    color 0.12s ease,
+    border-color 0.12s ease;
+}
+.perek-pill:hover {
+  border-color: var(--accent);
+}
+.perek-pill.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+/* perek drawer (an Overview/Geography/Tidbit pill) — reuses the comm-drawer
+   shell; the body holds the chapter-level enrichment */
+.perek-overview {
+  padding: 6px 0 12px;
+}
+.perek-title {
+  margin: 0 0 10px;
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--ink);
+  line-height: 1.3;
+}
+.perek-title[dir="rtl"],
+.perek-drawer[dir="rtl"] .perek-title {
+  font-family: "Frank Ruhl Libre", serif;
+}
+.perek-prose {
+  margin: 0;
+  font-size: 16px;
+  line-height: 1.68;
+  color: var(--ink);
+}
+.perek-prose[dir="rtl"] {
+  font-family: "Frank Ruhl Libre", serif;
+  font-size: 17px;
+}
+
 /* word/phrase translation gloss (text selection) */
 .xlate-pop {
   position: fixed;

--- a/packages/tanach/src/worker/index.ts
+++ b/packages/tanach/src/worker/index.ts
@@ -164,6 +164,42 @@ app.get('/api/events/:book/:chapter', async (c) => {
   return c.json({ book, chapter: Number(chapter), ref, sections: parsed?.sections ?? [] });
 });
 
+// Perek overview (whole-chapter enrichment): a short bilingual orienting
+// overview — a descriptive title + a few sentences on what the chapter is
+// about — opened from the reader's "Overview" pill. Runs through the core
+// runProducer; chapter-scoped, so the markInput's `id` ('perek') is nominal —
+// the key template owns the bytes (overview:v1:{book}:{chapter}), one entry
+// per chapter.
+app.get('/api/overview/:book/:chapter', async (c) => {
+  const book = c.req.param('book');
+  const chapter = c.req.param('chapter');
+  if (!isBook(book)) return c.json({ error: `Unknown book: ${book}` }, 400);
+  if (!/^\d+$/.test(chapter)) return c.json({ error: `Bad chapter: ${chapter}` }, 400);
+
+  const ref = `${book} ${chapter}`;
+  const rc: TanachRunCtx = { env: c.env, ctx: c.executionCtx, ref };
+  let artifact: StoredArtifact;
+  try {
+    artifact = await runTanachEnrichment(rc, 'overview', book, chapter, { id: 'perek' });
+  } catch (e) {
+    return runErrorResponse(c, e);
+  }
+  const p = artifact.parsed as {
+    titleEn?: string;
+    titleHe?: string;
+    en?: string;
+    he?: string;
+  } | null;
+  return c.json({
+    book,
+    chapter: Number(chapter),
+    titleEn: String(p?.titleEn ?? '').trim(),
+    titleHe: String(p?.titleHe ?? '').trim(),
+    en: String(p?.en ?? '').trim(),
+    he: String(p?.he ?? '').trim(),
+  });
+});
+
 // This week's Torah portion (parashat hashavua), from Sefaria's calendar.
 // Returns the parsha name + the book/chapter it starts at, so the reader can
 // jump straight there. Cached ~6h (it only changes on Shabbat).

--- a/packages/tanach/src/worker/producers/defs.ts
+++ b/packages/tanach/src/worker/producers/defs.ts
@@ -33,10 +33,17 @@ import {
   MIDRASH_SYNTH_USER_TEMPLATE,
 } from './midrash.ts';
 import { NOTE_SCHEMA, NOTE_SYSTEM, NOTE_USER_TEMPLATE } from './note.ts';
+import { OVERVIEW_SCHEMA, OVERVIEW_SYSTEM, OVERVIEW_USER_TEMPLATE } from './overview.ts';
 import { SYNTHESIS_SCHEMA, SYNTHESIS_SYSTEM, SYNTHESIS_USER_TEMPLATE } from './synthesis.ts';
 import { TRANSLATE_SCHEMA, TRANSLATE_SYSTEM, TRANSLATE_USER_TEMPLATE } from './translate.ts';
 
-export type TanachProducerId = 'events' | 'note' | 'synthesis' | 'midrash-synthesis' | 'translate';
+export type TanachProducerId =
+  | 'events'
+  | 'note'
+  | 'overview'
+  | 'synthesis'
+  | 'midrash-synthesis'
+  | 'translate';
 
 /** The recipe extractor every tanach producer carries: an LLM call with fixed
  *  prompts + a strict JSON schema + the exact call knobs the legacy producer
@@ -70,6 +77,16 @@ const noteExtractor: TanachLLMExtractor = {
   max_tokens: 700,
   temperature: 0.3,
   tag: 'tanach:note',
+};
+
+const overviewExtractor: TanachLLMExtractor = {
+  kind: 'llm',
+  system_prompt: OVERVIEW_SYSTEM,
+  user_prompt_template: OVERVIEW_USER_TEMPLATE,
+  output_schema: OVERVIEW_SCHEMA,
+  max_tokens: 700,
+  temperature: 0.3,
+  tag: 'tanach:overview',
 };
 
 const synthesisExtractor: TanachLLMExtractor = {
@@ -131,6 +148,24 @@ export const TANACH_PRODUCERS: Record<TanachProducerId, Producer> = {
     cardinality: 'per-input',
     scope: 'local',
     key_shape: 'enrich', // nominal — template owns note:v1:{book}:{chapter}:{start}-{end}
+    cacheVersion: '1',
+    source: 'code',
+  },
+  overview: {
+    id: 'overview',
+    label: 'Perek overview',
+    description: 'A short bilingual orienting overview of a whole chapter (title + summary)',
+    kind: 'enrichment',
+    inputs: [{ source: 'chapter-verses' }],
+    recipe: { extractor: overviewExtractor },
+    // inherits: the overview sits at the chapter the reader is on. Chapter-
+    // scoped — one per chapter, no per-instance variation (the key template
+    // ignores the instance; see run-ports.ts overview:v1:{book}:{chapter}).
+    // 'unit' = the whole-chapter level (the analogue of a daf's whole-page).
+    anchoring: { behavior: 'inherits', precision: 'unit', spine: 'tanach' },
+    cardinality: 'one',
+    scope: 'local',
+    key_shape: 'enrich', // nominal — template owns overview:v1:{book}:{chapter}
     cacheVersion: '1',
     source: 'code',
   },
@@ -217,7 +252,7 @@ export function markRunDefOf(id: 'events'): TanachMarkDef {
 }
 
 export function enrichRunDefOf(
-  id: 'note' | 'synthesis' | 'midrash-synthesis',
+  id: 'note' | 'overview' | 'synthesis' | 'midrash-synthesis',
 ): TanachEnrichmentDef {
   const p = TANACH_PRODUCERS[id];
   const ext = p.recipe.extractor as TanachLLMExtractor;

--- a/packages/tanach/src/worker/producers/defs.ts
+++ b/packages/tanach/src/worker/producers/defs.ts
@@ -84,7 +84,11 @@ const overviewExtractor: TanachLLMExtractor = {
   system_prompt: OVERVIEW_SYSTEM,
   user_prompt_template: OVERVIEW_USER_TEMPLATE,
   output_schema: OVERVIEW_SCHEMA,
-  max_tokens: 700,
+  // Headroom for a BILINGUAL title + summary: the note producer's 700 is for a
+  // single-language note, but EN + HE together (Hebrew is token-dense) on a
+  // long chapter overran it and truncated the JSON mid-string -> parse failure
+  // -> empty card. 1400 comfortably fits both halves.
+  max_tokens: 1400,
   temperature: 0.3,
   tag: 'tanach:overview',
 };

--- a/packages/tanach/src/worker/producers/overview.ts
+++ b/packages/tanach/src/worker/producers/overview.ts
@@ -1,0 +1,72 @@
+/**
+ * The "perek overview" enrichment — a whole-chapter smart-note.
+ *
+ * Given a chapter of the Hebrew Bible, an LLM writes a short orienting overview
+ * for a reader who just arrived: a descriptive title for the chapter and a few
+ * sentences on what it is about — the narrative arc (for narrative books) or
+ * the theme and structure (for poetry / law / wisdom) — and where it sits in
+ * the book's larger story. Bilingual (English + Hebrew). The reader opens it
+ * from a perek-level "Overview" pill, the tanach analogue of the Talmud reader's
+ * whole-daf Overview card.
+ *
+ * Strictly p'shat (plain, contextual sense) — the same discipline the events
+ * and note producers keep. Interesting against-the-grain readings drawn from
+ * midrash and the commentators belong to the (forthcoming) tidbit pill, not
+ * here; this pill is the plain orientation.
+ *
+ * This module carries the producer's RECIPE (prompts + schema); the run goes
+ * through the corpus-agnostic runProducer (producers/defs.ts assembles the
+ * Producer, run-ports.ts wires the ports). It is chapter-scoped, so its cache
+ * key (overview:v1:{book}:{chapter}) ignores any instance — see run-ports.ts.
+ */
+
+export interface PerekOverview {
+  /** Short descriptive title for the chapter, e.g. "The Binding of Isaac". */
+  titleEn: string;
+  titleHe: string;
+  /** A 3-5 sentence orienting overview of the chapter. */
+  en: string;
+  he: string;
+}
+
+export const OVERVIEW_SYSTEM = [
+  'You write a short orienting overview of a whole chapter of the Hebrew Bible,',
+  "on the p'shat (plain, contextual) level — for a reader who just opened it.",
+  '',
+  'Give the chapter a short descriptive TITLE and a few sentences of OVERVIEW.',
+  '',
+  'Rules:',
+  '- Title: 2 to 6 words naming what the chapter is (a scene, a theme, a law, a',
+  '  psalm\'s subject) — "The Binding of Isaac", "The Plague of Hail", "A Psalm',
+  '  of Refuge". Not a full sentence.',
+  '- Overview: 3 to 5 sentences. For a narrative chapter, the arc of what',
+  '  happens and how it moves. For poetry, law, wisdom, or prophecy, the theme,',
+  '  the structure, and what the chapter is doing. Orient the reader — say where',
+  "  this sits in the book's larger story when that helps.",
+  "- Strictly p'shat. No midrash, no homily, no theology, no commentary debates,",
+  '  no quoting commentators. Plain and concrete.',
+  '- Do not just list the verses or restate them one by one — synthesize.',
+  '- Give BOTH English ("titleEn"/"en") and natural, fluent Hebrew',
+  '  ("titleHe"/"he"). The Hebrew is real Hebrew, not a transliteration of the',
+  '  English.',
+].join('\n');
+
+/** Rendered with vars from the 'chapter-verses' source resolver (the same
+ *  resolver the events producer uses): {{ref}}, {{max_verse}}, {{verses_text}}. */
+export const OVERVIEW_USER_TEMPLATE = 'Chapter: {{ref}} ({{max_verse}} verses)\n\n{{verses_text}}';
+
+export const OVERVIEW_SCHEMA = {
+  name: 'perek_overview',
+  strict: true,
+  schema: {
+    type: 'object',
+    additionalProperties: false,
+    required: ['titleEn', 'titleHe', 'en', 'he'],
+    properties: {
+      titleEn: { type: 'string' },
+      titleHe: { type: 'string' },
+      en: { type: 'string' },
+      he: { type: 'string' },
+    },
+  },
+};

--- a/packages/tanach/src/worker/run-ports.ts
+++ b/packages/tanach/src/worker/run-ports.ts
@@ -102,6 +102,9 @@ const KEY_TEMPLATES: Record<string, KeyTemplate> = {
   note: {
     key: (a: TanachAddress) => `note:v1:${a.unit?.work}:${a.unit?.unit}:${a.start}-${a.end}`,
   },
+  // Chapter-scoped: the key ignores the instance (there's one overview per
+  // chapter), so enrichmentAddress('overview', …) carries no verse/range.
+  overview: { key: (a: TanachAddress) => `overview:v1:${a.unit?.work}:${a.unit?.unit}` },
   synthesis: {
     key: (a: TanachAddress) => `synthesis:v1:${a.unit?.work}:${a.unit?.unit}:${a.verse}`,
   },
@@ -143,6 +146,10 @@ export function enrichmentAddress(
   if (id === 'note') {
     const [start, end] = instanceId.split('-');
     return { unit, instanceId, start, end };
+  }
+  // Chapter-scoped (overview): the key template uses only {work}:{unit}.
+  if (id === 'overview') {
+    return { unit, instanceId };
   }
   return { unit, instanceId, verse: instanceId };
 }
@@ -356,7 +363,9 @@ const RESOLVE_PORTS: ResolveInputsPorts<TanachRunCtx, TanachEnrichmentDef, Tanac
   // exist; nothing declares {enrichment}/{mark} deps today, but the lookups
   // are real so the recursion closes through core if one ever does.
   loadEnrichmentDef: async (_rc, id) =>
-    id === 'note' || id === 'synthesis' || id === 'midrash-synthesis' ? enrichRunDefOf(id) : null,
+    id === 'note' || id === 'overview' || id === 'synthesis' || id === 'midrash-synthesis'
+      ? enrichRunDefOf(id)
+      : null,
   loadMarkDef: async (_rc, id) => (id === 'events' ? markRunDefOf(id) : null),
   runEnrichment: (rc, def, book, chapter, markInput, bypassCache, parentChain) =>
     runProducer(RUN_PORTS, rc, 'enrich', def, book, chapter, markInput, {
@@ -556,7 +565,7 @@ export async function runTanachEvents(
 
 export async function runTanachEnrichment(
   rc: TanachRunCtx,
-  id: 'note' | 'synthesis' | 'midrash-synthesis',
+  id: 'note' | 'overview' | 'synthesis' | 'midrash-synthesis',
   book: string,
   chapter: string,
   /** The instance the enrichment is FOR. Its `id` field is the legacy key

--- a/packages/tanach/src/worker/run-ports.ts
+++ b/packages/tanach/src/worker/run-ports.ts
@@ -543,7 +543,19 @@ const RUN_PORTS: RunProducerPorts<TanachRunCtx, TanachEnrichmentDef, TanachMarkD
     },
     enrichmentPreResolve: async () => null,
     enrichmentPostResolve: async () => ({}),
-    enrichmentPostParse: () => {},
+    // Reject an empty-but-valid-JSON generation so runProducer skips the cache
+    // write (the cache-gate only checks parse_error, so an all-empty result
+    // would otherwise be pinned and served forever). Throwing here means the
+    // next request regenerates. Scoped to overview — the per-verse producers
+    // gate their emptiness upstream (source resolvers raise 404 when there's
+    // nothing to synthesize).
+    enrichmentPostParse: (_rc, a) => {
+      if (a.def.id !== 'overview' || a.parse_error || !a.parsed) return;
+      const p = a.parsed as { titleEn?: string; en?: string; he?: string };
+      const empty =
+        !String(p.titleEn ?? '').trim() && !String(p.en ?? '').trim() && !String(p.he ?? '').trim();
+      if (empty) throw new Error('overview: empty generation (not caching)');
+    },
   },
 };
 

--- a/packages/tanach/tests/producer-defs.test.ts
+++ b/packages/tanach/tests/producer-defs.test.ts
@@ -22,12 +22,13 @@ describe('tanach spine registry', () => {
   });
 });
 
-describe('the five producers as core Producer objects', () => {
-  it('declares all five with their model shapes', () => {
+describe('the six producers as core Producer objects', () => {
+  it('declares all six with their model shapes', () => {
     expect(Object.keys(TANACH_PRODUCERS).sort()).toEqual([
       'events',
       'midrash-synthesis',
       'note',
+      'overview',
       'synthesis',
       'translate',
     ]);
@@ -57,6 +58,17 @@ describe('the five producers as core Producer objects', () => {
       expect(TANACH_PRODUCERS[id].scope).toBe('local');
     }
 
+    const overview = TANACH_PRODUCERS.overview;
+    expect(overview.kind).toBe('enrichment');
+    expect(overview.anchoring).toEqual({
+      behavior: 'inherits',
+      precision: 'unit', // whole-chapter scoped
+      spine: 'tanach',
+    });
+    expect(overview.cardinality).toBe('one');
+    expect(overview.scope).toBe('local');
+    expect(overview.cacheVersion).toBe('1'); // overview:v1:*
+
     const translate = TANACH_PRODUCERS.translate;
     expect(translate.anchoring.behavior).toBe('inherits');
     expect(translate.scope).toBe('global');
@@ -66,6 +78,7 @@ describe('the five producers as core Producer objects', () => {
     const knobs: Record<string, { max_tokens: number; temperature: number; tag: string }> = {
       events: { max_tokens: 900, temperature: 0.2, tag: 'tanach:events' },
       note: { max_tokens: 700, temperature: 0.3, tag: 'tanach:note' },
+      overview: { max_tokens: 700, temperature: 0.3, tag: 'tanach:overview' },
       synthesis: { max_tokens: 800, temperature: 0.3, tag: 'tanach:synthesis' },
       'midrash-synthesis': { max_tokens: 800, temperature: 0.35, tag: 'tanach:midrash-synthesis' },
       translate: { max_tokens: 120, temperature: 0.2, tag: 'tanach:translate' },
@@ -101,6 +114,10 @@ describe('the five producers as core Producer objects', () => {
     expect(note.mark).toBe('events');
     expect(note.dependencies).toEqual(['section-verses']);
     expect(note.system_prompt.length).toBeGreaterThan(50);
+
+    const overview = enrichRunDefOf('overview');
+    expect(overview.dependencies).toEqual(['chapter-verses']);
+    expect(overview.system_prompt.length).toBeGreaterThan(50);
 
     const synth = enrichRunDefOf('synthesis');
     expect(synth.dependencies).toEqual(['verse-text', 'commentaries']);

--- a/packages/tanach/tests/producer-defs.test.ts
+++ b/packages/tanach/tests/producer-defs.test.ts
@@ -78,7 +78,7 @@ describe('the six producers as core Producer objects', () => {
     const knobs: Record<string, { max_tokens: number; temperature: number; tag: string }> = {
       events: { max_tokens: 900, temperature: 0.2, tag: 'tanach:events' },
       note: { max_tokens: 700, temperature: 0.3, tag: 'tanach:note' },
-      overview: { max_tokens: 700, temperature: 0.3, tag: 'tanach:overview' },
+      overview: { max_tokens: 1400, temperature: 0.3, tag: 'tanach:overview' },
       synthesis: { max_tokens: 800, temperature: 0.3, tag: 'tanach:synthesis' },
       'midrash-synthesis': { max_tokens: 800, temperature: 0.35, tag: 'tanach:midrash-synthesis' },
       translate: { max_tokens: 120, temperature: 0.2, tag: 'tanach:translate' },


### PR DESCRIPTION
First of the tanach **perek pills** (Overview, with Geography and Tidbit to follow), mirroring the Talmud reader's whole-daf Overview card — scaled to tanach's simpler architecture (it had no pill/sidebar system, so this introduces a lightweight pill row + perek drawer the next two pills reuse).

## What it does
A reader opens the **Overview** pill at the top of a chapter and gets a short, bilingual orienting note: a descriptive title + a 3–5 sentence p'shat summary — the narrative arc for narrative chapters, or the theme/structure for poetry, law, wisdom, and prophecy.

Strictly **p'shat** (same discipline as the events/note producers) — interesting against-the-grain readings from midrash and the commentators are reserved for the forthcoming **Tidbit** pill.

## How it's built
Follows the existing tanach producer pattern exactly (recipe → defs → run-ports → route), through the same corpus-agnostic `runProducer` the other producers use.

- **`producers/overview.ts`** — the recipe (system/user prompts + strict bilingual schema `{titleEn, titleHe, en, he}`).
- **`producers/defs.ts`** — registers `overview` (enrichment, `scope: local`, `precision: unit`, `cardinality: one`); reuses the existing `chapter-verses` source resolver.
- **`run-ports.ts`** — key template `overview:v1:{book}:{chapter}` (chapter-scoped — the instance is ignored), address handling, load-def, run entry.
- **`worker/index.ts`** — `GET /api/overview/:book/:chapter`.
- **client (`App.tsx` + `styles.css`)** — a centered `.perek-pills` row at the top of the chapter; the Overview pill opens a perek drawer (reuses the `.comm-drawer` shell), mutually exclusive with the verse-source drawer. The enrichment is fetched **lazily** (warm in KV after the first reader). `PEREK_PILLS` is a list, so Geography/Tidbit drop in as siblings.

## Verification
- `pnpm typecheck`, `pnpm lint`, and the full tanach test suite (42 tests) — green. `producer-defs.test.ts` updated for the sixth producer.
- `vite build` — clean.
- **Live** (local worker, real LLM):
  - Genesis 22 → **"The Binding of Isaac"** / **"עקידת יצחק"** — accurate 5-sentence p'shat summary, fluent (non-transliterated) Hebrew.
  - Psalms 23 → **"The Shepherd's Psalm"** — confirms the poetry/theme branch.
  - Cache hit on re-fetch (~17ms).
  - EN and HE/RTL drawer render confirmed via headless screenshots.

## Next
Geography (places mentioned + where the perek takes place) and Tidbit (an interesting idea from midrash/commentaries) as sibling pills.