### PR TITLE
worker-health: drop unsupported orderBy (verified against live account)

### DIFF
--- a/packages/talmud/src/worker/worker-health.ts
+++ b/packages/talmud/src/worker/worker-health.ts
@@ -33,7 +33,6 @@ query WorkerHealth($accountTag: string!, $script: string!, $start: Time!, $end: 
       workersInvocationsAdaptive(
         limit: 100
         filter: { scriptName: $script, datetime_geq: $start, datetime_leq: $end }
-        orderBy: [count_DESC]
       ) {
         count
         dimensions { status }


### PR DESCRIPTION
Follow-up to #443. The live `/api/worker-health` probe — exactly the verification hook I built into that PR — returned a clean degraded error: `orderBy: unknown enum value count_DESC`. Good news: the token **has** Workers-analytics scope and every other field (`scriptName`, the datetime filters, `count`, `dimensions.status`) validated against the live account. `workersInvocationsAdaptive` just doesn't accept that `orderBy` enum — and I don't need ordering (only ~7 status values, aggregated by status). Dropping the clause. No logic change; tests still green.