### PR TITLE
Shared UI foundation: @corpus/ui design tokens + themes (adopt in tanach)

### DIFF
--- a/packages/tanach/package.json
+++ b/packages/tanach/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@corpus/core": "workspace:*",
+    "@corpus/ui": "workspace:*",
     "hono": "^4.6.0",
     "solid-js": "^1.9.0",
     "zod": "^4.4.3"

--- a/packages/tanach/src/client/main.tsx
+++ b/packages/tanach/src/client/main.tsx
@@ -1,4 +1,8 @@
 import { render } from 'solid-js/web';
+// Shared design tokens + the tanach theme, imported BEFORE the app stylesheet
+// so styles.css resolves the canonical vars (and the theme's overrides).
+import '@corpus/ui/tokens.css';
+import '@corpus/ui/themes/tanach.css';
 import { App } from './App.tsx';
 import { UsagePage } from './UsagePage.tsx';
 import './styles.css';

--- a/packages/tanach/src/client/styles.css
+++ b/packages/tanach/src/client/styles.css
@@ -1,13 +1,7 @@
-:root {
-  --ink: #1a1a1a;
-  --muted: #6b6b6b;
-  --line: #e3e0d8;
-  --bg: #faf8f3;
-  --accent: #7a5c2e;
-  --parchment: #f3e7c9;
-  --parchment-edge: #e6d3a6;
-  --stam: #2a1c0c;
-}
+/* Design tokens + the tanach palette/fonts come from @corpus/ui (imported in
+   main.tsx: tokens.css + themes/tanach.css). This sheet only consumes them:
+   --bg/--fg/--ink/--muted/--line/--accent/--parchment*, and the type split
+   --font-ui (chrome) / --font-serif (Latin reading) / --font-hebrew. */
 
 * {
   box-sizing: border-box;
@@ -17,7 +11,8 @@ body {
   margin: 0;
   background: var(--bg);
   color: var(--ink);
-  font-family: "Spectral", "Frank Ruhl Libre", Georgia, serif;
+  /* reading prose is the serif (Spectral); chrome opts into --font-ui below */
+  font-family: var(--font-serif);
   line-height: 1.6;
 }
 
@@ -32,6 +27,8 @@ body {
 }
 
 /* ---- top bar ---- */
+/* All top-bar chrome (brand, selects, buttons, toggles — they use
+   font-family: inherit) renders in the shared UI sans, not the reading serif. */
 .topbar {
   position: sticky;
   top: 0;
@@ -41,6 +38,7 @@ body {
   padding: 12px 20px;
   background: var(--bg);
   border-bottom: 1px solid var(--line);
+  font-family: var(--font-ui);
   z-index: 10;
 }
 .brand {
@@ -146,7 +144,7 @@ body {
   max-width: 900px;
   margin: 0 auto;
   color: var(--ink);
-  font-family: "Frank Ruhl Libre", serif;
+  font-family: var(--font-hebrew);
   font-size: 16px;
   line-height: 1.6;
   column-count: 2;
@@ -483,6 +481,7 @@ body {
   color: var(--ink);
 }
 .note-pop-label {
+  font-family: var(--font-ui);
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -519,13 +518,13 @@ body {
   }
 }
 .perek-pill {
-  font-family: inherit;
+  font-family: var(--font-ui);
   font-size: 12px;
   letter-spacing: 0.03em;
   text-transform: uppercase;
   padding: 5px 14px;
   border: 1px solid var(--parchment-edge);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--parchment);
   color: var(--accent);
   cursor: pointer;
@@ -557,7 +556,7 @@ body {
 }
 .perek-title[dir="rtl"],
 .perek-drawer[dir="rtl"] .perek-title {
-  font-family: "Frank Ruhl Libre", serif;
+  font-family: var(--font-hebrew);
 }
 .perek-prose {
   margin: 0;
@@ -566,7 +565,7 @@ body {
   color: var(--ink);
 }
 .perek-prose[dir="rtl"] {
-  font-family: "Frank Ruhl Libre", serif;
+  font-family: var(--font-hebrew);
   font-size: 17px;
 }
 
@@ -587,7 +586,7 @@ body {
   pointer-events: none;
 }
 .xlate-pop .xlate-he {
-  font-family: "Frank Ruhl Libre", serif;
+  font-family: var(--font-hebrew);
   font-size: 15px;
   color: #e9d9b8;
   white-space: nowrap;
@@ -669,6 +668,7 @@ body {
   border-bottom: 0;
 }
 .comm-name {
+  font-family: var(--font-ui);
   margin: 0 0 6px;
   font-size: 12px;
   text-transform: uppercase;
@@ -683,7 +683,7 @@ body {
   color: var(--ink);
 }
 .comm-text[dir="rtl"] {
-  font-family: "Frank Ruhl Libre", serif;
+  font-family: var(--font-hebrew);
   font-size: 16px;
 }
 .comm-muted {
@@ -705,7 +705,7 @@ body {
   border-radius: 50%;
   background: var(--accent);
   color: #fff;
-  font-family: "Frank Ruhl Libre", serif;
+  font-family: var(--font-hebrew);
   font-size: 10px;
   font-weight: 700;
   line-height: 1;
@@ -727,6 +727,7 @@ body {
   margin: 8px 0 6px;
 }
 .comm-synth-name {
+  font-family: var(--font-ui);
   margin: 0 0 6px;
   font-size: 12px;
   text-transform: uppercase;
@@ -741,7 +742,7 @@ body {
   color: var(--ink);
 }
 .comm-synth-text[dir="rtl"] {
-  font-family: "Frank Ruhl Libre", serif;
+  font-family: var(--font-hebrew);
   font-size: 16px;
 }
 
@@ -769,7 +770,7 @@ body {
   border: 1px solid #fbf8f1;
   border-radius: 50%;
   color: #fff;
-  font-family: "Frank Ruhl Libre", serif;
+  font-family: var(--font-hebrew);
   font-size: 9px;
   font-weight: 700;
   line-height: 1;
@@ -837,7 +838,7 @@ body {
   color: var(--muted);
 }
 .gem-text[dir="rtl"] {
-  font-family: "Frank Ruhl Libre", serif;
+  font-family: var(--font-hebrew);
   font-size: 15px;
 }
 
@@ -854,6 +855,7 @@ body {
   gap: 10px;
 }
 .comm-kind {
+  font-family: var(--font-ui);
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.05em;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@corpus/ui",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Shared design system for the corpus apps (talmud, tanach): canonical CSS design tokens + per-app theme overrides, and (later) a Solid component kit. Logic stays in @corpus/core; this is the look-and-feel layer both apps import.",
+  "sideEffects": [
+    "**/*.css"
+  ],
+  "exports": {
+    "./tokens.css": "./src/tokens.css",
+    "./themes/talmud.css": "./src/themes/talmud.css",
+    "./themes/tanach.css": "./src/themes/tanach.css"
+  }
+}

--- a/packages/ui/src/themes/talmud.css
+++ b/packages/ui/src/themes/talmud.css
@@ -1,0 +1,30 @@
+/*
+ * @corpus/ui — Talmud theme.
+ *
+ * Talmud's identity on the shared token vocabulary: the maroon palette and the
+ * self-hosted Mekorot Vilna / Rashi Hebrew faces. Imported after tokens.css.
+ *
+ * NOTE: this theme exists so the vocabulary is symmetric, but the talmud app
+ * does NOT consume @corpus/ui yet — that adoption is a later step (it already
+ * defines these values inline). Wiring talmud onto these tokens, then onto the
+ * shared component kit, is its own change. The @font-face declarations for
+ * Mekorot stay in the talmud app (it self-hosts the .ttf files).
+ */
+
+:root {
+  /* ---- colour ---- */
+  --bg: #fafaf7;
+  --fg: #1a1a1a;
+  --muted: #6b6b6b;
+  --line: #e5e3dc;
+  --accent: #8a2a2b;
+  --accent-strong: #6f2122;
+  --surface: #ffffff;
+  --surface-sunk: rgba(138, 42, 43, 0.06);
+
+  /* ---- type ---- */
+  /* --font-ui inherits the shared sans default (talmud chrome is already sans). */
+  --font-serif: Georgia, "Times New Roman", serif;
+  --font-hebrew: "Mekorot Vilna", serif;
+  --font-rashi: "Mekorot Rashi", "Mekorot Vilna", serif;
+}

--- a/packages/ui/src/themes/talmud.css
+++ b/packages/ui/src/themes/talmud.css
@@ -22,9 +22,12 @@
   --surface: #ffffff;
   --surface-sunk: rgba(138, 42, 43, 0.06);
 
-  /* ---- type ---- */
-  /* --font-ui inherits the shared sans default (talmud chrome is already sans). */
-  --font-serif: Georgia, "Times New Roman", serif;
+  /* ---- type ----
+   * --font-ui (chrome sans) and --font-serif (English reading serif, Spectral)
+   * are inherited from tokens.css UNCHANGED — shared across apps, so talmud's
+   * English prose matches tanach's. When talmud adopts @corpus/ui it must load
+   * Spectral (a <link>/@import, as tanach does) so --font-serif resolves to it
+   * rather than the Georgia fallback. Only the Hebrew faces are talmud's own. */
   --font-hebrew: "Mekorot Vilna", serif;
   --font-rashi: "Mekorot Rashi", "Mekorot Vilna", serif;
 }

--- a/packages/ui/src/themes/tanach.css
+++ b/packages/ui/src/themes/tanach.css
@@ -21,9 +21,10 @@
   --surface: #ffffff;
   --surface-sunk: rgba(122, 92, 46, 0.08);
 
-  /* ---- type ---- */
-  /* --font-ui inherits the shared sans default (chrome is sans now). */
-  --font-serif: "Spectral", "Frank Ruhl Libre", Georgia, serif;
+  /* ---- type ----
+   * --font-ui (chrome sans) and --font-serif (English reading serif, Spectral)
+   * are inherited from tokens.css UNCHANGED — they're shared across apps. Only
+   * the Hebrew face is tanach's own. */
   --font-hebrew: "Frank Ruhl Libre", "Noto Serif Hebrew", serif;
 
   /* ---- tanach-specific surfaces ---- */

--- a/packages/ui/src/themes/tanach.css
+++ b/packages/ui/src/themes/tanach.css
@@ -1,0 +1,36 @@
+/*
+ * @corpus/ui — Tanach theme.
+ *
+ * Tanach's identity on the shared token vocabulary: a warm brown / parchment
+ * palette, Spectral as the Latin reading serif, Frank Ruhl Libre for Hebrew.
+ * Imported after tokens.css; overrides only the values, never the names.
+ *
+ * `--ink` is kept as an alias of `--fg` so the existing tanach stylesheet
+ * (which referenced --ink) keeps resolving while it migrates onto the shared
+ * vocabulary.
+ */
+
+:root {
+  /* ---- colour ---- */
+  --bg: #faf8f3;
+  --fg: #1a1a1a;
+  --muted: #6b6b6b;
+  --line: #e3e0d8;
+  --accent: #7a5c2e;
+  --accent-strong: #5f4722;
+  --surface: #ffffff;
+  --surface-sunk: rgba(122, 92, 46, 0.08);
+
+  /* ---- type ---- */
+  /* --font-ui inherits the shared sans default (chrome is sans now). */
+  --font-serif: "Spectral", "Frank Ruhl Libre", Georgia, serif;
+  --font-hebrew: "Frank Ruhl Libre", "Noto Serif Hebrew", serif;
+
+  /* ---- tanach-specific surfaces ---- */
+  --parchment: #f3e7c9;
+  --parchment-edge: #e6d3a6;
+  --stam: #2a1c0c;
+
+  /* ---- back-compat alias (tanach styles referenced --ink) ---- */
+  --ink: var(--fg);
+}

--- a/packages/ui/src/tokens.css
+++ b/packages/ui/src/tokens.css
@@ -1,0 +1,45 @@
+/*
+ * @corpus/ui — canonical design tokens.
+ *
+ * One variable vocabulary shared by every corpus app (talmud, tanach). An app
+ * imports this FIRST, then a theme file (themes/<app>.css) that overrides the
+ * values for its own identity — palette + Hebrew typeface — without renaming a
+ * single token. Components and stylesheets reference only these vars, so the
+ * two apps stop drifting.
+ *
+ * The values here are neutral DEFAULTS (a theme is expected to override the
+ * colour + Hebrew-font tokens). The split that ends the "everything in one
+ * serif" look:
+ *   --font-ui      chrome — buttons, nav, pills, labels (a clean sans)
+ *   --font-serif   running READING prose in Latin script (English notes)
+ *   --font-hebrew  Hebrew scripture + Hebrew reading text (a theme sets the face)
+ *   --font-mono    numerics / code
+ */
+
+:root {
+  /* ---- colour (themes override) ---- */
+  --bg: #fafaf7;
+  --fg: #1a1a1a;
+  --muted: #6b6b6b;
+  --line: #e5e3dc;
+  --accent: #8a2a2b;
+  --accent-strong: #6f2122;
+  /* a tinted surface for raised cards / pills (themes refine) */
+  --surface: #ffffff;
+  --surface-sunk: rgba(0, 0, 0, 0.04);
+
+  /* ---- type ---- */
+  --font-ui: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-serif: Georgia, "Times New Roman", serif;
+  --font-hebrew: serif;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+
+  /* ---- shape ---- */
+  --radius: 6px;
+  --radius-lg: 10px;
+  --radius-pill: 999px;
+
+  /* ---- elevation ---- */
+  --shadow-pop: 0 10px 34px rgba(40, 30, 12, 0.16);
+  --shadow-drawer: -10px 0 34px rgba(40, 30, 12, 0.14);
+}

--- a/packages/ui/src/tokens.css
+++ b/packages/ui/src/tokens.css
@@ -28,9 +28,18 @@
   --surface: #ffffff;
   --surface-sunk: rgba(0, 0, 0, 0.04);
 
-  /* ---- type ---- */
+  /* ---- type ----
+   * --font-ui and --font-serif are SHARED across every app (one chrome sans,
+   * one English reading serif) — the English reading experience is identical
+   * everywhere. Only --font-hebrew (the Hebrew face) is themed per app, since
+   * that's the real per-corpus difference (tanach: Frank Ruhl; talmud: Mekorot
+   * Vilna). Themes therefore override --font-hebrew + the palette, NOT these.
+   *
+   * --font-serif names Spectral; each app must load it (tanach does via its
+   * index.html; talmud loads it when it adopts @corpus/ui). Georgia is the
+   * fallback until then. */
   --font-ui: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-  --font-serif: Georgia, "Times New Roman", serif;
+  --font-serif: "Spectral", Georgia, "Times New Roman", serif;
   --font-hebrew: serif;
   --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       '@corpus/core':
         specifier: workspace:*
         version: link:../core
+      '@corpus/ui':
+        specifier: workspace:*
+        version: link:../ui
       hono:
         specifier: ^4.6.0
         version: 4.12.14
@@ -127,6 +130,8 @@ importers:
       wrangler:
         specifier: ^4.90.1
         version: 4.90.1(@cloudflare/workers-types@4.20260511.1)
+
+  packages/ui: {}
 
 packages:
 


### PR DESCRIPTION
First step of unifying tanach + talmud styling onto **one design system** — the chosen approach: a **shared kit with per-app themes** (each app keeps its identity, the drift ends). This PR lands the **token layer** and adopts it in **tanach only**. The component kit and talmud adoption are the next steps.

## Why
The two apps were styled independently and drifted: tanach set its *entire* UI — buttons, nav, pills — in the **Spectral serif** (the "weird font"), while talmud uses a neutral sans for chrome and reserves special fonts for Hebrew text. They didn't even share token names (`--ink` vs `--fg`) or palettes. There was no shared style layer (`@corpus/core` is logic-only).

## New package: `@corpus/ui` (CSS-only for now)
- **`tokens.css`** — one canonical variable vocabulary both apps will share (colour, type, shape, elevation). The type split that fixes the serif-everything look:
  - `--font-ui` — chrome (buttons, nav, pills, labels): a clean sans
  - `--font-serif` — Latin reading prose (English notes/overview)
  - `--font-hebrew` — Hebrew scripture + reading text (set per theme)
- **`themes/tanach.css`** — tanach's identity (brown/parchment, Spectral reading serif, Frank Ruhl Hebrew). Keeps an `--ink` alias so the existing sheet resolves during migration.
- **`themes/talmud.css`** — talmud's identity (maroon, Mekorot Vilna/Rashi). Defined for symmetry but **not consumed yet** — talmud is untouched in this PR.

## Tanach adoption
- `main.tsx` imports `@corpus/ui/tokens.css` + `themes/tanach.css` before `styles.css`.
- `styles.css` drops its local `:root` (now sourced from tokens + theme), consumes the vars, and the Hebrew-font literals become `var(--font-hebrew)`.
- **The font fix:** chrome (topbar controls, the perek pills, the drawer/popover uppercase labels) now renders in `--font-ui` (system sans); scripture, the overview prose, and the commentary reading text stay serif.

## Verification
- Computed styles in the running app: `.brand` / `.perek-pill` / `.chapter-nav button` / `.comm-kind` = **sans**; `.perek-prose` = **Spectral serif**; `.scroll-band` = **Frank Ruhl** (via `--font-hebrew`). Screenshot confirms the topbar + pills + "OVERVIEW" label are crisp sans while "The Binding of Isaac" and the prose stay serif.
- `pnpm typecheck` (all packages), `pnpm lint`, tanach suite (42 tests), and `vite build` — green. **Talmud unchanged.**

## Next
- **PR B** — extract the Solid component kit (Drawer, Pill, Button, Prose, LangToggle); adopt in tanach (overview drawer/pills become first consumers).
- **PR C** — point talmud at the shared tokens + theme, then migrate its components onto the kit. Also: the tanach `/usage` page chrome (left serif here to keep this diff focused on the reader).