### PR TITLE
Source coverage: surface Mesorat HaShas parallels + commentary works rows

### DIFF
--- a/packages/talmud/src/client/i18n.ts
+++ b/packages/talmud/src/client/i18n.ts
@@ -615,6 +615,11 @@ const CATALOG = {
   'usage.src.yerushalmi': { en: 'Yerushalmi', he: 'ירושלמי' },
   'usage.src.halacha-refs': { en: 'Halacha', he: 'הלכה' },
   'usage.src.daf-topics': { en: 'Topics', he: 'נושאים' },
+  'usage.src.talmud-parallels': {
+    en: 'Parallel sugyot (Mesorat HaShas)',
+    he: 'סוגיות מקבילות (מסורת הש״ס)',
+  },
+  'usage.src.commentary-works': { en: 'Commentaries (all works)', he: 'מפרשים (כל החיבורים)' },
   'usage.src.dy': { en: 'DafYomi notes (all)', he: 'הערות דף יומי (הכול)' },
   'usage.src.dy.insights': { en: 'Insights', he: 'תובנות' },
   'usage.src.dy.background': { en: 'Background', he: 'רקע' },

--- a/packages/talmud/src/worker/cache-stats.ts
+++ b/packages/talmud/src/worker/cache-stats.ts
@@ -245,6 +245,16 @@ const nonEmptyValue: AlignPredicate = (v) => {
   return true;
 };
 
+// Commentary-works (keyForCommentaryWorks) caches an OBJECT
+// `{ works: CommentaryWork[], tractate, page, fetchedAt }` (or `{ error }`), so
+// nonEmptyValue would read every non-error fetch as "aligned" (the wrapper keys
+// are always present). Aligned = it actually carries at least one work.
+const alignedCommentaryWorks: AlignPredicate = (v) => {
+  if (!v || failed(v)) return false;
+  const d = v as { works?: unknown[] };
+  return Array.isArray(d.works) && d.works.length > 0;
+};
+
 // DafYomi content types (Kollel Iyun HaDaf), in display order. See
 // src/lib/sefref/dafyomi/masechtos.ts (DafyomiContentType).
 const DAFYOMI_TYPES = [
@@ -561,6 +571,10 @@ export async function computeCacheStats(cache: KVNamespace): Promise<CacheStats>
     yeruAligned,
     halRefsAligned,
     topicsAligned,
+    parallelsCount,
+    commWorksCount,
+    parallelsAligned,
+    commWorksAligned,
     dyTypes,
   ] = await Promise.all([
     countPrefix(cache, 'hb:v2:'),
@@ -586,6 +600,12 @@ export async function computeCacheStats(cache: KVNamespace): Promise<CacheStats>
     sampleAligned(cache, 'yerushalmi:v1:', nonEmptyValue),
     sampleAligned(cache, 'halacha-refs:v3:', nonEmptyValue),
     sampleAligned(cache, 'daf-topics:v1:', nonEmptyValue),
+    // Talmud↔Talmud parallels (Mesorat HaShas, Sefaria) + the broad commentary
+    // -spine works list (Sefaria links-with-text). Both per-daf source fetches.
+    countPrefix(cache, 'talmud-parallels:v1:'),
+    countPrefix(cache, 'commentaries:v1:'),
+    sampleAligned(cache, 'talmud-parallels:v1:', nonEmptyValue),
+    sampleAligned(cache, 'commentaries:v1:', alignedCommentaryWorks),
     sampleDafyomiTypes(cache),
   ]);
   const dafyomiAligned: AlignedSample | null =
@@ -622,6 +642,8 @@ export async function computeCacheStats(cache: KVNamespace): Promise<CacheStats>
     sefariaRow('yerushalmi', yeruCount, yeruAligned),
     sefariaRow('halacha-refs', halRefsCount, halRefsAligned),
     sefariaRow('daf-topics', topicsCount, topicsAligned),
+    sefariaRow('talmud-parallels', parallelsCount, parallelsAligned),
+    sefariaRow('commentary-works', commWorksCount, commWorksAligned),
     {
       id: 'dy',
       origin: 'DY',

--- a/packages/talmud/tests/source-coverage-dashboard.test.ts
+++ b/packages/talmud/tests/source-coverage-dashboard.test.ts
@@ -57,6 +57,14 @@ const CLASSIFICATION: Record<string, Classification> = {
     role: 'dashboard',
     note: 'dafyomi.co.il corpus (per-daf, sub-types fanned out)',
   },
+  keyForTalmudParallels: {
+    role: 'dashboard',
+    note: 'Mesorat HaShas Talmud↔Talmud parallels (Sefaria)',
+  },
+  keyForCommentaryWorks: {
+    role: 'dashboard',
+    note: 'commentary-spine works list (Sefaria links-with-text)',
+  },
 
   // --- Raw intermediate fetches behind a surfaced source --------------------
   keyForSefariaBundle: {
@@ -68,18 +76,10 @@ const CLASSIFICATION: Record<string, Classification> = {
     note: 'raw Sefaria segments — rolled into the gemara row',
   },
 
-  // --- Per-daf source content NOT yet surfaced (candidates to add) ----------
-  keyForTalmudParallels: {
-    role: 'not-source',
-    note: 'CANDIDATE: Mesorat HaShas Talmud↔Talmud parallels (Sefaria) — per-daf, not surfaced',
-  },
-  keyForCommentaryWorks: {
-    role: 'not-source',
-    note: 'CANDIDATE: per-daf commentary-spine works list (Sefaria) — not surfaced',
-  },
+  // --- Derived per-daf computations (not a fetched source) ------------------
   keyForMesorah: {
     role: 'not-source',
-    note: 'CANDIDATE: per-daf rabbi-transmission mesorah (Sefaria) — not surfaced',
+    note: 'derived rabbi-transmission chains (computed from the skeleton + rabbi-graph), not a fetched source',
   },
 
   // --- Per-ref caches (not keyed per daf) -----------------------------------


### PR DESCRIPTION
## Why

Follow-up to #425, which documented three per-daf source caches the coverage dashboard wasn't showing. On checking the write-sites, **two are genuine fetched sources** and one is not:

| cache | what it is | verdict |
|---|---|---|
| `talmud-parallels:v1` | Mesorat HaShas Talmud↔Talmud parallels (Sefaria `getRelated`), **warmed Shas-wide** | **surface** |
| `commentaries:v1` (`keyForCommentaryWorks`) | commentary-spine works list (Sefaria `/api/links?with_text=1`), per-daf | **surface** |
| `mesorah:v1` | rabbi-transmission chains **computed** from the cached skeleton + rabbi-graph (412s without a skeleton) | **derived — leave out** |

## What

- `cache-stats.ts`: count + sample both new prefixes and emit two `SourceRow`s (origin `Sefaria`). Parallels reuse the array `nonEmptyValue` predicate; commentary-works gets a dedicated `alignedCommentaryWorks` predicate, because its cached value is an object `{works,…}` — `nonEmptyValue` would mark every non-error fetch as aligned (the wrapper keys are always present).
- `i18n.ts`: labels — **Parallel sugyot (Mesorat HaShas)** / **Commentaries (all works)** (HE included). The client renderer is already generic (`usage.src.${id}`), so no UI change.
- `source-coverage-dashboard.test.ts` (the #425 drift guard): reclassify the two from `CANDIDATE` → `dashboard`, so their prefixes are now **required** to appear in `cache-stats.ts`. Correct mesorah's note to reflect that it's a derived computation, not a source.

The dashboard's "commentaries" row stays the Rashi+Tosafot context (`ctx:commentaries:v1`); the new row is the broader works list (`commentaries:v1`) — labeled to disambiguate.

## Checks
- `pnpm typecheck` clean
- `pnpm --filter talmud test` — 2462 passed (drift guard now enforces the 2 new rows)
- Biome clean