### PR TITLE
Unify the inspect-panel primitives into @corpus/ui (row + formatters)

### DIFF
--- a/packages/talmud/src/client/runTreeShared.tsx
+++ b/packages/talmud/src/client/runTreeShared.tsx
@@ -5,7 +5,13 @@
  * node icon, and the small formatters. One source of truth so the two surfaces
  * can never drift in their graph maths or visuals.
  */
+import { fmtCost, fmtMs } from '@corpus/ui/format';
 import { For, type JSX, Match, Show, Switch } from 'solid-js';
+
+// Display formatters now live in @corpus/ui (single source of truth, shared
+// with tanach's inspect panel); re-exported so existing run-tree imports keep
+// resolving. The format is unchanged.
+export { fmtCost, fmtMs };
 
 export type Authority = 'human' | 'rule' | 'ai';
 export type Staleness = 'fresh' | 'stale-recipe' | 'stale-inputs' | 'unknown';
@@ -66,10 +72,6 @@ export interface RunResult {
   resolved?: { system_prompt: string; user_prompt: string };
 }
 
-export const fmtMs = (ms: number | null | undefined): string =>
-  ms == null ? '—' : ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(ms < 10_000 ? 1 : 0)}s`;
-export const fmtCost = (c: number | null | undefined): string =>
-  typeof c === 'number' ? `$${c.toFixed(4)}` : '$0';
 export const prettifyId = (id: string): string =>
   id
     .split(/[.-]/)

--- a/packages/tanach/src/client/Inspector.tsx
+++ b/packages/tanach/src/client/Inspector.tsx
@@ -7,6 +7,7 @@
  */
 
 import { Drawer } from '@corpus/ui/Drawer';
+import { fmtCost, fmtMs, InspectorRow } from '@corpus/ui/InspectorRow';
 import { createResource, For, type JSX, Show } from 'solid-js';
 
 interface RunRow {
@@ -24,13 +25,6 @@ interface ChapterRuns {
   chapter: number;
   runs: RunRow[];
   totals: { count: number; cached: number; cost: number; coldMs: number };
-}
-
-function fmtMs(ms: number): string {
-  return ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${Math.round(ms)}ms`;
-}
-function fmtCost(usd: number): string {
-  return usd >= 0.01 || usd === 0 ? `$${usd.toFixed(3)}` : `$${usd.toFixed(4)}`;
 }
 
 export function Inspector(props: {
@@ -68,29 +62,13 @@ export function Inspector(props: {
               fallback={<p class="comm-muted">Nothing cached yet for this chapter.</p>}
             >
               {(run) => (
-                <div class="inspect-row">
-                  <span
-                    class="inspect-dot"
-                    classList={{ hit: run.cached }}
-                    title={run.cached ? 'cached' : 'not cached'}
-                  />
-                  <span class="inspect-label">
-                    {run.label}
-                    <Show when={run.instance}>
-                      {(inst) => <span class="inspect-inst"> · {inst()}</span>}
-                    </Show>
-                  </span>
-                  <span class="inspect-meta">
-                    <Show when={run.cached} fallback={<span class="inspect-miss">miss</span>}>
-                      <Show when={run.coldMs}>
-                        {(ms) => <span class="inspect-ms">{fmtMs(ms())}</span>}
-                      </Show>
-                      <Show when={run.cost != null}>
-                        <span class="inspect-cost">{fmtCost(run.cost ?? 0)}</span>
-                      </Show>
-                    </Show>
-                  </span>
-                </div>
+                <InspectorRow
+                  cached={run.cached}
+                  label={run.label}
+                  instance={run.instance}
+                  coldMs={run.coldMs}
+                  cost={run.cost}
+                />
               )}
             </For>
           </>

--- a/packages/tanach/src/client/main.tsx
+++ b/packages/tanach/src/client/main.tsx
@@ -6,6 +6,7 @@ import '@corpus/ui/themes/tanach.css';
 import '@corpus/ui/components.css';
 import '@corpus/ui/geomap.css';
 import '@corpus/ui/loadprogress.css';
+import '@corpus/ui/inspector.css';
 import { App } from './App.tsx';
 import { UsagePage } from './UsagePage.tsx';
 import './styles.css';

--- a/packages/tanach/src/client/styles.css
+++ b/packages/tanach/src/client/styles.css
@@ -336,62 +336,8 @@ body {
 }
 
 /* inspector drawer: one row per cached/missed producer piece */
-.inspect-totals {
-  font-family: var(--font-ui);
-  font-size: 12px;
-  color: var(--muted);
-  font-variant-numeric: tabular-nums;
-  padding: 2px 0 10px;
-  margin-bottom: 4px;
-  border-bottom: 1px solid var(--line);
-}
-.inspect-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 7px 0;
-  font-family: var(--font-ui);
-  font-size: 13px;
-}
-.inspect-row + .inspect-row {
-  border-top: 1px dashed var(--line);
-}
-.inspect-dot {
-  width: 8px;
-  height: 8px;
-  flex-shrink: 0;
-  border-radius: 50%;
-  background: var(--line);
-}
-.inspect-dot.hit {
-  background: #3f9d52;
-}
-.inspect-label {
-  flex: 1;
-  min-width: 0;
-  color: var(--ink);
-}
-.inspect-inst {
-  color: var(--muted);
-}
-.inspect-meta {
-  display: flex;
-  align-items: baseline;
-  gap: 8px;
-  flex-shrink: 0;
-  font-size: 12px;
-  font-variant-numeric: tabular-nums;
-}
-.inspect-ms {
-  color: var(--muted);
-}
-.inspect-cost {
-  color: var(--accent);
-}
-.inspect-miss {
-  color: var(--muted);
-  font-style: italic;
-}
+/* The inspect rows + totals are now the shared @corpus/ui InspectorRow —
+   see inspector.css. (.inspect-link below is tanach-only chrome.) */
 
 .usage {
   max-width: 920px;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -17,13 +17,16 @@
     "./components.css": "./src/components.css",
     "./geomap.css": "./src/geomap.css",
     "./loadprogress.css": "./src/loadprogress.css",
+    "./inspector.css": "./src/inspector.css",
+    "./format": "./src/format.ts",
     "./Pill": "./src/Pill.tsx",
     "./Drawer": "./src/Drawer.tsx",
     "./Button": "./src/Button.tsx",
     "./Prose": "./src/Prose.tsx",
     "./LangToggle": "./src/LangToggle.tsx",
     "./GeoMap": "./src/GeoMap.tsx",
-    "./LoadProgress": "./src/LoadProgress.tsx"
+    "./LoadProgress": "./src/LoadProgress.tsx",
+    "./InspectorRow": "./src/InspectorRow.tsx"
   },
   "peerDependencies": {
     "solid-js": "^1.9.0"

--- a/packages/ui/src/InspectorRow.tsx
+++ b/packages/ui/src/InspectorRow.tsx
@@ -1,0 +1,55 @@
+/**
+ * @corpus/ui — InspectorRow.
+ *
+ * One per-piece row for a reader's "inspect" panel: a cached/missed dot, the
+ * piece label (+ an optional instance/anchor), and meta (cold-build time +
+ * cost, or "miss"). Shared by every corpus app's inspect surface so the rows
+ * read identically. The app owns the panel shell, the data fetch, and the
+ * totals header; this is just the row.
+ *
+ * Styling: `.inspect-*` in inspector.css (shared tokens). Re-exports the shared
+ * fmtMs/fmtCost for the app's own totals line.
+ */
+
+import { type JSX, Show } from 'solid-js';
+import { fmtCost, fmtMs } from './format.ts';
+
+export { fmtCost, fmtMs };
+
+export interface InspectorRowProps {
+  /** Cache hit — fills the dot green; a miss shows "miss" in place of meta. */
+  cached: boolean;
+  label: string;
+  /** Anchor/instance suffix (verse, range, place, …). */
+  instance?: string | null;
+  /** Cold-build time (ms); shown only when cached. */
+  coldMs?: number | null;
+  /** Generation cost (USD); shown only when cached. */
+  cost?: number | null;
+}
+
+export function InspectorRow(props: InspectorRowProps): JSX.Element {
+  return (
+    <div class="inspect-row">
+      <span
+        class="inspect-dot"
+        classList={{ hit: props.cached }}
+        title={props.cached ? 'cached' : 'not cached'}
+      />
+      <span class="inspect-label">
+        {props.label}
+        <Show when={props.instance}>{(inst) => <span class="inspect-inst"> · {inst()}</span>}</Show>
+      </span>
+      <span class="inspect-meta">
+        <Show when={props.cached} fallback={<span class="inspect-miss">miss</span>}>
+          <Show when={props.coldMs != null}>
+            <span class="inspect-ms">{fmtMs(props.coldMs)}</span>
+          </Show>
+          <Show when={props.cost != null}>
+            <span class="inspect-cost">{fmtCost(props.cost)}</span>
+          </Show>
+        </Show>
+      </span>
+    </div>
+  );
+}

--- a/packages/ui/src/format.ts
+++ b/packages/ui/src/format.ts
@@ -1,0 +1,14 @@
+/**
+ * @corpus/ui — shared display formatters for the inspect/telemetry surfaces
+ * (cost + cold-build time), so both apps render numbers identically. Pure, no
+ * JSX — safe to import from logic-heavy files (e.g. talmud's run-tree).
+ */
+
+/** Cold-build time: "—" when unknown, "ms" under a second, else "s" (1 decimal
+ *  under 10s, whole seconds above). */
+export const fmtMs = (ms: number | null | undefined): string =>
+  ms == null ? '—' : ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(ms < 10_000 ? 1 : 0)}s`;
+
+/** USD cost to 4 decimals; "$0" when unknown. */
+export const fmtCost = (c: number | null | undefined): string =>
+  typeof c === 'number' ? `$${c.toFixed(4)}` : '$0';

--- a/packages/ui/src/inspector.css
+++ b/packages/ui/src/inspector.css
@@ -1,0 +1,62 @@
+/*
+ * @corpus/ui — inspect panel styles (the per-piece rows + the totals header),
+ * shared by every corpus app's "inspect" surface. Driven by the shared design
+ * tokens. The panel shell (a Drawer / dock) and the data are the app's.
+ */
+
+.inspect-totals {
+  font-family: var(--font-ui);
+  font-size: 12px;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  padding: 2px 0 10px;
+  margin-bottom: 4px;
+  border-bottom: 1px solid var(--line);
+}
+.inspect-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 0;
+  font-family: var(--font-ui);
+  font-size: 13px;
+}
+.inspect-row + .inspect-row {
+  border-top: 1px dashed var(--line);
+}
+.inspect-dot {
+  width: 8px;
+  height: 8px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  background: var(--line);
+}
+.inspect-dot.hit {
+  background: #3f9d52;
+}
+.inspect-label {
+  flex: 1;
+  min-width: 0;
+  color: var(--fg);
+}
+.inspect-inst {
+  color: var(--muted);
+}
+.inspect-meta {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-shrink: 0;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+.inspect-ms {
+  color: var(--muted);
+}
+.inspect-cost {
+  color: var(--accent);
+}
+.inspect-miss {
+  color: var(--muted);
+  font-style: italic;
+}


### PR DESCRIPTION
The two reader "inspect" panels diverge a lot — Talmud's is a 1714-line DAG/waterfall dock (`RunTreeDock`, `/api/daf-runs`, live activity), Tanach's is a 101-line flat list (`Inspector.tsx`, `/api/chapter-runs`) — so they can't collapse into one component. But they share two genuinely-common things: the per-piece **row** and the cost/time **formatters**. This extracts those (same philosophy as the LoadProgress unification: unify the shared core, keep per-app glue).

## Shared
- `@corpus/ui/format` — `fmtMs` / `fmtCost`. Canonical = Talmud's null-safe format, so Talmud's numbers are **unchanged**.
- `@corpus/ui/InspectorRow` — the shared row (cached dot + label + instance + cold-ms + cost / "miss"); re-exports the formatters.
- `@corpus/ui/inspector.css` — the `.inspect-*` row + totals styling, on shared tokens.

## Adoption
- **Tanach** `Inspector` renders `InspectorRow` + uses the shared formatters; its now-dead `.inspect-*` CSS moved to `inspector.css`.
- **Talmud** `runTreeShared` imports + re-exports `fmtMs`/`fmtCost` from `@corpus/ui` — one source of truth, **zero** call-site or visual change. The DAG dock is untouched.

Each app keeps its own panel shell + data fetch; only the shared primitives are unified.

## Gates
typecheck ✓ · lint ✓ · 2497 talmud + 49 tanach + 103 core tests ✓ · both apps build ✓