### PR TITLE
llm-cost: hard-cap the ledger scan at 1000 entries (stop exceededMemory)

### DIFF
--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -5631,13 +5631,23 @@ app.get('/api/admin/llm-cost', async (c) => {
     });
   }
   const payload = await coalesce(reportKey, async () => {
+    // Hard cap the scan. Each request reads every ledger key sequentially, so a
+    // large ledger (heavy warming) made one scan take ~25s and exhaust the
+    // isolate — outcome `exceededMemory`, which kills the WHOLE isolate and so
+    // took out co-tenant reader requests too (collateral 1101s). The coalesce +
+    // 45s cache above stops a concurrent stampede, but a single scan must also be
+    // bounded: 1000 entries (one list page) completes in ~2s well within limits.
+    // `truncated` signals the partial total; full-history accuracy wants an
+    // incremental background rollup (reading only new entries since a checkpoint)
+    // rather than rescanning the whole ledger per request — tracked as follow-up.
+    const SCAN_CAP = 1000;
     const keys: string[] = [];
     let cursor: string | undefined;
     do {
       const res = await cache.list({ prefix, cursor, limit: 1000 });
       for (const k of res.keys) keys.push(k.name);
       cursor = res.list_complete ? undefined : res.cursor;
-    } while (cursor && keys.length < 10000);
+    } while (cursor && keys.length < SCAN_CAP);
 
     let totalCost = 0;
     let totalCostInEst = 0;
@@ -5738,7 +5748,7 @@ app.get('/api/admin/llm-cost', async (c) => {
       byTag,
       byKind,
       byDaf,
-      truncated: keys.length >= 10000,
+      truncated: keys.length >= SCAN_CAP,
     };
     const json = JSON.stringify(result);
     // Short TTL: the dashboard polls "what just ran"; 45s is fresh enough and


### PR DESCRIPTION
Follow-up to #450. The worker-health watch kept flagging `exceededMemory` on `/api/admin/llm-cost` even after #450's coalesce+cache — because a **single cold scan never completes**: on a large ledger (heavy warming) it reads ~10k keys sequentially over ~25s and exhausts the isolate. That outcome (`exceededMemory`) kills the **whole isolate**, taking out co-tenant reader requests (collateral 1101s) — so it was still contributing to the user's reported symptom via a different path.

Cap one scan at **1000 entries** (one KV list page, ~2s) so it completes well within limits. #450's coalesce + 45s cache handle concurrency and repeat polls; `truncated` flags the partial total.

**Known limitation / follow-up:** full-history spend accuracy wants an *incremental* background rollup (read only new ledger entries since a checkpoint, accumulate into a stored summary) rather than rescanning the whole ledger per request. Flagged, not done here — this PR's job is to stop the isolate-fatal OOM now. This is an admin-dashboard endpoint; the reader path is unaffected and already verified fixed.

Verified: `biome ci .`, typecheck green.