### PR TITLE
Halacha: surface the cached codifier source texts in the card

### DIFF
--- a/packages/talmud/src/client/ArgumentSidebar.tsx
+++ b/packages/talmud/src/client/ArgumentSidebar.tsx
@@ -2041,9 +2041,151 @@ function HalachaCodification(props: SpecialBlockProps): JSX.Element {
             />
           </div>
           <CodificationMap nodes={m().nodes} edges={m().edges} />
+          <HalachaSourceTexts tractate={props.tractate} page={props.page} />
         </div>
       )}
     </Show>
+  );
+}
+
+// One codifier's grounded source texts (the real Sefaria text already cached in
+// the halacha-refs bundle), as returned by GET /api/halacha-text.
+interface HalachaTextRef {
+  ref: string;
+  hebrew: string;
+  english: string;
+  einMishpat: boolean;
+}
+interface HalachaTextNode {
+  id: string;
+  label: string;
+  short: string;
+  tier: string;
+  einMishpat: boolean;
+  refs: HalachaTextRef[];
+}
+
+// A collapsed "source texts" disclosure under the codification map: the actual
+// Mishneh Torah / Tur / Shulchan Aruch (+ secondary) text the card is built
+// from. Lazily fetched on first open (the bundle is already warm whenever a
+// codification card shows, so this is a cache hit), so the default view stays
+// uncluttered.
+function HalachaSourceTexts(props: { tractate: string; page: string }): JSX.Element {
+  const [open, setOpen] = createSignal(false);
+  const [nodes] = createResource(
+    () => (open() ? `${props.tractate}|${props.page}` : false),
+    async (): Promise<HalachaTextNode[]> => {
+      try {
+        const r = await fetch(
+          `/api/halacha-text/${encodeURIComponent(props.tractate)}/${encodeURIComponent(props.page)}`,
+        );
+        if (!r.ok) return [];
+        return ((await r.json()) as { nodes?: HalachaTextNode[] }).nodes ?? [];
+      } catch {
+        return [];
+      }
+    },
+  );
+  const muted: JSX.CSSProperties = {
+    'font-size': '0.72rem',
+    color: '#aaa',
+    'margin-top': '0.4rem',
+  };
+  return (
+    <div style={{ 'margin-top': '0.6rem' }}>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        style={{
+          'font-size': '0.66rem',
+          'text-transform': 'uppercase',
+          'letter-spacing': '0.06em',
+          color: '#888',
+          background: 'none',
+          border: 'none',
+          padding: '0',
+          cursor: 'pointer',
+          display: 'flex',
+          'align-items': 'center',
+          gap: '0.35rem',
+        }}
+      >
+        <span>{open() ? '▾' : '▸'}</span>
+        <span>{t('halacha.sourceTexts')}</span>
+      </button>
+      <Show when={open()}>
+        <Show when={!nodes.loading} fallback={<div style={muted}>…</div>}>
+          <Show
+            when={(nodes() ?? []).length > 0}
+            fallback={<div style={muted}>{t('halacha.sourceTexts.none')}</div>}
+          >
+            <div
+              style={{
+                'margin-top': '0.45rem',
+                display: 'flex',
+                'flex-direction': 'column',
+                gap: '0.7rem',
+              }}
+            >
+              <For each={nodes()}>
+                {(node) => (
+                  <div>
+                    <div style={{ 'font-size': '0.7rem', 'font-weight': 600, color: '#555' }}>
+                      {node.label}
+                    </div>
+                    <For each={node.refs}>
+                      {(r) => (
+                        <div
+                          style={{
+                            'margin-top': '0.35rem',
+                            'border-left': '2px solid #eee',
+                            'padding-left': '0.5rem',
+                          }}
+                        >
+                          <div style={{ 'font-size': '0.64rem', color: '#3a6ea5' }}>
+                            {r.ref}
+                            <Show when={r.einMishpat}>
+                              <span style={{ color: '#b8860b', 'margin-left': '0.4rem' }}>
+                                · Ein Mishpat
+                              </span>
+                            </Show>
+                          </div>
+                          <Show when={r.hebrew}>
+                            <p
+                              dir="rtl"
+                              style={{
+                                margin: '0.2rem 0 0',
+                                'font-size': '0.86rem',
+                                'line-height': '1.7',
+                                'text-align': 'right',
+                              }}
+                            >
+                              {r.hebrew}
+                            </p>
+                          </Show>
+                          <Show when={r.english}>
+                            <p
+                              style={{
+                                margin: '0.2rem 0 0',
+                                'font-size': '0.74rem',
+                                'line-height': '1.5',
+                                color: '#666',
+                              }}
+                            >
+                              {r.english}
+                            </p>
+                          </Show>
+                        </div>
+                      )}
+                    </For>
+                  </div>
+                )}
+              </For>
+            </div>
+          </Show>
+        </Show>
+      </Show>
+    </div>
   );
 }
 

--- a/packages/talmud/src/client/i18n.ts
+++ b/packages/talmud/src/client/i18n.ts
@@ -969,6 +969,11 @@ const CATALOG = {
 
   // — Halacha body —
   'halacha.codification': { en: 'Codification', he: 'פסיקה' },
+  'halacha.sourceTexts': { en: 'Source texts', he: 'לשון המקור' },
+  'halacha.sourceTexts.none': {
+    en: 'No codifier text cached for this daf yet',
+    he: 'לשון המקור עדיין לא נטענה לדף זה',
+  },
   'halacha.derivation': { en: 'Talmudic sources', he: 'מקורות בש״ס' },
   'halacha.note': { en: 'Note', he: 'הערה' },
   'halacha.dispute': { en: 'Where practice splits', he: 'היכן ההלכה נחלקת' },

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -60,7 +60,7 @@ import { type SectionExit, sectionExits } from '../lib/context/sectionExits';
 import { dafSpine } from '../lib/context/spine';
 import { spineLinks } from '../lib/context/spineLinks';
 import { buildGeoModel, type GeoEnrichment, type RabbiGeoSource } from '../lib/geographyModel';
-import { buildDerivation } from '../lib/halacha/codifiers';
+import { buildCodificationChain, buildDerivation } from '../lib/halacha/codifiers';
 import {
   buildRabbiEnrichUserMessage,
   type LocalRabbiInput,
@@ -1098,6 +1098,33 @@ app.get('/api/derivation/:tractate/:page', async (c) => {
   const linkLists = await Promise.all(refs.map((r) => getCodeSourcesCached(c.env.CACHE, r)));
   const sources = buildDerivation(linkLists.flat(), { tractate, page });
   return c.json({ sources });
+});
+
+// Halacha SOURCE TEXTS: the actual codifier text behind the codification card,
+// grouped into the deterministic codifier lineage (Rambam → Tur → Shulchan Aruch
+// + secondary glosses). The full Hebrew/English is ALREADY cached in the
+// halacha-refs bundle (it grounds the codification enrichment) — this only
+// surfaces it for the reader. Read-only, no LLM. HTML stripped for display; the
+// cached bundle (and the grounding prompt) keep the raw markup.
+app.get('/api/halacha-text/:tractate/:page', async (c) => {
+  const tractate = c.req.param('tractate');
+  const page = c.req.param('page');
+  if (!c.env.CACHE) return c.json({ error: 'CACHE unavailable' }, 503);
+  const bundle = await getHalachaRefsCached(c.env.CACHE, tractate, page).catch(() => undefined);
+  const nodes = buildCodificationChain(bundle, { includeSecondary: true }).map((n) => ({
+    id: n.id,
+    label: n.label,
+    short: n.short,
+    tier: n.tier,
+    einMishpat: n.einMishpat,
+    refs: n.refs.map((r) => ({
+      ref: r.ref,
+      hebrew: stripHtmlServer(r.hebrew ?? ''),
+      english: stripHtmlServer(r.english ?? ''),
+      einMishpat: !!r.einMishpat,
+    })),
+  }));
+  return c.json({ tractate, page, nodes });
 });
 
 app.get('/api/links/:tractate/:page', async (c) => {


### PR DESCRIPTION
## Why

Lever A of the halacha work. The investigation found that **the codifier text is already fetched and cached** — `HalachicSnippet` carries the full `hebrew`/`english` of each codifier section, and it grounds the `halacha.codification` enrichment. But the reader only saw the LLM's summary *ruling*, never the actual Mishneh Torah / Tur / Shulchan Aruch text. So "text expansion" is a display problem, not a fetch problem.

## What

Surface the already-cached text **without touching the LLM enrichment** (no `cache_version` bump → no Shas-wide cold-miss / re-warm):

- **`GET /api/halacha-text/:tractate/:page`** (read-only, no LLM): reads the cached `halacha-refs` bundle and returns the deterministic codifier lineage via the existing, unit-tested `buildCodificationChain` — each node carrying its grounded refs *with text*. HTML stripped for display via `stripHtmlServer`; the cached bundle (and the grounding prompt) keep raw markup.
- **Client:** a collapsed **"Source texts ▸"** disclosure under the `CodificationMap`, lazily fetched on first open (the bundle is warm whenever a codification card shows, so it's a cache hit), grouped by codifier, Ein Mishpat refs flagged, Hebrew RTL. Default view stays uncluttered.

## Why it's robust
The join is by **codifier work** (`buildCodificationChain` classifies `index_title`), not the LLM's free-text `ref` — so there's no ref-format fragility (the LLM might emit "OC 235:3" while the bundle has "Shulchan Arukh, Orach Chayim 235:3"). The text shown is exactly the lineage the card is built from.

No new cache key, so the #425 source-coverage drift guard is unaffected.

## Checks
- `pnpm typecheck` clean
- `pnpm --filter talmud test` — 2462 passed
- Biome clean
- Post-merge: will smoke-test `GET /api/halacha-text/Berakhot/2a` on prod (it returns real codifier text).

## Follow-ups (not in this PR)
- Lever B — warm `halacha-refs` Shas-wide to lift the 3% coverage (heavier; Sefaria-only/no-LLM).
- The bundle also has non-lineage codifiers (Smag, Sefer HaChinukh, …) that `buildCodificationChain` filters out; could add an "other codifiers" section if wanted.