### PR TITLE
Geo map: bigger, easier-to-click rabbi/place dots

### DIFF
--- a/packages/ui/src/GeoMap.tsx
+++ b/packages/ui/src/GeoMap.tsx
@@ -314,7 +314,7 @@ export function GeoMap(props: GeoMapProps): JSX.Element {
   // of a group stays at the centre (the labelled "anchor", e.g. the city dot);
   // the rest fan out. Single points are untouched.
   const GOLDEN = 2.39996323; // golden angle (radians)
-  const SPIRAL_STEP = 7; // px between successive ring radii
+  const SPIRAL_STEP = 9; // px between successive ring radii (room for bigger dots)
   const sites = createMemo(() => {
     const visible = props.points.filter((p) => inView(p.lng, p.lat));
     const groups = new Map<string, number>(); // location key -> running index
@@ -455,12 +455,17 @@ export function GeoMap(props: GeoMapProps): JSX.Element {
                         }
                       }}
                     >
+                      {/* a generous transparent hit-area so the small dot is
+                          easy to click/tap (the visible marker stays compact) */}
+                      <Show when={interactive}>
+                        <circle class="geomap-hit" cx={s.xy[0]} cy={s.xy[1]} r={11} />
+                      </Show>
                       <Show when={!!props.selected && props.selected === s.p.id}>
                         <circle
                           class="geomap-halo"
                           cx={s.xy[0]}
                           cy={s.xy[1]}
-                          r={s.p.star ? 7.5 : 6.5}
+                          r={s.p.star ? 9.5 : 8.5}
                         />
                       </Show>
                       <circle
@@ -473,7 +478,7 @@ export function GeoMap(props: GeoMapProps): JSX.Element {
                         }
                         cx={s.xy[0]}
                         cy={s.xy[1]}
-                        r={s.p.star ? 4.5 : 3.5}
+                        r={s.p.star ? 6.5 : 5.5}
                       />
                       <Show when={layers().labels && labelFor(s.p)}>
                         <text

--- a/packages/ui/src/geomap.css
+++ b/packages/ui/src/geomap.css
@@ -91,6 +91,11 @@
 .geomap-site:focus {
   outline: none;
 }
+/* invisible but clickable: enlarges the tap/click target around small dots */
+.geomap-hit {
+  fill: transparent;
+  pointer-events: all;
+}
 .geomap-dot {
   fill: var(--dot-fill, #fff);
   stroke: var(--dot-stroke, var(--accent));


### PR DESCRIPTION
The whole-daf rabbi dots (and Tanach place pins) were tiny (r 3.5) and fiddly to click. This enlarges them toward the trajectory-badge feel and adds a generous transparent hit-area so the click/tap target is forgiving:

- dot radius 3.5 → 5.5 (star 4.5 → 6.5); selection halo grown to match
- a transparent **r=11 hit circle** per interactive marker — the visible dot stays compact, but the whole neighbourhood around it is clickable
- spiral de-overlap step 7 → 9 so co-located dots have room to grow without colliding

Shared GeoMap change, so it lifts every map (Talmud whole-daf + per-rabbi trajectory, Tanach geography).

## Gates
typecheck ✓ · lint ✓ · 2497 talmud tests ✓ · both apps build ✓