### PR TITLE
worker-health: biome format fix (unbreak master)

### DIFF
--- a/packages/talmud/src/worker/worker-health.ts
+++ b/packages/talmud/src/worker/worker-health.ts
@@ -113,7 +113,9 @@ export async function fetchWorkerOutcomes(
       return { configured: true, ok: false, error: `HTTP ${res.status}`, scriptName };
     }
     const json = (await res.json()) as {
-      data?: { viewer?: { accounts?: Array<{ workersInvocationsAdaptiveGroups?: InvocationGroup[] }> } };
+      data?: {
+        viewer?: { accounts?: Array<{ workersInvocationsAdaptiveGroups?: InvocationGroup[] }> };
+      };
       errors?: Array<{ message?: string }>;
     };
     if (json.errors && json.errors.length > 0) {


### PR DESCRIPTION
Format-only follow-up to #445. The Groups rename pushed the response-type line past Biome's width and only the test file got re-formatted, so 'biome ci .' is red on master (deploy gated — prod unaffected, the health endpoint just degrades cleanly). No logic change. Verified locally with the exact CI command 'biome ci .' (609 files, 0 errors).