### PR TITLE
worker-health: use workersInvocationsAdaptiveGroups (aggregated node)

### DIFF
--- a/packages/talmud/src/worker/worker-health.ts
+++ b/packages/talmud/src/worker/worker-health.ts
@@ -6,7 +6,7 @@
  * only symptom readers saw was `error code: 1101`. The structural fix (rishonim
  * cap #440, coalescing #439, consumer concurrency #441) makes that outcome
  * improbable — but a future source-growth regression could push it back. This
- * watch closes the loop: it polls Cloudflare's `workersInvocationsAdaptive`
+ * watch closes the loop: it polls Cloudflare's `workersInvocationsAdaptiveGroups`
  * analytics each 5-min cron tick and emails when an isolate-fatal outcome
  * appears, so the next regression is caught in minutes, not from user reports.
  *
@@ -30,7 +30,7 @@ const QUERY = `
 query WorkerHealth($accountTag: string!, $script: string!, $start: Time!, $end: Time!) {
   viewer {
     accounts(filter: { accountTag: $accountTag }) {
-      workersInvocationsAdaptive(
+      workersInvocationsAdaptiveGroups(
         limit: 100
         filter: { scriptName: $script, datetime_geq: $start, datetime_leq: $end }
       ) {
@@ -113,7 +113,7 @@ export async function fetchWorkerOutcomes(
       return { configured: true, ok: false, error: `HTTP ${res.status}`, scriptName };
     }
     const json = (await res.json()) as {
-      data?: { viewer?: { accounts?: Array<{ workersInvocationsAdaptive?: InvocationGroup[] }> } };
+      data?: { viewer?: { accounts?: Array<{ workersInvocationsAdaptiveGroups?: InvocationGroup[] }> } };
       errors?: Array<{ message?: string }>;
     };
     if (json.errors && json.errors.length > 0) {
@@ -128,7 +128,7 @@ export async function fetchWorkerOutcomes(
         scriptName,
       };
     }
-    const groups = json.data?.viewer?.accounts?.[0]?.workersInvocationsAdaptive ?? [];
+    const groups = json.data?.viewer?.accounts?.[0]?.workersInvocationsAdaptiveGroups ?? [];
     return {
       configured: true,
       ok: true,

--- a/packages/talmud/tests/worker-health.test.ts
+++ b/packages/talmud/tests/worker-health.test.ts
@@ -54,7 +54,11 @@ function envWith(opts: {
   const fetchStub = vi.fn(async () => {
     const body = opts.graphqlError
       ? { errors: [{ message: opts.graphqlError }] }
-      : { data: { viewer: { accounts: [{ workersInvocationsAdaptive: opts.groups ?? [] }] } } };
+      : {
+          data: {
+            viewer: { accounts: [{ workersInvocationsAdaptiveGroups: opts.groups ?? [] }] },
+          },
+        };
     return new Response(JSON.stringify(body), { status: 200 });
   });
   return { env, fetchStub, kv };


### PR DESCRIPTION
Second live-probe iteration (the verifiable endpoint earning its keep). With `orderBy` gone (#444), `/api/worker-health` returned `unknown field "count"` — `workersInvocationsAdaptive` is the raw sampled-events node with no `count` aggregation. The aggregated dataset with `count` + `dimensions` is `workersInvocationsAdaptiveGroups`. `status`/`scriptName`/datetime filters already validated against the live account in the prior probe, so this should be the last schema fix. Tests updated to the Groups node name; all green.