### PR TITLE
Queue robustness: guard Sefaria link shape + budget commentary context

### DIFF
--- a/packages/talmud/src/worker/commentary.ts
+++ b/packages/talmud/src/worker/commentary.ts
@@ -77,7 +77,20 @@ export async function fetchCommentaryWorks(
   }
   if (!res.ok) return { error: `Sefaria ${res.status}` };
 
-  const raw = (await res.json()) as Array<{
+  // Sefaria's links endpoint normally returns an array, but on some refs it
+  // returns an error OBJECT (or non-JSON) with a 200 — which used to crash the
+  // rishonim mark with "raw is not iterable" and hard-fail the queue job.
+  // Guard the shape so a bad response degrades to a clean error instead.
+  let parsed: unknown;
+  try {
+    parsed = await res.json();
+  } catch (err) {
+    return { error: `Sefaria links non-JSON: ${String(err)}` };
+  }
+  if (!Array.isArray(parsed)) {
+    return { error: `Sefaria links non-array response (${typeof parsed})` };
+  }
+  const raw = parsed as Array<{
     ref?: string;
     sourceRef?: string;
     anchorRef?: string;

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -6970,7 +6970,11 @@ app.get('/api/references/:tractate/:page', async (c) => {
   try {
     const res = await fetch(url, { headers: { accept: 'application/json' } });
     if (!res.ok) return c.json({ error: `Sefaria ${res.status}` }, 502);
-    const raw = (await res.json()) as Array<{
+    // Guard the shape: Sefaria sometimes returns an error object (not an array)
+    // with a 200, which would otherwise crash the iteration below.
+    const parsed = (await res.json()) as unknown;
+    if (!Array.isArray(parsed)) return c.json({ error: 'Sefaria non-array links' }, 502);
+    const raw = parsed as Array<{
       ref?: string;
       sourceRef?: string;
       anchorRef?: string;

--- a/packages/talmud/src/worker/run-sources.ts
+++ b/packages/talmud/src/worker/run-sources.ts
@@ -64,14 +64,46 @@ function gemaraSliceToVars(s: GemaraSlice): Record<string, unknown> {
   };
 }
 
-function commentariesSliceToString(s: CommentariesSlice): string {
+// The full rishonim of a dense daf (e.g. Bava Metzia 2b) run to well over a
+// million tokens — enough to blow past the model's 1,048,576-token context
+// limit and HARD-FAIL the whole enrichment (a 400, so the daf got no synthesis
+// at all). Cap the commentary text fed into prompts: per-commentator caps keep
+// every commentator represented; the total budget is the backstop. Limits are
+// generous so ordinary dapim are unaffected (their text is well under), and the
+// cap never touches cache keys (those derive from markInput+recipe, not source
+// text) — so existing cached output is untouched and only re-runs see the trim.
+const COMMENTARY_PER_WORK_HE = 12_000;
+const COMMENTARY_PER_WORK_EN = 16_000;
+const COMMENTARY_TOTAL_BUDGET = 360_000;
+
+function capText(s: string, max: number): string {
+  const clean = (s ?? '').trim();
+  return clean.length > max ? `${clean.slice(0, max).trimEnd()} …[trimmed]` : clean;
+}
+
+export function commentariesSliceToString(s: CommentariesSlice): string {
   const names = Object.keys(s.by_commentator).sort();
-  return names
-    .map((n) => {
-      const row = s.by_commentator[n];
-      return `[${n}]\n${row.hebrew}\n${row.english}`.trim();
-    })
-    .join('\n\n---\n\n');
+  const parts: string[] = [];
+  let used = 0;
+  let omitted = 0;
+  for (const n of names) {
+    if (used >= COMMENTARY_TOTAL_BUDGET) {
+      omitted++;
+      continue;
+    }
+    const row = s.by_commentator[n];
+    const block = `[${n}]\n${capText(row.hebrew, COMMENTARY_PER_WORK_HE)}\n${capText(
+      row.english,
+      COMMENTARY_PER_WORK_EN,
+    )}`.trim();
+    parts.push(block);
+    used += block.length;
+  }
+  // Never silently truncate: tell the model (and the inspector) what was dropped.
+  if (omitted > 0) {
+    parts.push(`[… ${omitted} further commentaries omitted to fit the context budget]`);
+  }
+  return parts.join('\n\n---\n\n');
 }
 
 /**

--- a/packages/talmud/tests/commentary-budget.test.ts
+++ b/packages/talmud/tests/commentary-budget.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { type CommentariesSlice, commentariesSliceToString } from '../src/worker/run-sources';
+
+// A dense daf's full rishonim can exceed the model's 1M-token context limit and
+// hard-fail the enrichment (a 400 → no synthesis at all). commentariesSliceToString
+// caps the text fed into the prompt. These pin that: ordinary text is untouched,
+// pathological text is bounded, and the omission is announced (never silent).
+const slice = (by: Record<string, { hebrew: string; english: string }>): CommentariesSlice => ({
+  tractate: 'Bava Metzia',
+  page: '2a',
+  by_commentator: Object.fromEntries(Object.entries(by).map(([n, v]) => [n, { ...v, ref: n }])),
+});
+
+describe('commentariesSliceToString — context budget', () => {
+  it('leaves ordinary commentary untouched', () => {
+    const out = commentariesSliceToString(
+      slice({ Rashi: { hebrew: 'רש"י', english: 'Rashi says' } }),
+    );
+    expect(out).toBe('[Rashi]\nרש"י\nRashi says');
+    expect(out).not.toContain('trimmed');
+  });
+
+  it('caps a single huge commentator and marks the trim', () => {
+    const out = commentariesSliceToString(
+      slice({ Tosafot: { hebrew: 'ת'.repeat(50_000), english: 'a'.repeat(50_000) } }),
+    );
+    expect(out).toContain('[trimmed]');
+    // Bounded well under the raw 100k: per-work caps are 12k HE + 16k EN.
+    expect(out.length).toBeLessThan(40_000);
+  });
+
+  it('drops the long tail past the total budget and announces how many', () => {
+    // 60 commentators × ~12k chars each would be ~720k — over the 360k budget.
+    const many: Record<string, { hebrew: string; english: string }> = {};
+    for (let i = 0; i < 60; i++) {
+      many[`Work${String(i).padStart(2, '0')}`] = {
+        hebrew: 'ת'.repeat(11_000),
+        english: 'a'.repeat(11_000),
+      };
+    }
+    const out = commentariesSliceToString(slice(many));
+    expect(out).toMatch(/\d+ further commentaries omitted to fit the context budget/);
+  });
+
+  it('returns empty string when there is no commentary', () => {
+    expect(commentariesSliceToString(slice({}))).toBe('');
+  });
+});


### PR DESCRIPTION
Two recurring hard failures in the enrichment queue consumer, both visible on `/usage` telemetry (Queue job failures + Recent errors).

## 1. `raw is not iterable` — rishonim mark crash

`fetchCommentaryWorks` (`commentary.ts`) asserted `(await res.json()) as Array<...>` — a compile-time cast, **not** a runtime check — then iterated it. Sefaria's links endpoint sometimes returns an error **object** with a `200`, so `for (const l of raw)` threw and killed the whole queue job. Seen on **Rosh Hashanah 86a, Taanit 64a, Beitzah 46a**.

**Fix:** guard `Array.isArray` after parsing, degrade to a clean `{ error }`. Same guard added to the `/api/references` endpoint (identical unchecked-cast pattern).

## 2. >1M-token context → OpenRouter 400

`argument.synthesis` / `biyun.essay` on dense dapim (**Bava Metzia 2b**, repeatedly) assembled prompts of **~1.2M tokens** and hit `maximum context length is 1048576 tokens` → 400 → the daf got **no synthesis at all**. The `commentaries` source concatenated the full Hebrew+English of *every* rishon with **no cap**.

**Fix:** `commentariesSliceToString` now applies per-commentator caps (12k HE / 16k EN) plus a 360k-char total budget, and **announces** any omission rather than truncating silently.

### Why this is safe (no re-warm, no regression)
- Caps are generous — ordinary dapim are well under them, so their assembled text is unchanged.
- The cap **never touches cache keys** (those derive from `markInput` + recipe, not source text), so **existing cached syntheses are served untouched**. Only the currently-*failing* dapim change — from "nothing" to a trimmed-but-real result — on their next run.

## Tests
`commentary-budget.test.ts`: ordinary text untouched, a huge single commentator bounded, the long tail dropped with an announced count, empty slice → empty string.

`pnpm typecheck` / `pnpm test` (2469 pass) / `pnpm lint` green.