### PR TITLE
Shared UI kit: Solid components (Pill/Drawer/Button/Prose/LangToggle), adopt in tanach

### DIFF
--- a/packages/tanach/src/client/App.tsx
+++ b/packages/tanach/src/client/App.tsx
@@ -1,3 +1,8 @@
+import { Button } from '@corpus/ui/Button';
+import { Drawer } from '@corpus/ui/Drawer';
+import { LangToggle } from '@corpus/ui/LangToggle';
+import { Pill, PillRow } from '@corpus/ui/Pill';
+import { Prose } from '@corpus/ui/Prose';
 import {
   createEffect,
   createMemo,
@@ -643,42 +648,26 @@ export function App(): JSX.Element {
           </button>
         </Show>
 
-        {/* biome-ignore lint/a11y/useSemanticElements: a fieldset would bring UA margin/padding/min-inline-size and change the toggle's layout; div+role="group" carries the same semantics */}
-        <div class="lang-toggle" role="group" aria-label="Language">
-          <button
-            type="button"
-            classList={{ active: loc().lang === 'en' }}
-            onClick={() => update({ lang: 'en' })}
-          >
-            EN
-          </button>
-          <button
-            type="button"
-            classList={{ active: loc().lang === 'he' }}
-            onClick={() => update({ lang: 'he' })}
-          >
-            עב
-          </button>
-        </div>
+        <LangToggle lang={loc().lang} onChange={(lang) => update({ lang })} />
 
         <a class="usage-link" href="/usage" title="LLM usage">
           usage
         </a>
 
         <div class="chapter-nav">
-          <button
-            type="button"
+          <Button
             disabled={loc().chapter <= 1}
             onClick={() => goto(loc().book, loc().chapter - 1)}
+            aria-label="Previous chapter"
           >
             ‹
-          </button>
+          </Button>
           <span class="chapter-label">
             {loc().lang === 'he' ? hebrewNumeral(loc().chapter) : `ch. ${loc().chapter}`}
           </span>
-          <button type="button" onClick={() => goto(loc().book, loc().chapter + 1)}>
+          <Button onClick={() => goto(loc().book, loc().chapter + 1)} aria-label="Next chapter">
             ›
-          </button>
+          </Button>
         </div>
       </header>
 
@@ -707,20 +696,15 @@ export function App(): JSX.Element {
       <Show when={loc().view === 'scroll' && data()}>
         {(ch) => (
           <main class="scroll-main" ref={(el) => (scrollMain = el)}>
-            <div class="perek-pills">
+            <PillRow>
               <For each={PEREK_PILLS}>
                 {(p) => (
-                  <button
-                    type="button"
-                    class="perek-pill"
-                    classList={{ active: perekPill() === p.id }}
-                    onClick={() => openPill(p.id)}
-                  >
+                  <Pill active={perekPill() === p.id} onClick={() => openPill(p.id)}>
                     {p.label}
-                  </button>
+                  </Pill>
                 )}
               </For>
-            </div>
+            </PillRow>
             {/* biome-ignore lint/a11y/noStaticElementInteractions: scripture prose surface; onMouseUp is text-selection word lookup and onClick is a pointer convenience delegated to verse-number spans inside innerHTML — a role would mis-announce running text */}
             {/* biome-ignore lint/a11y/useKeyWithClickEvents: the click target (.vnum spans inside innerHTML) is not focusable; the same verse drawers are keyboard-reachable via the gutter <button>s (evt-margin / vgutter) */}
             <div
@@ -832,158 +816,137 @@ export function App(): JSX.Element {
           verse-source drawer, mutually exclusive with it */}
       <Show when={perekPill()} keyed>
         {(pill) => (
-          <aside class="comm-drawer perek-drawer" dir={loc().lang === 'he' ? 'rtl' : 'ltr'}>
-            <header class="comm-head">
-              <span class="comm-ref">
-                {loc().lang === 'he'
-                  ? `${heBook(loc().book)} ${hebrewNumeral(loc().chapter)}`
-                  : `${loc().book} ${loc().chapter}`}
-              </span>
-              <span class="comm-kind">{PILL_KIND[pill]}</span>
-              <button
-                type="button"
-                class="comm-close"
-                onClick={() => setPerekPill(null)}
-                aria-label="Close"
-              >
-                ×
-              </button>
-            </header>
-            <div class="comm-body">
-              <Show when={pill === 'overview'}>
-                <Show when={overview.loading}>
-                  <p class="comm-muted">Reading the chapter…</p>
-                </Show>
-                <Show when={currentOverview()}>
-                  {(o) => {
-                    const he = loc().lang === 'he';
-                    const title = he ? o().titleHe || o().titleEn : o().titleEn || o().titleHe;
-                    const body = he ? o().he || o().en : o().en || o().he;
-                    return (
-                      <section class="perek-overview">
-                        <Show when={title}>
-                          <h3 class="perek-title">{title}</h3>
-                        </Show>
-                        <p class="perek-prose" dir={he ? 'rtl' : 'ltr'}>
-                          {body}
-                        </p>
-                      </section>
-                    );
-                  }}
-                </Show>
-                {/* fetched but failed (overview() is null, not undefined) */}
-                <Show when={!overview.loading && overview() === null}>
-                  <p class="comm-muted">Couldn't load the overview — try reopening.</p>
-                </Show>
+          <Drawer
+            dir={loc().lang === 'he' ? 'rtl' : 'ltr'}
+            title={
+              loc().lang === 'he'
+                ? `${heBook(loc().book)} ${hebrewNumeral(loc().chapter)}`
+                : `${loc().book} ${loc().chapter}`
+            }
+            label={PILL_KIND[pill]}
+            onClose={() => setPerekPill(null)}
+          >
+            <Show when={pill === 'overview'}>
+              <Show when={overview.loading}>
+                <p class="comm-muted">Reading the chapter…</p>
               </Show>
-            </div>
-          </aside>
+              <Show when={currentOverview()}>
+                {(o) => (
+                  <section class="perek-overview">
+                    <Show
+                      when={
+                        loc().lang === 'he'
+                          ? o().titleHe || o().titleEn
+                          : o().titleEn || o().titleHe
+                      }
+                    >
+                      {(title) => <h3 class="perek-title">{title()}</h3>}
+                    </Show>
+                    <Prose en={o().en} he={o().he} lang={loc().lang} />
+                  </section>
+                )}
+              </Show>
+              {/* fetched but failed (overview() is null, not undefined) */}
+              <Show when={!overview.loading && overview() === null}>
+                <p class="comm-muted">Couldn't load the overview — try reopening.</p>
+              </Show>
+            </Show>
+          </Drawer>
         )}
       </Show>
 
       {/* Classic commentary drawer (click a verse number) */}
       <Show when={source()} keyed>
         {(s) => (
-          <aside class="comm-drawer" dir={loc().lang === 'he' ? 'rtl' : 'ltr'}>
-            <header class="comm-head">
-              <span class="comm-ref">
-                {loc().lang === 'he'
-                  ? `${heBook(loc().book)} ${hebrewNumeral(loc().chapter)}:${hebrewNumeral(s.verse)}`
-                  : `${loc().book} ${loc().chapter}:${s.verse}`}
-              </span>
-              <span class="comm-kind">{SECTION_TITLE[s.kind]}</span>
-              <button
-                type="button"
-                class="comm-close"
-                onClick={() => setSource(null)}
-                aria-label="Close"
-              >
-                ×
-              </button>
-            </header>
-            <div class="comm-body">
-              <Show when={s.kind === 'rishonim'}>
-                <Show when={richSet().has(s.verse)}>
-                  <section class="comm-synth">
-                    <h4 class="comm-synth-name">Synthesis</h4>
-                    <Show when={synthesis.loading}>
-                      <p class="comm-muted">Synthesizing the commentators…</p>
-                    </Show>
-                    <Show when={synthesis()}>
-                      {(sy) => (
-                        <p class="comm-synth-text" dir={loc().lang === 'he' ? 'rtl' : 'ltr'}>
-                          {loc().lang === 'he' ? sy().he || sy().en : sy().en || sy().he}
-                        </p>
-                      )}
-                    </Show>
-                  </section>
-                </Show>
-                <Show when={commentary.loading}>
-                  <p class="comm-muted">Loading commentary…</p>
-                </Show>
-                <Show when={commentary()}>
-                  {(d) => (
-                    <For
-                      each={d().commentaries}
-                      fallback={<p class="comm-muted">No commentary on this verse.</p>}
-                    >
-                      {(cm) => {
-                        // The rishonim themselves always show in the Hebrew /
-                        // Aramaic original (the English is a weak translation);
-                        // fall back to English only when no Hebrew is available.
-                        const useEn = cm.he.length === 0;
-                        return (
-                          <section class="comm-entry">
-                            <h4 class="comm-name">{loc().lang === 'he' ? cm.heName : cm.en}</h4>
-                            <For each={useEn ? cm.enText : cm.he}>
-                              {(seg) => (
-                                <p class="comm-text" dir={useEn ? 'ltr' : 'rtl'} innerHTML={seg} />
-                              )}
-                            </For>
-                          </section>
-                        );
-                      }}
-                    </For>
-                  )}
-                </Show>
+          <Drawer
+            dir={loc().lang === 'he' ? 'rtl' : 'ltr'}
+            title={
+              loc().lang === 'he'
+                ? `${heBook(loc().book)} ${hebrewNumeral(loc().chapter)}:${hebrewNumeral(s.verse)}`
+                : `${loc().book} ${loc().chapter}:${s.verse}`
+            }
+            label={SECTION_TITLE[s.kind]}
+            onClose={() => setSource(null)}
+          >
+            <Show when={s.kind === 'rishonim'}>
+              <Show when={richSet().has(s.verse)}>
+                <section class="comm-synth">
+                  <h4 class="comm-synth-name">Synthesis</h4>
+                  <Show when={synthesis.loading}>
+                    <p class="comm-muted">Synthesizing the commentators…</p>
+                  </Show>
+                  <Show when={synthesis()}>
+                    {(sy) => (
+                      <p class="comm-synth-text" dir={loc().lang === 'he' ? 'rtl' : 'ltr'}>
+                        {loc().lang === 'he' ? sy().he || sy().en : sy().en || sy().he}
+                      </p>
+                    )}
+                  </Show>
+                </section>
               </Show>
+              <Show when={commentary.loading}>
+                <p class="comm-muted">Loading commentary…</p>
+              </Show>
+              <Show when={commentary()}>
+                {(d) => (
+                  <For
+                    each={d().commentaries}
+                    fallback={<p class="comm-muted">No commentary on this verse.</p>}
+                  >
+                    {(cm) => {
+                      // The rishonim themselves always show in the Hebrew /
+                      // Aramaic original (the English is a weak translation);
+                      // fall back to English only when no Hebrew is available.
+                      const useEn = cm.he.length === 0;
+                      return (
+                        <section class="comm-entry">
+                          <h4 class="comm-name">{loc().lang === 'he' ? cm.heName : cm.en}</h4>
+                          <For each={useEn ? cm.enText : cm.he}>
+                            {(seg) => (
+                              <p class="comm-text" dir={useEn ? 'ltr' : 'rtl'} innerHTML={seg} />
+                            )}
+                          </For>
+                        </section>
+                      );
+                    }}
+                  </For>
+                )}
+              </Show>
+            </Show>
 
-              <Show when={s.kind === 'gemara'}>
-                <Show when={gemara.loading}>
-                  <p class="comm-muted">Finding Talmud passages…</p>
-                </Show>
-                <Show when={gemara()}>
-                  {(g) => <PassageList passages={g().passages} empty="Not cited in the Talmud." />}
-                </Show>
+            <Show when={s.kind === 'gemara'}>
+              <Show when={gemara.loading}>
+                <p class="comm-muted">Finding Talmud passages…</p>
               </Show>
+              <Show when={gemara()}>
+                {(g) => <PassageList passages={g().passages} empty="Not cited in the Talmud." />}
+              </Show>
+            </Show>
 
-              <Show when={s.kind === 'midrash'}>
-                <Show when={(idxByVerse().get(s.verse)?.midrash ?? 0) >= MIDRASH_MIN}>
-                  <section class="comm-synth">
-                    <h4 class="comm-synth-name">Synthesis</h4>
-                    <Show when={midrashSynth.loading}>
-                      <p class="comm-muted">Synthesizing the midrashim…</p>
-                    </Show>
-                    <Show when={midrashSynth()}>
-                      {(sy) => (
-                        <p class="comm-synth-text" dir={loc().lang === 'he' ? 'rtl' : 'ltr'}>
-                          {loc().lang === 'he' ? sy().he || sy().en : sy().en || sy().he}
-                        </p>
-                      )}
-                    </Show>
-                  </section>
-                </Show>
-                <Show when={midrash.loading}>
-                  <p class="comm-muted">Loading midrash…</p>
-                </Show>
-                <Show when={midrash()}>
-                  {(md) => (
-                    <PassageList passages={md().passages} empty="No midrash on this verse." />
-                  )}
-                </Show>
+            <Show when={s.kind === 'midrash'}>
+              <Show when={(idxByVerse().get(s.verse)?.midrash ?? 0) >= MIDRASH_MIN}>
+                <section class="comm-synth">
+                  <h4 class="comm-synth-name">Synthesis</h4>
+                  <Show when={midrashSynth.loading}>
+                    <p class="comm-muted">Synthesizing the midrashim…</p>
+                  </Show>
+                  <Show when={midrashSynth()}>
+                    {(sy) => (
+                      <p class="comm-synth-text" dir={loc().lang === 'he' ? 'rtl' : 'ltr'}>
+                        {loc().lang === 'he' ? sy().he || sy().en : sy().en || sy().he}
+                      </p>
+                    )}
+                  </Show>
+                </section>
               </Show>
-            </div>
-          </aside>
+              <Show when={midrash.loading}>
+                <p class="comm-muted">Loading midrash…</p>
+              </Show>
+              <Show when={midrash()}>
+                {(md) => <PassageList passages={md().passages} empty="No midrash on this verse." />}
+              </Show>
+            </Show>
+          </Drawer>
         )}
       </Show>
     </div>

--- a/packages/tanach/src/client/main.tsx
+++ b/packages/tanach/src/client/main.tsx
@@ -3,6 +3,7 @@ import { render } from 'solid-js/web';
 // so styles.css resolves the canonical vars (and the theme's overrides).
 import '@corpus/ui/tokens.css';
 import '@corpus/ui/themes/tanach.css';
+import '@corpus/ui/components.css';
 import { App } from './App.tsx';
 import { UsagePage } from './UsagePage.tsx';
 import './styles.css';

--- a/packages/tanach/src/client/styles.css
+++ b/packages/tanach/src/client/styles.css
@@ -429,25 +429,7 @@ body {
   background: var(--accent);
   color: #fff;
 }
-.lang-toggle {
-  display: inline-flex;
-  border: 1px solid var(--line);
-  border-radius: 6px;
-  overflow: hidden;
-}
-.lang-toggle button {
-  font-family: inherit;
-  font-size: 13px;
-  padding: 5px 10px;
-  border: 0;
-  background: #fff;
-  color: var(--muted);
-  cursor: pointer;
-}
-.lang-toggle button.active {
-  background: var(--accent);
-  color: #fff;
-}
+/* (the EN/עב toggle now renders via @corpus/ui's <LangToggle> — .ui-lang-toggle) */
 
 /* section-note popover (clicking a margin anchor) */
 .note-pop {
@@ -501,49 +483,12 @@ body {
   font-style: italic;
 }
 
-/* perek-level pills (Overview, …): a centered row of chips at the top of the
-   chapter, each opening the perek drawer. The chapter analogue of the Talmud
-   reader's whole-daf header chips. */
-.perek-pills {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 8px;
-  max-width: 900px;
-  margin: 0 auto 18px;
-}
-@media (max-width: 1240px) {
-  .perek-pills {
-    max-width: 620px;
-  }
-}
-.perek-pill {
-  font-family: var(--font-ui);
-  font-size: 12px;
-  letter-spacing: 0.03em;
-  text-transform: uppercase;
-  padding: 5px 14px;
-  border: 1px solid var(--parchment-edge);
-  border-radius: var(--radius-pill);
-  background: var(--parchment);
-  color: var(--accent);
-  cursor: pointer;
-  transition:
-    background-color 0.12s ease,
-    color 0.12s ease,
-    border-color 0.12s ease;
-}
-.perek-pill:hover {
-  border-color: var(--accent);
-}
-.perek-pill.active {
-  background: var(--accent);
-  border-color: var(--accent);
-  color: #fff;
-}
+/* perek-level pills (Overview, …) now render via @corpus/ui's <Pill>/<PillRow>
+   (.ui-pill / .ui-pill-row in @corpus/ui/components.css). Tanach's parchment
+   chip look is preserved through the --pill-bg / --pill-border theme tokens. */
 
-/* perek drawer (an Overview/Geography/Tidbit pill) — reuses the comm-drawer
-   shell; the body holds the chapter-level enrichment */
+/* perek drawer body (rendered inside @corpus/ui's <Drawer>): the overview's
+   title heading. The prose itself is @corpus/ui's <Prose> (.ui-prose). */
 .perek-overview {
   padding: 6px 0 12px;
 }
@@ -554,19 +499,8 @@ body {
   color: var(--ink);
   line-height: 1.3;
 }
-.perek-title[dir="rtl"],
-.perek-drawer[dir="rtl"] .perek-title {
+.ui-drawer[dir="rtl"] .perek-title {
   font-family: var(--font-hebrew);
-}
-.perek-prose {
-  margin: 0;
-  font-size: 16px;
-  line-height: 1.68;
-  color: var(--ink);
-}
-.perek-prose[dir="rtl"] {
-  font-family: var(--font-hebrew);
-  font-size: 17px;
 }
 
 /* word/phrase translation gloss (text selection) */
@@ -618,48 +552,9 @@ body {
   color: var(--accent);
 }
 
-/* classic-commentary drawer */
-.comm-drawer {
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  width: min(420px, 92vw);
-  background: #fbf8f1;
-  border-left: 1px solid var(--line);
-  box-shadow: -10px 0 34px rgba(60, 40, 12, 0.14);
-  z-index: 50;
-  display: flex;
-  flex-direction: column;
-}
-.comm-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 14px 18px;
-  border-bottom: 1px solid var(--line);
-  flex: none;
-}
-.comm-ref {
-  font-size: 17px;
-  font-weight: 600;
-  color: var(--ink);
-}
-.comm-close {
-  border: 0;
-  background: none;
-  font-size: 22px;
-  line-height: 1;
-  color: var(--muted);
-  cursor: pointer;
-}
-.comm-close:hover {
-  color: var(--ink);
-}
-.comm-body {
-  overflow-y: auto;
-  padding: 6px 18px 32px;
-}
+/* The commentary drawer SHELL is now @corpus/ui's <Drawer> (.ui-drawer);
+   below are only the drawer's BODY content classes (commentary entries,
+   synthesis, passages) that tanach still owns. */
 .comm-entry {
   padding: 14px 0;
   border-bottom: 1px solid var(--line);
@@ -847,23 +742,6 @@ body {
   padding: 14px 0 4px;
   border-top: 1px solid var(--line);
   margin-top: 6px;
-}
-
-/* focused source drawer: kind label in the header */
-.comm-head {
-  justify-content: flex-start;
-  gap: 10px;
-}
-.comm-kind {
-  font-family: var(--font-ui);
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--accent);
-  font-weight: 600;
-}
-.comm-close {
-  margin-inline-start: auto;
 }
 
 /* Mikraot Gedolot gutter anchors + icons (positioned by MikraotGedolot) */

--- a/packages/tanach/vite.config.ts
+++ b/packages/tanach/vite.config.ts
@@ -5,4 +5,8 @@ import solid from 'vite-plugin-solid';
 export default defineConfig({
   plugins: [solid(), cloudflare()],
   publicDir: 'static',
+  // @corpus/ui ships Solid .tsx as source (a workspace package). Excluding it
+  // from esbuild dep pre-bundling lets vite-plugin-solid run its JSX transform
+  // on those components (esbuild's generic JSX would otherwise mishandle them).
+  optimizeDeps: { exclude: ['@corpus/ui'] },
 });

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,13 +3,29 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "description": "Shared design system for the corpus apps (talmud, tanach): canonical CSS design tokens + per-app theme overrides, and (later) a Solid component kit. Logic stays in @corpus/core; this is the look-and-feel layer both apps import.",
+  "description": "Shared design system for the corpus apps (talmud, tanach): canonical CSS design tokens + per-app theme overrides, and a Solid component kit (Drawer, Pill, Button, Prose, LangToggle). Logic stays in @corpus/core; this is the look-and-feel layer both apps import.",
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
   "sideEffects": [
     "**/*.css"
   ],
   "exports": {
     "./tokens.css": "./src/tokens.css",
     "./themes/talmud.css": "./src/themes/talmud.css",
-    "./themes/tanach.css": "./src/themes/tanach.css"
+    "./themes/tanach.css": "./src/themes/tanach.css",
+    "./components.css": "./src/components.css",
+    "./Pill": "./src/Pill.tsx",
+    "./Drawer": "./src/Drawer.tsx",
+    "./Button": "./src/Button.tsx",
+    "./Prose": "./src/Prose.tsx",
+    "./LangToggle": "./src/LangToggle.tsx"
+  },
+  "peerDependencies": {
+    "solid-js": "^1.9.0"
+  },
+  "devDependencies": {
+    "solid-js": "^1.9.0",
+    "typescript": "^5.7.0"
   }
 }

--- a/packages/ui/src/Button.tsx
+++ b/packages/ui/src/Button.tsx
@@ -1,0 +1,34 @@
+/**
+ * @corpus/ui — Button.
+ *
+ * The standard bordered control button used in app chrome (chapter / daf nav,
+ * toggles). Chrome, so it renders in --font-ui. Styling: `.ui-button` in
+ * components.css. `active` marks a pressed/selected state; `disabled` greys it.
+ */
+
+import type { JSX } from 'solid-js';
+
+export interface ButtonProps {
+  onClick?: () => void;
+  disabled?: boolean;
+  active?: boolean;
+  title?: string;
+  'aria-label'?: string;
+  children: JSX.Element;
+}
+
+export function Button(props: ButtonProps): JSX.Element {
+  return (
+    <button
+      type="button"
+      class="ui-button"
+      classList={{ active: props.active }}
+      disabled={props.disabled}
+      title={props.title}
+      aria-label={props['aria-label']}
+      onClick={() => props.onClick?.()}
+    >
+      {props.children}
+    </button>
+  );
+}

--- a/packages/ui/src/Drawer.tsx
+++ b/packages/ui/src/Drawer.tsx
@@ -1,0 +1,42 @@
+/**
+ * @corpus/ui — Drawer.
+ *
+ * A fixed right-edge panel with a header (a ref title + a kind label + a close
+ * button) and a scrolling body. The shell both apps use for on-demand detail:
+ * the tanach reader's perek pills (Overview, …) and its verse-source drawer
+ * (Commentary / Talmud / Midrash) both render through it. Styling: `.ui-drawer`
+ * in components.css.
+ */
+
+import type { JSX } from 'solid-js';
+
+export interface DrawerProps {
+  /** The reference shown at the head, e.g. "Genesis 22" or "Genesis 22:5". */
+  title: JSX.Element;
+  /** Optional kind label, e.g. "Overview" / "Commentary". */
+  label?: JSX.Element;
+  /** Reading direction for the panel (English ltr / Hebrew rtl). */
+  dir?: 'ltr' | 'rtl';
+  onClose: () => void;
+  children: JSX.Element;
+}
+
+export function Drawer(props: DrawerProps): JSX.Element {
+  return (
+    <aside class="ui-drawer" dir={props.dir ?? 'ltr'}>
+      <header class="ui-drawer-head">
+        <span class="ui-drawer-ref">{props.title}</span>
+        {props.label ? <span class="ui-drawer-kind">{props.label}</span> : null}
+        <button
+          type="button"
+          class="ui-drawer-close"
+          onClick={() => props.onClose()}
+          aria-label="Close"
+        >
+          ×
+        </button>
+      </header>
+      <div class="ui-drawer-body">{props.children}</div>
+    </aside>
+  );
+}

--- a/packages/ui/src/LangToggle.tsx
+++ b/packages/ui/src/LangToggle.tsx
@@ -1,0 +1,35 @@
+/**
+ * @corpus/ui — LangToggle.
+ *
+ * The EN / עב segmented switch in app chrome. Chrome (--font-ui). Styling:
+ * `.ui-lang-toggle` in components.css.
+ */
+
+import type { JSX } from 'solid-js';
+
+export interface LangToggleProps {
+  lang: 'en' | 'he';
+  onChange: (lang: 'en' | 'he') => void;
+}
+
+export function LangToggle(props: LangToggleProps): JSX.Element {
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: a fieldset brings UA margin/min-inline-size that changes the segmented layout; div+role="group" carries the same semantics
+    <div class="ui-lang-toggle" role="group" aria-label="Language">
+      <button
+        type="button"
+        classList={{ active: props.lang === 'en' }}
+        onClick={() => props.onChange('en')}
+      >
+        EN
+      </button>
+      <button
+        type="button"
+        classList={{ active: props.lang === 'he' }}
+        onClick={() => props.onChange('he')}
+      >
+        עב
+      </button>
+    </div>
+  );
+}

--- a/packages/ui/src/Pill.tsx
+++ b/packages/ui/src/Pill.tsx
@@ -1,0 +1,37 @@
+/**
+ * @corpus/ui — Pill.
+ *
+ * A small rounded chip-button, used for whole-unit affordances (the tanach
+ * reader's perek pills: Overview / Geography / Tidbit). Styling lives in
+ * components.css (`.ui-pill`), driven by the shared tokens; the app imports
+ * @corpus/ui/components.css once.
+ */
+
+import type { JSX } from 'solid-js';
+
+export interface PillProps {
+  /** Selected state (the open pill). */
+  active?: boolean;
+  onClick?: () => void;
+  title?: string;
+  children: JSX.Element;
+}
+
+export function Pill(props: PillProps): JSX.Element {
+  return (
+    <button
+      type="button"
+      class="ui-pill"
+      classList={{ active: props.active }}
+      title={props.title}
+      onClick={() => props.onClick?.()}
+    >
+      {props.children}
+    </button>
+  );
+}
+
+/** A centered row of pills, sitting at the top of a unit (chapter / daf). */
+export function PillRow(props: { children: JSX.Element }): JSX.Element {
+  return <div class="ui-pill-row">{props.children}</div>;
+}

--- a/packages/ui/src/Prose.tsx
+++ b/packages/ui/src/Prose.tsx
@@ -1,0 +1,40 @@
+/**
+ * @corpus/ui — Prose.
+ *
+ * A bilingual reading-prose block: given English + Hebrew text and the reader's
+ * language, it shows the preferred one (falling back to the other when the
+ * preferred is empty) with the correct direction and reading font — English in
+ * --font-serif, Hebrew in --font-hebrew. This is the SHARED English-reading
+ * treatment both apps use, so a note reads the same in tanach and talmud.
+ * Styling: `.ui-prose` in components.css.
+ */
+
+import type { JSX } from 'solid-js';
+
+export interface ProseProps {
+  en?: string;
+  he?: string;
+  /** Preferred language; falls back to the other when the preferred is empty. */
+  lang: 'en' | 'he';
+  /** Extra class(es) for spacing/size tweaks at the call site. */
+  class?: string;
+}
+
+export function Prose(props: ProseProps): JSX.Element {
+  // Decide which language is actually shown (honour the preference, fall back),
+  // then direction + font follow the shown text — not the preference.
+  const shown = (): 'en' | 'he' => {
+    if (props.lang === 'he') return props.he ? 'he' : 'en';
+    return props.en ? 'en' : 'he';
+  };
+  const text = (): string => (shown() === 'he' ? props.he : props.en) ?? '';
+  return (
+    <p
+      class="ui-prose"
+      classList={props.class ? { [props.class]: true } : undefined}
+      dir={shown() === 'he' ? 'rtl' : 'ltr'}
+    >
+      {text()}
+    </p>
+  );
+}

--- a/packages/ui/src/components.css
+++ b/packages/ui/src/components.css
@@ -1,0 +1,165 @@
+/*
+ * @corpus/ui — component-kit styles.
+ *
+ * The look for the shared Solid components (Pill, Drawer, Button, Prose,
+ * LangToggle), all driven by the design tokens. An app imports this once
+ * (after tokens.css + its theme). Components carry only structure + class
+ * names; this sheet owns the appearance, so both apps render them identically
+ * (modulo the themed tokens — palette + Hebrew face).
+ *
+ * Component-level tokens use var(--x, fallback) so an app can refine a piece
+ * (e.g. tanach's parchment pills) without the component knowing.
+ */
+
+/* ---- Pill (PillRow) ---- */
+.ui-pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+  max-width: 900px;
+  margin: 0 auto 18px;
+}
+@media (max-width: 1240px) {
+  .ui-pill-row {
+    max-width: 620px;
+  }
+}
+.ui-pill {
+  font-family: var(--font-ui);
+  font-size: 12px;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  padding: 5px 14px;
+  border: 1px solid var(--pill-border, var(--line));
+  border-radius: var(--radius-pill);
+  background: var(--pill-bg, var(--surface-sunk));
+  color: var(--accent);
+  cursor: pointer;
+  transition:
+    background-color 0.12s ease,
+    color 0.12s ease,
+    border-color 0.12s ease;
+}
+.ui-pill:hover {
+  border-color: var(--accent);
+}
+.ui-pill.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+/* ---- Drawer ---- */
+.ui-drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: min(420px, 92vw);
+  background: var(--surface);
+  border-left: 1px solid var(--line);
+  box-shadow: var(--shadow-drawer);
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+}
+.ui-drawer-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--line);
+  flex: none;
+}
+.ui-drawer-ref {
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--fg);
+}
+.ui-drawer-kind {
+  font-family: var(--font-ui);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--accent);
+  font-weight: 600;
+}
+.ui-drawer-close {
+  margin-inline-start: auto;
+  border: 0;
+  background: none;
+  font-size: 22px;
+  line-height: 1;
+  color: var(--muted);
+  cursor: pointer;
+}
+.ui-drawer-close:hover {
+  color: var(--fg);
+}
+.ui-drawer-body {
+  overflow-y: auto;
+  padding: 6px 18px 32px;
+}
+
+/* ---- Button (standard bordered control) ---- */
+.ui-button {
+  font-family: var(--font-ui);
+  font-size: 15px;
+  padding: 4px 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--surface);
+  color: var(--fg);
+  cursor: pointer;
+  transition:
+    border-color 0.12s ease,
+    background-color 0.12s ease,
+    color 0.12s ease;
+}
+.ui-button:hover:not(:disabled):not(.active) {
+  border-color: var(--accent);
+}
+.ui-button:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.ui-button.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+/* ---- Prose (bilingual reading block) ---- */
+.ui-prose {
+  margin: 0;
+  font-family: var(--font-serif);
+  font-size: 16px;
+  line-height: 1.68;
+  color: var(--fg);
+}
+.ui-prose[dir="rtl"] {
+  font-family: var(--font-hebrew);
+  font-size: 17px;
+}
+
+/* ---- LangToggle (EN / עב segmented) ---- */
+.ui-lang-toggle {
+  display: inline-flex;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+.ui-lang-toggle button {
+  font-family: var(--font-ui);
+  font-size: 13px;
+  padding: 5px 10px;
+  border: 0;
+  background: var(--surface);
+  color: var(--muted);
+  cursor: pointer;
+}
+.ui-lang-toggle button.active {
+  background: var(--accent);
+  color: #fff;
+}

--- a/packages/ui/src/themes/tanach.css
+++ b/packages/ui/src/themes/tanach.css
@@ -32,6 +32,10 @@
   --parchment-edge: #e6d3a6;
   --stam: #2a1c0c;
 
+  /* ---- component refinements: pills keep tanach's parchment chip look ---- */
+  --pill-bg: var(--parchment);
+  --pill-border: var(--parchment-edge);
+
   /* ---- back-compat alias (tanach styles referenced --ink) ---- */
   --ink: var(--fg);
 }

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "//": "Solid component lib: override the base's app-only ambient types (Workers/Vite) — these components need only DOM (from lib) + solid-js (via jsxImportSource).",
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": []
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,7 +131,14 @@ importers:
         specifier: ^4.90.1
         version: 4.90.1(@cloudflare/workers-types@4.20260511.1)
 
-  packages/ui: {}
+  packages/ui:
+    devDependencies:
+      solid-js:
+        specifier: ^1.9.0
+        version: 1.9.12
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
 
 packages:
 


### PR DESCRIPTION
PR B of the design-system unification (shared kit, per-app theme). Extracts the reusable Solid components into `@corpus/ui` and makes **tanach** the first consumer. Both apps reinvented these (drawer, pills, buttons, prose); now they're one implementation, styled by the shared tokens.

## `@corpus/ui` becomes a Solid component lib
- **Pill / PillRow**, **Drawer**, **Button**, **Prose** (the bilingual EN/HE reading block — the "same prose" treatment), **LangToggle**. Structure-only components; appearance lives in `components.css` (`.ui-*`), driven by the tokens. A component-level hook (`--pill-bg`) lets an app refine a piece (tanach keeps its parchment chip) without the component knowing.
- First `.tsx` in the package, so it's now a **first-class workspace citizen**: its own `tsconfig.json` (extends the base, overrides the app-only ambient `types`) + a `typecheck` script → it joins `pnpm -r typecheck`. Biome already lints it. (This is the "linters, etc." follow-through.)
- tanach's `vite.config.ts` excludes `@corpus/ui` from esbuild dep pre-bundling so `vite-plugin-solid` runs the JSX transform on the shared components.

## Tanach adoption
- The perek pills, **both drawers** (overview + verse-source), the EN/עב toggle, and the chapter-nav buttons now render via the kit; the overview prose renders via `<Prose>`.
- The duplicated CSS (`.perek-pill` / `.lang-toggle` / `.comm-drawer` shell / `.perek-prose`) is deleted — tanach keeps only its drawer **body-content** classes (commentary entries, synthesis, passages).

## Verification
- `pnpm typecheck` (core/ui/tanach/talmud), `pnpm lint` (592 files), `vite build` — all green.
- **Live in dev mode** (the esbuild path, which differs from the build): confirmed every component renders — `.ui-pill-row`/`.ui-pill`, `.ui-lang-toggle`, `.chapter-nav .ui-button`, `.ui-drawer` (kind "Overview"), `.ui-prose` (the overview text), and the title. Screenshot is visually identical to before — the extraction is transparent.
- **Talmud untouched.**

## Next
- **PR C** — point talmud at the shared tokens + `themes/talmud.css`, then migrate talmud's drawer/pills/buttons/prose onto the kit (talmud's English prose becomes the shared Spectral serif; it loads the font then).