### PR TITLE
llm-cost: fix the cache TTL (45 -> 60, KV minimum) — the real 500

### DIFF
--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -5764,9 +5764,12 @@ app.get('/api/admin/llm-cost', async (c) => {
       truncated: keys.length >= SCAN_CAP,
     };
     const json = JSON.stringify(result);
-    // Short TTL: the dashboard polls "what just ran"; 45s is fresh enough and
-    // collapses a burst of polls into one scan.
-    await cache.put(reportKey, json, { expirationTtl: 45 });
+    // Short TTL collapses a burst of dashboard polls into one scan. 60s is the
+    // Cloudflare KV MINIMUM (a put with ttl < 60 throws "Invalid expiration_ttl",
+    // which is what made #450's cache silently never populate — so every request
+    // re-scanned and the OOM persisted). Keep it at exactly the floor for
+    // freshness.
+    await cache.put(reportKey, json, { expirationTtl: 60 });
     return json;
   });
   return new Response(payload, {


### PR DESCRIPTION
The actual exception, finally caught from a worker tail:

`KV PUT failed: 400 Invalid expiration_ttl of 45. Expiration TTL must be at least 60.`

Cloudflare KV requires `expirationTtl >= 60`. #450's result cache used **45**, so the `cache.put` **always threw**. That had two effects:
1. The result cache **silently never populated** → every request re-scanned the full ledger → the concurrent-scan **OOM persisted** despite #450's coalesce+cache.
2. After #452 (cap) + #453 (batch) made the scan actually complete, the throw surfaced as the **500** I was chasing.

One-line floor fix (45 → 60). Now the cache populates, so coalesce + cap + batch finally compose: a bounded, fast scan on miss; a single cheap KV read on the (now-working) 60s cache hit.

This was the root all along — the earlier PRs reduced the per-scan cost (real improvements), but the cache that was meant to make repeat/concurrent polls cheap was a no-op due to the invalid TTL. Verified: `biome ci .`, typecheck green; will confirm a fast 200 + cache HIT post-deploy.