### PR TITLE
Tanach: warm-cron for this week's parsha enrichments

### DIFF
--- a/packages/tanach/src/worker/index.ts
+++ b/packages/tanach/src/worker/index.ts
@@ -26,6 +26,7 @@ import type { TanachEnv, TanachRunCtx } from './run-ports.ts';
 import { runTanachEnrichment, runTanachEvents, TanachSourceError } from './run-ports.ts';
 import { asVerses, fetchPassages, fetchVerseCommentaries, sefaria } from './sefaria-sources.ts';
 import { readUsage, recordUsage } from './usage.ts';
+import { runTanachWarm } from './warm-cron.ts';
 
 interface Env extends TanachEnv {
   ASSETS: Fetcher;
@@ -650,4 +651,15 @@ app.get('/api/chapter-runs/:book/:chapter', async (c) => {
 // Everything else: serve the built SPA (static assets + index.html fallback).
 app.get('*', (c) => c.env.ASSETS.fetch(c.req.raw));
 
-export default app;
+// The Hono app, named, for tests (app.request(...)). The runtime entry is the
+// default export below.
+export { app };
+
+// fetch (the Hono app) + scheduled (the warm-cron that keeps this week's
+// parsha's chapter enrichments hot — see warm-cron.ts).
+export default {
+  fetch: (req: Request, env: Env, ctx: ExecutionContext) => app.fetch(req, env, ctx),
+  scheduled: (_controller: ScheduledController, env: Env, ctx: ExecutionContext) => {
+    ctx.waitUntil(runTanachWarm(env, ctx));
+  },
+};

--- a/packages/tanach/src/worker/warm-cron.ts
+++ b/packages/tanach/src/worker/warm-cron.ts
@@ -1,0 +1,117 @@
+/**
+ * Tanach warm-cron — keeps THIS WEEK'S parsha's chapter-level enrichments warm
+ * so the reader opens it instantly (no cold LLM on the Overview / Geography
+ * pills or the section anchors).
+ *
+ * Each tick: resolve the current parsha (Sefaria's calendar), expand it to its
+ * chapter range, and warm a small BATCH of {chapter × producer} entries
+ * (overview, geography, events), advancing a cursor. Once the whole parsha is
+ * warmed the cursor latches and subsequent ticks are no-ops until the parsha
+ * changes (the cursor stores the ref and resets when it moves). The producers
+ * are cache-respecting (runProducer), so re-touching a warm entry costs nothing
+ * — only a genuinely cold chapter pays an LLM call.
+ *
+ * Gentle by design: ~21 entries per double-parsha, BATCH per tick, so a fresh
+ * parsha warms over a handful of ticks and steady state is idle. To force a
+ * re-warm (e.g. after a producer version bump), delete the cursor key.
+ */
+
+import { isBook } from '../lib/books.ts';
+import {
+  runTanachEnrichment,
+  runTanachEvents,
+  type TanachEnv,
+  type TanachRunCtx,
+} from './run-ports.ts';
+
+const CURSOR_KEY = 'tanach-warm-cursor:v1';
+/** Chapter-level enrichments that power the reader's pills + section labels.
+ *  Per-verse pieces (note / commentary / midrash / …) stay on-demand. */
+const PRODUCERS = ['overview', 'geography', 'events'] as const;
+/** Entries warmed per tick — small so one invocation stays well within the
+ *  scheduled CPU/subrequest budget even when every entry is cold. */
+const BATCH = 4;
+
+interface WarmCursor {
+  /** The parsha ref this cursor is walking; a change resets idx to 0. */
+  ref: string;
+  /** Next index into the (chapter × producer) list; >= length = fully warmed. */
+  idx: number;
+}
+
+interface ParshaRange {
+  book: string;
+  startCh: number;
+  endCh: number;
+  ref: string;
+}
+
+/** This week's parsha as a chapter range, from Sefaria's calendar (diaspora).
+ *  The ref looks like "Numbers 19:1-25:9" (a double parsha) or "Genesis 1:1-6:8";
+ *  we take the book + the start..end chapters. null when unresolvable. */
+async function currentParsha(): Promise<ParshaRange | null> {
+  let cal: {
+    calendar_items?: Array<{ title?: { en?: string }; ref?: string }>;
+  };
+  try {
+    const r = await fetch('https://www.sefaria.org/api/calendars?diaspora=1');
+    cal = (await r.json()) as typeof cal;
+  } catch {
+    return null;
+  }
+  const p = (cal.calendar_items ?? []).find((it) => it?.title?.en === 'Parashat Hashavua');
+  const m = p?.ref?.match(/^(.+?)\s+(\d+):\d+(?:\s*-\s*(\d+):\d+)?/);
+  if (!p?.ref || !m || !isBook(m[1])) return null;
+  const startCh = Number(m[2]);
+  const endCh = m[3] ? Number(m[3]) : startCh;
+  if (!Number.isFinite(startCh) || !Number.isFinite(endCh) || endCh < startCh) return null;
+  return { book: m[1], startCh, endCh, ref: p.ref };
+}
+
+async function readCursor(cache: KVNamespace): Promise<WarmCursor> {
+  const raw = await cache.get(CURSOR_KEY);
+  if (!raw) return { ref: '', idx: 0 };
+  try {
+    return JSON.parse(raw) as WarmCursor;
+  } catch {
+    return { ref: '', idx: 0 };
+  }
+}
+
+export async function runTanachWarm(env: TanachEnv, ctx: ExecutionContext): Promise<void> {
+  if (!env.CACHE) return;
+  const parsha = await currentParsha();
+  if (!parsha) return;
+
+  // The ordered work-list: every chapter of the parsha × the chapter producers.
+  const entries: { chapter: number; producer: (typeof PRODUCERS)[number] }[] = [];
+  for (let ch = parsha.startCh; ch <= parsha.endCh; ch++) {
+    for (const producer of PRODUCERS) entries.push({ chapter: ch, producer });
+  }
+
+  let cursor = await readCursor(env.CACHE);
+  if (cursor.ref !== parsha.ref) cursor = { ref: parsha.ref, idx: 0 };
+  if (cursor.idx >= entries.length) return; // this parsha is fully warmed
+
+  let idx = cursor.idx;
+  let warmed = 0;
+  while (warmed < BATCH && idx < entries.length) {
+    const { chapter, producer } = entries[idx];
+    const chap = String(chapter);
+    const rc: TanachRunCtx = { env, ctx, ref: `${parsha.book} ${chapter}` };
+    try {
+      if (producer === 'events') {
+        await runTanachEvents(rc, parsha.book, chap);
+      } else {
+        await runTanachEnrichment(rc, producer, parsha.book, chap, { id: 'perek' });
+      }
+    } catch (e) {
+      console.error(`[tanach-warm] ${producer} ${parsha.book} ${chapter} failed:`, e);
+    }
+    idx++;
+    warmed++;
+  }
+
+  await env.CACHE.put(CURSOR_KEY, JSON.stringify({ ref: parsha.ref, idx } satisfies WarmCursor));
+  console.log(`[tanach-warm] ${parsha.ref}: warmed ${warmed}, cursor ${idx}/${entries.length}`);
+}

--- a/packages/tanach/tests/producer-routes.test.ts
+++ b/packages/tanach/tests/producer-routes.test.ts
@@ -24,7 +24,7 @@ vi.mock('@corpus/core/llm/llm', async (importOriginal) => {
 });
 
 import { runLLM } from '@corpus/core/llm/llm';
-import app from '../src/worker/index';
+import { app } from '../src/worker/index';
 
 const runLLMMock = vi.mocked(runLLM);
 

--- a/packages/tanach/wrangler.toml
+++ b/packages/tanach/wrangler.toml
@@ -42,3 +42,9 @@ HOURLY_CUSTOM_BUDGET_USD = "5"
 
 # Secret (set with `wrangler secret put OPENROUTER_API_KEY`; locally via
 # packages/tanach/.dev.vars): OPENROUTER_API_KEY.
+
+# Warm-cron: keep this week's parsha's chapter enrichments hot (warm-cron.ts).
+# Every 30 min — a fresh parsha warms over a few ticks, then the cursor latches
+# and ticks are no-ops until the parsha changes.
+[triggers]
+crons = ["*/30 * * * *"]


### PR DESCRIPTION
Tanach had no scheduled handler. This adds one that keeps **this week's parsha's** chapter-level enrichments hot, so a reader opening the weekly portion never hits a cold LLM on the Overview / Geography pills or the section anchors.

## How
- **`warm-cron.ts`** — each tick resolves the current parsha from Sefaria's calendar, expands it to its chapter range (e.g. Chukat-Balak → Numbers 19–25), and warms a small `BATCH` of `{chapter × producer}` entries (`overview`, `geography`, `events`) behind a cursor.
  - The cursor stores the parsha **ref** and resets `idx` when it changes; once the whole parsha is warmed it **latches** and ticks are no-ops.
  - Producers run cache-respecting (`runProducer`), so re-touching a warm entry is free — only a genuinely cold chapter pays an LLM call. Spend is bounded by the existing budget guard.
  - Per-verse pieces (note / commentary / midrash) stay on-demand. Delete the cursor key to force a re-warm (e.g. after a producer version bump).
- **`index.ts`** — default export is now `{ fetch, scheduled }` (was the bare Hono app); the app is also a **named** export so tests keep using `app.request(...)`. `scheduled` fires `runTanachWarm`.
- **`wrangler.toml`** — `[triggers] crons = ["*/30 * * * *"]`: a fresh parsha warms over a few ticks (BATCH 4 × ~21 entries), then idle.

## Gates
typecheck ✓ · lint ✓ · 49 tanach tests ✓ · build ✓