### PR TITLE
Tanach: re-measure margin anchors on band reflow (fix stranded labels)

### DIFF
--- a/packages/tanach/src/client/App.tsx
+++ b/packages/tanach/src/client/App.tsx
@@ -315,6 +315,16 @@ export function App(): JSX.Element {
     { v: number; top: number; left: number; side: 'left' | 'right'; kinds: SourceKind[] }[]
   >([]);
   const [reflow, setReflow] = createSignal(0);
+  const bumpReflow = () => setReflow((n) => n + 1);
+  // Re-measure on ANY geometry change of the text band. The reading column is
+  // CSS multi-column (column-count: 2), which rebalances as fonts + content
+  // settle — moving verses near the column break into the other column AFTER
+  // the initial measure. A one-shot fonts.ready + double-rAF misses that late
+  // reflow and strands the margin labels/icons at stale positions (e.g. piled
+  // at the bottom). A ResizeObserver on the band catches every reflow.
+  const bandObserver =
+    typeof ResizeObserver !== 'undefined' ? new ResizeObserver(() => bumpReflow()) : null;
+  onCleanup(() => bandObserver?.disconnect());
 
   const measure = () => {
     if (loc().view !== 'scroll' || !scrollMain || !scrollBand) {
@@ -394,10 +404,9 @@ export function App(): JSX.Element {
   };
 
   onMount(() => {
-    const bump = () => setReflow((n) => n + 1);
-    window.addEventListener('resize', bump);
-    document.fonts?.ready.then(bump);
-    onCleanup(() => window.removeEventListener('resize', bump));
+    window.addEventListener('resize', bumpReflow);
+    document.fonts?.ready.then(bumpReflow);
+    onCleanup(() => window.removeEventListener('resize', bumpReflow));
   });
 
   createEffect(() => {
@@ -827,7 +836,11 @@ export function App(): JSX.Element {
             <div
               class="scroll-band"
               dir="rtl"
-              ref={(el) => (scrollBand = el)}
+              ref={(el) => {
+                scrollBand = el;
+                bandObserver?.disconnect();
+                if (el) bandObserver?.observe(el);
+              }}
               onMouseUp={onTextSelect}
               onClick={onTextClick}
             >


### PR DESCRIPTION
**Bug:** the reader's margin event-labels ("Balaam sets out", "The angel and the jenny", …) and source-icon gutters intermittently strand at the wrong spot — e.g. piled at the bottom of the chapter, detached from their verses.

**Cause:** the reading column is CSS multi-column (`column-count: 2`). Multi-column **rebalances** as fonts + content settle, moving verses near the column break into the other column *after* the initial measure. The anchors are absolutely positioned from a `getBoundingClientRect` snapshot, and the existing triggers — a one-shot `document.fonts.ready`, a double-`requestAnimationFrame`, and `window` resize — miss that late reflow, leaving the snapshot stale.

**Fix:** a `ResizeObserver` on the text band. Any geometry change (column rebalance, font swap, late content) bumps the existing `reflow` signal and re-measures, so the anchors always settle onto their verses. Observed in the band `ref`, disconnected on cleanup. No behaviour change on a stable layout (the observer just guarantees a final correct measure).

## Gates
typecheck ✓ · lint ✓ · 49 tanach tests ✓ · build ✓