### PR TITLE
worker-health: query sum.requests (the real workersInvocationsAdaptive schema)

### DIFF
--- a/packages/talmud/src/worker/worker-health.ts
+++ b/packages/talmud/src/worker/worker-health.ts
@@ -6,7 +6,7 @@
  * only symptom readers saw was `error code: 1101`. The structural fix (rishonim
  * cap #440, coalescing #439, consumer concurrency #441) makes that outcome
  * improbable — but a future source-growth regression could push it back. This
- * watch closes the loop: it polls Cloudflare's `workersInvocationsAdaptiveGroups`
+ * watch closes the loop: it polls Cloudflare's `workersInvocationsAdaptive`
  * analytics each 5-min cron tick and emails when an isolate-fatal outcome
  * appears, so the next regression is caught in minutes, not from user reports.
  *
@@ -30,11 +30,11 @@ const QUERY = `
 query WorkerHealth($accountTag: string!, $script: string!, $start: Time!, $end: Time!) {
   viewer {
     accounts(filter: { accountTag: $accountTag }) {
-      workersInvocationsAdaptiveGroups(
+      workersInvocationsAdaptive(
         limit: 100
         filter: { scriptName: $script, datetime_geq: $start, datetime_leq: $end }
       ) {
-        count
+        sum { requests }
         dimensions { status }
       }
     }
@@ -42,7 +42,9 @@ query WorkerHealth($accountTag: string!, $script: string!, $start: Time!, $end: 
 }`;
 
 interface InvocationGroup {
-  count?: number;
+  // workersInvocationsAdaptive is sampling-adjusted; `sum.requests` is the
+  // estimated invocation count for the group (there is no top-level `count`).
+  sum?: { requests?: number };
   dimensions?: { status?: string };
 }
 
@@ -72,7 +74,7 @@ export function parseOutcomes(groups: InvocationGroup[]): Record<string, number>
   for (const g of groups) {
     const status = g.dimensions?.status;
     if (!status) continue;
-    byStatus[status] = (byStatus[status] ?? 0) + (g.count ?? 0);
+    byStatus[status] = (byStatus[status] ?? 0) + (g.sum?.requests ?? 0);
   }
   return byStatus;
 }
@@ -114,7 +116,7 @@ export async function fetchWorkerOutcomes(
     }
     const json = (await res.json()) as {
       data?: {
-        viewer?: { accounts?: Array<{ workersInvocationsAdaptiveGroups?: InvocationGroup[] }> };
+        viewer?: { accounts?: Array<{ workersInvocationsAdaptive?: InvocationGroup[] }> };
       };
       errors?: Array<{ message?: string }>;
     };
@@ -130,7 +132,7 @@ export async function fetchWorkerOutcomes(
         scriptName,
       };
     }
-    const groups = json.data?.viewer?.accounts?.[0]?.workersInvocationsAdaptiveGroups ?? [];
+    const groups = json.data?.viewer?.accounts?.[0]?.workersInvocationsAdaptive ?? [];
     return {
       configured: true,
       ok: true,

--- a/packages/talmud/tests/worker-health.test.ts
+++ b/packages/talmud/tests/worker-health.test.ts
@@ -10,10 +10,10 @@ import {
 describe('parseOutcomes', () => {
   it('folds invocation groups into a status -> count map', () => {
     const m = parseOutcomes([
-      { count: 100, dimensions: { status: 'success' } },
-      { count: 3, dimensions: { status: 'exceededMemory' } },
-      { count: 2, dimensions: { status: 'exceededMemory' } }, // accumulates
-      { count: 5, dimensions: {} }, // no status -> ignored
+      { sum: { requests: 100 }, dimensions: { status: 'success' } },
+      { sum: { requests: 3 }, dimensions: { status: 'exceededMemory' } },
+      { sum: { requests: 2 }, dimensions: { status: 'exceededMemory' } }, // accumulates
+      { sum: { requests: 5 }, dimensions: {} }, // no status -> ignored
     ]);
     expect(m).toEqual({ success: 100, exceededMemory: 5 });
   });
@@ -34,7 +34,7 @@ describe('fatalCount', () => {
 
 // A minimal env + fetch stub so the alert path is testable without the network.
 function envWith(opts: {
-  groups?: Array<{ count: number; dimensions: { status: string } }>;
+  groups?: Array<{ sum: { requests: number }; dimensions: { status: string } }>;
   graphqlError?: string;
   configured?: boolean;
   kv?: Map<string, string>;
@@ -56,7 +56,7 @@ function envWith(opts: {
       ? { errors: [{ message: opts.graphqlError }] }
       : {
           data: {
-            viewer: { accounts: [{ workersInvocationsAdaptiveGroups: opts.groups ?? [] }] },
+            viewer: { accounts: [{ workersInvocationsAdaptive: opts.groups ?? [] }] },
           },
         };
     return new Response(JSON.stringify(body), { status: 200 });
@@ -87,8 +87,8 @@ describe('checkWorkerHealthAndAlert', () => {
     const sent: unknown[] = [];
     const { env, fetchStub } = envWith({
       groups: [
-        { count: 500, dimensions: { status: 'success' } },
-        { count: 4, dimensions: { status: 'exceededMemory' } },
+        { sum: { requests: 500 }, dimensions: { status: 'success' } },
+        { sum: { requests: 4 }, dimensions: { status: 'exceededMemory' } },
       ],
       email: (m) => sent.push(m),
     });
@@ -104,7 +104,7 @@ describe('checkWorkerHealthAndAlert', () => {
   it('stays silent when there are no fatal outcomes', async () => {
     const sent: unknown[] = [];
     const { env, fetchStub } = envWith({
-      groups: [{ count: 500, dimensions: { status: 'success' } }],
+      groups: [{ sum: { requests: 500 }, dimensions: { status: 'success' } }],
       email: (m) => sent.push(m),
     });
     vi.stubGlobal('fetch', fetchStub);


### PR DESCRIPTION
Final iteration of the alert query, now grounded in Cloudflare's official [Querying Workers Metrics tutorial](https://developers.cloudflare.com/analytics/graphql-api/tutorials/querying-workers-metrics/) rather than guessing against the live probe.

The live `/api/worker-health` probe walked me through the schema: `orderBy count_DESC` rejected (#444), then `count` unknown, then `...Groups` node doesn't exist. The real shape: node `workersInvocationsAdaptive` (no suffix), **no** top-level `count` — the invocation count is `sum { requests }` (sampling-adjusted), grouped by `dimensions { status }`. Token scope + `status`/`scriptName`/datetime filters were already validated live, so this is the last field to fix.

Verified locally with `biome ci .` (609 files, 0 errors) + typecheck + tests before pushing.