### PR TITLE
Unify the reader load bar into @corpus/ui/LoadProgress

### DIFF
--- a/packages/talmud/src/client/DafLoadProgress.tsx
+++ b/packages/talmud/src/client/DafLoadProgress.tsx
@@ -1,24 +1,24 @@
 /**
- * Unified daf-load progress bar. Replaces the scatter of per-anchor spinners
- * with ONE slim sticky bar + a single status line describing what's still
- * loading. Combines two cohorts into one fraction:
+ * Daf-load progress — the talmud adapter over the shared @corpus/ui LoadProgress
+ * bar. Replaces the scatter of per-anchor spinners with ONE slim sticky bar +
+ * a single status line. Combines two cohorts into one fraction:
  *
  *   1. Anchor extraction — the mark runs (rabbi/argument/pesukim/…), read from
  *      markStatuses().
  *   2. Section prefetch — the syntheses + suggested-questions warmed by
  *      dafPrefetch, read from prefetchProgress().
  *
- * Auto-hides shortly after everything completes. On a fully-warm daf (all KV
- * cache hits) it barely flickers; on a cold daf it tracks the real work.
+ * All the talmud-specific math (the 30/70 phase weighting, the cache-snapshot
+ * grounding, the t()-driven labels, the pause/failure notice) lives here; the
+ * shared component owns the render + the auto-show/hide behaviour.
  */
 
-import { createEffect, createMemo, createSignal, type JSX, onCleanup, Show } from 'solid-js';
+import { LoadProgress, type LoadProgressNotice } from '@corpus/ui/LoadProgress';
+import { createMemo, type JSX } from 'solid-js';
 import { loadNotice, prefetchProgress } from './dafPrefetch';
 import { dafCacheProgress } from './dafRunsStore';
 import { t } from './i18n';
 import { markStatuses } from './MarksRegistryPanel';
-
-const COMPLETE_LINGER_MS = 700;
 
 interface DafLoadProgressProps {
   /** When true, render for the mobile bottom shelf: no sticky/top pinning
@@ -47,8 +47,6 @@ export default function DafLoadProgress(props: DafLoadProgressProps = {}): JSX.E
   // anchor extraction then snapping backwards when the prefetch cohort appears.
   // Anchors occupy the first 30%; section prefetch the remaining 70%.
   const ANCHOR_WEIGHT = 30;
-  // The client warm engine (anchors + prefetch) drives the smooth, low-latency
-  // live climb — the part that made this bar more reliable than the waterfall.
   const enginePercent = createMemo(() => {
     const { m, pf } = combined();
     if (m.total === 0 && pf.total === 0) return 0;
@@ -65,8 +63,7 @@ export default function DafLoadProgress(props: DafLoadProgressProps = {}): JSX.E
   // Inspect waterfall reads — so the two can't disagree about what's loaded (a
   // warm revisit with a full cache reads ~100% at once). max() so the snapshot
   // only ever ADVANCES the bar; it never drags the live climb backward on a cold
-  // load, where the snapshot lags the warm. (Stale cross-daf rows are guarded in
-  // the store, so this fraction is always for the current daf.)
+  // load, where the snapshot lags the warm.
   const percent = createMemo(() => Math.max(enginePercent(), dafCacheProgress().pct));
 
   const label = createMemo(() => {
@@ -84,151 +81,26 @@ export default function DafLoadProgress(props: DafLoadProgressProps = {}): JSX.E
     return t('dafLoad.upToDate');
   });
 
-  // Visibility: show whenever there's incomplete work; linger briefly at 100%
-  // so the fill animation reads as "done" before the bar slides away.
-  const [visible, setVisible] = createSignal(false);
-  let hideTimer: ReturnType<typeof setTimeout> | undefined;
-  createEffect(() => {
+  const loading = () => {
     const c = combined();
-    const incomplete = c.marksLoading || c.prefetchActive;
-    if (incomplete) {
-      if (hideTimer) {
-        clearTimeout(hideTimer);
-        hideTimer = undefined;
-      }
-      setVisible(true);
-    } else if (visible()) {
-      // All done — linger then hide.
-      if (hideTimer) clearTimeout(hideTimer);
-      hideTimer = setTimeout(() => setVisible(false), COMPLETE_LINGER_MS);
-    }
-  });
-  onCleanup(() => {
-    if (hideTimer) clearTimeout(hideTimer);
-  });
+    return c.marksLoading || c.prefetchActive;
+  };
 
   // Top-level notice: a budget pause or a wave of failures, so generation
-  // problems don't read as a silently-stuck bar. Persists (independent of the
-  // bar's auto-hide) until the next daf clears the cohort.
-  const notice = createMemo(() => loadNotice(prefetchProgress()));
+  // problems don't read as a silently-stuck bar.
+  const notice = createMemo<LoadProgressNotice | null>(() => {
+    const kind = loadNotice(prefetchProgress());
+    if (!kind) return null;
+    return { kind, text: kind === 'paused' ? t('dafLoad.paused') : t('dafLoad.failed') };
+  });
 
   return (
-    <>
-      <Show when={notice()}>
-        {(kind) => (
-          <div
-            role="status"
-            aria-live="polite"
-            style={{
-              display: 'flex',
-              'align-items': 'center',
-              gap: '0.4rem',
-              ...(props.embedded
-                ? { position: 'static' as const }
-                : { position: 'sticky' as const, top: 0, 'z-index': 50 }),
-              width: '100%',
-              'box-sizing': 'border-box',
-              padding: '0.4rem 0.55rem',
-              'margin-bottom': props.embedded ? '0' : '0.5rem',
-              'border-radius': '4px',
-              border: `1px solid ${kind() === 'paused' ? '#f59e0b' : '#ef4444'}`,
-              background: kind() === 'paused' ? '#fffbeb' : '#fef2f2',
-              color: kind() === 'paused' ? '#92400e' : '#b91c1c',
-              'font-family': 'system-ui, -apple-system, sans-serif',
-              'font-size': '0.72rem',
-              'line-height': 1.4,
-            }}
-          >
-            <span aria-hidden="true">{kind() === 'paused' ? '⏸' : '⚠'}</span>
-            <span>{kind() === 'paused' ? t('dafLoad.paused') : t('dafLoad.failed')}</span>
-          </div>
-        )}
-      </Show>
-      <Show when={visible() && !notice()}>
-        <div
-          role="status"
-          aria-live="polite"
-          style={{
-            // Default: pinned directly above the daf — rendered inside the daf
-            // body column so it's exactly the daf's width, and sticky so it
-            // stays above the daf as the reader scrolls. Parchment background so
-            // daf text scrolling underneath doesn't bleed through.
-            // Embedded (mobile shelf): the shelf is already fixed, so render
-            // flat with no sticky pinning and no bottom margin.
-            ...(props.embedded
-              ? { position: 'static' as const }
-              : { position: 'sticky' as const, top: 0, 'z-index': 50 }),
-            width: '100%',
-            'box-sizing': 'border-box',
-            background: 'var(--bg)',
-            padding: '0.4rem 0.25rem',
-            'margin-bottom': props.embedded ? '0' : '0.5rem',
-            'font-family': 'system-ui, -apple-system, sans-serif',
-            'font-size': '0.72rem',
-            color: 'var(--muted)',
-          }}
-        >
-          <div
-            style={{
-              display: 'flex',
-              'align-items': 'center',
-              gap: '0.45rem',
-              'margin-bottom': '0.3rem',
-            }}
-          >
-            <span
-              style={{
-                display: 'inline-block',
-                width: '0.6rem',
-                height: '0.6rem',
-                'border-radius': '50%',
-                border: '2px solid var(--line)',
-                'border-top-color': 'var(--accent)',
-                animation: 'daf-spin 0.8s linear infinite',
-                'flex-shrink': 0,
-              }}
-            />
-            <span
-              style={{
-                flex: 1,
-                'min-width': 0,
-                'white-space': 'nowrap',
-                overflow: 'hidden',
-                'text-overflow': 'ellipsis',
-                'letter-spacing': '0.01em',
-              }}
-            >
-              {label()}
-            </span>
-            <span
-              style={{ 'font-variant-numeric': 'tabular-nums', color: '#a39a8c', 'flex-shrink': 0 }}
-              aria-hidden="true"
-            >
-              {percent()}%
-            </span>
-          </div>
-          {/* track — thin parchment rule that fills with the accent */}
-          <div
-            style={{
-              height: '2px',
-              background: 'var(--line)',
-              'border-radius': '1px',
-              overflow: 'hidden',
-            }}
-          >
-            <div
-              style={{
-                height: '100%',
-                width: `${percent()}%`,
-                background: 'var(--accent)',
-                'border-radius': '1px',
-                transition: 'width 0.4s ease',
-                opacity: 0.8,
-              }}
-            />
-          </div>
-        </div>
-      </Show>
-    </>
+    <LoadProgress
+      percent={percent}
+      label={label}
+      loading={loading}
+      notice={notice}
+      embedded={props.embedded}
+    />
   );
 }

--- a/packages/talmud/src/client/main.tsx
+++ b/packages/talmud/src/client/main.tsx
@@ -5,6 +5,7 @@ import { render } from 'solid-js/web';
 import '@corpus/ui/tokens.css';
 import '@corpus/ui/themes/talmud.css';
 import '@corpus/ui/geomap.css';
+import '@corpus/ui/loadprogress.css';
 import App from './App';
 import { installGlobalErrorLogger } from './missLog';
 

--- a/packages/tanach/src/client/ChapterLoadProgress.tsx
+++ b/packages/tanach/src/client/ChapterLoadProgress.tsx
@@ -1,16 +1,14 @@
 /**
- * Chapter load bar — one slim sticky bar + a status line describing what's
- * still loading for the open chapter, the tanach analogue of the talmud
- * reader's daf-load bar. Reads the chapterLoad tracker (the chapter's pieces
- * report their state there) and shows a single fraction. Auto-hides shortly
- * after everything settles: on a warm chapter (all KV hits) it barely
- * flickers; on a cold one it tracks the real work (Sefaria + the LLM calls).
+ * Chapter load bar — the tanach adapter over the shared @corpus/ui LoadProgress
+ * bar (the analogue of the talmud reader's daf-load bar). Reads the chapterLoad
+ * tracker (each of the chapter's pieces reports its state there), maps it to a
+ * single fraction + label, and renders the shared bar as a centered banner. The
+ * render + auto-show/hide behaviour live in the shared component.
  */
 
-import { createEffect, createMemo, createSignal, type JSX, onCleanup, Show } from 'solid-js';
+import { LoadProgress } from '@corpus/ui/LoadProgress';
+import { createMemo, type JSX } from 'solid-js';
 import { chapterLoadEntries } from './chapterLoad.ts';
-
-const COMPLETE_LINGER_MS = 700;
 
 export function ChapterLoadProgress(): JSX.Element {
   const cohort = createMemo(() => {
@@ -25,7 +23,7 @@ export function ChapterLoadProgress(): JSX.Element {
     return c.total === 0 ? 0 : Math.round((c.done / c.total) * 100);
   });
 
-  const incomplete = createMemo(() => {
+  const loading = createMemo(() => {
     const c = cohort();
     return c.total > 0 && c.done < c.total;
   });
@@ -36,40 +34,5 @@ export function ChapterLoadProgress(): JSX.Element {
     return 'Up to date';
   });
 
-  // Visibility: show while there's incomplete work; linger briefly at 100% so
-  // the fill animation reads as "done" before the bar slides away.
-  const [visible, setVisible] = createSignal(false);
-  let hideTimer: ReturnType<typeof setTimeout> | undefined;
-  createEffect(() => {
-    if (incomplete()) {
-      if (hideTimer) {
-        clearTimeout(hideTimer);
-        hideTimer = undefined;
-      }
-      setVisible(true);
-    } else if (visible()) {
-      if (hideTimer) clearTimeout(hideTimer);
-      hideTimer = setTimeout(() => setVisible(false), COMPLETE_LINGER_MS);
-    }
-  });
-  onCleanup(() => {
-    if (hideTimer) clearTimeout(hideTimer);
-  });
-
-  return (
-    <Show when={visible()}>
-      <div class="chapter-load" role="status" aria-live="polite">
-        <div class="chapter-load-row">
-          <span class="chapter-load-spinner" aria-hidden="true" />
-          <span class="chapter-load-label">{label()}</span>
-          <span class="chapter-load-pct" aria-hidden="true">
-            {percent()}%
-          </span>
-        </div>
-        <div class="chapter-load-track">
-          <div class="chapter-load-fill" style={{ width: `${percent()}%` }} />
-        </div>
-      </div>
-    </Show>
-  );
+  return <LoadProgress percent={percent} label={label} loading={loading} variant="banner" />;
 }

--- a/packages/tanach/src/client/main.tsx
+++ b/packages/tanach/src/client/main.tsx
@@ -5,6 +5,7 @@ import '@corpus/ui/tokens.css';
 import '@corpus/ui/themes/tanach.css';
 import '@corpus/ui/components.css';
 import '@corpus/ui/geomap.css';
+import '@corpus/ui/loadprogress.css';
 import { App } from './App.tsx';
 import { UsagePage } from './UsagePage.tsx';
 import './styles.css';

--- a/packages/tanach/src/client/styles.css
+++ b/packages/tanach/src/client/styles.css
@@ -126,65 +126,8 @@ body {
   color: #a23;
 }
 
-/* chapter load bar: a slim bar + status line for the pieces loading on the
-   open chapter (text, sections, sources, and the overview while its pill is
-   open). Sits just under the topbar; auto-hides shortly after everything
-   settles. */
-.chapter-load {
-  max-width: 900px;
-  margin: 0 auto;
-  padding: 8px 20px 6px;
-  background: var(--bg);
-  font-family: var(--font-ui);
-  font-size: 12px;
-  color: var(--muted);
-}
-.chapter-load-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-bottom: 5px;
-}
-.chapter-load-spinner {
-  display: inline-block;
-  width: 11px;
-  height: 11px;
-  flex-shrink: 0;
-  border: 2px solid var(--line);
-  border-top-color: var(--accent);
-  border-radius: 50%;
-  animation: chapter-spin 0.8s linear infinite;
-}
-.chapter-load-label {
-  flex: 1;
-  min-width: 0;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  letter-spacing: 0.01em;
-}
-.chapter-load-pct {
-  flex-shrink: 0;
-  font-variant-numeric: tabular-nums;
-}
-.chapter-load-track {
-  height: 2px;
-  background: var(--line);
-  border-radius: 1px;
-  overflow: hidden;
-}
-.chapter-load-fill {
-  height: 100%;
-  background: var(--accent);
-  border-radius: 1px;
-  opacity: 0.8;
-  transition: width 0.4s ease;
-}
-@keyframes chapter-spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
+/* The chapter load bar is now the shared @corpus/ui LoadProgress (banner
+   variant) — see loadprogress.css. */
 
 /* shared chapter-nav footer (used by the scroll caption) */
 .chapter-foot {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -16,12 +16,14 @@
     "./themes/tanach.css": "./src/themes/tanach.css",
     "./components.css": "./src/components.css",
     "./geomap.css": "./src/geomap.css",
+    "./loadprogress.css": "./src/loadprogress.css",
     "./Pill": "./src/Pill.tsx",
     "./Drawer": "./src/Drawer.tsx",
     "./Button": "./src/Button.tsx",
     "./Prose": "./src/Prose.tsx",
     "./LangToggle": "./src/LangToggle.tsx",
-    "./GeoMap": "./src/GeoMap.tsx"
+    "./GeoMap": "./src/GeoMap.tsx",
+    "./LoadProgress": "./src/LoadProgress.tsx"
   },
   "peerDependencies": {
     "solid-js": "^1.9.0"

--- a/packages/ui/src/LoadProgress.tsx
+++ b/packages/ui/src/LoadProgress.tsx
@@ -1,0 +1,117 @@
+/**
+ * @corpus/ui — LoadProgress.
+ *
+ * One slim reader load bar + status line, shared by every corpus app. It owns
+ * the RENDER (spinner + label + percent + a 2px fill track) and the VISIBILITY
+ * behaviour (show while work is in flight, linger briefly at 100% so the fill
+ * reads as "done", then auto-hide). Each app feeds it normalized signals via a
+ * thin adapter — the percent/label computation and the per-app layout glue stay
+ * in the app:
+ *
+ *   - Talmud: a sticky bar pinned in the daf column (`variant="sticky"`), with
+ *     an `embedded` mobile-shelf variant.
+ *   - Tanach: a centered banner under the topbar (`variant="banner"`).
+ *
+ * Styling: `.loadprogress*` in loadprogress.css (shared design tokens).
+ */
+
+import { createEffect, createSignal, type JSX, onCleanup, Show } from 'solid-js';
+
+/** A top-level alert shown in place of the bar (a budget pause / a wave of
+ *  failures) so a stuck generation doesn't read as a silently-frozen bar. */
+export interface LoadProgressNotice {
+  kind: 'paused' | 'failed';
+  text: string;
+}
+
+export interface LoadProgressProps {
+  /** 0-100 progress. */
+  percent: () => number;
+  /** Status label shown while the bar is visible. */
+  label: () => string;
+  /** Raw "work still in flight" state. The bar shows while true and lingers
+   *  `lingerMs` after it goes false before hiding. */
+  loading: () => boolean;
+  /** Optional notice; when present it replaces the bar and persists
+   *  independently of the auto-hide. Omit (or return null) for no notice. */
+  notice?: () => LoadProgressNotice | null;
+  /** Layout: 'sticky' pins it in the content column (default); 'banner'
+   *  centers it under a topbar (max-width, not pinned). */
+  variant?: 'sticky' | 'banner';
+  /** Render flat (static, no bottom margin) for an already-fixed mobile shelf. */
+  embedded?: boolean;
+  /** ms to linger at 100% after completion before hiding (default 700). */
+  lingerMs?: number;
+}
+
+export function LoadProgress(props: LoadProgressProps): JSX.Element {
+  const variant = () => props.variant ?? 'sticky';
+  const notice = () => props.notice?.() ?? null;
+
+  // Show while loading; on completion, linger then hide so the fill animation
+  // reads as "done" before the bar slides away.
+  const [visible, setVisible] = createSignal(false);
+  let hideTimer: ReturnType<typeof setTimeout> | undefined;
+  createEffect(() => {
+    if (props.loading()) {
+      if (hideTimer) {
+        clearTimeout(hideTimer);
+        hideTimer = undefined;
+      }
+      setVisible(true);
+    } else if (visible()) {
+      if (hideTimer) clearTimeout(hideTimer);
+      hideTimer = setTimeout(() => setVisible(false), props.lingerMs ?? 700);
+    }
+  });
+  onCleanup(() => {
+    if (hideTimer) clearTimeout(hideTimer);
+  });
+
+  return (
+    <>
+      <Show when={notice()}>
+        {(n) => (
+          <div
+            class="loadprogress-notice"
+            classList={{
+              sticky: variant() === 'sticky',
+              banner: variant() === 'banner',
+              embedded: !!props.embedded,
+              paused: n().kind === 'paused',
+              failed: n().kind === 'failed',
+            }}
+            role="status"
+            aria-live="polite"
+          >
+            <span aria-hidden="true">{n().kind === 'paused' ? '⏸' : '⚠'}</span>
+            <span>{n().text}</span>
+          </div>
+        )}
+      </Show>
+      <Show when={visible() && !notice()}>
+        <div
+          class="loadprogress"
+          classList={{
+            sticky: variant() === 'sticky',
+            banner: variant() === 'banner',
+            embedded: !!props.embedded,
+          }}
+          role="status"
+          aria-live="polite"
+        >
+          <div class="loadprogress-row">
+            <span class="loadprogress-spinner" aria-hidden="true" />
+            <span class="loadprogress-label">{props.label()}</span>
+            <span class="loadprogress-pct" aria-hidden="true">
+              {props.percent()}%
+            </span>
+          </div>
+          <div class="loadprogress-track">
+            <div class="loadprogress-fill" style={{ width: `${props.percent()}%` }} />
+          </div>
+        </div>
+      </Show>
+    </>
+  );
+}

--- a/packages/ui/src/loadprogress.css
+++ b/packages/ui/src/loadprogress.css
@@ -1,0 +1,119 @@
+/*
+ * @corpus/ui — LoadProgress styles. A slim load bar + status line driven by the
+ * shared design tokens. Imported once per app alongside the other @corpus/ui
+ * CSS. Two layout variants: `.sticky` (pinned in the content column — Talmud)
+ * and `.banner` (centered under a topbar — Tanach); `.embedded` flattens either
+ * for an already-fixed mobile shelf.
+ */
+
+.loadprogress {
+  box-sizing: border-box;
+  width: 100%;
+  background: var(--bg);
+  font-family: var(--font-ui);
+  font-size: 0.74rem;
+  color: var(--muted);
+}
+.loadprogress.sticky {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  padding: 0.4rem 0.25rem;
+  margin-bottom: 0.5rem;
+}
+.loadprogress.banner {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 8px 20px 6px;
+}
+.loadprogress.embedded {
+  position: static;
+  margin-bottom: 0;
+}
+
+.loadprogress-row {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-bottom: 0.3rem;
+}
+.loadprogress-spinner {
+  display: inline-block;
+  width: 0.7rem;
+  height: 0.7rem;
+  flex-shrink: 0;
+  border: 2px solid var(--line);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: loadprogress-spin 0.8s linear infinite;
+}
+.loadprogress-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  letter-spacing: 0.01em;
+}
+.loadprogress-pct {
+  flex-shrink: 0;
+  font-variant-numeric: tabular-nums;
+  opacity: 0.75;
+}
+.loadprogress-track {
+  height: 2px;
+  background: var(--line);
+  border-radius: 1px;
+  overflow: hidden;
+}
+.loadprogress-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 1px;
+  opacity: 0.8;
+  transition: width 0.4s ease;
+}
+
+/* top-level notice (pause / failures) — replaces the bar */
+.loadprogress-notice {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  box-sizing: border-box;
+  width: 100%;
+  padding: 0.4rem 0.55rem;
+  border-radius: 4px;
+  font-family: var(--font-ui);
+  font-size: 0.74rem;
+  line-height: 1.4;
+}
+.loadprogress-notice.sticky {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  margin-bottom: 0.5rem;
+}
+.loadprogress-notice.banner {
+  max-width: 900px;
+  margin: 0 auto 0.5rem;
+}
+.loadprogress-notice.embedded {
+  position: static;
+  margin-bottom: 0;
+}
+.loadprogress-notice.paused {
+  border: 1px solid #f59e0b;
+  background: #fffbeb;
+  color: #92400e;
+}
+.loadprogress-notice.failed {
+  border: 1px solid #ef4444;
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
+@keyframes loadprogress-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}


### PR DESCRIPTION
Talmud's `DafLoadProgress` and Tanach's `ChapterLoadProgress` were near-identical copies (spinner + label + percent + a 2px fill track, show-while-loading + 700ms linger). This extracts the shared **render + visibility behaviour** into one `@corpus/ui/LoadProgress` component; each app keeps a thin adapter that maps its own data to the shared signals.

## Shared component
- `LoadProgress(props)` — `percent` / `label` / `loading` signals + optional `notice`, a `variant` (`'sticky'` for Talmud's in-column bar, `'banner'` for Tanach's centered one) and an `embedded` mobile-shelf flag. Owns the auto-show/hide + linger.
- `loadprogress.css` — styling on the shared design tokens, both layout variants, one spinner keyframe. Imported by both apps' `main.tsx`.

## Per-app adapters (unchanged public API + mount points)
- **Talmud** `DafLoadProgress` — keeps the 30/70 anchor/prefetch phase weighting, the cache-snapshot grounding (`max()` with `/api/daf-runs`), the `t()` labels, and the pause/failure notice.
- **Tanach** `ChapterLoadProgress` — flat `done/total` + label, `variant="banner"`.
- Dropped Tanach's now-dead `.chapter-load*` CSS (served by `loadprogress.css`). Talmud's `daf-spin` keyframe stays (still used by other spinners).

Inspector unification is the planned follow-up.

## Gates
typecheck ✓ · lint ✓ · 2497 talmud + 49 tanach + 103 core tests ✓ · both apps build ✓