### PR TITLE
Halacha lever B: gated Shas-wide warm of the halacha-refs source

### DIFF
--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -283,6 +283,8 @@ import {
 import { readUsageSummary, recordUsage } from './usage-rollup';
 import {
   getWarmTotal,
+  halachaWarmProgressProcessed,
+  readHalachaWarmCursor,
   readSefariaWarmCursor,
   readWarmCursor,
   runWarmCron,
@@ -5838,9 +5840,11 @@ app.get('/api/admin/warm-status', async (c) => {
   if (!cache) return c.json({ error: 'no cache binding' }, 503);
   const cursor = await readWarmCursor(cache);
   const sefariaCursor = await readSefariaWarmCursor(cache);
+  const halachaCursor = await readHalachaWarmCursor(cache);
   const total = getWarmTotal();
   const processed = warmProgressProcessed(cursor);
   const sefariaProcessed = sefariaWarmProgressProcessed(sefariaCursor);
+  const halachaProcessed = halachaWarmProgressProcessed(halachaCursor);
   return c.json({
     done: cursor.done === true,
     tractateIdx: cursor.tractateIdx,
@@ -5855,6 +5859,14 @@ app.get('/api/admin/warm-status', async (c) => {
       total,
       percent: total === 0 ? 0 : Math.round((sefariaProcessed / total) * 1000) / 10,
       wraps: sefariaCursor.wraps ?? 0,
+    },
+    halacha: {
+      tractateIdx: halachaCursor.tractateIdx,
+      amudIdx: halachaCursor.amudIdx,
+      processed: halachaProcessed,
+      total,
+      percent: total === 0 ? 0 : Math.round((halachaProcessed / total) * 1000) / 10,
+      wraps: halachaCursor.wraps ?? 0,
     },
   });
 });

--- a/packages/talmud/src/worker/warm-cron.ts
+++ b/packages/talmud/src/worker/warm-cron.ts
@@ -14,6 +14,7 @@ import { listDafyomiMasechtos } from '../lib/sefref/dafyomi/masechtos';
 import { TRACTATE_IDS } from '../lib/sefref/hebrewbooks/client';
 import {
   keyForDafyomi,
+  keyForHalachaRefs,
   keyForHebrewBooks,
   keyForSefariaBundle,
   keyForSefariaSegments,
@@ -22,6 +23,7 @@ import {
 import { computeCacheStats, writeCachedCacheStats } from './cache-stats';
 import {
   getDafyomiContentCached,
+  getHalachaRefsCached,
   getHebrewBooksDafCached,
   getSefariaPageCached,
   getSefariaSegmentsCached,
@@ -32,8 +34,16 @@ import type { JobMessage } from './types';
 
 const CURSOR_KEY = 'warm-cursor:v1';
 const SEFARIA_CURSOR_KEY = 'warm-cursor-sefaria:v1';
+const HALACHA_CURSOR_KEY = 'halacha-warm-cursor:v1';
 const BATCH_SIZE = 20;
 const FETCH_SLEEP_MS = 1000;
+// Halacha refs fan out internally: one getRelated + up to maxPerBook (6) getText
+// PER codifier work, all in parallel — a single amud can burst 30-50 Sefaria
+// subrequests. So this phase uses a much smaller per-tick batch than the Sefaria
+// phase to stay well under the Workers per-invocation subrequest cap and to keep
+// the parallel bursts polite to Sefaria. ~5 amudim/tick × 12 ticks/hr ≈ a
+// ~4-day full pass over Shas.
+const HALACHA_BATCH = 5;
 
 const TRACTATES = Object.keys(TRACTATE_IDS);
 const AMUDIM_BY_TRACTATE: string[][] = TRACTATES.map((t) => [...iterAmudim(t)]);
@@ -70,6 +80,13 @@ export interface WarmEnv {
    *  fan-out + pesukim) to extract across the whole shas. Set via wrangler.toml
    *  [vars] once you're ready to pay for the backfill. */
   OBSERVATIONS_WARM_SHAS?: string;
+  /** When '1', a small independent phase walks all of Shas filling the
+   *  halacha-refs source cache (Sefaria codifier links + their text) — the
+   *  source behind the halacha card + GET /api/halacha-text. Sefaria-only, no
+   *  LLM. OFF by default: it's a multi-day, getText-heavy Sefaria fill; set via
+   *  wrangler.toml [vars] when you're ready to run it. Lifts the ~3% coverage
+   *  (lazy/on-demand today) to the real halacha density of Shas. */
+  HALACHA_WARM_SHAS?: string;
 }
 
 export function getWarmTotal(): number {
@@ -305,6 +322,11 @@ export async function runWarmCron(env: WarmEnv): Promise<void> {
   // Gradual dafyomi.co.il ingestion (gated, self-latching). Independent phase.
   await runDafyomiBackfill(env);
 
+  // Gradual halacha-refs source fill (gated). Independent + small-batch because
+  // each amud bursts many Sefaria getText calls. Runs every tick regardless of
+  // the HB/Sefaria phase progress below.
+  await runHalachaPhase(env);
+
   const cursor = await readWarmCursor(cache);
   if (!cursor.done) {
     await runHbPhase(env, cursor);
@@ -458,5 +480,88 @@ async function runSefariaPhase(env: WarmEnv): Promise<void> {
   const elapsed = Date.now() - start;
   console.log(
     `[warm-cron] Sefaria processed=${processed} fetched=${fetched} elapsed=${elapsed}ms cursor=${tractateIdx}:${amudIdx} wraps=${wraps}`,
+  );
+}
+
+interface HalachaWarmCursor {
+  tractateIdx: number;
+  amudIdx: number;
+  /** Full passes over Shas (incremented on wrap), mirroring the Sefaria cursor. */
+  wraps?: number;
+}
+
+async function readHalachaCursor(cache: KVNamespace): Promise<HalachaWarmCursor> {
+  const raw = await cache.get(HALACHA_CURSOR_KEY);
+  if (!raw) return { tractateIdx: 0, amudIdx: 0, wraps: 0 };
+  try {
+    return JSON.parse(raw) as HalachaWarmCursor;
+  } catch {
+    return { tractateIdx: 0, amudIdx: 0, wraps: 0 };
+  }
+}
+
+export async function readHalachaWarmCursor(cache: KVNamespace): Promise<HalachaWarmCursor> {
+  return readHalachaCursor(cache);
+}
+
+export function halachaWarmProgressProcessed(cursor: HalachaWarmCursor): number {
+  let n = 0;
+  for (let i = 0; i < cursor.tractateIdx && i < AMUDIM_BY_TRACTATE.length; i++) {
+    n += AMUDIM_BY_TRACTATE[i].length;
+  }
+  n += cursor.amudIdx;
+  return Math.min(n, TOTAL_AMUDIM);
+}
+
+/**
+ * Gated by HALACHA_WARM_SHAS='1'. Walks all of Shas a few amudim per tick,
+ * filling the `halacha-refs` source cache (Sefaria codifier links + their text)
+ * that backs the halacha card and GET /api/halacha-text. Each amud bursts many
+ * Sefaria getText calls (up to maxPerBook per codifier work), so the batch is
+ * small. Empty bundles (dapim with no codifier link) are cached too, so the walk
+ * is idempotent (skip-if-cached) and `/usage` coverage settles at the real
+ * halacha density of Shas rather than the ~3% the lazy/on-demand path showed.
+ * 30-day TTL like the other Sefaria sources, so the cursor wraps and refills.
+ */
+export async function runHalachaPhase(env: WarmEnv): Promise<void> {
+  if (env.HALACHA_WARM_SHAS !== '1' || !env.CACHE) return;
+  const cache = env.CACHE;
+  const cursor = await readHalachaCursor(cache);
+  let { tractateIdx, amudIdx, wraps = 0 } = cursor;
+  let processed = 0;
+  let fetched = 0;
+  const start = Date.now();
+
+  while (processed < HALACHA_BATCH) {
+    while (tractateIdx < TRACTATES.length && amudIdx >= AMUDIM_BY_TRACTATE[tractateIdx].length) {
+      tractateIdx++;
+      amudIdx = 0;
+    }
+    if (tractateIdx >= TRACTATES.length) {
+      wraps++;
+      tractateIdx = 0;
+      amudIdx = 0;
+      console.log(`[warm-cron] halacha pass ${wraps} complete — wrapping`);
+    }
+
+    const tractate = TRACTATES[tractateIdx];
+    const amud = AMUDIM_BY_TRACTATE[tractateIdx][amudIdx];
+    // Skip if already cached (incl. an empty bundle for a no-halacha daf), so a
+    // pass only pays Sefaria for the dapim it hasn't filled yet.
+    const hit = await cache.get(keyForHalachaRefs(tractate, amud));
+    if (hit === null) {
+      await getHalachaRefsCached(cache, tractate, amud);
+      fetched++;
+      await new Promise((r) => setTimeout(r, FETCH_SLEEP_MS));
+    }
+
+    amudIdx++;
+    processed++;
+  }
+
+  await cache.put(HALACHA_CURSOR_KEY, JSON.stringify({ tractateIdx, amudIdx, wraps }));
+  const elapsed = Date.now() - start;
+  console.log(
+    `[warm-cron] halacha processed=${processed} fetched=${fetched} elapsed=${elapsed}ms cursor=${tractateIdx}:${amudIdx} wraps=${wraps}`,
   );
 }

--- a/packages/talmud/tests/halacha-warm.test.ts
+++ b/packages/talmud/tests/halacha-warm.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  halachaWarmProgressProcessed,
+  readHalachaWarmCursor,
+  runHalachaPhase,
+} from '../src/worker/warm-cron';
+
+const CURSOR_KEY = 'halacha-warm-cursor:v1';
+
+// Minimal KV stub: the cursor key reads back what was put; halacha-refs keys are
+// "all cached" or "all cold" per the flag — so the phase can be exercised
+// without touching Sefaria (an all-cached run skips every fetch).
+function mockCache(opts: { halachaCached: boolean }) {
+  const puts: Record<string, string> = {};
+  const get = vi.fn(async (k: string) => {
+    if (k === CURSOR_KEY) return puts[k] ?? null;
+    if (k.startsWith('halacha-refs:')) return opts.halachaCached ? '{}' : null;
+    return null;
+  });
+  const put = vi.fn(async (k: string, v: string) => {
+    puts[k] = v;
+  });
+  return { puts, get, put } as unknown as KVNamespace & {
+    puts: Record<string, string>;
+    get: ReturnType<typeof vi.fn>;
+    put: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe('runHalachaPhase — gated Shas-wide halacha-refs fill', () => {
+  it('is a no-op when HALACHA_WARM_SHAS is unset (dormant by default)', async () => {
+    const cache = mockCache({ halachaCached: true });
+    await runHalachaPhase({ CACHE: cache });
+    expect(cache.get).not.toHaveBeenCalled();
+    expect(cache.put).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when the flag is '0'", async () => {
+    const cache = mockCache({ halachaCached: true });
+    await runHalachaPhase({ CACHE: cache, HALACHA_WARM_SHAS: '0' });
+    expect(cache.put).not.toHaveBeenCalled();
+  });
+
+  it('advances the cursor by one batch and skips already-cached dapim (no fetch)', async () => {
+    const cache = mockCache({ halachaCached: true });
+    await runHalachaPhase({ CACHE: cache, HALACHA_WARM_SHAS: '1' });
+    const raw = cache.puts[CURSOR_KEY];
+    expect(raw).toBeTruthy();
+    const cursor = JSON.parse(raw);
+    // Exactly one batch of amudim consumed (HALACHA_BATCH = 5), regardless of
+    // which tractate leads the walk.
+    expect(halachaWarmProgressProcessed(cursor)).toBe(5);
+    expect(cursor.wraps).toBe(0);
+    // Every probed key was already cached, so no halacha-refs were (re)written —
+    // only the cursor key is put.
+    const putKeys = cache.put.mock.calls.map((c) => c[0] as string);
+    expect(putKeys).toEqual([CURSOR_KEY]);
+  });
+
+  it('resumes from a persisted cursor', async () => {
+    const cache = mockCache({ halachaCached: true });
+    cache.puts[CURSOR_KEY] = JSON.stringify({ tractateIdx: 0, amudIdx: 10, wraps: 0 });
+    await runHalachaPhase({ CACHE: cache, HALACHA_WARM_SHAS: '1' });
+    const cursor = JSON.parse(cache.puts[CURSOR_KEY]);
+    expect(halachaWarmProgressProcessed(cursor)).toBe(15); // 10 + one batch of 5
+  });
+});
+
+describe('halacha warm cursor helpers', () => {
+  it('defaults a missing cursor to the start', async () => {
+    const cache = mockCache({ halachaCached: false });
+    expect(await readHalachaWarmCursor(cache)).toEqual({ tractateIdx: 0, amudIdx: 0, wraps: 0 });
+  });
+
+  it('counts processed amudim from the cursor position', () => {
+    expect(halachaWarmProgressProcessed({ tractateIdx: 0, amudIdx: 0 })).toBe(0);
+    expect(halachaWarmProgressProcessed({ tractateIdx: 0, amudIdx: 7 })).toBe(7);
+  });
+});


### PR DESCRIPTION
## Why

`halacha-refs` is fetched **lazily** — only when a daf is viewed and the codification enrichment resolves it. That's the whole reason `/usage` shows **Halacha at ~3%** (only ~143 visited dapim are cached). This warms it across Shas in the background so the halacha card + `GET /api/halacha-text` (lever A, #430) are present and instant everywhere, and the coverage number reflects the real halacha density.

## What

An **independent, gated** warm phase (`runHalachaPhase`), modeled on the existing dafyomi/observations phases:

- **Dormant by default.** Gated by `HALACHA_WARM_SHAS='1'`; unset → the phase returns immediately, so this merge changes nothing until you flip the flag.
- **Idempotent.** Own cursor (`halacha-warm-cursor:v1`), skip-if-cached. Empty bundles (dapim with no codifier link) are cached too, so coverage settles at Shas's true halacha density (not 100%), and a pass only pays Sefaria for unfilled dapim. 30-day-TTL wrap-and-refill, like the other Sefaria sources.
- **Small batch on purpose.** `fetchHalachicRefs` bursts up to `maxPerBook` (6) `getText` calls **per codifier work, in parallel** — a single amud can be 30-50 Sefaria subrequests. So `HALACHA_BATCH=5` (vs the Sefaria phase's 20) keeps each cron tick well under the Workers per-invocation subrequest cap and polite to Sefaria. ~5 amudim/tick ≈ a **~4-day** full pass. **Sefaria-only, no LLM ($0 model cost).**
- **Observable.** `GET /api/admin/warm-status` now reports a `halacha` cursor + percent.

## Scope boundary
This warms the **source** (Sefaria codifier text), not the LLM `halacha.codification` summary, which still generates lazily per daf. So a never-visited daf gets instant source refs + source texts; the LLM lineage prose still computes on first view. (Warming that too would be a separate, expensive LLM fill — deliberately not here.)

## How to enable
Set `HALACHA_WARM_SHAS = "1"` in `wrangler.toml` `[vars]` (or the dashboard env). Watch progress at `/api/admin/warm-status` → `halacha.percent`. Leave unset to keep it off.

## Checks
- `pnpm typecheck` clean
- `pnpm --filter talmud test` — 2471 passed (incl. 6 new: gate no-op when unset/'0', one-batch cursor advance with skip-if-cached/no-fetch, cursor resume, progress math)
- Biome clean
- No new cache key → #425 drift guard unaffected.