### PR TITLE
Tanach: HTTP-cache the geography + overview pill responses

### DIFF
--- a/packages/tanach/src/worker/index.ts
+++ b/packages/tanach/src/worker/index.ts
@@ -192,6 +192,10 @@ app.get('/api/overview/:book/:chapter', async (c) => {
     en?: string;
     he?: string;
   } | null;
+  // Deterministic per (book, chapter) and lang-independent (both langs in the
+  // body) — and already KV-cached server-side. Let the browser cache it too so
+  // re-opening the pill / navigating back is instant instead of a worker hit.
+  c.header('Cache-Control', 'public, max-age=600, stale-while-revalidate=86400');
   return c.json({
     book,
     chapter: Number(chapter),
@@ -242,6 +246,9 @@ app.get('/api/geography/:book/:chapter', async (c) => {
       seen.add(key);
       return true;
     });
+  // Deterministic per (book, chapter), lang-independent, already KV-cached
+  // server-side — let the browser cache it so re-opening Geography is instant.
+  c.header('Cache-Control', 'public, max-age=600, stale-while-revalidate=86400');
   return c.json({ book, chapter: Number(chapter), places });
 });
 


### PR DESCRIPTION
The perek pills (geography, overview) are fetched lazily on click and re-fetched on every pill toggle / chapter revisit, each round-tripping the worker — even though each response is **deterministic** per (book, chapter), **lang-independent** (both langs in the body), and already **KV-cached server-side**.

Adds `Cache-Control: public, max-age=600, stale-while-revalidate=86400` to both routes so the **browser** serves repeat opens from its own cache (instant, no worker hit), while a re-warm still propagates within minutes (fresh) to a day (SWR).

- The first cold open is unchanged (still computes + caches server-side); this targets the common repeat/navigation path the user hits while browsing.
- Talmud's whole-daf geography is already eager (loads with the daf's mark cohort) + server-cached, so no change needed there.

## Gates
typecheck ✓ · lint ✓ · 49 tanach tests ✓ · build ✓