### PR TITLE
Tanach: chapter load bar (reader progress indicator)

### DIFF
--- a/packages/tanach/src/client/App.tsx
+++ b/packages/tanach/src/client/App.tsx
@@ -23,6 +23,8 @@ import {
   type SourceVerse,
   verseKinds,
 } from '../lib/sources.ts';
+import { ChapterLoadProgress } from './ChapterLoadProgress.tsx';
+import { reportLoad, resetChapterLoad } from './chapterLoad.ts';
 import { MikraotGedolot } from './MikraotGedolot.tsx';
 
 interface Verse {
@@ -593,6 +595,38 @@ export function App(): JSX.Element {
     setPerekPill(null);
   });
 
+  // ---- Chapter load bar feed ----
+  // Reset first (this effect is created before the reporters, so on a chapter
+  // change it runs first and clears the previous chapter's entries); then each
+  // piece reports its state. The always-on chapter pieces key by a stable id so
+  // they overwrite across chapters; the overview reports only while its pill is
+  // open (its resource keeps a stale value across chapters otherwise).
+  createEffect(() => {
+    chapterKey();
+    resetChapterLoad();
+  });
+  createEffect(() => {
+    if (data.loading) reportLoad('text', 'Text', 'loading');
+    else if (data.error) reportLoad('text', 'Text', 'error');
+    else if (data()) reportLoad('text', 'Text', 'ok');
+  });
+  createEffect(() => {
+    if (events.loading) reportLoad('events', 'Sections', 'loading');
+    else if (events.error) reportLoad('events', 'Sections', 'error');
+    else if (events()) reportLoad('events', 'Sections', 'ok');
+  });
+  createEffect(() => {
+    if (sourcesIndex.loading) reportLoad('sources', 'Sources', 'loading');
+    else if (sourcesIndex.error) reportLoad('sources', 'Sources', 'error');
+    else if (sourcesIndex() !== undefined) reportLoad('sources', 'Sources', 'ok');
+  });
+  createEffect(() => {
+    if (perekPill() !== 'overview') return;
+    if (overview.loading) reportLoad('overview', 'Overview', 'loading');
+    else if (overview.error) reportLoad('overview', 'Overview', 'error');
+    else if (overview()) reportLoad('overview', 'Overview', 'ok');
+  });
+
   return (
     <div
       class="app"
@@ -671,9 +705,7 @@ export function App(): JSX.Element {
         </div>
       </header>
 
-      <Show when={data.loading}>
-        <p class="status">Loading…</p>
-      </Show>
+      <ChapterLoadProgress />
       <Show when={data.error}>
         <p class="status error">{(data.error as Error)?.message}</p>
       </Show>

--- a/packages/tanach/src/client/ChapterLoadProgress.tsx
+++ b/packages/tanach/src/client/ChapterLoadProgress.tsx
@@ -1,0 +1,75 @@
+/**
+ * Chapter load bar — one slim sticky bar + a status line describing what's
+ * still loading for the open chapter, the tanach analogue of the talmud
+ * reader's daf-load bar. Reads the chapterLoad tracker (the chapter's pieces
+ * report their state there) and shows a single fraction. Auto-hides shortly
+ * after everything settles: on a warm chapter (all KV hits) it barely
+ * flickers; on a cold one it tracks the real work (Sefaria + the LLM calls).
+ */
+
+import { createEffect, createMemo, createSignal, type JSX, onCleanup, Show } from 'solid-js';
+import { chapterLoadEntries } from './chapterLoad.ts';
+
+const COMPLETE_LINGER_MS = 700;
+
+export function ChapterLoadProgress(): JSX.Element {
+  const cohort = createMemo(() => {
+    const all = chapterLoadEntries();
+    const done = all.filter((e) => e.state === 'ok' || e.state === 'error').length;
+    const loading = all.find((e) => e.state === 'loading');
+    return { total: all.length, done, loadingLabel: loading?.label ?? null };
+  });
+
+  const percent = createMemo(() => {
+    const c = cohort();
+    return c.total === 0 ? 0 : Math.round((c.done / c.total) * 100);
+  });
+
+  const incomplete = createMemo(() => {
+    const c = cohort();
+    return c.total > 0 && c.done < c.total;
+  });
+
+  const label = createMemo(() => {
+    const c = cohort();
+    if (c.loadingLabel) return `Loading ${c.loadingLabel.toLowerCase()}…`;
+    return 'Up to date';
+  });
+
+  // Visibility: show while there's incomplete work; linger briefly at 100% so
+  // the fill animation reads as "done" before the bar slides away.
+  const [visible, setVisible] = createSignal(false);
+  let hideTimer: ReturnType<typeof setTimeout> | undefined;
+  createEffect(() => {
+    if (incomplete()) {
+      if (hideTimer) {
+        clearTimeout(hideTimer);
+        hideTimer = undefined;
+      }
+      setVisible(true);
+    } else if (visible()) {
+      if (hideTimer) clearTimeout(hideTimer);
+      hideTimer = setTimeout(() => setVisible(false), COMPLETE_LINGER_MS);
+    }
+  });
+  onCleanup(() => {
+    if (hideTimer) clearTimeout(hideTimer);
+  });
+
+  return (
+    <Show when={visible()}>
+      <div class="chapter-load" role="status" aria-live="polite">
+        <div class="chapter-load-row">
+          <span class="chapter-load-spinner" aria-hidden="true" />
+          <span class="chapter-load-label">{label()}</span>
+          <span class="chapter-load-pct" aria-hidden="true">
+            {percent()}%
+          </span>
+        </div>
+        <div class="chapter-load-track">
+          <div class="chapter-load-fill" style={{ width: `${percent()}%` }} />
+        </div>
+      </div>
+    </Show>
+  );
+}

--- a/packages/tanach/src/client/chapterLoad.ts
+++ b/packages/tanach/src/client/chapterLoad.ts
@@ -1,0 +1,44 @@
+/**
+ * Chapter load tracker — the data behind the reader's load bar.
+ *
+ * Tanach has no enrichment queue (the talmud loading bar reads a mark-status +
+ * prefetch store); here the pieces are plain createResources, so each one
+ * reports its state into this tiny registry and the bar derives a fraction
+ * from it. A piece enters the registry the moment it starts loading and is
+ * "done" on ok/error, so the bar reflects BOTH the auto-loaded chapter pieces
+ * (text, sections, sources) and any on-demand ones (the overview, a note) the
+ * moment they fire. resetChapterLoad() clears it on chapter change so a stale
+ * piece from the previous chapter never counts.
+ */
+
+import { createSignal } from 'solid-js';
+
+export type LoadState = 'loading' | 'ok' | 'error';
+
+export interface LoadEntry {
+  id: string;
+  label: string;
+  state: LoadState;
+}
+
+const [entries, setEntries] = createSignal<Record<string, LoadEntry>>({});
+
+/** Report a piece's current load state. Idempotent: a no-op when unchanged
+ *  (so the signal only fires on a real transition). */
+export function reportLoad(id: string, label: string, state: LoadState): void {
+  setEntries((prev) => {
+    const cur = prev[id];
+    if (cur && cur.state === state && cur.label === label) return prev;
+    return { ...prev, [id]: { id, label, state } };
+  });
+}
+
+/** Clear the tracker — call when the chapter changes. */
+export function resetChapterLoad(): void {
+  setEntries((prev) => (Object.keys(prev).length === 0 ? prev : {}));
+}
+
+/** The tracked pieces, in insertion order. */
+export function chapterLoadEntries(): LoadEntry[] {
+  return Object.values(entries());
+}

--- a/packages/tanach/src/client/styles.css
+++ b/packages/tanach/src/client/styles.css
@@ -126,6 +126,66 @@ body {
   color: #a23;
 }
 
+/* chapter load bar: a slim bar + status line for the pieces loading on the
+   open chapter (text, sections, sources, and the overview while its pill is
+   open). Sits just under the topbar; auto-hides shortly after everything
+   settles. */
+.chapter-load {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 8px 20px 6px;
+  background: var(--bg);
+  font-family: var(--font-ui);
+  font-size: 12px;
+  color: var(--muted);
+}
+.chapter-load-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 5px;
+}
+.chapter-load-spinner {
+  display: inline-block;
+  width: 11px;
+  height: 11px;
+  flex-shrink: 0;
+  border: 2px solid var(--line);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: chapter-spin 0.8s linear infinite;
+}
+.chapter-load-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  letter-spacing: 0.01em;
+}
+.chapter-load-pct {
+  flex-shrink: 0;
+  font-variant-numeric: tabular-nums;
+}
+.chapter-load-track {
+  height: 2px;
+  background: var(--line);
+  border-radius: 1px;
+  overflow: hidden;
+}
+.chapter-load-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 1px;
+  opacity: 0.8;
+  transition: width 0.4s ease;
+}
+@keyframes chapter-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 /* shared chapter-nav footer (used by the scroll caption) */
 .chapter-foot {
   display: flex;


### PR DESCRIPTION
First half of porting talmud's loading bar + inspector to tanach. This PR is the **load bar**; the inspector follows.

## What it does
A slim progress bar under the topbar shows what's loading for the open chapter — "Loading text… / sections… / sources…" with a climbing percentage — and auto-hides shortly after everything settles. On a warm chapter (all KV hits) it barely flickers; on a cold one it tracks the real Sefaria + LLM work.

## How (scaled to tanach's model)
Talmud's bar reads a mark-status + prefetch store, which is coupled to its enrichment queue. Tanach has **no queue** — its pieces are plain `createResource`s — so the port is simpler:
- **`chapterLoad.ts`** — a tiny tracker: `reportLoad(id, label, state)` / `resetChapterLoad()` / `chapterLoadEntries()`. A piece enters the registry the moment it starts loading and is "done" on ok/error.
- **`ChapterLoadProgress.tsx`** — one bar + status line; derives `done/total` and lingers ~700ms at 100% before hiding.
- **`App.tsx`** feeds it: the always-on chapter pieces (text, sections, sources) report on every chapter (stable ids overwrite across chapters); the overview reports while its pill is open. A reset effect — created *before* the reporters so it runs first on a chapter change — clears the previous chapter's entries. Replaces the bare "Loading…" text.
- Styled with the shared `@corpus/ui` tokens (`--font-ui` / `--accent` / `--line`).

## Verification
- `pnpm typecheck`, `pnpm lint`, `vite build` — green.
- **Live**: on a cold chapter the bar climbs text → sections → sources (0 → 33 → 67 → 100%), the label tracks what's in flight, then it hides. Screenshot confirms it sits cleanly under the topbar above the pills.

## Next
- **Inspector** — `GET /api/chapter-runs/:book/:chapter` enumerating each producer's cache status / cost / time (the cache is the index, as in talmud), plus a panel to view it. Tanach's runProducer entries already carry the CostStamp + timing, so the data's there.