### PR TITLE
Phase 1: materialized daf-view endpoint (the warm read path)

### DIFF
--- a/packages/talmud/src/worker/daf-view.ts
+++ b/packages/talmud/src/worker/daf-view.ts
@@ -1,0 +1,88 @@
+/**
+ * Materialized daf view — the warm read path.
+ *
+ * Today a reader opening a daf fires ONE /api/daf (the source text) and then up
+ * to ~16 separate /api/run calls, one per piece, each polling until ready. For a
+ * WARM daf (everything already generated) that's 16 round trips for data that's
+ * all sitting in KV. This endpoint collapses it: `GET /api/daf-view/:t/:p`
+ * returns ALL currently-cached pieces' content for the daf in ONE response, so
+ * the client renders a warm daf from a single (edge-cached) fetch.
+ *
+ * Read-only: it never triggers generation. Pieces that aren't cached yet are
+ * listed in `cold` so the client knows what still needs a /api/run. The
+ * separation of concerns is deliberate — the warm path is a dumb cached read;
+ * the cold path keeps the existing per-piece generate-and-poll machinery.
+ *
+ * This module holds the pure, testable bits (the cache-control policy + the
+ * completeness/shape helpers). The KV reads + registry enumeration live in the
+ * route handler, which reuses the same helpers the inspector's /api/daf-runs
+ * probe path already uses.
+ */
+
+export interface DafViewPiece {
+  producerId: string;
+  kind: 'mark' | 'enrichment';
+  label: string;
+  /** Present for per-instance enrichments (one entry per target-mark instance). */
+  instanceId?: string;
+  instanceLabel?: string;
+  /** The structured output the card renders from (RunResult.parsed). */
+  parsed: unknown;
+  /** Aggregate enrichments: each dependency's parsed output (RunResult.deps_resolved). */
+  deps_resolved?: Record<string, unknown>;
+}
+
+export interface DafView {
+  tractate: string;
+  page: string;
+  lang: 'en' | 'he';
+  /** True when every enumerated registry piece has cached content — the view is
+   *  stable and safe to edge-cache hard. */
+  complete: boolean;
+  /** Registry producers enumerated (marks + whole-daf + per-instance enrichments). */
+  total: number;
+  /** How many of those produced cached content. */
+  cached: number;
+  /** Producer ids with missing content — what the client still needs to generate. */
+  cold: string[];
+  /** Cached pieces keyed by `pieceKey` (producerId, or producerId::instanceId). */
+  pieces: Record<string, DafViewPiece>;
+}
+
+/**
+ * Edge cache-control for the view.
+ *
+ * A COMPLETE view is immutable until a producer version bump or a human edit
+ * (both of which change the underlying piece, flipping the view back to
+ * partial), so cache it hard at the edge — that's how millions of readers of the
+ * same Daf Yomi page get served from the colo without ever waking the worker.
+ *
+ * A PARTIAL view is still warming, so use a short max-age: it refreshes quickly
+ * as pieces fill in, while still absorbing a cold-open herd for a few seconds.
+ */
+export function dafViewCacheControl(complete: boolean): string {
+  return complete ? 'public, max-age=3600, stale-while-revalidate=86400' : 'public, max-age=20';
+}
+
+/** Stable map key for a piece: per-instance pieces append their instance id. */
+export function pieceKey(producerId: string, instanceId?: string): string {
+  return instanceId ? `${producerId}::${instanceId}` : producerId;
+}
+
+/** A producer's enumeration result, reduced to what completeness needs. */
+export interface EnumeratedPiece {
+  producerId: string;
+  /** Expected to have content but none cached (for per-instance: not all
+   *  instances cached). */
+  cold: boolean;
+}
+
+/** Roll enumerated producers up into the view's completeness verdict + cold list
+ *  (deduped, since a per-instance producer contributes one entry per instance). */
+export function dafViewCompleteness(items: EnumeratedPiece[]): {
+  complete: boolean;
+  cold: string[];
+} {
+  const cold = [...new Set(items.filter((i) => i.cold).map((i) => i.producerId))];
+  return { complete: cold.length === 0, cold };
+}

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -172,6 +172,13 @@ import { aiMatchToSegments } from './context-match';
 import { collectContext, type SourceTiming } from './context-providers';
 import { dafCostReport } from './daf-cost';
 import { recordEnrichmentDafIndex, recordMarkDafIndex } from './daf-index';
+import {
+  type DafViewPiece,
+  dafViewCacheControl,
+  dafViewCompleteness,
+  type EnumeratedPiece,
+  pieceKey,
+} from './daf-view';
 import { getRabbiEntryOr404, readJsonBody } from './http-helpers';
 import {
   aggregateProbes,
@@ -2698,6 +2705,123 @@ async function dafGroupsFromIndex(
     marks,
   };
 }
+
+// GET /api/daf-view/:tractate/:page — the warm read path (Phase 1). Returns ALL
+// currently-cached pieces' CONTENT for the daf in ONE response (read-only; never
+// generates), with completeness-aware Cache-Control so a fully-warm daf is
+// served from the edge. The client renders warm pieces from this single fetch
+// instead of firing ~16 /api/run calls; `cold` lists what still needs
+// generation (the cold path keeps the existing per-piece machinery). See
+// daf-view.ts. Enumeration mirrors the /api/daf-runs probe path (marks +
+// whole-daf + per-instance local enrichments; the `argument` per-section facets
+// are deferred for the same dual-instance reason).
+app.get('/api/daf-view/:tractate/:page', async (c) => {
+  const tractate = c.req.param('tractate');
+  const page = c.req.param('page');
+  const lang: 'en' | 'he' = c.req.query('lang') === 'he' ? 'he' : 'en';
+
+  const iid = await instanceIdOf({ fields: {} });
+  const markAnchorById = new Map(CODE_MARKS.map((m) => [m.id, (m as { anchor?: string }).anchor]));
+  const localEnrichments = CODE_ENRICHMENTS.filter(
+    (e) => e.scope === 'local' && e.target_mark !== 'argument',
+  );
+  const perInstanceTargets = new Set(
+    localEnrichments
+      .map((e) => e.target_mark)
+      .filter((m): m is string => !!m && markAnchorById.get(m) !== 'whole-daf'),
+  );
+  const instancesByMark = new Map<string, RawInstance[]>();
+  await Promise.all(
+    [...perInstanceTargets].map(async (mid) => {
+      instancesByMark.set(mid, await readMarkInstances(c.env, mid, tractate, page));
+    }),
+  );
+
+  const pieces: Record<string, DafViewPiece> = {};
+  const enumerated: EnumeratedPiece[] = [];
+  const depsOf = (res: RunResult | null) =>
+    (res as { deps_resolved?: Record<string, unknown> } | null)?.deps_resolved;
+
+  // Marks — one cache entry each.
+  await Promise.all(
+    CODE_MARKS.map(async (def) => {
+      const res = await readCachedResult(c.env, keyForMark(def, tractate, page, lang));
+      enumerated.push({ producerId: def.id, cold: !res });
+      if (res) {
+        pieces[pieceKey(def.id)] = {
+          producerId: def.id,
+          kind: 'mark',
+          label: def.label ?? def.id,
+          parsed: res.parsed,
+        };
+      }
+    }),
+  );
+
+  // Enrichments — whole-daf (single entry) + per-instance (one per target instance).
+  await Promise.all(
+    localEnrichments.map(async (def) => {
+      const targetMark = def.target_mark;
+      const perInstance = !!targetMark && markAnchorById.get(targetMark) !== 'whole-daf';
+      if (perInstance) {
+        const insts = instancesByMark.get(targetMark as string) ?? [];
+        let anyCold = insts.length === 0; // no instances surfaced yet → still cold
+        await Promise.all(
+          insts.map(async (inst) => {
+            const instanceId = await instanceIdOf(inst);
+            const res = await readCachedResult(
+              c.env,
+              keyForEnrichment(def, instanceId, { tractate, page }, undefined, lang),
+            );
+            if (res) {
+              pieces[pieceKey(def.id, instanceId)] = {
+                producerId: def.id,
+                kind: 'enrichment',
+                label: def.label,
+                instanceId,
+                instanceLabel: instanceLabel((inst as { fields?: Record<string, unknown> }).fields),
+                parsed: res.parsed,
+                deps_resolved: depsOf(res),
+              };
+            } else {
+              anyCold = true;
+            }
+          }),
+        );
+        enumerated.push({ producerId: def.id, cold: anyCold });
+      } else {
+        const res = await readCachedResult(
+          c.env,
+          keyForEnrichment(def, iid, { tractate, page }, undefined, lang),
+        );
+        enumerated.push({ producerId: def.id, cold: !res });
+        if (res) {
+          pieces[pieceKey(def.id)] = {
+            producerId: def.id,
+            kind: 'enrichment',
+            label: def.label,
+            parsed: res.parsed,
+            deps_resolved: depsOf(res),
+          };
+        }
+      }
+    }),
+  );
+
+  const { complete, cold } = dafViewCompleteness(enumerated);
+  c.header('Cache-Control', dafViewCacheControl(complete));
+  c.header('x-daf-view', complete ? 'complete' : 'partial');
+  return c.json({
+    tractate,
+    page,
+    lang,
+    complete,
+    total: enumerated.length,
+    cached: Object.keys(pieces).length,
+    cold,
+    pieces,
+  });
+});
 
 app.get('/api/daf-runs/:tractate/:page', async (c) => {
   const tractate = c.req.param('tractate');

--- a/packages/talmud/tests/daf-view.test.ts
+++ b/packages/talmud/tests/daf-view.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { dafViewCacheControl, dafViewCompleteness, pieceKey } from '../src/worker/daf-view';
+
+describe('dafViewCacheControl', () => {
+  it('caches a COMPLETE view hard at the edge (warm dapim served from the colo)', () => {
+    const cc = dafViewCacheControl(true);
+    expect(cc).toContain('public');
+    expect(cc).toMatch(/max-age=3600/);
+    expect(cc).toMatch(/stale-while-revalidate=86400/);
+  });
+
+  it('keeps a PARTIAL (still-warming) view short so it refreshes as pieces fill in', () => {
+    const cc = dafViewCacheControl(false);
+    expect(cc).toContain('public');
+    expect(cc).toMatch(/max-age=20\b/);
+    expect(cc).not.toContain('stale-while-revalidate'); // don't pin a stale partial
+  });
+});
+
+describe('pieceKey', () => {
+  it('uses the producer id for whole-daf / mark pieces', () => {
+    expect(pieceKey('rabbi')).toBe('rabbi');
+    expect(pieceKey('argument-overview')).toBe('argument-overview');
+  });
+  it('appends the instance id for per-instance pieces', () => {
+    expect(pieceKey('pesukim.synthesis', 'abaye')).toBe('pesukim.synthesis::abaye');
+  });
+  it('does not collide a whole-daf piece with a per-instance one of the same producer', () => {
+    expect(pieceKey('x')).not.toBe(pieceKey('x', 'i'));
+  });
+});
+
+describe('dafViewCompleteness', () => {
+  it('is complete only when nothing is cold', () => {
+    const r = dafViewCompleteness([
+      { producerId: 'rabbi', cold: false },
+      { producerId: 'argument-overview', cold: false },
+    ]);
+    expect(r.complete).toBe(true);
+    expect(r.cold).toEqual([]);
+  });
+
+  it('lists cold producers and flips complete to false', () => {
+    const r = dafViewCompleteness([
+      { producerId: 'rabbi', cold: false },
+      { producerId: 'tidbit', cold: true },
+      { producerId: 'geography', cold: true },
+    ]);
+    expect(r.complete).toBe(false);
+    expect(r.cold.sort()).toEqual(['geography', 'tidbit']);
+  });
+
+  it('dedups a per-instance producer that contributes multiple entries', () => {
+    // pesukim.synthesis enumerated once per instance; some cold, some warm.
+    const r = dafViewCompleteness([
+      { producerId: 'pesukim.synthesis', cold: false },
+      { producerId: 'pesukim.synthesis', cold: true },
+      { producerId: 'pesukim.synthesis', cold: true },
+    ]);
+    expect(r.cold).toEqual(['pesukim.synthesis']); // one entry, not three
+    expect(r.complete).toBe(false);
+  });
+
+  it('an empty registry is trivially complete', () => {
+    expect(dafViewCompleteness([])).toEqual({ complete: true, cold: [] });
+  });
+});


### PR DESCRIPTION
First step of the architecture we discussed: **separate the warm read path from the cold generate path.**

`GET /api/daf-view/:tractate/:page` returns **all currently-cached pieces' content for a daf in one response** (read-only — never generates), with **completeness-aware edge caching**. The client can then render a warm daf from a single fetch instead of firing ~16 `/api/run` calls + polling.

## What it does
- **`daf-view.ts`** (pure, tested): `dafViewCacheControl` — a **complete** view caches hard at the edge (`max-age=3600, stale-while-revalidate=86400`), so millions reading the same Daf Yomi page are served from the colo without waking the worker; a **partial** (still-warming) view gets a short `max-age=20` so it refreshes as pieces fill in and absorbs the cold-open herd for a few seconds. Plus `pieceKey` + `dafViewCompleteness`.
- The handler enumerates marks + whole-daf + per-instance local enrichments — mirroring the proven `/api/daf-runs` probe path, including the exact key computation (`instanceIdOf` -> `keyForEnrichment`) — batch-reads their content in parallel, and assembles one payload.

## Safety
- **Cache keys are untouched** — pure read, zero re-warm exposure.
- **Additive** — nothing consumes it yet; the client switch-over (replacing the fan-out) is the next PR, and it's reversible.
- The `argument` per-section facets are deferred (the dual display/synth instance-id caveat the inspector path already carries) — Phase 1b.

## Verification
`typecheck`, `biome ci .`, full suite (2506) green. After deploy I'll curl the live endpoint, confirm content parity with the per-card responses, and confirm the `Cache-Control` + edge `x-cache: hit` on repeat.

Part of: warm path = edge-cached materialized view; cold path = DO + Workflow (later phases).