### PR TITLE
Watch + alert on isolate-fatal worker outcomes (the OOM safety net)

### DIFF
--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -293,6 +293,7 @@ import {
   warmProgressProcessed,
 } from './warm-cron';
 import { lookupGloss } from './word-glosses';
+import { checkWorkerHealthAndAlert, fetchWorkerOutcomes } from './worker-health';
 import { runYomiWarmCron } from './yomi-cron';
 
 // `Bindings` and `JobMessage` now live in ./types (a neutral module so route
@@ -6872,6 +6873,13 @@ app.get('/api/usage/health', (c) =>
   ),
 );
 
+// Read-only worker-invocation outcomes (last 15m) from Cloudflare analytics —
+// the same dataset the OOM alert watches. Surfaces `exceededMemory` &c. so the
+// isolate-fatal class is verifiable on demand, and lets the GraphQL field names
+// be confirmed against the live account (the cron alert degrades quietly if the
+// token lacks scope; this route shows exactly why).
+app.get('/api/worker-health', async (c) => c.json(await fetchWorkerOutcomes(c.env, 15)));
+
 // Check off / restore a bug report (by its timestamp id). Toggles membership in
 // the dismissed set; the backlog payload splits reports into active vs. done
 // from it. Open + reversible — it's dev triage, not destructive.
@@ -11122,12 +11130,17 @@ export default {
           },
         ),
       );
+      // Independent health watch: alert if an isolate-fatal outcome
+      // (exceededMemory — the cold-daf OOM) appeared in the last window.
+      // Self-contained + best-effort; never throws into the cron.
+      ctx.waitUntil(checkWorkerHealthAndAlert(wrapped, Date.now()));
     }
   },
   // Queue consumer — wrangler.toml binds queue=enrichment-jobs to this
-  // export. Each message is one /api/run job. max_concurrency=2 caps
-  // simultaneous LLM workloads; max_batch_size=1 means one job per
-  // invocation (no batching), which keeps memory bounded per worker.
+  // export. Each message is one /api/run job. max_concurrency (wrangler.toml,
+  // currently 16) caps simultaneous LLM workloads AND simultaneous memory on a
+  // shared isolate; max_batch_size=1 means one job per invocation (no batching),
+  // which keeps memory bounded per worker.
   queue: async (
     batch: MessageBatch<JobMessage>,
     env: Bindings,

--- a/packages/talmud/src/worker/worker-health.ts
+++ b/packages/talmud/src/worker/worker-health.ts
@@ -1,0 +1,201 @@
+/**
+ * Worker health watch — alert on isolate-fatal outcomes (the cold-daf OOM).
+ *
+ * The OOM that took out every card was invisible until someone hand-tailed the
+ * worker: Cloudflare killed the isolate with outcome `exceededMemory`, and the
+ * only symptom readers saw was `error code: 1101`. The structural fix (rishonim
+ * cap #440, coalescing #439, consumer concurrency #441) makes that outcome
+ * improbable — but a future source-growth regression could push it back. This
+ * watch closes the loop: it polls Cloudflare's `workersInvocationsAdaptive`
+ * analytics each 5-min cron tick and emails when an isolate-fatal outcome
+ * appears, so the next regression is caught in minutes, not from user reports.
+ *
+ * Reuses the account-scoped CF_ANALYTICS_TOKEN + CLOUDFLARE_ACCOUNT_ID already
+ * used by aigw-analytics.ts. If the token lacks "Account Analytics: Read" for
+ * Workers (or the dataset field names ever drift), the query degrades to
+ * { ok: false, error } and NO false alert fires — the error is visible via
+ * GET /api/worker-health for diagnosis. Never throws into the cron.
+ */
+
+const GRAPHQL_URL = 'https://api.cloudflare.com/client/v4/graphql';
+
+// Isolate-FATAL outcomes: the isolate is destroyed and every co-tenant request
+// on it fails. `exceededMemory` is the cold-daf OOM specifically; `exceededCpu`
+// is the same class of co-tenant-killing failure. `scriptThrewException` is an
+// uncaught throw (the 1101 page) — alert-worthy, but it does NOT necessarily
+// kill co-tenants, so it's reported but weighted separately by the caller.
+export const FATAL_OUTCOMES = ['exceededMemory', 'exceededCpu'] as const;
+
+const QUERY = `
+query WorkerHealth($accountTag: string!, $script: string!, $start: Time!, $end: Time!) {
+  viewer {
+    accounts(filter: { accountTag: $accountTag }) {
+      workersInvocationsAdaptive(
+        limit: 100
+        filter: { scriptName: $script, datetime_geq: $start, datetime_leq: $end }
+        orderBy: [count_DESC]
+      ) {
+        count
+        dimensions { status }
+      }
+    }
+  }
+}`;
+
+interface InvocationGroup {
+  count?: number;
+  dimensions?: { status?: string };
+}
+
+export interface WorkerOutcomes {
+  configured: boolean;
+  ok: boolean;
+  error?: string;
+  scriptName?: string;
+  windowStart?: string;
+  windowEnd?: string;
+  /** invocation count keyed by status (outcome), e.g. { success, exceededMemory }. */
+  byStatus?: Record<string, number>;
+}
+
+interface HealthEnv {
+  CACHE?: KVNamespace;
+  EMAIL?: {
+    send: (m: { from: string; to: string; subject: string; text: string }) => Promise<unknown>;
+  };
+  CLOUDFLARE_ACCOUNT_ID?: string;
+  CF_ANALYTICS_TOKEN?: string;
+}
+
+/** Pure: fold raw invocation groups into a status -> count map. */
+export function parseOutcomes(groups: InvocationGroup[]): Record<string, number> {
+  const byStatus: Record<string, number> = {};
+  for (const g of groups) {
+    const status = g.dimensions?.status;
+    if (!status) continue;
+    byStatus[status] = (byStatus[status] ?? 0) + (g.count ?? 0);
+  }
+  return byStatus;
+}
+
+/** Pure: total of the isolate-fatal outcomes in a status -> count map. */
+export function fatalCount(byStatus: Record<string, number> | undefined): number {
+  if (!byStatus) return 0;
+  return FATAL_OUTCOMES.reduce((n, s) => n + (byStatus[s] ?? 0), 0);
+}
+
+export async function fetchWorkerOutcomes(
+  env: HealthEnv,
+  minutes = 15,
+  scriptName = 'talmud',
+): Promise<WorkerOutcomes> {
+  const account = env.CLOUDFLARE_ACCOUNT_ID;
+  const token = env.CF_ANALYTICS_TOKEN;
+  if (!token || !account) {
+    const missing = [!token && 'CF_ANALYTICS_TOKEN', !account && 'CLOUDFLARE_ACCOUNT_ID']
+      .filter(Boolean)
+      .join(', ');
+    return { configured: false, ok: false, error: `not configured (missing: ${missing})` };
+  }
+  const end = new Date();
+  const start = new Date(end.getTime() - minutes * 60 * 1000);
+  const windowStart = start.toISOString();
+  const windowEnd = end.toISOString();
+  try {
+    const res = await fetch(GRAPHQL_URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+      body: JSON.stringify({
+        query: QUERY,
+        variables: { accountTag: account, script: scriptName, start: windowStart, end: windowEnd },
+      }),
+    });
+    if (!res.ok) {
+      return { configured: true, ok: false, error: `HTTP ${res.status}`, scriptName };
+    }
+    const json = (await res.json()) as {
+      data?: { viewer?: { accounts?: Array<{ workersInvocationsAdaptive?: InvocationGroup[] }> } };
+      errors?: Array<{ message?: string }>;
+    };
+    if (json.errors && json.errors.length > 0) {
+      return {
+        configured: true,
+        ok: false,
+        error: json.errors
+          .map((e) => e.message)
+          .filter(Boolean)
+          .join('; ')
+          .slice(0, 300),
+        scriptName,
+      };
+    }
+    const groups = json.data?.viewer?.accounts?.[0]?.workersInvocationsAdaptive ?? [];
+    return {
+      configured: true,
+      ok: true,
+      scriptName,
+      windowStart,
+      windowEnd,
+      byStatus: parseOutcomes(groups),
+    };
+  } catch (err) {
+    return {
+      configured: true,
+      ok: false,
+      error: String((err as Error)?.message ?? err).slice(0, 300),
+      scriptName,
+    };
+  }
+}
+
+/**
+ * Poll the last ~15 min and email if an isolate-fatal outcome appeared. KV-deduped
+ * to one alert per hour bucket (a single OOM event sprays many invocations; we
+ * don't want one per cron tick). Best-effort and self-contained: any failure is
+ * logged, never thrown into the cron.
+ */
+export async function checkWorkerHealthAndAlert(env: HealthEnv, nowMs: number): Promise<void> {
+  try {
+    const outcomes = await fetchWorkerOutcomes(env, 15);
+    if (!outcomes.ok) {
+      // Not configured / token scope / schema drift: stay quiet (no false alert),
+      // but log so the cause is visible. /api/worker-health surfaces it too.
+      if (outcomes.configured) console.warn('[health] outcomes query failed:', outcomes.error);
+      return;
+    }
+    const fatal = fatalCount(outcomes.byStatus);
+    if (fatal <= 0) return;
+
+    const cache = env.CACHE;
+    const email = env.EMAIL;
+    const hourBucket = Math.floor(nowMs / 3_600_000);
+    const dedupeKey = `health-alert:fatal:${hourBucket}`;
+    if (cache) {
+      const already = await cache.get(dedupeKey);
+      if (already) return; // already alerted this hour
+    }
+    if (email) {
+      const lines = Object.entries(outcomes.byStatus ?? {})
+        .filter(([s]) => (FATAL_OUTCOMES as readonly string[]).includes(s))
+        .map(([s, n]) => `  ${s}: ${n}`)
+        .join('\n');
+      await email.send({
+        from: 'health@shaunregenbaum.com',
+        to: 'shaunregenbaum@gmail.com',
+        subject: `[talmud] isolate-fatal outcome: ${fatal} in last 15m`,
+        text:
+          `The talmud worker logged ${fatal} isolate-fatal invocation(s) in the last 15 minutes ` +
+          `(${outcomes.windowStart} → ${outcomes.windowEnd}):\n\n${lines}\n\n` +
+          `This is the class of failure behind the cold-daf OOM (exceededMemory → error code 1101 ` +
+          `for every co-tenant request). Check whether a recent change grew per-job source memory.\n\n` +
+          `Live: https://talmud.shaunregenbaum.com/api/worker-health\n` +
+          `Usage: https://talmud.shaunregenbaum.com/usage\n`,
+      });
+    }
+    if (cache) {
+      await cache.put(dedupeKey, '1', { expirationTtl: 3_600 });
+    }
+  } catch (err) {
+    console.error('[health] checkWorkerHealthAndAlert failed:', err);
+  }
+}

--- a/packages/talmud/tests/worker-health.test.ts
+++ b/packages/talmud/tests/worker-health.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  checkWorkerHealthAndAlert,
+  FATAL_OUTCOMES,
+  fatalCount,
+  fetchWorkerOutcomes,
+  parseOutcomes,
+} from '../src/worker/worker-health';
+
+describe('parseOutcomes', () => {
+  it('folds invocation groups into a status -> count map', () => {
+    const m = parseOutcomes([
+      { count: 100, dimensions: { status: 'success' } },
+      { count: 3, dimensions: { status: 'exceededMemory' } },
+      { count: 2, dimensions: { status: 'exceededMemory' } }, // accumulates
+      { count: 5, dimensions: {} }, // no status -> ignored
+    ]);
+    expect(m).toEqual({ success: 100, exceededMemory: 5 });
+  });
+});
+
+describe('fatalCount', () => {
+  it('sums only the isolate-fatal outcomes', () => {
+    expect(
+      fatalCount({ success: 999, exceededMemory: 4, exceededCpu: 1, scriptThrewException: 7 }),
+    ).toBe(5);
+    expect(fatalCount({ success: 10 })).toBe(0);
+    expect(fatalCount(undefined)).toBe(0);
+  });
+  it('exceededMemory (the cold-daf OOM) is a fatal outcome', () => {
+    expect(FATAL_OUTCOMES).toContain('exceededMemory');
+  });
+});
+
+// A minimal env + fetch stub so the alert path is testable without the network.
+function envWith(opts: {
+  groups?: Array<{ count: number; dimensions: { status: string } }>;
+  graphqlError?: string;
+  configured?: boolean;
+  kv?: Map<string, string>;
+  email?: (m: unknown) => void;
+}) {
+  const kv = opts.kv ?? new Map<string, string>();
+  const CACHE = {
+    get: async (k: string) => kv.get(k) ?? null,
+    put: async (k: string, v: string) => void kv.set(k, v),
+  } as unknown as KVNamespace;
+  const env = {
+    CACHE,
+    EMAIL: opts.email ? { send: async (m: unknown) => opts.email?.(m) } : undefined,
+    CLOUDFLARE_ACCOUNT_ID: opts.configured === false ? undefined : 'acct',
+    CF_ANALYTICS_TOKEN: opts.configured === false ? undefined : 'tok',
+  };
+  const fetchStub = vi.fn(async () => {
+    const body = opts.graphqlError
+      ? { errors: [{ message: opts.graphqlError }] }
+      : { data: { viewer: { accounts: [{ workersInvocationsAdaptive: opts.groups ?? [] }] } } };
+    return new Response(JSON.stringify(body), { status: 200 });
+  });
+  return { env, fetchStub, kv };
+}
+
+describe('fetchWorkerOutcomes', () => {
+  it('degrades to not-configured when token/account are missing (no throw)', async () => {
+    const { env } = envWith({ configured: false });
+    const out = await fetchWorkerOutcomes(env, 15);
+    expect(out.configured).toBe(false);
+    expect(out.ok).toBe(false);
+  });
+
+  it('degrades to ok:false (never throws) when the GraphQL schema/field names drift', async () => {
+    const { env, fetchStub } = envWith({ graphqlError: 'unknown field "status"' });
+    vi.stubGlobal('fetch', fetchStub);
+    const out = await fetchWorkerOutcomes(env, 15);
+    vi.unstubAllGlobals();
+    expect(out.ok).toBe(false);
+    expect(out.error).toContain('unknown field');
+  });
+});
+
+describe('checkWorkerHealthAndAlert', () => {
+  it('emails once when an isolate-fatal outcome appears, then dedupes within the hour', async () => {
+    const sent: unknown[] = [];
+    const { env, fetchStub } = envWith({
+      groups: [
+        { count: 500, dimensions: { status: 'success' } },
+        { count: 4, dimensions: { status: 'exceededMemory' } },
+      ],
+      email: (m) => sent.push(m),
+    });
+    vi.stubGlobal('fetch', fetchStub);
+    const now = 1_000_000_000_000;
+    await checkWorkerHealthAndAlert(env, now);
+    await checkWorkerHealthAndAlert(env, now + 60_000); // same hour bucket
+    vi.unstubAllGlobals();
+    expect(sent).toHaveLength(1);
+    expect((sent[0] as { subject: string }).subject).toContain('isolate-fatal');
+  });
+
+  it('stays silent when there are no fatal outcomes', async () => {
+    const sent: unknown[] = [];
+    const { env, fetchStub } = envWith({
+      groups: [{ count: 500, dimensions: { status: 'success' } }],
+      email: (m) => sent.push(m),
+    });
+    vi.stubGlobal('fetch', fetchStub);
+    await checkWorkerHealthAndAlert(env, 1_000_000_000_000);
+    vi.unstubAllGlobals();
+    expect(sent).toHaveLength(0);
+  });
+
+  it('stays silent (no false alert) when the query fails', async () => {
+    const sent: unknown[] = [];
+    const { env, fetchStub } = envWith({ graphqlError: 'boom', email: (m) => sent.push(m) });
+    vi.stubGlobal('fetch', fetchStub);
+    await checkWorkerHealthAndAlert(env, 1_000_000_000_000);
+    vi.unstubAllGlobals();
+    expect(sent).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
The fourth and final leg of the durable OOM fix — the observability net. The cold-daf OOM was **invisible** until someone hand-tailed the worker (`outcome: exceededMemory`); readers only ever saw `error code: 1101`. After this, the next regression pages me in minutes instead of via user reports.

## What it does

- **`worker-health.ts`** queries Cloudflare's `workersInvocationsAdaptive` analytics for the talmud script's invocation outcomes over the last 15 min, reusing the account-scoped `CF_ANALYTICS_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` already wired for AI Gateway cost.
- **`checkWorkerHealthAndAlert`** emails (via the existing `EMAIL` binding) when an **isolate-fatal** outcome (`exceededMemory` / `exceededCpu`) appears, **KV-deduped to one alert per hour** (a single OOM sprays many invocations). Runs on the existing 5-min cron tick — no new cron, no new binding.
- **`GET /api/worker-health`** — read-only probe returning the raw outcomes, so the isolate-fatal class is verifiable on demand.

## Honest about the one external unknown

Cloudflare's public docs don't pin the exact `workersInvocationsAdaptive` field names, and I can't introspect the schema without an account-scoped token in hand. So this is built to **degrade safely**: if the token lacks Workers-analytics scope, or the field names ever drift, the query returns `{ ok: false, error }` and **no false alert fires** — the error is visible at `/api/worker-health`. It never throws into the cron. After deploy, hit `/api/worker-health` once to confirm the field names resolve against the live account; if they don't, it's a one-line fix and nothing is broken in the meantime.

Also fixed the stale queue-consumer comment that still claimed `max_concurrency=2`.

## Tests

`tests/worker-health.test.ts`: pure aggregation (`parseOutcomes`, `fatalCount`), graceful degradation (missing config, GraphQL schema drift), and the alert decision (fires once on a fatal outcome, dedupes within the hour, silent when clean or when the query fails).

`pnpm typecheck`, `pnpm lint`, full suite (2497 tests) green.

---

This completes the "fix it forever" set: **#439** (mitigation) + **#440** (per-job memory cap) + **#441** (concurrency bound) = a provable peak-memory ceiling, and **this** = the alert if it's ever breached again.