### PR TITLE
Usage projection: exact per-producer denominator + drop demand-driven .qa

### DIFF
--- a/packages/talmud/src/client/UsagePage.tsx
+++ b/packages/talmud/src/client/UsagePage.tsx
@@ -1716,7 +1716,14 @@ function ShasEstimate(props: { est: ReturnType<typeof estimateShasCost> }): JSX.
                   </td>
                   <td style={numCell}>{fmtUsd(p.unitUsd)}</td>
                   <td style={{ ...numCell, color: '#999' }}>
-                    {p.instancesPerAmud > 1.05 ? `${p.instancesPerAmud.toFixed(1)}×` : '1×'}
+                    {/* Demand-driven (.qa) producers are keyed per user question,
+                        not per amud, so a per-amud rate is meaningless and they
+                        are not projected across shas. */}
+                    {p.demandDriven
+                      ? '—'
+                      : p.instancesPerAmud > 1.05
+                        ? `${p.instancesPerAmud.toFixed(1)}×`
+                        : '1×'}
                   </td>
                   <td style={{ ...numCell, color: '#2a8a42' }}>{fmtUsd(p.incurredUsd)}</td>
                   <td style={numCell}>{fmtUsd(p.remainingUsd)}</td>

--- a/packages/talmud/src/lib/shasCost.ts
+++ b/packages/talmud/src/lib/shasCost.ts
@@ -12,9 +12,19 @@
  *
  * The hard part is that one cumulative cache count conflates two things — how
  * often a producer fires per amud (its multiplicity) and how many amudim it has
- * been warmed on. We separate them with a `frontier`: the most-covered mark's
- * count is a proxy for "amudim that have been through the pipeline at all"
- * (every amud that's warmed fires the core marks). Then:
+ * been warmed on. The clean separator is the producer's OWN distinct-daf
+ * coverage (`coverageDapim`, supplied by cache-stats): warmedAmudim =
+ * coverageDapim, so multiplicity = count / coverageDapim exactly, with no
+ * dependence on any other producer. When that is present we use it directly.
+ *
+ * When it is absent we fall back to a `frontier` proxy: the most-covered mark's
+ * count stands in for "amudim that have been through the pipeline at all" (every
+ * warmed amud fires the core marks). This proxy is fragile — it divides one
+ * producer's count by ANOTHER producer's coverage, so a version-skew between an
+ * enrichment and its target mark distorts the rate (the rabbi.*.evidence
+ * pathology: the rabbi mark re-warmed a small subset after a version bump, so
+ * dividing the broadly-warmed evidence count by the mark's small coverage read
+ * ~3x too high). Hence coverageDapim is strongly preferred. Fallback rules:
  *
  *   - A mark caches once per amud, so its multiplicity is 1 and warmedAmudim =
  *     min(count, frontier).
@@ -32,18 +42,22 @@
  *     mark). If target_mark coverage is missing, we fall back to the frontier.
  *
  * Method (per producer):
- *   frontier         = min(amudim, max mark coverageCount)  // amudim warmed at all
+ *   frontier         = min(amudim, max mark coverageCount)  // fallback only
  *   unitUsd          = costUsd / pricedCalls   // avg $/priced call (window-independent)
- *   warmedAmudim     = distinct amudim warmed (see rules above)
+ *   warmedAmudim     = coverageDapim, else the frontier proxy (see rules above)
  *   instancesPerAmud = coverageCount / warmedAmudim         // >= 1
  *   fullShasUsd      = unitUsd * instancesPerAmud * amudim
  *   incurredUsd      = unitUsd * coverageCount              // est. cost to reach current coverage
  *   remainingUsd     = max(0, fullShasUsd - incurredUsd)
  *       Positive whenever warmedAmudim < amudim, so the lightly-warmed long tail
  *       — and a partly-warmed fan-out — still owe a pass.
- *       Residual caveat: a fan-out enrichment with count <= frontier reads as
- *       once-per-amud, so its remaining is a lower bound until it crosses the
- *       frontier. Conservative, and acceptable for an estimate.
+ *       Residual caveat: in the fallback path a fan-out enrichment with count <=
+ *       frontier reads as once-per-amud, so its remaining is a lower bound until
+ *       it crosses the frontier. Conservative, and acceptable for an estimate.
+ *
+ * Demand-driven exclusion: `.qa` answerers are keyed per user question, not per
+ * amud — there is no shas to warm — so they are NOT projected (fullShas =
+ * incurred, remaining = 0). Their real incurred spend still appears.
  *
  * Workers-AI gross-up: the in-app price table covers OpenRouter models but
  * leaves Workers-AI (`@cf/*`) at $0, so per-producer unitUsd misses that spend.
@@ -70,8 +84,15 @@ export interface CoverageRowLike {
   id: string;
   count: number;
   /** Enrichment only: the mark it fires off of (used as the warmed-amud
-   *  denominator for proven fan-outs). Ignored for marks. */
+   *  denominator for proven fan-outs ONLY when `coverageDapim` is absent).
+   *  Ignored for marks. */
   target_mark?: string;
+  /** Distinct dapim this producer is actually cached on, at the current cache
+   *  version (English). When present this is the EXACT warmed-amud denominator —
+   *  it makes `count / warmedAmudim` the true avg instances-per-warmed-daf,
+   *  independent of the target mark's (possibly version-skewed) coverage. The
+   *  target-mark proxy below is only a fallback for when this is unknown. */
+  coverageDapim?: number;
 }
 
 /** An AI Gateway per-model row (subset) for the Workers-AI gross-up. */
@@ -106,6 +127,10 @@ export interface ProducerCost {
   incurredUsd: number;
   /** Est. cost still to pay to finish shas, priced terms. */
   remainingUsd: number;
+  /** Demand-driven producer (a `.qa` answerer keyed per user question): there is
+   *  no shas to warm, so it is NOT projected forward — fullShasUsd === incurredUsd
+   *  and remainingUsd === 0. Its `instancesPerAmud` is informational only. */
+  demandDriven: boolean;
 }
 
 export interface ShasCostTotals {
@@ -162,6 +187,16 @@ export function estimateShasCost(input: ShasCostInput): ShasCostEstimate {
     row?: CoverageRowLike,
   ): number => {
     if (count <= 0) return 0;
+    // EXACT denominator when cache-stats supplies the producer's own distinct-daf
+    // coverage: instancesPerAmud = count / coverageDapim is the true avg
+    // instances-per-warmed-daf. This is independent of the target mark, so it
+    // does not distort when the mark and enrichment are at different warming
+    // frontiers (e.g. the rabbi mark bumped a cache version and re-warmed only a
+    // subset while rabbi.relationships.evidence stayed broadly warmed — the proxy
+    // below then divided by the smaller mark coverage and overstated the rate).
+    const cd = row?.coverageDapim;
+    if (typeof cd === 'number' && cd > 0) return Math.min(cd, amudim || cd);
+    // Fallback (no per-producer daf coverage): the original frontier heuristic.
     if (kind === 'mark' || count <= frontier) return Math.min(count, frontier); // once-per-amud reading
     // count > frontier => provably a fan-out. Use its target_mark coverage as
     // the distinct-amud denominator, clamped to the frontier; fall back to the
@@ -185,9 +220,14 @@ export function estimateShasCost(input: ShasCostInput): ShasCostEstimate {
       const count = row?.count ?? 0;
       const warmedAmudim = warmedAmudimFor(kind, count, row);
       const instancesPerAmud = count > 0 && warmedAmudim > 0 ? count / warmedAmudim : 1;
-      const fullShasUsd = unitUsd * instancesPerAmud * amudim;
       const incurredUsd = unitUsd * count;
-      const remainingUsd = Math.max(0, fullShasUsd - incurredUsd);
+      // `.qa` answerers are keyed per user QUESTION, not per amud — there is no
+      // shas to warm, so projecting a per-amud fire-rate across all of shas is
+      // meaningless (it invented a large phantom "remaining"). Count their real
+      // incurred spend, but do not project: fullShas = incurred, remaining = 0.
+      const demandDriven = kind === 'enrichment' && id.endsWith('.qa');
+      const fullShasUsd = demandDriven ? incurredUsd : unitUsd * instancesPerAmud * amudim;
+      const remainingUsd = demandDriven ? 0 : Math.max(0, fullShasUsd - incurredUsd);
       rows.push({
         id,
         kind,
@@ -197,6 +237,7 @@ export function estimateShasCost(input: ShasCostInput): ShasCostEstimate {
         fullShasUsd,
         incurredUsd,
         remainingUsd,
+        demandDriven,
       });
     }
   };

--- a/packages/talmud/src/worker/cache-stats.ts
+++ b/packages/talmud/src/worker/cache-stats.ts
@@ -147,6 +147,9 @@ export interface EnrichmentCacheRow {
   cache_version: string;
   count: number; // entries at the CURRENT cache_version (English)
   heCount: number; // entries at the CURRENT cache_version, Hebrew (:he)
+  /** Local scope only: distinct dapim cached at the current version (EN). The
+   *  exact warmed-amud denominator for the shas-cost projection. */
+  coverageDapim?: number;
   versions: Record<string, number>;
   staleCount: number;
 }
@@ -396,8 +399,16 @@ async function countPrefix(cache: KVNamespace, prefix: string): Promise<number> 
  * colon-delimited segment of what remains. The trailing colon in `prefix`
  * keeps `mark:argument:` from matching `mark:argument-move:…`.
  */
-async function countByVersion(cache: KVNamespace, prefix: string): Promise<Record<string, number>> {
+/** Per-version key tallies for one producer prefix: total `counts`, plus
+ *  `dapim` = distinct dapim each version is cached on (exact for daf-scoped
+ *  keys; callers read it only for local-scope producers, where the trailing
+ *  `<tractate>:<page>` is always present). */
+async function countByVersion(
+  cache: KVNamespace,
+  prefix: string,
+): Promise<{ counts: Record<string, number>; dapim: Record<string, number> }> {
   const counts: Record<string, number> = {};
+  const dafSets: Record<string, Set<string>> = {};
   let cursor: string | undefined;
   for (;;) {
     const res = (await cache.list({ prefix, cursor, limit: 1000 })) as {
@@ -414,12 +425,26 @@ async function countByVersion(cache: KVNamespace, prefix: string): Promise<Recor
       // so the usage page can report EN vs HE coverage separately.
       const bucket = segs[1] === 'he' ? `${version}:he` : version;
       counts[bucket] = (counts[bucket] ?? 0) + 1;
+      // Distinct-daf tracking: the daf is the trailing `<tractate>:<page>`,
+      // after stripping an optional `q_<hash>` qualifier. Global keys (no daf)
+      // yield a spurious pair, but those are gated out at the read site (local
+      // scope only). This is the exact warmed-amud denominator for the cost
+      // model — independent of any other producer's coverage.
+      const tail = segs[segs.length - 1]?.startsWith('q_') ? segs.slice(0, -1) : segs;
+      if (tail.length >= 2) {
+        const daf = `${tail[tail.length - 2]}:${tail[tail.length - 1]}`;
+        const set = dafSets[bucket] ?? new Set<string>();
+        set.add(daf);
+        dafSets[bucket] = set;
+      }
     }
     if (res.list_complete) break;
     cursor = res.cursor;
     if (!cursor) break;
   }
-  return counts;
+  const dapim: Record<string, number> = {};
+  for (const [b, s] of Object.entries(dafSets)) dapim[b] = s.size;
+  return { counts, dapim };
 }
 
 function staleSum(versions: Record<string, number>, current: string): number {
@@ -701,7 +726,7 @@ export async function computeCacheStats(cache: KVNamespace): Promise<CacheStats>
   for (const e of enrichDefs) for (const dep of e.dependencies) addDep(e.target_mark, dep);
 
   const marks: MarkCacheRow[] = markDefs.map((m, i) => {
-    const versions = markVersions[i];
+    const versions = markVersions[i].counts;
     const count = versions[m.cache_version] ?? 0;
     const heCount = versions[`${m.cache_version}:he`] ?? 0;
     return {
@@ -720,9 +745,14 @@ export async function computeCacheStats(cache: KVNamespace): Promise<CacheStats>
   });
 
   const enrichments: EnrichmentCacheRow[] = enrichDefs.map((e, i) => {
-    const versions = enrichVersions[i];
+    const versions = enrichVersions[i].counts;
     const count = versions[e.cache_version] ?? 0;
     const heCount = versions[`${e.cache_version}:he`] ?? 0;
+    // Distinct dapim this enrichment is cached on at the current version (EN).
+    // Local scope only — global/spine keys carry no daf, so the figure would be
+    // spurious and the cost model must fall back to its frontier proxy for them.
+    const coverageDapim =
+      e.scope === 'local' ? (enrichVersions[i].dapim[e.cache_version] ?? 0) : undefined;
     return {
       id: e.id,
       label: e.label,
@@ -732,6 +762,7 @@ export async function computeCacheStats(cache: KVNamespace): Promise<CacheStats>
       cache_version: e.cache_version,
       count,
       heCount,
+      coverageDapim,
       versions,
       staleCount: staleSum(versions, e.cache_version),
     };

--- a/packages/talmud/tests/shas-cost.test.ts
+++ b/packages/talmud/tests/shas-cost.test.ts
@@ -108,6 +108,53 @@ describe('estimateShasCost', () => {
     expect(flow.remainingUsd).toBeCloseTo(0.2); // 20 of 100 amudim still owed
   });
 
+  it('uses the producer own coverageDapim as the exact denominator (beats the proxy)', () => {
+    // Fan-out enrichment cached on 500 distinct dapim with 6000 entries = 12x.
+    // Its target mark is VERSION-SKEWED (re-warmed only 200 dapim), so the old
+    // proxy would read 6000 / 200 = 30x. coverageDapim pins the true 6000/500.
+    const input = baseInput({
+      amudim: 2711,
+      byEnrichment: { 'rabbi.relationships.evidence': { costUsd: 12, pricedCalls: 6000 } }, // $0.002
+      marks: [
+        { id: 'argument', count: 600 },
+        { id: 'rabbi', count: 200 },
+      ],
+      enrichments: [
+        {
+          id: 'rabbi.relationships.evidence',
+          count: 6000,
+          target_mark: 'rabbi',
+          coverageDapim: 500,
+        },
+      ],
+    });
+    const ev = estimateShasCost(input).byProducer.find(
+      (p) => p.id === 'rabbi.relationships.evidence',
+    )!;
+    expect(ev.instancesPerAmud).toBeCloseTo(12); // 6000/500, NOT 6000/200 = 30
+    expect(ev.fullShasUsd).toBeCloseTo(0.002 * 12 * 2711);
+  });
+
+  it('does not project demand-driven .qa producers across shas', () => {
+    const input = baseInput({
+      byEnrichment: { 'pesukim.qa': { costUsd: 0.5, pricedCalls: 100 } }, // $0.005/call
+      enrichments: [{ id: 'pesukim.qa', count: 100, coverageDapim: 40 }],
+    });
+    const qa = estimateShasCost(input).byProducer.find((p) => p.id === 'pesukim.qa')!;
+    expect(qa.demandDriven).toBe(true);
+    expect(qa.incurredUsd).toBeCloseTo(0.5); // real spend kept
+    expect(qa.fullShasUsd).toBeCloseTo(0.5); // == incurred, NOT projected forward
+    expect(qa.remainingUsd).toBe(0); // no phantom "remaining"
+  });
+
+  it('still projects a normal (non-.qa) enrichment and flags it not demand-driven', () => {
+    const com = estimateShasCost(baseInput()).byProducer.find(
+      (p) => p.id === 'argument-move.commentaries',
+    )!;
+    expect(com.demandDriven).toBe(false);
+    expect(com.remainingUsd).toBeGreaterThanOrEqual(0);
+  });
+
   it('keeps mark and enrichment coverage separate even if ids collide', () => {
     const input = baseInput({
       byMark: { foo: { costUsd: 1, pricedCalls: 100 } },


### PR DESCRIPTION
Two honesty fixes to the shas-cost projection on `/usage` (`src/lib/shasCost.ts`). Both follow up the cost-leak thread (#426 + the KV cleanup): the leak was real spend; these are about the *projection* reading true.

## 1. Per-instance multiplier overstated by version skew

`instancesPerAmud = count / warmedAmudim`, and `warmedAmudim` was proxied by the **target mark's** coverage. That divides one producer's count by *another* producer's coverage — so when a mark bumps a cache version and re-warms only a subset while its enrichment stays broadly warmed, the ratio inflates.

**Live example:** the `rabbi` mark's current version covers **222** dapim, while `rabbi.relationships.evidence` covers **588**. The model read `6700/222 ≈ 30×` instead of the true `6700/588 ≈ 11.4×` — overstating the rabbi-evidence "remaining" by ~3×. (This is the `33.7×` the original `/usage` snapshot showed.)

**Fix:** `cache-stats` now emits each local enrichment's **own** distinct-daf coverage (`coverageDapim`), and `shasCost` uses it as the *exact* denominator when present, falling back to the frontier/target-mark proxy only when unknown. `countByVersion` tracks distinct dapim per version (gated to local scope — global keys carry no daf).

## 2. `.qa` answerers were projected across shas

`.qa` producers are keyed per user **question** (a `q_<hash>` per question), never warmed shas-wide — so a per-amud fire-rate × all of shas invented a large phantom "remaining" (`pesukim.qa`, `argument-move.qa`, `aggadata.qa`).

**Fix:** demand-driven (`.qa`) producers keep their real incurred spend but are **not projected** — `fullShas = incurred`, `remaining = 0` — and the `/usage` table shows `—` for their meaningless `/amud` rate.

## Safety

- Existing cost rows are unchanged when `coverageDapim` is absent (the fallback path is untouched), so all prior `shas-cost` tests pass as-is.
- New tests: the exact denominator beats a skewed proxy (`6700/500` not `6700/200`); `.qa` is not projected (`demandDriven`, `remaining=0`).
- `pnpm typecheck` / `pnpm test` (2465 pass) / `pnpm lint` all green.