### PR TITLE
daf-view: empty-but-cached mark is complete, not cold (enable hard edge cache)

### DIFF
--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -2739,13 +2739,16 @@ app.get('/api/daf-view/:tractate/:page', async (c) => {
 
   const pieces: Record<string, DafViewPiece> = {};
   const enumerated: EnumeratedPiece[] = [];
+  const markCached = new Map<string, boolean>();
   const depsOf = (res: RunResult | null) =>
     (res as { deps_resolved?: Record<string, unknown> } | null)?.deps_resolved;
 
-  // Marks — one cache entry each.
+  // Marks — one cache entry each. (Awaited before the enrichments pass below, so
+  // markCached is populated when the per-instance cold check reads it.)
   await Promise.all(
     CODE_MARKS.map(async (def) => {
       const res = await readCachedResult(c.env, keyForMark(def, tractate, page, lang));
+      markCached.set(def.id, !!res);
       enumerated.push({ producerId: def.id, cold: !res });
       if (res) {
         pieces[pieceKey(def.id)] = {
@@ -2765,7 +2768,11 @@ app.get('/api/daf-view/:tractate/:page', async (c) => {
       const perInstance = !!targetMark && markAnchorById.get(targetMark) !== 'whole-daf';
       if (perInstance) {
         const insts = instancesByMark.get(targetMark as string) ?? [];
-        let anyCold = insts.length === 0; // no instances surfaced yet → still cold
+        // Zero instances is "cold" ONLY if the parent mark itself isn't cached
+        // yet (still warming). A cached-but-empty mark (this daf genuinely has no
+        // pesukim/aggadata/…) is COMPLETE — nothing to render — so it must not
+        // hold the whole view in the soft-cache tier forever.
+        let anyCold = insts.length === 0 ? !markCached.get(targetMark as string) : false;
         await Promise.all(
           insts.map(async (inst) => {
             const instanceId = await instanceIdOf(inst);


### PR DESCRIPTION
Refinement to #461 found while verifying it live. A daf with no pesukim/aggadata/etc. was reporting `complete: false` because a per-instance enrichment with **zero** target instances was counted as cold — so a genuinely-warm daf never reached the long-lived edge cache (the 'millions served from the colo' win), only the 20s soft tier.

Fix: zero instances is cold **only if the parent mark is itself uncached** (still warming). A cached-but-empty mark genuinely has nothing to render → complete. Now a fully-warmed daf flips to `complete: true` and gets `max-age=3600, stale-while-revalidate=86400`.

typecheck, biome ci, tests green.