### PR TITLE
argument-move: dedupe doubled instances at the source (unpin duplicate-instance cards)

### DIFF
--- a/packages/talmud/src/lib/check/passes.ts
+++ b/packages/talmud/src/lib/check/passes.ts
@@ -168,6 +168,41 @@ function instancesOf(parsed: unknown): RangeInstance[] {
   return Array.isArray(arr) ? (arr as RangeInstance[]) : [];
 }
 
+/** The identity shared by the `duplicate-instance` check and the
+ *  `dedupe-instances` transform, so they can never drift. A TRUE duplicate is
+ *  the same move slot (deterministic id), same range, same start+end excerpt;
+ *  two legitimate moves that merely share a segment and a formulaic opening
+ *  (תא שמע / אמר רבא) differ on id / end anchor / order and so survive. */
+function duplicateInstanceKey(inst: RangeInstance): string {
+  const ex = typeof inst.fields?.excerpt === 'string' ? normalizeHebrew(inst.fields.excerpt) : '';
+  const endEx =
+    typeof inst.fields?.endExcerpt === 'string' ? normalizeHebrew(inst.fields.endExcerpt) : '';
+  const id = typeof inst.fields?.id === 'string' ? inst.fields.id : '';
+  return `${id}|${inst.startSegIdx}|${inst.endSegIdx}|${ex}|${endEx}`;
+}
+
+/** dedupe-instances (transform) — drop instances the `duplicate-instance` check
+ *  would flag as emitted-twice, keeping the first. Using the SAME identity as
+ *  the check means it can only ever remove an instance the check would reject —
+ *  never a legitimately-distinct move. Run it AFTER the re-anchor transform so
+ *  it dedupes the FINAL anchored ranges the validator will see; that way a
+ *  doubled LLM emission can never hard-block the cache write (which pins the
+ *  card) nor inflate the per-move enrichment fan-out. */
+function dedupeInstances(parsed: unknown): unknown {
+  const insts = instancesOf(parsed);
+  if (insts.length < 2) return parsed;
+  const seen = new Set<string>();
+  const out: RangeInstance[] = [];
+  for (const inst of insts) {
+    const key = duplicateInstanceKey(inst);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(inst);
+  }
+  if (out.length === insts.length) return parsed; // nothing dropped
+  return { ...(parsed as object), instances: out };
+}
+
 /** anchor-verbatim — the instance's `excerpt` can actually be located in the
  *  segment it was anchored to, USING THE SAME MATCHER THAT PLACED IT. The
  *  re-anchorers (reanchorArgumentMove / -Pesukim / -Aggadata) call findExcerpt,
@@ -383,22 +418,15 @@ const partitionClean: PostPass = {
           detail: `${s}-${e}`,
         });
       }
-      // True-duplicate identity, not just range+opener: two legitimate moves can
-      // share a segment and a formulaic opening (תא שמע / אמר רבא) yet differ in
-      // their deterministic id, end anchor, or order. Keying on those avoids
-      // hard-blocking a correct output while still catching a genuinely emitted-
-      // twice instance (same id ⇒ same move slot).
-      const ex =
-        typeof inst.fields?.excerpt === 'string' ? normalizeHebrew(inst.fields.excerpt) : '';
-      const endEx =
-        typeof inst.fields?.endExcerpt === 'string' ? normalizeHebrew(inst.fields.endExcerpt) : '';
-      const id = typeof inst.fields?.id === 'string' ? inst.fields.id : '';
-      const key = `${id}|${s}|${e}|${ex}|${endEx}`;
+      // True-duplicate identity, not just range+opener (see duplicateInstanceKey):
+      // the `dedupe-instances` transform removes these at the source using the
+      // SAME key, so a producer listing that pass never reaches this check.
+      const key = duplicateInstanceKey(inst);
       if (seen.has(key))
         issues.push({
           kind: 'duplicate-instance',
           severity: severityOf('duplicate-instance', ctx.defId),
-          match: ex || undefined,
+          match: typeof inst.fields?.excerpt === 'string' ? inst.fields.excerpt : undefined,
           index: typeof s === 'number' ? s : -1,
         });
       else seen.add(key);
@@ -542,6 +570,7 @@ export const PASSES: Record<string, PostPass> = {
     phase: 'transform',
     run: (parsed) => ({ parsed: deriveVoiceEdges(parsed) }),
   },
+  'dedupe-instances': transform('dedupe-instances', (p) => dedupeInstances(p)),
   'yerushalmi-floor': yerushalmiFloorPass,
   'hebrew-excerpt': hebrewExcerpt,
   'hebrew-gloss': hebrewGloss,

--- a/packages/talmud/src/worker/code-marks.ts
+++ b/packages/talmud/src/worker/code-marks.ts
@@ -3726,7 +3726,15 @@ CODE_MARKS.push({
     fan_out_over: 'argument',
   },
   dependencies: ['gemara', { mark: 'argument' }],
-  passes: ['reanchor-argument-move', 'anchor-verbatim', 'partition-clean'],
+  // dedupe-instances runs AFTER reanchor (so it sees the final anchored ranges
+  // the partition-clean validator will check) and BEFORE the validators — a
+  // doubled LLM emission is dropped at the source instead of hard-failing the
+  // `duplicate-instance` check and pinning the card. Cache version is
+  // intentionally NOT bumped: the dedupe is backward-compatible (it only removes
+  // instances the check already rejected) and a Shas-wide re-warm of this core
+  // mark is not worth it for rare duplicates — cold/re-warmed dapim pick it up,
+  // and the handful of currently-pinned dapim heal on a cheap targeted re-warm.
+  passes: ['reanchor-argument-move', 'dedupe-instances', 'anchor-verbatim', 'partition-clean'],
   status: 'promoted',
   def_hash: 'argument-move-v9',
   cache_version: '9',

--- a/packages/talmud/tests/check/soft-checks.test.ts
+++ b/packages/talmud/tests/check/soft-checks.test.ts
@@ -245,6 +245,41 @@ describe('partition-clean', () => {
     expect(issues).toEqual([]);
   });
 
+  it('dedupe-instances drops an exact duplicate at the source, so partition-clean stays clean', async () => {
+    const dup = {
+      startSegIdx: 3,
+      endSegIdx: 4,
+      fields: { id: '3-4_0', excerpt: 'אמר רבא הלכה', endExcerpt: 'כרבי יהודה' },
+    };
+    const { parsed, issues } = await runPasses(
+      ['dedupe-instances', 'partition-clean'],
+      { instances: [dup, { ...dup, fields: { ...dup.fields } }] },
+      ctx({ defId: 'argument-move' }),
+    );
+    expect((parsed as { instances: unknown[] }).instances).toHaveLength(1);
+    expect(issues).toEqual([]); // the duplicate was removed before the check ran
+  });
+
+  it('dedupe-instances keeps two distinct moves that share a range + opener', async () => {
+    const a = {
+      startSegIdx: 6,
+      endSegIdx: 6,
+      fields: { id: '6-6_0', excerpt: 'תא שמע', endExcerpt: 'פטור' },
+    };
+    const b = {
+      startSegIdx: 6,
+      endSegIdx: 6,
+      fields: { id: '6-6_1', excerpt: 'תא שמע', endExcerpt: 'חייב' },
+    };
+    const { parsed, issues } = await runPasses(
+      ['dedupe-instances', 'partition-clean'],
+      { instances: [a, b] },
+      ctx({ defId: 'argument-move' }),
+    );
+    expect((parsed as { instances: unknown[] }).instances).toHaveLength(2); // both survive
+    expect(issues).toEqual([]);
+  });
+
   it('flags overlapping section ranges only for the argument mark, and only soft (a shared boundary can be legitimate)', async () => {
     const overlapping = {
       instances: [

--- a/packages/talmud/tests/check/wiring.test.ts
+++ b/packages/talmud/tests/check/wiring.test.ts
@@ -18,7 +18,12 @@ import { CODE_ENRICHMENTS, CODE_MARKS } from '../../src/worker/code-marks';
 describe('declarative pass wiring', () => {
   const markChecks: Record<string, string[]> = {
     argument: ['reanchor-argument', 'anchor-verbatim', 'partition-clean'],
-    'argument-move': ['reanchor-argument-move', 'anchor-verbatim', 'partition-clean'],
+    'argument-move': [
+      'reanchor-argument-move',
+      'dedupe-instances',
+      'anchor-verbatim',
+      'partition-clean',
+    ],
     pesukim: ['reanchor-pesukim', 'anchor-verbatim'],
     aggadata: ['reanchor-aggadata', 'anchor-verbatim'],
   };


### PR DESCRIPTION
## Problem

The `argument-move` mark occasionally emits the **same move twice**. The `duplicate-instance` lint check is **`hard`**, so a doubled emission blocks the cache write and **pins the card** — recurring on Chullin 40a, Kiddushin 29b, Bava Kamma 17b, Avodah Zarah 2a, Berakhot 3b/4a, Chullin 35b. The duplicate also inflates the per-move enrichment fan-out (commentaries / synthesis / suggested-questions).

## Fix

A `dedupe-instances` transform pass that removes exactly the instances the `duplicate-instance` check would reject. It shares **one identity helper** (`duplicateInstanceKey`) with the check, so the two can never drift — it can only ever remove an instance the check already rejects, **never** a legitimately-distinct move (two real moves that share a segment + a formulaic opener like `תא שמע` differ on id/end/order and survive).

Wired into `argument-move` **after** `reanchor-argument-move` (so it dedupes the *final* anchored ranges the validator checks) and **before** the validators.

### Cost decision: no cache-version bump
Deliberately **not** bumping `argument-move`'s cache version. The dedupe is backward-compatible (only removes instances the check already rejected), and a Shas-wide re-warm of this core mark isn't worth it for rare duplicates. Cold and re-warmed dapim pick it up automatically; the handful of currently-pinned dapim heal on a cheap **targeted** re-warm.

## Tests
- `dedupe-instances` drops an exact duplicate → `partition-clean` stays clean.
- Two distinct moves sharing a range + opener both survive.
- `wiring.test.ts` pins the new passes order (it caught the change).

`pnpm typecheck` / `pnpm test` (2477 pass) / `pnpm lint` green.