### PR TITLE
Geo: map navigation presets, clickable Tanach places, rabbi map on shared atlas

### DIFF
--- a/packages/talmud/src/client/ArgumentSidebar.tsx
+++ b/packages/talmud/src/client/ArgumentSidebar.tsx
@@ -17,7 +17,13 @@ import {
   TIDBIT_RECIPE,
   YERUSHALMI_RECIPE,
 } from '@corpus/core/sidebar/recipe';
-import { GeoMap, type GeoPoint, type GeoTrajectoryStop } from '@corpus/ui/GeoMap';
+import {
+  fitBbox,
+  GEO_BBOX,
+  GeoMap,
+  type GeoPoint,
+  type GeoTrajectoryStop,
+} from '@corpus/ui/GeoMap';
 import {
   createEffect,
   createMemo,
@@ -2861,6 +2867,23 @@ function GeographyMapBlock(props: SpecialBlockProps): JSX.Element {
     return stops.length ? stops : undefined;
   });
 
+  // View: 'fit' auto-frames the daf's rabbis (the dots cluster, so the fixed
+  // full-region view wasted space); 'bavel'/'ey' zoom to a region. Drilling a
+  // sage temporarily fits the map to that rabbi's whole path.
+  const [view, setView] = createSignal<'fit' | 'bavel' | 'ey'>('fit');
+  const mapBbox = createMemo(() => {
+    const traj = trajectory();
+    if (traj) return fitBbox(traj, TALMUD_GEO_BBOX, { minSpan: 1.2 });
+    if (view() === 'bavel') return GEO_BBOX.bavel;
+    if (view() === 'ey') return GEO_BBOX.israel;
+    return fitBbox(points(), TALMUD_GEO_BBOX, { minSpan: 1.2 });
+  });
+  const VIEW_PRESETS: { id: 'fit' | 'bavel' | 'ey'; label: string }[] = [
+    { id: 'fit', label: t('geography.view.fit') },
+    { id: 'bavel', label: t('geography.bavel') },
+    { id: 'ey', label: t('geography.eretzYisrael') },
+  ];
+
   return (
     <Show
       when={hasMap()}
@@ -2891,8 +2914,35 @@ function GeographyMapBlock(props: SpecialBlockProps): JSX.Element {
         </Show>
       }
     >
+      {/* zoom presets: fit to the rabbis, or jump to a region (disabled while
+          drilling a sage's path, which fits the map to that path) */}
+      <Show when={!trajectory()}>
+        <div style={{ display: 'flex', gap: '4px', 'margin-bottom': '6px' }}>
+          <For each={VIEW_PRESETS}>
+            {(preset) => (
+              <button
+                type="button"
+                onClick={() => setView(preset.id)}
+                style={{
+                  'font-family': 'var(--font-ui)',
+                  'font-size': '0.66rem',
+                  'letter-spacing': '0.03em',
+                  padding: '2px 9px',
+                  border: `1px solid ${view() === preset.id ? 'var(--accent)' : 'var(--line)'}`,
+                  'border-radius': '999px',
+                  background: view() === preset.id ? 'var(--accent)' : 'var(--surface)',
+                  color: view() === preset.id ? '#fff' : 'var(--muted)',
+                  cursor: 'pointer',
+                }}
+              >
+                {preset.label}
+              </button>
+            )}
+          </For>
+        </div>
+      </Show>
       <GeoMap
-        bbox={TALMUD_GEO_BBOX}
+        bbox={mapBbox()}
         points={points()}
         lang={lang() === 'he' ? 'he' : 'en'}
         height={520}

--- a/packages/talmud/src/client/RabbiTrajectoryMap.tsx
+++ b/packages/talmud/src/client/RabbiTrajectoryMap.tsx
@@ -1,28 +1,21 @@
 /**
  * Per-rabbi places MAP — the map-first replacement for the old vertical
- * "Places — Timeline". A rabbi's life is drawn as a numbered path across the
- * same two region maps the whole-daf geography card uses (shared geoMapBase),
- * built from the one shared builder (buildTrajectory). Clicking a numbered stop
- * opens its detail below the maps: the life-stage, the context sentence, the
- * on-daf evidence ("show on daf"), and the "you are here" marker for the
- * current sugya.
+ * "Places — Timeline". A rabbi's life is drawn as a numbered path on the shared
+ * @corpus/ui GeoMap (the SAME real-coordinate atlas the whole-daf geography card
+ * uses), built from the one shared builder (buildTrajectory). Clicking a
+ * numbered badge opens its detail below the map: the life-stage, the context
+ * sentence, the on-daf evidence ("show on daf"), and the "you are here" marker
+ * for the current sugya.
  *
  * Replaces RabbiPlacesTimeline: same data + evidence + location, map instead of
  * a list.
  */
 
+import { fitBbox, GEO_BBOX, GeoMap, type GeoTrajectoryStop } from '@corpus/ui/GeoMap';
 import { createMemo, createSignal, For, type JSX, Show } from 'solid-js';
 import { buildTrajectory, type TrajectoryStop } from '../lib/geographyModel';
-import {
-  collapsePlaced,
-  type PlacedStop,
-  RegionMapCard,
-  regionTint,
-  TRAJ_COLOR,
-  TrajectoryBadges,
-} from './geoMapBase';
-import { BAVEL_SHAPE, ISRAEL_SHAPE } from './geoShapes';
-import { t } from './i18n';
+import { collapsePlaced, type PlacedStop, regionTint, stopLatLng, TRAJ_COLOR } from './geoMapBase';
+import { lang, t } from './i18n';
 import type { GeographyData, GeographyEvidence } from './RabbiGeographyCard';
 
 export interface LocationInference {
@@ -60,10 +53,6 @@ export default function RabbiTrajectoryMap(props: Props): JSX.Element {
   // Stops we can actually plot — the detail card + default selection key off
   // these so a numbered badge is always reachable.
   const positioned = (): PlacedStop[] => placed().filter((p) => p.pos);
-  // Only render a region's map when the rabbi actually has a stop there — a
-  // pure-Bavel rabbi shows just Bavel; a pure-Eretz-Yisrael one just that.
-  const showIsrael = (): boolean => positioned().some((p) => p.stop.region === 'israel');
-  const showBavel = (): boolean => positioned().some((p) => p.stop.region === 'bavel');
 
   const evidenceByKey = (): Map<string, GeographyEvidence> => {
     const m = new Map<string, GeographyEvidence>();
@@ -143,6 +132,35 @@ export default function RabbiTrajectoryMap(props: Props): JSX.Element {
     return r === 'unknown' ? t('region.unknown') : t('region.other');
   };
 
+  // The numbered life-path drawn on the shared GeoMap: one stop per placed node
+  // (in life order), positioned by real lat/lng; the open node is `active` so
+  // its badge rings and labels. seq === the PlacedStop num, so a badge click
+  // maps straight back to its node.
+  const trajStops = createMemo<GeoTrajectoryStop[]>(() => {
+    const active = activeNum();
+    return placed().flatMap((p) => {
+      const ll = stopLatLng(p.stop);
+      if (!ll) return [];
+      return [
+        {
+          lat: ll.lat,
+          lng: ll.lng,
+          seq: p.num,
+          label: p.stop.place,
+          active: p.num === active,
+        },
+      ];
+    });
+  });
+  // Auto-frame the path: a pure-Bavel rabbi fits Bavel, a pure-EY one fits EY,
+  // a migrant fits the whole journey across both. minSpan keeps a single-stop
+  // rabbi from zooming to street level.
+  const mapBbox = createMemo(() => fitBbox(trajStops(), GEO_BBOX.nearEast, { minSpan: 1.4 }));
+  const onTrajectoryStop = (s: GeoTrajectoryStop) => {
+    const p = placed().find((pp) => pp.num === s.seq);
+    if (p) pick(p);
+  };
+
   return (
     <Show when={positioned().length > 0}>
       <div
@@ -166,41 +184,17 @@ export default function RabbiTrajectoryMap(props: Props): JSX.Element {
           {t('rabbi.places.title')}
         </div>
 
-        {/* The region maps, stacked — only those the rabbi actually visited. */}
-        <div style={{ display: 'flex', 'flex-direction': 'column', gap: '0.4rem' }}>
-          <Show when={showIsrael()}>
-            <RegionMapCard
-              shape={ISRAEL_SHAPE}
-              heading={t('geography.eretzYisrael')}
-              headingColor="#1f2937"
-              aria={t('geography.eretzYisrael.aria')}
-              layout="column"
-            >
-              <TrajectoryBadges
-                placed={placed()}
-                region="israel"
-                onPick={pick}
-                activeNum={activeNum()}
-              />
-            </RegionMapCard>
-          </Show>
-          <Show when={showBavel()}>
-            <RegionMapCard
-              shape={BAVEL_SHAPE}
-              heading={t('geography.bavel')}
-              headingColor="#1e40af"
-              aria={t('geography.bavel.aria')}
-              layout="column"
-            >
-              <TrajectoryBadges
-                placed={placed()}
-                region="bavel"
-                onPick={pick}
-                activeNum={activeNum()}
-              />
-            </RegionMapCard>
-          </Show>
-        </div>
+        {/* The life-path on the shared real-coordinate atlas — auto-framed to
+            wherever the rabbi lived. Clicking a numbered badge opens its node. */}
+        <GeoMap
+          bbox={mapBbox()}
+          points={[]}
+          lang={lang() === 'he' ? 'he' : 'en'}
+          height={300}
+          layerToggle={false}
+          trajectory={trajStops()}
+          onTrajectoryStop={onTrajectoryStop}
+        />
 
         {/* Detail card for the open node — renders EVERY event collapsed at that
             spot (e.g. moved-to + studied + notable in one city) so nothing the

--- a/packages/talmud/src/client/geoMapBase.tsx
+++ b/packages/talmud/src/client/geoMapBase.tsx
@@ -78,6 +78,28 @@ export function stopPosition(stop: TrajectoryStop): { x: number; y: number } | n
   return null;
 }
 
+/** Real-world lat/lng of a trajectory stop — the @corpus/ui GeoMap re-projects
+ *  these. Mirrors stopPosition: known city coords, else the region's lat/lng
+ *  centroid, else null (unplottable). Non-null exactly when stopPosition is. */
+export function stopLatLng(stop: TrajectoryStop): { lat: number; lng: number } | null {
+  if (stop.cityName) {
+    const c = CITY_BY_NAME.get(stop.cityName);
+    if (c) return { lat: c.lat, lng: c.lng };
+  }
+  if (stop.region === 'israel' || stop.region === 'bavel') {
+    const cities = GEO_CITIES.filter((c) => c.region === stop.region);
+    if (!cities.length) return null;
+    let lat = 0;
+    let lng = 0;
+    for (const c of cities) {
+      lat += c.lat;
+      lng += c.lng;
+    }
+    return { lat: lat / cities.length, lng: lng / cities.length };
+  }
+  return null;
+}
+
 /** A positioned, numbered stop (index in the full ordered trajectory). */
 export interface PlacedStop {
   /** Representative stop (the first at this spot) — drives the badge + position. */

--- a/packages/talmud/src/client/i18n.ts
+++ b/packages/talmud/src/client/i18n.ts
@@ -1151,6 +1151,7 @@ const CATALOG = {
   'geography.euphrates': { en: 'Euphrates', he: 'פרת' },
   'geography.tigris': { en: 'Tigris', he: 'חידקל' },
   'geography.migration': { en: 'Migration', he: 'הגירה' },
+  'geography.view.fit': { en: 'Fit', he: 'הכל' },
   'geography.trajectory.hint': {
     en: 'click a rabbi to trace their path',
     he: 'לחצו על חכם כדי לעקוב אחר מסלולו',

--- a/packages/tanach/src/client/App.tsx
+++ b/packages/tanach/src/client/App.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@corpus/ui/Button';
 import { Drawer } from '@corpus/ui/Drawer';
-import { type GeoBBox, GeoMap } from '@corpus/ui/GeoMap';
+import { fitBbox, GeoMap } from '@corpus/ui/GeoMap';
 import { LangToggle } from '@corpus/ui/LangToggle';
 import { Pill, PillRow } from '@corpus/ui/Pill';
 import { Prose } from '@corpus/ui/Prose';
@@ -201,6 +201,8 @@ interface GeoPlace {
   he: string;
   lat: number;
   lng: number;
+  /** Verse number(s) where the place is named — clicking the pin highlights them. */
+  verses: number[];
 }
 interface PerekGeography {
   book: string;
@@ -215,25 +217,6 @@ const PEREK_PILLS: { id: PerekPill; label: string }[] = [
 ];
 const PILL_KIND: Record<PerekPill, string> = { overview: 'Overview', geography: 'Geography' };
 
-/** Frame a perek's places: fit the map bbox to the points (with padding + a
- *  minimum span so a lone place isn't a single point). Falls back to Israel. */
-function fitBbox(places: GeoPlace[]): GeoBBox {
-  if (!places.length) return { lonMin: 34, lonMax: 36.3, latMin: 29.4, latMax: 33.6 };
-  const lats = places.map((p) => p.lat);
-  const lngs = places.map((p) => p.lng);
-  const latMin = Math.min(...lats);
-  const latMax = Math.max(...lats);
-  const lngMin = Math.min(...lngs);
-  const lngMax = Math.max(...lngs);
-  const padLat = Math.max((latMax - latMin) * 0.3, 0.7);
-  const padLng = Math.max((lngMax - lngMin) * 0.3, 0.7);
-  return {
-    latMin: latMin - padLat,
-    latMax: latMax + padLat,
-    lonMin: lngMin - padLng,
-    lonMax: lngMax + padLng,
-  };
-}
 interface CommentaryEntry {
   key: string;
   en: string;
@@ -506,11 +489,13 @@ export function App(): JSX.Element {
     setWordSel(null);
   });
 
-  // Highlight the relevant verses: a section's range (note popover) or the
-  // single verse whose source drawer is open (rishonim / gemara / midrash).
+  // Highlight the relevant verses: a section's range (note popover), the single
+  // verse whose source drawer is open (rishonim / gemara / midrash), or the
+  // verse(s) a clicked Geography place is named in.
   createEffect(() => {
     const sel = selected();
     const src = source();
+    const pv = new Set(placeVerses());
     paragraphs();
     requestAnimationFrame(() => {
       if (!scrollBand) return;
@@ -521,7 +506,7 @@ export function App(): JSX.Element {
         const vn = Number(e.dataset.vn);
         const inNote = sel && vn >= sel.start && vn <= sel.end;
         const inSource = src && vn === src.verse;
-        if (inNote || inSource) e.classList.add('hl');
+        if (inNote || inSource || pv.has(vn)) e.classList.add('hl');
       });
     });
   });
@@ -638,6 +623,32 @@ export function App(): JSX.Element {
     if (geography.loading) return null;
     const g = geography();
     return g && g.book === loc().book && g.chapter === loc().chapter ? g : null;
+  });
+  // Clicking a Geography place pin highlights the verse(s) it's named in (and
+  // scrolls to the first), the way clicking a place works on the Talmud daf.
+  const [placeVerses, setPlaceVerses] = createSignal<number[]>([]);
+  const [selectedPlaceId, setSelectedPlaceId] = createSignal<string | undefined>();
+  const highlightPlace = (verses: number[]) => {
+    setPlaceVerses(verses);
+    const first = verses.slice().sort((a, b) => a - b)[0];
+    if (!first) return;
+    requestAnimationFrame(() => {
+      scrollBand
+        ?.querySelector(`.vtext[data-vn="${first}"]`)
+        ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    });
+  };
+  const clearPlace = () => {
+    setPlaceVerses([]);
+    setSelectedPlaceId(undefined);
+  };
+  // Clear the place highlight when the geography pill closes or the chapter changes.
+  createEffect(() => {
+    chapterKey();
+    clearPlace();
+  });
+  createEffect(() => {
+    if (perekPill() !== 'geography') clearPlace();
   });
   // createResource keeps the PREVIOUS chapter's value during a refetch, so the
   // drawer must not render it: only show the overview once it has loaded AND
@@ -987,6 +998,13 @@ export function App(): JSX.Element {
                       }))}
                       lang={loc().lang}
                       height={460}
+                      selected={selectedPlaceId()}
+                      onSelect={(pt) => {
+                        const place = g().places.find((p) => p.en === pt.id);
+                        if (!place) return;
+                        setSelectedPlaceId(pt.id);
+                        highlightPlace(place.verses);
+                      }}
                     />
                   </Show>
                 )}

--- a/packages/tanach/src/worker/index.ts
+++ b/packages/tanach/src/worker/index.ts
@@ -221,16 +221,21 @@ app.get('/api/geography/:book/:chapter', async (c) => {
   } catch (e) {
     return runErrorResponse(c, e);
   }
-  const parsed = artifact.parsed as { places?: { en?: string; he?: string }[] } | null;
+  const parsed = artifact.parsed as {
+    places?: { en?: string; he?: string; verses?: number[] }[];
+  } | null;
   const seen = new Set<string>();
   const places = (parsed?.places ?? [])
     .map((p) => {
       const en = String(p?.en ?? '').trim();
       const g = en ? lookupPlace(en) : null;
       if (!g) return null;
-      return { en, he: String(p?.he ?? '').trim(), lat: g.lat, lng: g.lng };
+      const verses = Array.isArray(p?.verses)
+        ? p.verses.filter((v) => Number.isInteger(v) && v >= 1)
+        : [];
+      return { en, he: String(p?.he ?? '').trim(), lat: g.lat, lng: g.lng, verses };
     })
-    .filter((p): p is { en: string; he: string; lat: number; lng: number } => {
+    .filter((p): p is { en: string; he: string; lat: number; lng: number; verses: number[] } => {
       if (!p) return false;
       const key = `${p.lat},${p.lng}`; // dedupe places that resolve to one point
       if (seen.has(key)) return false;

--- a/packages/tanach/src/worker/producers/geography.ts
+++ b/packages/tanach/src/worker/producers/geography.ts
@@ -19,6 +19,9 @@ export interface PerekPlace {
   en: string;
   /** Hebrew name as it appears in the text (for the map label). */
   he: string;
+  /** Verse number(s) in the chapter where the place is named — so clicking the
+   *  map pin can highlight the text it came from. */
+  verses: number[];
 }
 
 export const GEOGRAPHY_SYSTEM = [
@@ -34,6 +37,9 @@ export const GEOGRAPHY_SYSTEM = [
   '  Use the standard spelling, not a variant — it is used to look the place up.',
   '- "he" is the Hebrew name AS IT APPEARS in the text (with nikud if present):',
   '  "חֶבְרוֹן", "בְּאֵר שֶׁבַע", "אוּר", "חָרָן", "מִצְרַיִם".',
+  '- "verses" is the verse NUMBER(s) in this chapter where the place is named',
+  '  (the leading numbers in the supplied text). Usually one; list every verse',
+  '  it is named in if more than one.',
   '- Do NOT include people, tribes, or peoples — only physical places.',
   '- Do NOT invent coordinates or places not in the text.',
   '- Return them in the order they first appear.',
@@ -56,10 +62,11 @@ export const GEOGRAPHY_SCHEMA = {
         items: {
           type: 'object',
           additionalProperties: false,
-          required: ['en', 'he'],
+          required: ['en', 'he', 'verses'],
           properties: {
             en: { type: 'string' },
             he: { type: 'string' },
+            verses: { type: 'array', items: { type: 'integer', minimum: 1 } },
           },
         },
       },

--- a/packages/tanach/src/worker/run-ports.ts
+++ b/packages/tanach/src/worker/run-ports.ts
@@ -106,7 +106,8 @@ const KEY_TEMPLATES: Record<string, KeyTemplate> = {
   // chapter), so enrichmentAddress('overview', …) carries no verse/range.
   overview: { key: (a: TanachAddress) => `overview:v1:${a.unit?.work}:${a.unit?.unit}` },
   // Chapter-scoped like overview (one geography per chapter; instance ignored).
-  geography: { key: (a: TanachAddress) => `geography:v1:${a.unit?.work}:${a.unit?.unit}` },
+  // v2: the output now carries per-place verse numbers (for click-to-highlight).
+  geography: { key: (a: TanachAddress) => `geography:v2:${a.unit?.work}:${a.unit?.unit}` },
   synthesis: {
     key: (a: TanachAddress) => `synthesis:v1:${a.unit?.work}:${a.unit?.unit}:${a.verse}`,
   },

--- a/packages/ui/src/GeoMap.tsx
+++ b/packages/ui/src/GeoMap.tsx
@@ -55,6 +55,8 @@ export interface GeoTrajectoryStop {
   /** Badge number (1-based); falls back to position when omitted. */
   seq?: number;
   label?: string;
+  /** Emphasised stop (e.g. the "you are here" / selected node). */
+  active?: boolean;
 }
 
 export interface GeoMapProps {
@@ -76,6 +78,8 @@ export interface GeoMapProps {
    *  and dims the regular markers — a drill-down overlay (e.g. one sage's
    *  journey). Clear it to return to the full map. */
   trajectory?: GeoTrajectoryStop[];
+  /** Click a numbered trajectory badge (makes them interactive buttons). */
+  onTrajectoryStop?: (stop: GeoTrajectoryStop, index: number) => void;
 }
 
 /** Standard viewports apps can reuse. */
@@ -84,7 +88,35 @@ export const GEO_BBOX = {
   israel: { lonMin: 34, lonMax: 36.3, latMin: 29.4, latMax: 33.6 },
   // Babylonia + Eretz Yisrael — the talmudic world.
   bavelToEy: { lonMin: 33.5, lonMax: 46.5, latMin: 30.5, latMax: 35.5 },
+  // Bavel alone (the academies cluster) — for a zoom preset.
+  bavel: { lonMin: 42.5, lonMax: 45.6, latMin: 31, latMax: 34 },
 } satisfies Record<string, GeoBBox>;
+
+/** Fit a bbox to a set of points (with padding + a minimum span so a lone or
+ *  tightly-clustered set isn't a pinprick). Falls back when there are none. */
+export function fitBbox(
+  pts: { lat: number; lng: number }[],
+  fallback: GeoBBox = GEO_BBOX.israel,
+  opts?: { padFrac?: number; minSpan?: number },
+): GeoBBox {
+  if (!pts.length) return fallback;
+  const padFrac = opts?.padFrac ?? 0.3;
+  const minSpan = opts?.minSpan ?? 0.7;
+  const lats = pts.map((p) => p.lat);
+  const lngs = pts.map((p) => p.lng);
+  const latMin = Math.min(...lats);
+  const latMax = Math.max(...lats);
+  const lngMin = Math.min(...lngs);
+  const lngMax = Math.max(...lngs);
+  const padLat = Math.max((latMax - latMin) * padFrac, minSpan);
+  const padLng = Math.max((lngMax - lngMin) * padFrac, minSpan);
+  return {
+    latMin: latMin - padLat,
+    latMax: latMax + padLat,
+    lonMin: lngMin - padLng,
+    lonMax: lngMax + padLng,
+  };
+}
 
 const LAYER_LABELS: Record<GeoLayer, string> = {
   water: 'Seas',
@@ -192,6 +224,9 @@ export function GeoMap(props: GeoMapProps): JSX.Element {
       xy: proj().project(s.lng, s.lat),
       seq: s.seq ?? i + 1,
       label: s.label,
+      active: !!s.active,
+      stop: s,
+      index: i,
     })),
   );
   const trajPath = createMemo(() => {
@@ -332,14 +367,47 @@ export function GeoMap(props: GeoMapProps): JSX.Element {
               <path class="geomap-traj-path" d={trajPath()} />
             </Show>
             <For each={trajStops()}>
-              {(s) => (
-                <>
-                  <circle class="geomap-traj-badge" cx={s.xy[0]} cy={s.xy[1]} r="8" />
-                  <text class="geomap-traj-num" x={s.xy[0]} y={s.xy[1] + 3} text-anchor="middle">
-                    {s.seq}
-                  </text>
-                </>
-              )}
+              {(s) => {
+                const interactive = !!props.onTrajectoryStop;
+                return (
+                  // biome-ignore lint/a11y/noStaticElementInteractions: an SVG <g> badge can't be a real <button>; role + tabindex + keydown make it keyboard-operable
+                  <g
+                    class="geomap-traj-stop"
+                    classList={{ active: s.active, interactive }}
+                    role={interactive ? 'button' : undefined}
+                    tabindex={interactive ? 0 : undefined}
+                    aria-label={interactive ? s.label || `Stop ${s.seq}` : undefined}
+                    onClick={() => props.onTrajectoryStop?.(s.stop, s.index)}
+                    onKeyDown={(e) => {
+                      if (interactive && (e.key === 'Enter' || e.key === ' ')) {
+                        e.preventDefault();
+                        props.onTrajectoryStop?.(s.stop, s.index);
+                      }
+                    }}
+                  >
+                    <circle
+                      class="geomap-traj-badge"
+                      classList={{ active: s.active }}
+                      cx={s.xy[0]}
+                      cy={s.xy[1]}
+                      r="8"
+                    />
+                    <text class="geomap-traj-num" x={s.xy[0]} y={s.xy[1] + 3} text-anchor="middle">
+                      {s.seq}
+                    </text>
+                    <Show when={s.active && s.label}>
+                      <text
+                        class="geomap-traj-label"
+                        x={s.xy[0]}
+                        y={s.xy[1] + 19}
+                        text-anchor="middle"
+                      >
+                        {s.label}
+                      </text>
+                    </Show>
+                  </g>
+                );
+              }}
             </For>
           </g>
         </Show>

--- a/packages/ui/src/geomap.css
+++ b/packages/ui/src/geomap.css
@@ -141,6 +141,18 @@
   fill: var(--accent);
   stroke: var(--bg);
   stroke-width: 1.5;
+  transition: r 0.12s ease;
+}
+.geomap-traj-stop.interactive {
+  cursor: pointer;
+}
+.geomap-traj-stop.interactive:focus {
+  outline: none;
+}
+.geomap-traj-stop.interactive:focus-visible .geomap-traj-badge,
+.geomap-traj-badge.active {
+  stroke: var(--fg);
+  stroke-width: 2;
 }
 .geomap-traj-num {
   font-family: var(--font-ui);
@@ -148,6 +160,20 @@
   font-weight: 700;
   fill: #fff;
   pointer-events: none;
+}
+.geomap-traj-label {
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: 600;
+  fill: var(--fg);
+  paint-order: stroke;
+  stroke: var(--bg);
+  stroke-width: 3px;
+  pointer-events: none;
+}
+.geomap-he .geomap-traj-label {
+  font-family: var(--font-hebrew);
+  font-size: 12.5px;
 }
 .geomap-he .geomap-label {
   font-family: var(--font-hebrew);


### PR DESCRIPTION
Three improvements to the shared `@corpus/ui` GeoMap and its consumers, all on real coordinates (no map-tile copy).

## Talmud whole-daf geography map
- **Auto-fit by default** to the daf's rabbis (the dots cluster, so the fixed full-region view wasted space).
- **Zoom presets** — Fit / Bavel / Eretz Yisrael — so you can jump to the busy area.
- `fitBbox` + `GEO_BBOX.bavel` added to the shared kit.

## Tanach Geography pill — clickable places
- Place pins are now **clickable**: clicking a pin highlights and scrolls to the verse(s) the place is named in — mirroring Talmud's click-to-highlight.
- The geography producer now names the **verse(s)** each place appears in (schema + prompt). Cache key bumped `geography:v1` → `v2` to regenerate.

## Per-rabbi map → shared atlas
- `RabbiTrajectoryMap` migrated off the old hand-drawn two-region outlines onto the **shared real-coordinate atlas** (coastline + rivers), so it matches the whole-daf map.
- The life-path is the GeoMap **trajectory overlay** — now **clickable + active-aware** (the open node rings and labels), auto-framed with `fitBbox`. `stopLatLng` resolves each stop's real lat/lng.
- The detail card / on-daf evidence / "you are here" chrome is unchanged.

## Gates
typecheck ✓ · lint ✓ · 2489 talmud + 49 tanach + 103 core tests ✓ · both apps build ✓