### PR TITLE
Tanach: chapter inspector (Inspect — what's cached + cost)

### DIFF
--- a/packages/tanach/src/client/App.tsx
+++ b/packages/tanach/src/client/App.tsx
@@ -25,6 +25,7 @@ import {
 } from '../lib/sources.ts';
 import { ChapterLoadProgress } from './ChapterLoadProgress.tsx';
 import { reportLoad, resetChapterLoad } from './chapterLoad.ts';
+import { Inspector } from './Inspector.tsx';
 import { MikraotGedolot } from './MikraotGedolot.tsx';
 
 interface Verse {
@@ -566,10 +567,21 @@ export function App(): JSX.Element {
   // panel). Opening a pill lazily fetches its enrichment (warm in KV after the
   // first reader); the resource only fires while its pill is open.
   const [perekPill, setPerekPill] = createSignal<PerekPill | null>(null);
+  // The inspector (what's cached for this chapter + cost) — another tenant of
+  // the one fixed right panel, so it's mutually exclusive with the pills and
+  // the verse-source drawer.
+  const [inspectOpen, setInspectOpen] = createSignal(false);
   const openPill = (id: PerekPill) => {
     setSource(null);
     setSelected(null);
+    setInspectOpen(false);
     setPerekPill((cur) => (cur === id ? null : id));
+  };
+  const toggleInspect = () => {
+    setSource(null);
+    setSelected(null);
+    setPerekPill(null);
+    setInspectOpen((v) => !v);
   };
   const [overview] = createResource(
     () => (perekPill() === 'overview' ? chapterKey() : undefined),
@@ -586,13 +598,17 @@ export function App(): JSX.Element {
     const o = overview();
     return o && o.book === loc().book && o.chapter === loc().chapter ? o : null;
   });
-  // Opening a verse-source drawer closes any open pill (one right panel).
+  // Opening a verse-source drawer closes any open pill / inspector (one panel).
   createEffect(() => {
-    if (source()) setPerekPill(null);
+    if (source()) {
+      setPerekPill(null);
+      setInspectOpen(false);
+    }
   });
   createEffect(() => {
     chapterKey();
     setPerekPill(null);
+    setInspectOpen(false);
   });
 
   // ---- Chapter load bar feed ----
@@ -687,6 +703,15 @@ export function App(): JSX.Element {
         <a class="usage-link" href="/usage" title="LLM usage">
           usage
         </a>
+        <button
+          type="button"
+          class="usage-link inspect-link"
+          classList={{ active: inspectOpen() }}
+          onClick={toggleInspect}
+          title="Inspect this chapter's cache + cost"
+        >
+          inspect
+        </button>
 
         <div class="chapter-nav">
           <Button
@@ -842,6 +867,15 @@ export function App(): JSX.Element {
             </Show>
           </div>
         )}
+      </Show>
+
+      {/* Inspector drawer (what's cached for this chapter + cost) */}
+      <Show when={inspectOpen()}>
+        <Inspector
+          book={loc().book}
+          chapter={loc().chapter}
+          onClose={() => setInspectOpen(false)}
+        />
       </Show>
 
       {/* Perek-level pill drawer (Overview, …) — same fixed right panel as the

--- a/packages/tanach/src/client/Inspector.tsx
+++ b/packages/tanach/src/client/Inspector.tsx
@@ -1,0 +1,101 @@
+/**
+ * Chapter inspector — a panel listing what's cached for the open chapter and
+ * what each piece cost, the tanach analogue of the talmud reader's Inspect
+ * waterfall. Reads GET /api/chapter-runs/:book/:chapter (the cache is the
+ * index) and renders one row per producer piece: a hit/miss dot, its label
+ * (+ verse/range), generation time, and cost. Rendered in the shared <Drawer>.
+ */
+
+import { Drawer } from '@corpus/ui/Drawer';
+import { createResource, For, type JSX, Show } from 'solid-js';
+
+interface RunRow {
+  id: string;
+  label: string;
+  instance: string | null;
+  cached: boolean;
+  model: string | null;
+  coldMs: number | null;
+  cost: number | null;
+  tokens: number | null;
+}
+interface ChapterRuns {
+  book: string;
+  chapter: number;
+  runs: RunRow[];
+  totals: { count: number; cached: number; cost: number; coldMs: number };
+}
+
+function fmtMs(ms: number): string {
+  return ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${Math.round(ms)}ms`;
+}
+function fmtCost(usd: number): string {
+  return usd >= 0.01 || usd === 0 ? `$${usd.toFixed(3)}` : `$${usd.toFixed(4)}`;
+}
+
+export function Inspector(props: {
+  book: string;
+  chapter: number;
+  onClose: () => void;
+}): JSX.Element {
+  const [runs] = createResource(
+    () => ({ book: props.book, chapter: props.chapter }),
+    async (k) => {
+      const res = await fetch(`/api/chapter-runs/${encodeURIComponent(k.book)}/${k.chapter}`);
+      return res.ok ? ((await res.json()) as ChapterRuns) : null;
+    },
+  );
+
+  return (
+    <Drawer
+      title={`${props.book} ${props.chapter}`}
+      label="Inspect"
+      dir="ltr"
+      onClose={props.onClose}
+    >
+      <Show when={runs.loading}>
+        <p class="comm-muted">Reading the cache…</p>
+      </Show>
+      <Show when={runs()}>
+        {(r) => (
+          <>
+            <div class="inspect-totals">
+              {r().totals.cached}/{r().totals.count} cached · {fmtCost(r().totals.cost)} ·{' '}
+              {fmtMs(r().totals.coldMs)}
+            </div>
+            <For
+              each={r().runs}
+              fallback={<p class="comm-muted">Nothing cached yet for this chapter.</p>}
+            >
+              {(run) => (
+                <div class="inspect-row">
+                  <span
+                    class="inspect-dot"
+                    classList={{ hit: run.cached }}
+                    title={run.cached ? 'cached' : 'not cached'}
+                  />
+                  <span class="inspect-label">
+                    {run.label}
+                    <Show when={run.instance}>
+                      {(inst) => <span class="inspect-inst"> · {inst()}</span>}
+                    </Show>
+                  </span>
+                  <span class="inspect-meta">
+                    <Show when={run.cached} fallback={<span class="inspect-miss">miss</span>}>
+                      <Show when={run.coldMs}>
+                        {(ms) => <span class="inspect-ms">{fmtMs(ms())}</span>}
+                      </Show>
+                      <Show when={run.cost != null}>
+                        <span class="inspect-cost">{fmtCost(run.cost ?? 0)}</span>
+                      </Show>
+                    </Show>
+                  </span>
+                </div>
+              )}
+            </For>
+          </>
+        )}
+      </Show>
+    </Drawer>
+  );
+}

--- a/packages/tanach/src/client/styles.css
+++ b/packages/tanach/src/client/styles.css
@@ -380,6 +380,75 @@ body {
 .usage-link:hover {
   color: var(--accent);
 }
+/* the "inspect" topbar toggle is a button styled like the usage link */
+.inspect-link {
+  font-family: var(--font-ui);
+  background: none;
+  cursor: pointer;
+  padding: 0;
+}
+.inspect-link.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* inspector drawer: one row per cached/missed producer piece */
+.inspect-totals {
+  font-family: var(--font-ui);
+  font-size: 12px;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  padding: 2px 0 10px;
+  margin-bottom: 4px;
+  border-bottom: 1px solid var(--line);
+}
+.inspect-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 0;
+  font-family: var(--font-ui);
+  font-size: 13px;
+}
+.inspect-row + .inspect-row {
+  border-top: 1px dashed var(--line);
+}
+.inspect-dot {
+  width: 8px;
+  height: 8px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  background: var(--line);
+}
+.inspect-dot.hit {
+  background: #3f9d52;
+}
+.inspect-label {
+  flex: 1;
+  min-width: 0;
+  color: var(--ink);
+}
+.inspect-inst {
+  color: var(--muted);
+}
+.inspect-meta {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-shrink: 0;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+.inspect-ms {
+  color: var(--muted);
+}
+.inspect-cost {
+  color: var(--accent);
+}
+.inspect-miss {
+  color: var(--muted);
+  font-style: italic;
+}
 
 .usage {
   max-width: 920px;

--- a/packages/tanach/src/worker/index.ts
+++ b/packages/tanach/src/worker/index.ts
@@ -18,6 +18,7 @@ import type { Context } from 'hono';
 import { Hono } from 'hono';
 import { isBook } from '../lib/books.ts';
 import { COMMENTATORS } from '../lib/commentators.ts';
+import { chapterRuns } from './inspect.ts';
 import type { EventSection } from './producers/events.ts';
 import { translateHebrew } from './producers/translate.ts';
 import type { TanachEnv, TanachRunCtx } from './run-ports.ts';
@@ -582,6 +583,18 @@ app.get('/api/midrash-synthesis/:book/:chapter/:verse', async (c) => {
 
 // Self-tracked LLM usage (totals + per-producer + recent calls).
 app.get('/api/usage', async (c) => c.json(await readUsage(c.env.CACHE)));
+
+// Inspector: what's cached for a chapter + each piece's cost/time. Enumerates
+// the producers' deterministic keys (the cache is the index) — the two
+// chapter-level pieces by exact key, the per-instance ones by KV prefix list —
+// and reads the telemetry off each StoredArtifact envelope. Read-only.
+app.get('/api/chapter-runs/:book/:chapter', async (c) => {
+  const book = c.req.param('book');
+  const chapter = c.req.param('chapter');
+  if (!isBook(book)) return c.json({ error: `Unknown book: ${book}` }, 400);
+  if (!/^\d+$/.test(chapter)) return c.json({ error: `Bad chapter: ${chapter}` }, 400);
+  return c.json(await chapterRuns(c.env.CACHE, book, chapter));
+});
 
 // Everything else: serve the built SPA (static assets + index.html fallback).
 app.get('*', (c) => c.env.ASSETS.fetch(c.req.raw));

--- a/packages/tanach/src/worker/inspect.ts
+++ b/packages/tanach/src/worker/inspect.ts
@@ -1,0 +1,146 @@
+/**
+ * Chapter inspector — what's cached for a chapter, and what it cost.
+ *
+ * The tanach analogue of the talmud reader's Inspect waterfall. Like talmud,
+ * there is no separate index: the CACHE *is* the index. The producers' keys are
+ * deterministic, so we read the two chapter-level ones by exact key (showing
+ * them even when cold = a miss), and enumerate the per-instance ones (note,
+ * synthesis, midrash-synthesis) by KV prefix list. Each producer entry written
+ * through runProducer is a StoredArtifact envelope carrying model + elapsed_ms
+ * + the CostStamp, so the per-piece time and cost come straight off it; the
+ * pre-migration raw-payload entries read as cached-but-untimed.
+ *
+ * Pure over a minimal KV surface so it unit-tests without a Worker.
+ */
+
+import type { CostStamp } from '@corpus/core/model/provenance';
+import type { StoredArtifact } from '@corpus/core/store/envelope';
+import { isStoredArtifact } from './run-ports.ts';
+
+export interface RunRow {
+  /** Producer id. */
+  id: string;
+  label: string;
+  /** The per-instance discriminator (verse / range) or null for whole-chapter. */
+  instance: string | null;
+  cached: boolean;
+  model: string | null;
+  /** Generation wall-time (ms) from the cached envelope, when known. */
+  coldMs: number | null;
+  /** Estimated (or billed) generation cost in USD, when known. */
+  cost: number | null;
+  tokens: number | null;
+}
+
+export interface ChapterRuns {
+  book: string;
+  chapter: number;
+  runs: RunRow[];
+  totals: { count: number; cached: number; cost: number; coldMs: number };
+}
+
+/** The minimal KV surface the inspector reads (KVNamespace satisfies this). */
+export interface RunsCache {
+  get(key: string): Promise<string | null>;
+  list(opts: { prefix: string }): Promise<{ keys: { name: string }[] }>;
+}
+
+const NO_TELEMETRY = { model: null, coldMs: null, cost: null, tokens: null };
+
+/** Project a stored cache value into a row's cache/telemetry fields. A null raw
+ *  means a miss; a non-envelope (legacy raw payload) is cached-but-untimed. */
+export function telemetryOf(
+  raw: string | null,
+): Pick<RunRow, 'cached' | 'model' | 'coldMs' | 'cost' | 'tokens'> {
+  if (raw === null) return { cached: false, ...NO_TELEMETRY };
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { cached: true, ...NO_TELEMETRY };
+  }
+  if (!isStoredArtifact(parsed)) return { cached: true, ...NO_TELEMETRY };
+  const env = parsed as StoredArtifact;
+  const cost = (env.cost ?? null) as CostStamp | null;
+  return {
+    cached: true,
+    // 'legacy-cache' is the synthetic model the read adapter stamps on wrapped
+    // pre-envelope payloads — not a real model.
+    model: env.model && env.model !== 'legacy-cache' ? env.model : null,
+    coldMs: env.elapsed_ms || null,
+    cost: cost ? (cost.estimatedUsd ?? cost.billedUsd ?? null) : null,
+    tokens: cost ? cost.tokensIn + cost.tokensOut : null,
+  };
+}
+
+/** The two whole-chapter producers, addressed by exact key. */
+const CHAPTER_PRODUCERS = [
+  { id: 'events', label: 'Sections', key: (b: string, c: string) => `events:v2:${b}:${c}` },
+  { id: 'overview', label: 'Overview', key: (b: string, c: string) => `overview:v1:${b}:${c}` },
+];
+
+/** The per-instance producers, enumerated by KV prefix; `inst` labels the row
+ *  from the key tail (the range for note, the verse for the per-verse ones). */
+const INSTANCE_PRODUCERS = [
+  {
+    id: 'note',
+    label: 'Section note',
+    prefix: (b: string, c: string) => `note:v1:${b}:${c}:`,
+    inst: (tail: string) => tail,
+  },
+  {
+    id: 'synthesis',
+    label: 'Commentary synthesis',
+    prefix: (b: string, c: string) => `synthesis:v1:${b}:${c}:`,
+    inst: (tail: string) => `v${tail}`,
+  },
+  {
+    id: 'midrash-synthesis',
+    label: 'Midrash synthesis',
+    prefix: (b: string, c: string) => `midrash-synth:v1:${b}:${c}:`,
+    inst: (tail: string) => `v${tail}`,
+  },
+];
+
+/** Enumerate every cached producer piece for a chapter + its telemetry. */
+export async function chapterRuns(
+  cache: RunsCache,
+  book: string,
+  chapter: string,
+): Promise<ChapterRuns> {
+  // Chapter-level: exact reads in parallel (shown even on a miss).
+  const chapterRows = await Promise.all(
+    CHAPTER_PRODUCERS.map(async (p): Promise<RunRow> => {
+      const raw = await cache.get(p.key(book, chapter));
+      return { id: p.id, label: p.label, instance: null, ...telemetryOf(raw) };
+    }),
+  );
+
+  // Per-instance: list each prefix, then read the found keys in parallel.
+  const instanceRows: RunRow[] = [];
+  for (const p of INSTANCE_PRODUCERS) {
+    const prefix = p.prefix(book, chapter);
+    const { keys } = await cache.list({ prefix });
+    const rows = await Promise.all(
+      keys.map(async (k): Promise<RunRow> => {
+        const raw = await cache.get(k.name);
+        return {
+          id: p.id,
+          label: p.label,
+          instance: p.inst(k.name.slice(prefix.length)),
+          ...telemetryOf(raw),
+        };
+      }),
+    );
+    instanceRows.push(...rows);
+  }
+
+  const runs = [...chapterRows, ...instanceRows];
+  const totals = {
+    count: runs.length,
+    cached: runs.filter((r) => r.cached).length,
+    cost: runs.reduce((s, r) => s + (r.cost ?? 0), 0),
+    coldMs: runs.reduce((s, r) => s + (r.coldMs ?? 0), 0),
+  };
+  return { book, chapter: Number(chapter), runs, totals };
+}

--- a/packages/tanach/tests/inspect.test.ts
+++ b/packages/tanach/tests/inspect.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import { chapterRuns, type RunsCache, telemetryOf } from '../src/worker/inspect';
+
+/** A StoredArtifact-shaped envelope (the fields telemetryOf reads). */
+function envelope(over: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    content: '{}',
+    parsed: {},
+    parse_error: null,
+    model: 'openrouter/deepseek/deepseek-v4-flash',
+    transport: 'ai-gateway',
+    attempts: 1,
+    usage: { prompt_tokens: 100, completion_tokens: 50 },
+    elapsed_ms: 1234,
+    prompt_chars: 0,
+    resolved: { system_prompt: '', user_prompt: '' },
+    cache_hit: false,
+    cost: { estimatedUsd: 0.0004, billedUsd: null, tokensIn: 100, tokensOut: 50 },
+    ...over,
+  });
+}
+
+describe('telemetryOf', () => {
+  it('a miss (null) is not cached, no telemetry', () => {
+    expect(telemetryOf(null)).toEqual({
+      cached: false,
+      model: null,
+      coldMs: null,
+      cost: null,
+      tokens: null,
+    });
+  });
+
+  it('an envelope yields model, time, cost, tokens', () => {
+    expect(telemetryOf(envelope())).toEqual({
+      cached: true,
+      model: 'openrouter/deepseek/deepseek-v4-flash',
+      coldMs: 1234,
+      cost: 0.0004,
+      tokens: 150,
+    });
+  });
+
+  it('a legacy raw payload reads as cached-but-untimed', () => {
+    const legacy = JSON.stringify({ book: 'Genesis', chapter: 1, en: 'x', he: 'y' });
+    expect(telemetryOf(legacy)).toEqual({
+      cached: true,
+      model: null,
+      coldMs: null,
+      cost: null,
+      tokens: null,
+    });
+  });
+
+  it("the synthetic 'legacy-cache' model is normalised to null", () => {
+    expect(telemetryOf(envelope({ model: 'legacy-cache' })).model).toBeNull();
+  });
+
+  it('falls back to billedUsd when no estimate', () => {
+    const t = telemetryOf(
+      envelope({ cost: { estimatedUsd: null, billedUsd: 0.002, tokensIn: 1, tokensOut: 2 } }),
+    );
+    expect(t.cost).toBe(0.002);
+    expect(t.tokens).toBe(3);
+  });
+});
+
+describe('chapterRuns', () => {
+  function fakeCache(store: Record<string, string>): RunsCache {
+    return {
+      get: async (key) => store[key] ?? null,
+      list: async ({ prefix }) => ({
+        keys: Object.keys(store)
+          .filter((k) => k.startsWith(prefix))
+          .map((name) => ({ name })),
+      }),
+    };
+  }
+
+  it('shows the two chapter pieces always (cached or miss) and lists per-instance pieces', async () => {
+    const store = {
+      'overview:v1:Genesis:22': envelope({
+        elapsed_ms: 5000,
+        cost: { estimatedUsd: 0.01, billedUsd: null, tokensIn: 200, tokensOut: 100 },
+      }),
+      'note:v1:Genesis:22:1-19': envelope(),
+      'note:v1:Genesis:22:20-24': envelope(),
+      'synthesis:v1:Genesis:22:2': envelope(),
+      // events is intentionally absent -> a miss row
+      // an unrelated chapter must not leak in:
+      'overview:v1:Genesis:23': envelope(),
+      'note:v1:Genesis:23:1-5': envelope(),
+    };
+    const res = await chapterRuns(fakeCache(store), 'Genesis', '22');
+
+    const ids = res.runs.map((r) => `${r.id}${r.instance ? `:${r.instance}` : ''}`);
+    // two chapter rows first (events missing, overview present), then the instances
+    expect(ids).toEqual(['events', 'overview', 'note:1-19', 'note:20-24', 'synthesis:v2']);
+
+    const events = res.runs.find((r) => r.id === 'events');
+    expect(events?.cached).toBe(false);
+    const overview = res.runs.find((r) => r.id === 'overview');
+    expect(overview?.cached).toBe(true);
+    expect(overview?.coldMs).toBe(5000);
+
+    expect(res.totals.count).toBe(5);
+    expect(res.totals.cached).toBe(4); // all but the missing events
+    // overview 0.01 + three instance envelopes at 0.0004 each
+    expect(res.totals.cost).toBeCloseTo(0.01 + 0.0004 * 3, 6);
+  });
+
+  it('handles a multi-word book name (space in the key) in the prefix', async () => {
+    const store = {
+      'overview:v1:I Samuel:3': envelope(),
+      'note:v1:I Samuel:3:1-10': envelope(),
+    };
+    const res = await chapterRuns(fakeCache(store), 'I Samuel', '3');
+    expect(res.runs.find((r) => r.id === 'note')?.instance).toBe('1-10');
+    expect(res.runs.find((r) => r.id === 'overview')?.cached).toBe(true);
+  });
+});


### PR DESCRIPTION
Second half of porting talmud's loading bar + inspector to tanach (the load bar merged in #436). An **"inspect" toggle** in the topbar opens a panel listing every producer piece for the open chapter with its **cache status, generation time, and cost** — the tanach analogue of talmud's Inspect waterfall.

## Server (read-only)
- **`inspect.ts`** — `chapterRuns(cache, book, chapter)`. Like talmud, **the cache *is* the index**: the two whole-chapter producers (events, overview) are read by exact key (shown even on a miss); the per-instance ones (note, synthesis, midrash-synthesis) are enumerated by **KV prefix `list`**. Telemetry (model / `elapsed_ms` / cost / tokens) comes straight off each `StoredArtifact` envelope's `CostStamp`; pre-migration raw-payload entries read as cached-but-untimed. Pure over a minimal KV surface, so it **unit-tests without a Worker** (7 tests: telemetry projection, miss/legacy/`legacy-cache` cases, chapter-scoped enumeration with no cross-chapter leak, multi-word book keys).
- **`GET /api/chapter-runs/:book/:chapter`** wires it.

## Client
- **`Inspector.tsx`** — fetches the runs and renders them in the shared `@corpus/ui` `<Drawer>` (mutually exclusive with the pills + verse-source drawer): a totals line (`cached/count · cost · time`) and one row per piece (hit/miss dot, label + verse/range, time, cost).
- An **"inspect"** topbar toggle beside "usage"; styled with the shared tokens.

## Verification
- `pnpm typecheck`, `pnpm lint`, tanach suite (**49 tests**, incl. 7 new), `vite build` — green.
- **Live** (Genesis 22 after warming): the endpoint returns events + overview cached with model/time/cost/tokens; the panel shows **3/3 cached · $0.0006 · 12.5s** with rows for Sections, Overview, and a per-instance **"Section note · 1-19"** (12.1s cold). Screenshot confirms the drawer + the active topbar toggle.

## Notes / future
- Scoped to the 5 AI producers (the ones with cost). Source caches (commentary/gemara/srcidx) and a per-piece detail/prompt view (talmud's DAG + detail pane) are deliberately out of this first cut — tanach's producers are mostly independent, so there's no rich dependency graph to show.