### PR TITLE
Fix cold-daf isolate OOM that failed every card with a JSON.parse error

### DIFF
--- a/packages/talmud/src/client/MarkEnrichmentCards.tsx
+++ b/packages/talmud/src/client/MarkEnrichmentCards.tsx
@@ -34,6 +34,7 @@ import {
   isPausedBody,
   isServiceUnavailableError,
   PAUSED_ERROR,
+  parseRunJson,
   QUEUE_PRIORITY,
   RequestQueue,
   type RunResult,
@@ -155,6 +156,26 @@ const POLL_INTERVAL_MS = 1500;
 // users don't see the synthesis card time out before the worker finishes.
 const POLL_TIMEOUT_MS = 600_000;
 
+// Short backoffs (ms) for retrying ONLY the initial POST when the edge returns
+// a non-JSON error page (isolate recycled / OOM). One transient blip then
+// self-heals instead of failing the card. Once a job is `pending`, polling
+// takes over and is NOT retried here (it would re-enqueue generation).
+const RUN_POST_BACKOFF_MS = [500, 1500];
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const id = setTimeout(resolve, ms);
+    signal?.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(id);
+        reject(new DOMException('Aborted', 'AbortError'));
+      },
+      { once: true },
+    );
+  });
+}
+
 async function runEnrichmentImpl(
   enrichmentId: string,
   tractate: string,
@@ -162,19 +183,35 @@ async function runEnrichmentImpl(
   markInput: unknown,
   signal?: AbortSignal,
 ): Promise<RunResult> {
-  const r = await fetch('/api/run', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      enrichment_id: enrichmentId,
-      tractate,
-      page,
-      mark_input: markInput,
-      lang: lang(),
-    }),
-    signal,
+  const body = JSON.stringify({
+    enrichment_id: enrichmentId,
+    tractate,
+    page,
+    mark_input: markInput,
+    lang: lang(),
   });
-  const j = (await r.json()) as RunResponse | { error?: string };
+  let r: Response;
+  let j: RunResponse | { error?: string };
+  for (let attempt = 0; ; attempt++) {
+    r = await fetch('/api/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+      signal,
+    });
+    try {
+      j = (await parseRunJson(r)) as RunResponse | { error?: string };
+      break;
+    } catch (err) {
+      // parseRunJson throws a service-unavailable error only when the body is
+      // NON-JSON — i.e. a Cloudflare edge page (1101 / empty 5xx) from a
+      // recycled or OOM'd isolate. Retry a couple of times on a short backoff;
+      // any other failure (abort, genuine 4xx with a JSON body) rethrows.
+      if (isAbort(err) || attempt >= RUN_POST_BACKOFF_MS.length || !isServiceUnavailableError(err))
+        throw err;
+      await sleep(RUN_POST_BACKOFF_MS[attempt], signal);
+    }
+  }
   if (isPausedBody(j)) throw new Error(PAUSED_ERROR);
   if (!r.ok && r.status !== 202) {
     throw new Error((j as { error?: string }).error ?? `HTTP ${r.status}`);
@@ -247,7 +284,15 @@ async function pollJob(runId: string, cacheKey?: string, signal?: AbortSignal): 
     await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
     if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
     const r = await fetch(`/api/run-status/${encodeURIComponent(runId)}${qs}`, { signal });
-    const j = (await r.json()) as RunResponse | { status: 'pending' };
+    let j: RunResponse | { status: 'pending' };
+    try {
+      j = (await parseRunJson(r)) as RunResponse | { status: 'pending' };
+    } catch (err) {
+      if (isAbort(err)) throw err;
+      // A transient non-JSON edge error (isolate recycled mid-poll). The job may
+      // still be running server-side, so keep polling instead of failing the card.
+      continue;
+    }
     if (isPausedBody(j)) throw new Error(PAUSED_ERROR);
     if ('status' in j) {
       if (j.status === 'ok') return (j as { result: RunResult }).result;
@@ -258,17 +303,17 @@ async function pollJob(runId: string, cacheKey?: string, signal?: AbortSignal): 
   throw new Error(`job ${runId} timed out after ${POLL_TIMEOUT_MS / 1000}s`);
 }
 
-// The Cloudflare queue consumer runs at max_concurrency=50 and the run route's
-// cache-hit hot-path is a single KV read, so the browser can dispatch well
-// beyond the old value of 4 — the bottleneck on a warmed daf was this client
-// gate, not the server. 16 fills a page's section/move/anchor cards ~4× faster
-// vs the old 4 (cache hits especially). Upper-bound note: on a COLD page each
-// in-flight slot can enqueue a job that fans out (×5 for argument-move), so 16
-// → up to ~80 concurrent OpenRouter calls from one tab. 16 is the practical
-// ceiling — push higher and cold loads risk OpenRouter 429s with no real gain
-// (a viewport rarely shows >16 cards needing fetch; the rest are
-// scroll-deferred). Watching for errors at 16; the 429 path already falls back.
-const enrichmentQueue = new RequestQueue(16);
+// On a WARM daf each run is a single KV read, so a high gate just fills cards
+// faster. But on a COLD daf each in-flight slot triggers a fresh generation
+// that loads the daf's heavy source slices (the rishonim commentary bundle is
+// several MB on a dense daf) into the SHARED Cloudflare isolate. At 16 those
+// concurrent loads blew the hard 128 MB per-isolate memory limit — the isolate
+// was killed and every in-flight card got `error code: 1101`. 6 keeps warm-daf
+// fill snappy (a viewport rarely shows >6 cards needing fetch) while cutting
+// the cold-daf memory pressure well under the limit; the server now also
+// coalesces same-daf slice loads, so concurrent runs share one copy instead
+// of N.
+const enrichmentQueue = new RequestQueue(6);
 
 /**
  * Enqueue one enrichment run on the shared queue from OUTSIDE this component

--- a/packages/talmud/src/client/MarksRegistryPanel.tsx
+++ b/packages/talmud/src/client/MarksRegistryPanel.tsx
@@ -41,6 +41,7 @@ import {
 } from 'solid-js';
 import { trackAI } from './aiActivity';
 import { devModeActive } from './DevModeShelf';
+import { parseRunJson } from './enrichmentQueue';
 import { lang } from './i18n';
 import type {
   MarkDef as RendererMarkDef,
@@ -346,7 +347,10 @@ async function postAndAwait(body: unknown): Promise<RunResult> {
     headers: { 'Content-Type': 'application/json', ...studioHeaders() },
     body: JSON.stringify(body),
   });
-  const j = (await r.json()) as RunResponse | { error?: string };
+  // parseRunJson surfaces a non-JSON edge error page (1101 / empty 5xx from a
+  // recycled or OOM'd isolate) as a clean retryable error instead of a raw
+  // JSON.parse crash.
+  const j = (await parseRunJson(r)) as RunResponse | { error?: string };
   if (!r.ok && r.status !== 202) {
     throw new Error((j as { error?: string }).error ?? `HTTP ${r.status}`);
   }
@@ -365,7 +369,14 @@ async function pollJob(runId: string, cacheKey?: string): Promise<RunResult> {
   while (Date.now() - start < POLL_TIMEOUT_MS) {
     await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
     const r = await fetch(`/api/run-status/${encodeURIComponent(runId)}${qs}`);
-    const j = (await r.json()) as RunResponse;
+    let j: RunResponse;
+    try {
+      j = (await parseRunJson(r)) as RunResponse;
+    } catch {
+      // Transient non-JSON edge error mid-poll; the job may still be running
+      // server-side, so keep polling rather than failing.
+      continue;
+    }
     if ('status' in j) {
       if (j.status === 'ok') return (j as { result: RunResult }).result;
       if (j.status === 'error') throw new Error((j as { error: string }).error);

--- a/packages/talmud/src/client/enrichmentQueue.ts
+++ b/packages/talmud/src/client/enrichmentQueue.ts
@@ -89,6 +89,32 @@ export function isServiceUnavailableError(err: unknown): boolean {
   return SERVICE_UNAVAILABLE_RE.test(msg);
 }
 
+/**
+ * Parse a `/api/run` or `/api/run-status` response body as JSON, defensively.
+ *
+ * When a Cloudflare isolate is recycled or exceeds its 128 MB memory limit
+ * (a cold dense daf opening many heavy generations at once), the edge returns
+ * an error PAGE — `error code: 1101`, or an empty 5xx — with a NON-JSON body.
+ * A bare `r.json()` then throws "unexpected character at line 1 column 1",
+ * which surfaced to readers as every card failing simultaneously with a raw
+ * parse stack. Detect the non-JSON body and throw a calm message that
+ * `isServiceUnavailableError` classifies as transient, so the UI shows a
+ * "try again" state and callers can retry instead of crashing.
+ */
+export async function parseRunJson(r: Response): Promise<unknown> {
+  const text = await r.text();
+  try {
+    return JSON.parse(text);
+  } catch {
+    const snippet = text.trim().replace(/\s+/g, ' ').slice(0, 80);
+    // "temporarily unavailable" + the HTTP status both match
+    // SERVICE_UNAVAILABLE_RE, so this is treated as a retryable blip, never a bug.
+    throw new Error(
+      `Server temporarily unavailable (HTTP ${r.status}${snippet ? `: ${snippet}` : ''})`,
+    );
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Client-side result cache
 // ---------------------------------------------------------------------------

--- a/packages/talmud/src/worker/coalesce.ts
+++ b/packages/talmud/src/worker/coalesce.ts
@@ -1,0 +1,34 @@
+/**
+ * In-flight request coalescing.
+ *
+ * When a cold daf is opened the client fires many `/api/run` jobs at once, and
+ * each one independently loads the daf's heavy source slices (the full rishonim
+ * commentary bundle is multiple MB on a dense daf — Bava Metzia 2b et al.).
+ * Parsing N copies of that into the SAME Cloudflare isolate blows the hard
+ * 128 MB per-isolate memory limit, the isolate is killed, and every in-flight
+ * request returns `error code: 1101` (which the client then can't JSON.parse).
+ *
+ * `coalesce` collapses concurrent loads of the same key onto ONE shared promise
+ * (and thus ONE parsed object in memory) instead of N copies. The entry is
+ * dropped the moment it settles, so this is a concurrency dedup, NOT a cache —
+ * KV remains the cache, and a caller arriving after settle does its own (fast,
+ * KV-backed) load. The returned value MUST be treated as read-only by callers,
+ * since concurrent callers share the same object instance.
+ */
+
+const inflight = new Map<string, Promise<unknown>>();
+
+export function coalesce<T>(key: string, fn: () => Promise<T>): Promise<T> {
+  const existing = inflight.get(key) as Promise<T> | undefined;
+  if (existing) return existing;
+  const p = (async () => fn())().finally(() => {
+    inflight.delete(key);
+  });
+  inflight.set(key, p);
+  return p;
+}
+
+/** Test-only: number of loads currently in flight. */
+export function inflightSize(): number {
+  return inflight.size;
+}

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -158,6 +158,7 @@ import {
   writeCachedCacheStats,
 } from './cache-stats';
 import { fetchZoneActivity } from './cf-zone-analytics';
+import { coalesce } from './coalesce';
 import {
   CODE_ENRICHMENTS,
   CODE_MARKS,
@@ -3165,76 +3166,87 @@ app.delete('/api/enrichments/:id', async (c) => {
 // other run paths too).
 const SLICE_TTL_S = 30 * 24 * 3600;
 
-async function getGemaraSlice(
+// Coalesced across concurrent same-daf callers: a cold daf-open fires many
+// runs at once and each would otherwise parse its own copy of the daf text
+// into the shared isolate. The result is read-only to all callers.
+function getGemaraSlice(
   env: Bindings,
   tractate: string,
   page: string,
   bypass: boolean,
 ): Promise<GemaraSlice> {
-  const cache = env.CACHE;
-  const key = keyForGemara(tractate, page);
-  if (cache && !bypass) {
-    const cached = await cache.get(key);
-    if (cached) {
-      try {
-        return JSON.parse(cached) as GemaraSlice;
-      } catch {
-        /* fall through */
+  return coalesce(`slice:gemara:${tractate}:${page}:${bypass}`, async () => {
+    const cache = env.CACHE;
+    const key = keyForGemara(tractate, page);
+    if (cache && !bypass) {
+      const cached = await cache.get(key);
+      if (cached) {
+        try {
+          return JSON.parse(cached) as GemaraSlice;
+        } catch {
+          /* fall through */
+        }
       }
     }
-  }
-  const [hb, sef, segs] = await Promise.all([
-    getHebrewBooksDafCached(cache, tractate, page),
-    getSefariaPageCached(cache, tractate, page),
-    getSefariaSegmentsCached(cache, tractate, page),
-  ]);
-  const slice: GemaraSlice = {
-    tractate,
-    page,
-    hebrew: hb?.main ?? sef?.mainText.hebrew ?? '',
-    english: sef?.mainText.english ?? '',
-    segments_he: (segs?.he ?? []).map(stripHtmlServer),
-    segments_en: (segs?.en ?? []).map(stripHtmlServer),
-  };
-  if (cache) await cache.put(key, JSON.stringify(slice), { expirationTtl: SLICE_TTL_S });
-  return slice;
+    const [hb, sef, segs] = await Promise.all([
+      getHebrewBooksDafCached(cache, tractate, page),
+      getSefariaPageCached(cache, tractate, page),
+      getSefariaSegmentsCached(cache, tractate, page),
+    ]);
+    const slice: GemaraSlice = {
+      tractate,
+      page,
+      hebrew: hb?.main ?? sef?.mainText.hebrew ?? '',
+      english: sef?.mainText.english ?? '',
+      segments_he: (segs?.he ?? []).map(stripHtmlServer),
+      segments_en: (segs?.en ?? []).map(stripHtmlServer),
+    };
+    if (cache) await cache.put(key, JSON.stringify(slice), { expirationTtl: SLICE_TTL_S });
+    return slice;
+  });
 }
 
-async function getCommentariesSlice(
+// The single biggest per-run source object: the full rishonim commentary
+// bundle runs to several MB on a dense daf. Coalesced so concurrent same-daf
+// runs share ONE parsed copy in the isolate instead of each materializing its
+// own (the root of the 128 MB OOM on cold dapim). Read-only to all callers.
+function getCommentariesSlice(
   env: Bindings,
   tractate: string,
   page: string,
   bypass: boolean,
 ): Promise<CommentariesSlice> {
-  const cache = env.CACHE;
-  const key = keyForCommentaries(tractate, page);
-  if (cache && !bypass) {
-    const cached = await cache.get(key);
-    if (cached) {
-      try {
-        return JSON.parse(cached) as CommentariesSlice;
-      } catch {
-        /* fall through */
+  return coalesce(`slice:commentaries:${tractate}:${page}:${bypass}`, async () => {
+    const cache = env.CACHE;
+    const key = keyForCommentaries(tractate, page);
+    if (cache && !bypass) {
+      const cached = await cache.get(key);
+      if (cached) {
+        try {
+          return JSON.parse(cached) as CommentariesSlice;
+        } catch {
+          /* fall through */
+        }
       }
     }
-  }
-  // Rishonim now arrive as per-comment, segment-anchored entries; collapse them
-  // back into the per-commentator { hebrew, english, ref } map this slice
-  // exposes to enrichment prompts (joining a commentator's comments in order).
-  const bundle = await getRishonimCached(cache, tractate, page);
-  const by_commentator: Record<string, { hebrew: string; english: string; ref: string }> = {};
-  for (const c of bundle ?? []) {
-    const ex = by_commentator[c.label];
-    if (ex) {
-      ex.hebrew = `${ex.hebrew} ${c.hebrew}`.trim();
-      ex.english = `${ex.english} ${c.english}`.trim();
-    } else {
-      by_commentator[c.label] = { hebrew: c.hebrew, english: c.english, ref: c.ref };
+    // Rishonim now arrive as per-comment, segment-anchored entries; collapse them
+    // back into the per-commentator { hebrew, english, ref } map this slice
+    // exposes to enrichment prompts (joining a commentator's comments in order).
+    const bundle = await getRishonimCached(cache, tractate, page);
+    const by_commentator: Record<string, { hebrew: string; english: string; ref: string }> = {};
+    for (const c of bundle ?? []) {
+      const ex = by_commentator[c.label];
+      if (ex) {
+        ex.hebrew = `${ex.hebrew} ${c.hebrew}`.trim();
+        ex.english = `${ex.english} ${c.english}`.trim();
+      } else {
+        by_commentator[c.label] = { hebrew: c.hebrew, english: c.english, ref: c.ref };
+      }
     }
-  }
-  const slice: CommentariesSlice = { tractate, page, by_commentator };
-  if (cache) await cache.put(key, JSON.stringify(slice), { expirationTtl: SLICE_TTL_S });
-  return slice;
+    const slice: CommentariesSlice = { tractate, page, by_commentator };
+    if (cache) await cache.put(key, JSON.stringify(slice), { expirationTtl: SLICE_TTL_S });
+    return slice;
+  });
 }
 
 /** Cap a long passage so the prompt stays bounded — a whole Yerushalmi halacha

--- a/packages/talmud/tests/coalesce.test.ts
+++ b/packages/talmud/tests/coalesce.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { coalesce, inflightSize } from '../src/worker/coalesce';
+
+// Regression guard for the cold-daf OOM: many /api/run jobs open at once and
+// each loads the same multi-MB source slice. coalesce must collapse concurrent
+// same-key loads onto ONE execution (one parsed copy in the isolate) so N
+// concurrent runs don't blow the 128 MB per-isolate memory limit.
+describe('coalesce', () => {
+  it('runs fn ONCE for concurrent same-key callers and shares the result', async () => {
+    let calls = 0;
+    let release!: (v: { big: string }) => void;
+    const gate = new Promise<{ big: string }>((res) => {
+      release = res;
+    });
+    const load = () => {
+      calls++;
+      return gate;
+    };
+
+    const a = coalesce('slice:commentaries:Chullin:53a:false', load);
+    const b = coalesce('slice:commentaries:Chullin:53a:false', load);
+    const c = coalesce('slice:commentaries:Chullin:53a:false', load);
+    expect(inflightSize()).toBe(1);
+
+    const obj = { big: 'x' };
+    release(obj);
+    const [ra, rb, rc] = await Promise.all([a, b, c]);
+
+    expect(calls).toBe(1); // one shared load, not three copies
+    expect(ra).toBe(rb); // same object instance shared across callers
+    expect(rb).toBe(rc);
+    expect(ra).toBe(obj);
+  });
+
+  it('does NOT share across different keys (different daf / bypass)', async () => {
+    let calls = 0;
+    const load = async () => {
+      calls++;
+      return calls;
+    };
+    const [x, y] = await Promise.all([
+      coalesce('slice:gemara:Chullin:53a:false', load),
+      coalesce('slice:gemara:Chullin:53b:false', load),
+    ]);
+    expect(calls).toBe(2);
+    expect(x).not.toBe(y);
+  });
+
+  it('drops the in-flight entry on settle (a cache, KV remains the cache)', async () => {
+    await coalesce('k1', async () => 1);
+    expect(inflightSize()).toBe(0);
+    // A later call re-runs (does not serve a stale shared value).
+    let ran = false;
+    await coalesce('k1', async () => {
+      ran = true;
+      return 2;
+    });
+    expect(ran).toBe(true);
+  });
+
+  it('propagates rejection to all awaiters and clears the entry', async () => {
+    const boom = () => Promise.reject(new Error('load failed'));
+    const a = coalesce('k-err', boom);
+    const b = coalesce('k-err', boom);
+    await expect(a).rejects.toThrow('load failed');
+    await expect(b).rejects.toThrow('load failed');
+    expect(inflightSize()).toBe(0); // no leak after failure
+  });
+});

--- a/packages/talmud/tests/enrichment-queue.test.ts
+++ b/packages/talmud/tests/enrichment-queue.test.ts
@@ -3,9 +3,52 @@ import {
   isAbort,
   isServiceUnavailableError,
   PAUSED_ERROR,
+  parseRunJson,
   QUEUE_PRIORITY,
   RequestQueue,
 } from '../src/client/enrichmentQueue';
+
+// Regression guard for the "every card fails with `JSON.parse: unexpected
+// character at line 1 column 1`" incident: when a Cloudflare isolate is
+// recycled or OOMs, /api/run returns a NON-JSON edge page. A bare r.json()
+// crashed; parseRunJson must turn that into a calm, retryable error instead.
+describe('parseRunJson', () => {
+  it('returns the parsed body for valid JSON (ok and handled-error alike)', async () => {
+    const ok = await parseRunJson(new Response(JSON.stringify({ status: 'ok', result: 1 })));
+    expect(ok).toEqual({ status: 'ok', result: 1 });
+    // A genuine 4xx with a JSON body must still parse (so its real error surfaces).
+    const bad = await parseRunJson(
+      new Response(JSON.stringify({ error: 'bad input' }), { status: 400 }),
+    );
+    expect(bad).toEqual({ error: 'bad input' });
+  });
+
+  it('throws a transient/retryable error for a Cloudflare 1101 edge page', async () => {
+    const r = new Response('error code: 1101', {
+      status: 500,
+      headers: { 'content-type': 'text/plain' },
+    });
+    await expect(parseRunJson(r)).rejects.toThrow();
+    const err = await parseRunJson(new Response('error code: 1101', { status: 500 })).catch(
+      (e) => e,
+    );
+    // Must be classified transient — NOT a raw parse crash — so the UI shows a
+    // retry state and callers retry instead of failing every card.
+    expect(isServiceUnavailableError(err)).toBe(true);
+  });
+
+  it('throws a transient error for an empty 5xx body', async () => {
+    const err = await parseRunJson(new Response('', { status: 503 })).catch((e) => e);
+    expect(isServiceUnavailableError(err)).toBe(true);
+  });
+
+  it('throws a transient error for an HTML gateway page', async () => {
+    const err = await parseRunJson(
+      new Response('<!DOCTYPE html><title>502 Bad Gateway</title>', { status: 502 }),
+    ).catch((e) => e);
+    expect(isServiceUnavailableError(err)).toBe(true);
+  });
+});
 
 describe('isServiceUnavailableError', () => {
   it('flags AI-provider outages / timeouts (calm "try later" states)', () => {


### PR DESCRIPTION
## Symptom

On a cold dense daf (Chullin 52a/53a, Bava Metzia 2b, …) every sidebar card failed at once with:

> Rabbis: JSON.parse: unexpected character at line 1 column 1 of the JSON data
> Overview: JSON.parse: …  (and so on for every card)

…under the banner *"Some content couldn't be generated just now."*

## Root cause (confirmed live)

Reproduced against prod with the 15-way concurrent burst a daf-open fires: **every `/api/run` returned HTTP 500 `error code: 1101`**, and `wrangler tail` showed the cause in the worker's own log — `outcome: "exceededMemory"`, `"Worker exceeded memory limit"`.

Opening a cold daf dispatches up to **16 concurrent generations**, and each one materializes the daf's heavy source slices (the rishonim commentary bundle is **several MB** on a dense daf) into the **same Cloudflare isolate**. The combined footprint blows the hard **128 MB per-isolate limit** → the isolate is killed → every in-flight request gets Cloudflare's non-JSON `error code: 1101` page → the client's `await r.json()` throws at column 1 → all cards fail together.

It surfaced *now* because a batch of source-growth work landed recently (Mesorat HaShas parallels, codifier source texts, Shas-wide halacha-refs warm, external spines); #433 ("budget commentary context", same day) is direct evidence the bundles ballooned to ~1.2M tokens — it capped the LLM side but not the in-memory footprint.

## Fix — three layers

**Server (durable):** `coalesce.ts` collapses concurrent same-daf source loads onto **one shared in-memory copy** — an in-flight dedup keyed per (slice, daf, bypass), dropped on settle (a concurrency dedup, *not* a cache; KV stays the cache). The two biggest read-only slices (`commentaries`, `gemara`) go through it, so N concurrent runs no longer hold N copies. The existing prompt-build cap is untouched (the `commentary-verbatim` check still needs full text).

**Client (resilience + mitigation):** lower the run gate **16 → 6** (warm dapim are still single KV reads; a viewport rarely shows >6 cards needing fetch). `parseRunJson` turns a non-JSON edge page (1101 / empty 5xx / HTML) into a calm **service-unavailable, retryable** error instead of a `JSON.parse` crash. The initial POST retries it twice on a short backoff so a transient blip self-heals; the poll loop treats a mid-poll edge error as "keep polling" rather than failing the card.

## Tests (regression guards)

- `coalesce.test.ts` — one shared load for concurrent same-key callers; no sharing across keys; drop-on-settle; rejection fan-out with no leak.
- `parseRunJson` cases in `enrichment-queue.test.ts` — the exact `error code: 1101` body must classify **transient** (not crash); genuine JSON 4xx still parse through.

`pnpm typecheck`, `pnpm lint`, `pnpm build`, and the full unit suite (2485 tests) all green.