### PR TITLE
llm-cost: cap scan at 800 to respect the subrequest limit

### DIFF
--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -5640,14 +5640,20 @@ app.get('/api/admin/llm-cost', async (c) => {
     // `truncated` signals the partial total; full-history accuracy wants an
     // incremental background rollup (reading only new entries since a checkpoint)
     // rather than rescanning the whole ledger per request — tracked as follow-up.
-    const SCAN_CAP = 1000;
+    // SCAN_CAP also has to respect the per-request SUBREQUEST limit (~1000): each
+    // ledger entry is one KV get, plus the list + cache get/put. 800 leaves
+    // headroom so a full scan can't throw "too many subrequests" (which surfaced
+    // as a 500 once batching made the reads fast enough to reach the cap). Match
+    // the list page size so the first page can't overshoot the cap.
+    const SCAN_CAP = 800;
     const keys: string[] = [];
     let cursor: string | undefined;
     do {
-      const res = await cache.list({ prefix, cursor, limit: 1000 });
+      const res = await cache.list({ prefix, cursor, limit: SCAN_CAP });
       for (const k of res.keys) keys.push(k.name);
       cursor = res.list_complete ? undefined : res.cursor;
     } while (cursor && keys.length < SCAN_CAP);
+    if (keys.length > SCAN_CAP) keys.length = SCAN_CAP;
 
     let totalCost = 0;
     let totalCostInEst = 0;


### PR DESCRIPTION
Last limit in the chain. Batched reads (#453) made one scan fast enough to reach the **~1000 subrequest-per-request limit** (1000 KV gets + list + cache ops) → 'too many subrequests' → a **self-contained 500** (notably NOT `exceededMemory` — so no co-tenant collateral; the reader-killing OOM is already gone).

Cap at **800** entries (800 gets + list + cache get/put stays under 1000) and match the list page size so it can't overshoot. With #439 + #450 + #452 + #453 + this, the endpoint is fast, bounded, and stable.

**Architectural note:** per-request scanning is now capped at ~800 entries by the subrequest limit — fine for 'recent activity', but full-history spend accuracy needs an *incremental background rollup* (accumulate new entries each cron tick into a persistent summary). That's the proper follow-up; this PR's job is a stable, non-fatal endpoint.