### PR TITLE
Cap rishonim source text at the cache boundary (bound per-job memory)

### DIFF
--- a/packages/talmud/src/worker/source-cache.ts
+++ b/packages/talmud/src/worker/source-cache.ts
@@ -146,6 +146,39 @@ export async function getSefariaPageCached(
   }
 }
 
+// Per-comment text caps for the rishonim bundle. A handful of long
+// commentators (Shita Mekubetzet, Maharsha, …) can each run to tens of
+// thousands of chars; concatenating the full Hebrew+English of every comment on
+// a dense daf is what drove a generation job's in-memory footprint to several
+// MB and OOM'd the shared isolate (and produced the ~1.2M-token prompts of
+// #433). Capping each comment at THIS cache boundary bounds the bundle — and
+// everything derived from it (the commentaries slice, the context items) — to
+// (#comments × cap), regardless of how dense the daf is. Caps are generous, so
+// ordinary comments are untouched and short verbatim quotes stay within them.
+// This trims source TEXT only, never cache keys, so existing cached enrichment
+// OUTPUT is unaffected — only fresh runs see the trim (same policy as the
+// prompt-side cap in run-sources.ts / #433).
+const RISHON_PER_COMMENT_HE = 8_000;
+const RISHON_PER_COMMENT_EN = 10_000;
+
+function capCommentText(s: string, max: number): string {
+  return s && s.length > max ? `${s.slice(0, max).trimEnd()} …[trimmed]` : s;
+}
+
+/** Bound each comment's HE/EN text. Returns the SAME array when nothing exceeds
+ *  the caps (the common case), so already-short dapim pay no allocation. */
+export function capRishonimBundle(bundle: RishonimBundle): RishonimBundle {
+  let changed = false;
+  const out = bundle.map((c) => {
+    const hebrew = capCommentText(c.hebrew ?? '', RISHON_PER_COMMENT_HE);
+    const english = capCommentText(c.english ?? '', RISHON_PER_COMMENT_EN);
+    if (hebrew === c.hebrew && english === c.english) return c;
+    changed = true;
+    return { ...c, hebrew, english };
+  });
+  return changed ? out : bundle;
+}
+
 export async function getRishonimCached(
   cache: KVNamespace | undefined,
   tractate: string,
@@ -161,9 +194,13 @@ export async function getRishonimCached(
   const key = keyForRishonim(tractate, page);
   const hit = await readCache<RishonimBundle>(cache, key);
   track?.onCache?.(hit ? 'hit' : 'miss');
-  if (hit) return hit;
+  // Cap on read AND write: a fresh fetch stores the bounded bundle (no version
+  // bump, so no Shas-wide re-warm); an older full entry is still bounded in the
+  // object we RETAIN through the multi-second LLM call (the sustained memory
+  // pressure), even though its KV value stays full until it next refreshes.
+  if (hit) return capRishonimBundle(hit);
   try {
-    const data = await sefariaAPI.fetchRishonim(tractate, page);
+    const data = capRishonimBundle(await sefariaAPI.fetchRishonim(tractate, page));
     await writeCache(cache, key, data);
     return data;
   } catch {

--- a/packages/talmud/tests/rishonim-cap.test.ts
+++ b/packages/talmud/tests/rishonim-cap.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import type { RishonimBundle } from '../src/lib/sefref/sefaria/client';
+import { capRishonimBundle } from '../src/worker/source-cache';
+
+// Memory regression guard. The cold-daf isolate OOM was driven by the rishonim
+// bundle: a few long commentators (Shita Mekubetzet, Maharsha) concatenated with
+// NO cap pushed a generation job past the 128 MB isolate limit. capRishonimBundle
+// must bound each comment's text so the bundle — and the slice/context derived
+// from it — can't scale with daf density. If this budget is ever loosened, the
+// OOM can return; this test fails first.
+const HE_CAP = 8_000;
+const EN_CAP = 10_000;
+
+function comment(over: Partial<RishonimBundle[number]>): RishonimBundle[number] {
+  return { label: 'Maharsha', ref: 'x', hebrew: '', english: '', segStart: 0, segEnd: 0, ...over };
+}
+
+describe('capRishonimBundle', () => {
+  it('bounds a pathologically long comment to the per-language caps', () => {
+    const huge = capRishonimBundle([
+      comment({ hebrew: 'א'.repeat(200_000), english: 'a'.repeat(200_000) }),
+    ]);
+    expect(huge[0].hebrew.length).toBeLessThanOrEqual(HE_CAP + 16); // + " …[trimmed]"
+    expect(huge[0].english.length).toBeLessThanOrEqual(EN_CAP + 16);
+    expect(huge[0].hebrew).toContain('[trimmed]');
+  });
+
+  it('keeps the total bundle footprint O(#comments × cap), not O(daf density)', () => {
+    const dense: RishonimBundle = Array.from({ length: 60 }, (_, i) =>
+      comment({ label: `r${i}`, hebrew: 'א'.repeat(50_000), english: 'a'.repeat(50_000) }),
+    );
+    const capped = capRishonimBundle(dense);
+    const bytes = capped.reduce((n, c) => n + c.hebrew.length + c.english.length, 0);
+    // 60 comments × ~18k = ~1.1MB ceiling — vs ~6MB uncapped. Bounded by the cap.
+    expect(bytes).toBeLessThan(60 * (HE_CAP + EN_CAP + 32));
+    // Sanity: the same input uncapped would be ~6MB, far over the ceiling.
+    expect(60 * 100_000).toBeGreaterThan(bytes * 4);
+  });
+
+  it('leaves ordinary comments untouched and returns the SAME array (no realloc)', () => {
+    const normal: RishonimBundle = [
+      comment({ label: 'Rashba', hebrew: 'א'.repeat(1_200), english: 'a'.repeat(900) }),
+      comment({ label: 'Ritva', hebrew: 'ב'.repeat(800), english: 'b'.repeat(700) }),
+    ];
+    const out = capRishonimBundle(normal);
+    expect(out).toBe(normal); // identity preserved when nothing exceeds the cap
+    expect(out[0].hebrew).toBe('א'.repeat(1_200));
+  });
+
+  it('handles missing/empty text fields safely', () => {
+    const out = capRishonimBundle([
+      comment({ hebrew: '', english: '' }),
+      comment({ hebrew: undefined as unknown as string, english: undefined as unknown as string }),
+    ]);
+    expect(out[0].hebrew).toBe('');
+    expect(out[1].hebrew ?? '').toBe('');
+  });
+});


### PR DESCRIPTION
The durable half of the cold-daf isolate OOM (#439 was the mitigation: client gate 16→6, coalescing, no-crash parsing). This makes **per-job memory stop scaling with daf density** — the actual root.

## Why the rishonim bundle

The OOM came from a generation job materializing the daf's source bundles. The **rishonim bundle is the shared root**: both heavy paths derive from it —
- the commentaries slice (`getCommentariesSlice`), and
- the context pool (`collectContext` → `fromRishonim`).

A few long commentators (Shita Mekubetzet, Maharsha) concatenated with **no cap** is exactly what #433 documented blowing past 1.2M tokens on dense dapim.

## The fix

Cap each comment's HE/EN at the **`getRishonimCached` boundary** (8k / 10k chars). The bundle — and everything derived from it — is then bounded by `(#comments × cap)`, regardless of how dense the daf is.

- **Read *and* write:** a fresh fetch stores the bounded bundle; an older full KV entry is still bounded in the object we *retain* through the multi-second LLM call (the sustained memory pressure). So **no version bump, no Shas-wide re-warm**.
- **Source text only, never cache keys** — existing cached enrichment output is untouched; only fresh runs see the trim. Same policy #433 established for the prompt-side cap.
- **Nothing reader-facing is truncated:** the only two callers of `getRishonimCached` are prompt/check consumers; the reader's commentary drawer is a separate path (`fetchCommentaryWorks`).

## The invariant this establishes

With #439's coalescing (concurrent same-daf runs share one copy) and the next PR's consumer-concurrency bound, peak isolate memory becomes a **provable constant** — `max_concurrency × per-job cap` — instead of a function of traffic × data growth.

## Regression guard

`tests/rishonim-cap.test.ts`: a pathological comment is bounded to the caps; a dense 60-comment bundle stays `O(#comments × cap)` (~1 MB vs ~6 MB uncapped); ordinary comments are untouched (same-array identity, no realloc). If the budget is ever loosened, this fails first.

`pnpm typecheck`, `pnpm lint`, full suite (2489 tests) green.