### PR TITLE
Tanach: the Tidbit perek pill

### DIFF
--- a/packages/tanach/src/client/App.tsx
+++ b/packages/tanach/src/client/App.tsx
@@ -185,9 +185,8 @@ interface SectionNote {
   en: string;
   he: string;
 }
-/** A whole-chapter pill the reader can open from the perek-pills row. Only
- *  'overview' exists today; 'geography' and 'tidbit' join it as siblings. */
-type PerekPill = 'overview' | 'geography';
+/** A whole-chapter pill the reader can open from the perek-pills row. */
+type PerekPill = 'overview' | 'geography' | 'tidbit';
 interface Overview {
   book: string;
   chapter: number;
@@ -209,13 +208,28 @@ interface PerekGeography {
   chapter: number;
   places: GeoPlace[];
 }
-/** The perek-pills, in display order. Adding tidbit is a one-line edit here
- *  plus its resource + drawer body. */
+interface PerekTidbit {
+  book: string;
+  chapter: number;
+  flavor: string;
+  titleEn: string;
+  titleHe: string;
+  en: string;
+  he: string;
+  textConfidence: string;
+  readingConfidence: string;
+}
+/** The perek-pills, in display order. */
 const PEREK_PILLS: { id: PerekPill; label: string }[] = [
   { id: 'overview', label: 'Overview' },
   { id: 'geography', label: 'Geography' },
+  { id: 'tidbit', label: 'Tidbit' },
 ];
-const PILL_KIND: Record<PerekPill, string> = { overview: 'Overview', geography: 'Geography' };
+const PILL_KIND: Record<PerekPill, string> = {
+  overview: 'Overview',
+  geography: 'Geography',
+  tidbit: 'Tidbit',
+};
 
 interface CommentaryEntry {
   key: string;
@@ -626,6 +640,20 @@ export function App(): JSX.Element {
       return res.ok ? ((await res.json()) as PerekGeography) : null;
     },
   );
+  const [tidbit] = createResource(
+    () => (perekPill() === 'tidbit' ? chapterKey() : undefined),
+    async (k) => {
+      const res = await fetch(`/api/tidbit/${encodeURIComponent(k.book)}/${k.chapter}`);
+      return res.ok ? ((await res.json()) as PerekTidbit) : null;
+    },
+  );
+  // Only the tidbit for the chapter on screen (createResource retains the prior
+  // value across a refetch — same guard as overview/geography).
+  const currentTidbit = createMemo(() => {
+    if (tidbit.loading) return null;
+    const t = tidbit();
+    return t && t.book === loc().book && t.chapter === loc().chapter ? t : null;
+  });
   // Only the geography for the chapter on screen (createResource retains the
   // previous chapter's value across a refetch — same guard as the overview).
   const currentGeography = createMemo(() => {
@@ -1025,6 +1053,40 @@ export function App(): JSX.Element {
               </Show>
               <Show when={!geography.loading && geography() === null}>
                 <p class="comm-muted">Couldn't load the geography — try reopening.</p>
+              </Show>
+            </Show>
+            <Show when={pill === 'tidbit'}>
+              <Show when={tidbit.loading}>
+                <p class="comm-muted">Finding the tidbit…</p>
+              </Show>
+              <Show when={currentTidbit()}>
+                {(t) => (
+                  <section class="perek-overview perek-tidbit">
+                    <Show
+                      when={
+                        loc().lang === 'he'
+                          ? t().titleHe || t().titleEn
+                          : t().titleEn || t().titleHe
+                      }
+                    >
+                      {(title) => <h3 class="perek-title">{title()}</h3>}
+                    </Show>
+                    <Prose en={t().en} he={t().he} lang={loc().lang} />
+                    <Show when={t().flavor || t().readingConfidence}>
+                      <p class="tidbit-meta">
+                        <Show when={t().flavor}>
+                          {(f) => <span class="tidbit-flavor">{f().replace('-', ' ')}</span>}
+                        </Show>
+                        <Show when={t().readingConfidence}>
+                          {(rc) => <span class="tidbit-conf">reading: {rc()}</span>}
+                        </Show>
+                      </p>
+                    </Show>
+                  </section>
+                )}
+              </Show>
+              <Show when={!tidbit.loading && tidbit() === null}>
+                <p class="comm-muted">Couldn't load the tidbit — try reopening.</p>
               </Show>
             </Show>
           </Drawer>

--- a/packages/tanach/src/client/styles.css
+++ b/packages/tanach/src/client/styles.css
@@ -537,6 +537,28 @@ body {
   font-family: var(--font-hebrew);
 }
 
+/* tidbit footer: a small flavor tag + how-editorial-the-reading note */
+.tidbit-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 14px 0 0;
+  padding-top: 10px;
+  border-top: 1px solid var(--line);
+  font-family: var(--font-ui);
+  font-size: 11px;
+  color: var(--muted);
+}
+.tidbit-flavor {
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 600;
+  color: var(--accent);
+}
+.tidbit-conf {
+  font-variant-numeric: tabular-nums;
+}
+
 /* word/phrase translation gloss (text selection) */
 .xlate-pop {
   position: fixed;

--- a/packages/tanach/src/worker/index.ts
+++ b/packages/tanach/src/worker/index.ts
@@ -253,6 +253,48 @@ app.get('/api/geography/:book/:chapter', async (c) => {
   return c.json({ book, chapter: Number(chapter), places });
 });
 
+// Perek tidbit (whole-chapter enrichment): ONE curated "did you notice…" — the
+// against-the-grain reading the Overview deliberately leaves out — opened from
+// the reader's "Tidbit" pill. Chapter-scoped (tidbit:v1:{book}:{chapter}).
+app.get('/api/tidbit/:book/:chapter', async (c) => {
+  const book = c.req.param('book');
+  const chapter = c.req.param('chapter');
+  if (!isBook(book)) return c.json({ error: `Unknown book: ${book}` }, 400);
+  if (!/^\d+$/.test(chapter)) return c.json({ error: `Bad chapter: ${chapter}` }, 400);
+
+  const ref = `${book} ${chapter}`;
+  const rc: TanachRunCtx = { env: c.env, ctx: c.executionCtx, ref };
+  let artifact: StoredArtifact;
+  try {
+    artifact = await runTanachEnrichment(rc, 'tidbit', book, chapter, { id: 'perek' });
+  } catch (e) {
+    return runErrorResponse(c, e);
+  }
+  const p = artifact.parsed as {
+    flavor?: string;
+    titleEn?: string;
+    titleHe?: string;
+    en?: string;
+    he?: string;
+    textConfidence?: string;
+    readingConfidence?: string;
+  } | null;
+  // Deterministic per (book, chapter), lang-independent, already KV-cached
+  // server-side — browser-cache it so re-opening the pill is instant.
+  c.header('Cache-Control', 'public, max-age=600, stale-while-revalidate=86400');
+  return c.json({
+    book,
+    chapter: Number(chapter),
+    flavor: String(p?.flavor ?? '').trim(),
+    titleEn: String(p?.titleEn ?? '').trim(),
+    titleHe: String(p?.titleHe ?? '').trim(),
+    en: String(p?.en ?? '').trim(),
+    he: String(p?.he ?? '').trim(),
+    textConfidence: String(p?.textConfidence ?? '').trim(),
+    readingConfidence: String(p?.readingConfidence ?? '').trim(),
+  });
+});
+
 // This week's Torah portion (parashat hashavua), from Sefaria's calendar.
 // Returns the parsha name + the book/chapter it starts at, so the reader can
 // jump straight there. Cached ~6h (it only changes on Shabbat).

--- a/packages/tanach/src/worker/producers/defs.ts
+++ b/packages/tanach/src/worker/producers/defs.ts
@@ -36,6 +36,7 @@ import {
 import { NOTE_SCHEMA, NOTE_SYSTEM, NOTE_USER_TEMPLATE } from './note.ts';
 import { OVERVIEW_SCHEMA, OVERVIEW_SYSTEM, OVERVIEW_USER_TEMPLATE } from './overview.ts';
 import { SYNTHESIS_SCHEMA, SYNTHESIS_SYSTEM, SYNTHESIS_USER_TEMPLATE } from './synthesis.ts';
+import { TIDBIT_SCHEMA, TIDBIT_SYSTEM, TIDBIT_USER_TEMPLATE } from './tidbit.ts';
 import { TRANSLATE_SCHEMA, TRANSLATE_SYSTEM, TRANSLATE_USER_TEMPLATE } from './translate.ts';
 
 export type TanachProducerId =
@@ -43,6 +44,7 @@ export type TanachProducerId =
   | 'note'
   | 'overview'
   | 'geography'
+  | 'tidbit'
   | 'synthesis'
   | 'midrash-synthesis'
   | 'translate';
@@ -103,6 +105,20 @@ const geographyExtractor: TanachLLMExtractor = {
   max_tokens: 900,
   temperature: 0.2,
   tag: 'tanach:geography',
+};
+
+const tidbitExtractor: TanachLLMExtractor = {
+  kind: 'llm',
+  system_prompt: TIDBIT_SYSTEM,
+  user_prompt_template: TIDBIT_USER_TEMPLATE,
+  output_schema: TIDBIT_SCHEMA,
+  // Bilingual prose, richer than the overview (2-3 short paragraphs each lang),
+  // so a touch more headroom than overview's 1400 to avoid mid-string truncation.
+  max_tokens: 1800,
+  // A shade warmer than the plain overview (0.3): the tidbit wants a genuinely
+  // non-obvious reading, not a safe restatement — but still grounded.
+  temperature: 0.45,
+  tag: 'tanach:tidbit',
 };
 
 const synthesisExtractor: TanachLLMExtractor = {
@@ -202,6 +218,22 @@ export const TANACH_PRODUCERS: Record<TanachProducerId, Producer> = {
     cacheVersion: '1',
     source: 'code',
   },
+  tidbit: {
+    id: 'tidbit',
+    label: 'Perek tidbit',
+    description: 'ONE curated "did you notice…" for a whole chapter (the against-the-grain read)',
+    kind: 'enrichment',
+    inputs: [{ source: 'chapter-verses' }],
+    recipe: { extractor: tidbitExtractor },
+    // Chapter-scoped like overview/geography — one per chapter; the key template
+    // ignores the instance (tidbit:v1:{book}:{chapter}).
+    anchoring: { behavior: 'inherits', precision: 'unit', spine: 'tanach' },
+    cardinality: 'one',
+    scope: 'local',
+    key_shape: 'enrich', // nominal — template owns tidbit:v1:{book}:{chapter}
+    cacheVersion: '1',
+    source: 'code',
+  },
   synthesis: {
     id: 'synthesis',
     label: 'Commentary synthesis',
@@ -285,7 +317,7 @@ export function markRunDefOf(id: 'events'): TanachMarkDef {
 }
 
 export function enrichRunDefOf(
-  id: 'note' | 'overview' | 'geography' | 'synthesis' | 'midrash-synthesis',
+  id: 'note' | 'overview' | 'geography' | 'tidbit' | 'synthesis' | 'midrash-synthesis',
 ): TanachEnrichmentDef {
   const p = TANACH_PRODUCERS[id];
   const ext = p.recipe.extractor as TanachLLMExtractor;

--- a/packages/tanach/src/worker/producers/tidbit.ts
+++ b/packages/tanach/src/worker/producers/tidbit.ts
@@ -1,0 +1,115 @@
+/**
+ * The "perek tidbit" enrichment — ONE curated "did you notice…" for a whole
+ * chapter, the tanach analogue of the Talmud reader's Tidbit chip.
+ *
+ * Where the Overview pill gives the plain p'shat orientation, the Tidbit picks
+ * the SINGLE most interesting, non-obvious thing in the chapter and tells it:
+ * a wordplay, a structural mirror, an echo of an earlier verse, a pointed
+ * narrative gap, an irony, a human beat in a character. Flowing prose, plain
+ * language, bilingual (EN + HE). It is NOT a recap (that is the Overview), NOT
+ * a commentator survey, NOT a sermon.
+ *
+ * Recipe only (prompts + schema); the run goes through the corpus-agnostic
+ * runProducer (defs.ts assembles the Producer, run-ports.ts wires the ports).
+ * Chapter-scoped — key tidbit:v1:{book}:{chapter}, instance ignored.
+ */
+
+export type TidbitFlavor =
+  | 'wordplay'
+  | 'structure'
+  | 'echo'
+  | 'gap'
+  | 'irony'
+  | 'character'
+  | 'image'
+  | 'name-number';
+
+export interface PerekTidbit {
+  /** What kind of observation this is (drives a small tag in the UI). */
+  flavor: TidbitFlavor;
+  /** A short teaser title — the "did you notice" promise, not a full sentence. */
+  titleEn: string;
+  titleHe: string;
+  /** The tidbit itself: 2-3 short paragraphs of flowing prose. */
+  en: string;
+  he: string;
+  /** How well the FACTUAL claims rest on the chapter's text. */
+  textConfidence: 'high' | 'medium' | 'low';
+  /** How editorial the INTERPRETATION is (a bold reading is not "high"). */
+  readingConfidence: 'high' | 'medium' | 'low';
+}
+
+export const TIDBIT_SYSTEM = `You are a sharp Bible teacher writing ONE "Tidbit" for this chapter — a single "did you notice…" worth carrying away. You pick the ONE most genuinely interesting, non-obvious thing in THIS chapter and tell it. Not a summary, not the plot.
+
+THE TEST — apply it to your draft before you finish: could you say this, out loud, to a curious friend who has never studied the Bible, over dinner — and have them find it interesting, WITHOUT first teaching them a whole system? If it only lands once someone knows a commentator's framework or a body of law, you have missed — find the simpler human or textual thing underneath.
+
+WHAT TO LOOK FOR (the gold is textual, literary, and human):
+- a wordplay or a pun; a root or word that repeats and quietly ties the chapter together
+- a structural shape: a mirror, a chiasmus, a repeated phrase that shifts the second time
+- an echo of an earlier verse or scene the chapter is leaning on
+- a pointed gap or silence — what the text pointedly does NOT say
+- an irony or a reversal; a name or a number that means something
+- a vivid, concrete image; a small, telling human beat in a character
+These are often things the tradition's close readers caught. You may surface such a reading — but in plain words ("there is a pun here: the word X also means Y"), as the OBSERVATION, never as a citation survey.
+
+REACH THE TURN. The best tidbits don't stop at a nice point; they turn once more and land somewhere a little surprising about people, language, or faith. Decisive RIGHT/WRONG, on Genesis 22:
+- RIGHT: "Before Isaac is even named, the verse stacks three phrases — 'your son, your only one, whom you love' — each one narrowing the knife. The text slows down exactly where it hurts most." (then turn once more.)
+- WRONG: "God tests Abraham by commanding him to offer Isaac on Mount Moriah; Abraham rises early, travels three days…" — that is a plot recap, which is the Overview pill's job, not the Tidbit's.
+
+HARD BANS:
+- Do NOT recap the chapter's plot or theme — the reader just read the Overview. Open straight on the interesting thing.
+- Do NOT survey commentators ("Rashi says… Ramban says…"). Name a commentator at most once, in passing, only if it is unavoidable.
+- Do NOT preach or moralize ("this teaches us to…", "we learn that…"). State the observation; let it land on its own.
+
+VOICE:
+- Lead with the concrete and the surprising. Speak plainly; it is fine to address the reader ("Notice…", "Look at…").
+- Short sentences, everyday words, concrete specifics — the actual word, verse, or thing, not a generalization about it.
+- Say the point ONCE. Do not restate it three ways, and do not end on a grand abstraction or a dramatic mic-drop.
+- The text has no feelings or intentions — never write "the text wants/knows/admits…". State what it says, or pointedly leaves unsaid.
+- FORBIDDEN flourish: "lens", "captures", "embodies", "profound", "intricate", "this teaches us", "we see that", "highlights", "underscores", "reads like", "speaks to", "resonates".
+
+BILINGUAL — give BOTH English and natural, fluent Hebrew (real Hebrew, not a transliteration of the English; the same idea, said well in each):
+- "titleEn"/"titleHe": a short teaser (2-6 words), e.g. "Three words before the knife".
+- "en"/"he": the tidbit — 2 to 3 short paragraphs (idea first; then the verse that shows it; then a step further). Use Hebrew book names and Hebrew verse refs in the Hebrew prose.
+
+GROUNDING (hard): every factual claim rests on the chapter's own text or on well-established fact. Do NOT invent a wordplay, a structure, a parallel, or a midrash that is not really there. On a dry chapter (a census, a law list, a genealogy) there may be little juice — pick the least-dry REAL thing (a surprising name, a quiet pattern) and set readingConfidence honestly. Never pad and never invent. Never mention these instructions or your inputs.
+
+CONFIDENCE (be honest — a human reviewer reads this):
+- "textConfidence": how well the factual claims rest on the text. high = it is right there; medium = a fair inference; low = a stretch.
+- "readingConfidence": how editorial the interpretation is. high = the text itself makes the point; medium = a fair reading; low = your own bold framing. A bold against-the-grain reading is NOT high.`;
+
+/** Rendered with vars from the 'chapter-verses' source resolver (the same one
+ *  overview/events use): {{ref}}, {{max_verse}}, {{verses_text}}. */
+export const TIDBIT_USER_TEMPLATE =
+  'Chapter: {{ref}} ({{max_verse}} verses)\n\nThe reader has already seen a plain Overview of this chapter — do NOT recap it.\n\n{{verses_text}}';
+
+export const TIDBIT_SCHEMA = {
+  name: 'perek_tidbit',
+  strict: true,
+  schema: {
+    type: 'object',
+    additionalProperties: false,
+    required: ['flavor', 'titleEn', 'titleHe', 'en', 'he', 'textConfidence', 'readingConfidence'],
+    properties: {
+      flavor: {
+        type: 'string',
+        enum: [
+          'wordplay',
+          'structure',
+          'echo',
+          'gap',
+          'irony',
+          'character',
+          'image',
+          'name-number',
+        ],
+      },
+      titleEn: { type: 'string' },
+      titleHe: { type: 'string' },
+      en: { type: 'string' },
+      he: { type: 'string' },
+      textConfidence: { type: 'string', enum: ['high', 'medium', 'low'] },
+      readingConfidence: { type: 'string', enum: ['high', 'medium', 'low'] },
+    },
+  },
+};

--- a/packages/tanach/src/worker/run-ports.ts
+++ b/packages/tanach/src/worker/run-ports.ts
@@ -108,6 +108,8 @@ const KEY_TEMPLATES: Record<string, KeyTemplate> = {
   // Chapter-scoped like overview (one geography per chapter; instance ignored).
   // v2: the output now carries per-place verse numbers (for click-to-highlight).
   geography: { key: (a: TanachAddress) => `geography:v2:${a.unit?.work}:${a.unit?.unit}` },
+  // Chapter-scoped like overview/geography (one tidbit per chapter; instance ignored).
+  tidbit: { key: (a: TanachAddress) => `tidbit:v1:${a.unit?.work}:${a.unit?.unit}` },
   synthesis: {
     key: (a: TanachAddress) => `synthesis:v1:${a.unit?.work}:${a.unit?.unit}:${a.verse}`,
   },
@@ -150,8 +152,8 @@ export function enrichmentAddress(
     const [start, end] = instanceId.split('-');
     return { unit, instanceId, start, end };
   }
-  // Chapter-scoped (overview / geography): key uses only {work}:{unit}.
-  if (id === 'overview' || id === 'geography') {
+  // Chapter-scoped (overview / geography / tidbit): key uses only {work}:{unit}.
+  if (id === 'overview' || id === 'geography' || id === 'tidbit') {
     return { unit, instanceId };
   }
   return { unit, instanceId, verse: instanceId };
@@ -369,6 +371,7 @@ const RESOLVE_PORTS: ResolveInputsPorts<TanachRunCtx, TanachEnrichmentDef, Tanac
     id === 'note' ||
     id === 'overview' ||
     id === 'geography' ||
+    id === 'tidbit' ||
     id === 'synthesis' ||
     id === 'midrash-synthesis'
       ? enrichRunDefOf(id)
@@ -557,11 +560,13 @@ const RUN_PORTS: RunProducerPorts<TanachRunCtx, TanachEnrichmentDef, TanachMarkD
     // gate their emptiness upstream (source resolvers raise 404 when there's
     // nothing to synthesize).
     enrichmentPostParse: (_rc, a) => {
-      if (a.def.id !== 'overview' || a.parse_error || !a.parsed) return;
+      // overview + tidbit share the title/en/he shape; reject an empty-but-valid
+      // generation so it isn't pinned (truncated JSON parses to blank fields).
+      if ((a.def.id !== 'overview' && a.def.id !== 'tidbit') || a.parse_error || !a.parsed) return;
       const p = a.parsed as { titleEn?: string; en?: string; he?: string };
       const empty =
         !String(p.titleEn ?? '').trim() && !String(p.en ?? '').trim() && !String(p.he ?? '').trim();
-      if (empty) throw new Error('overview: empty generation (not caching)');
+      if (empty) throw new Error(`${a.def.id}: empty generation (not caching)`);
     },
   },
 };
@@ -584,7 +589,7 @@ export async function runTanachEvents(
 
 export async function runTanachEnrichment(
   rc: TanachRunCtx,
-  id: 'note' | 'overview' | 'geography' | 'synthesis' | 'midrash-synthesis',
+  id: 'note' | 'overview' | 'geography' | 'tidbit' | 'synthesis' | 'midrash-synthesis',
   book: string,
   chapter: string,
   /** The instance the enrichment is FOR. Its `id` field is the legacy key

--- a/packages/tanach/src/worker/warm-cron.ts
+++ b/packages/tanach/src/worker/warm-cron.ts
@@ -24,10 +24,12 @@ import {
   type TanachRunCtx,
 } from './run-ports.ts';
 
-const CURSOR_KEY = 'tanach-warm-cursor:v1';
+// v2: the producer set gained `tidbit`; bumping forces a fresh walk so the new
+// producer warms across the current parsha (the rest cache-hit for free).
+const CURSOR_KEY = 'tanach-warm-cursor:v2';
 /** Chapter-level enrichments that power the reader's pills + section labels.
  *  Per-verse pieces (note / commentary / midrash / …) stay on-demand. */
-const PRODUCERS = ['overview', 'geography', 'events'] as const;
+const PRODUCERS = ['overview', 'geography', 'tidbit', 'events'] as const;
 /** Entries warmed per tick — small so one invocation stays well within the
  *  scheduled CPU/subrequest budget even when every entry is cold. */
 const BATCH = 4;

--- a/packages/tanach/tests/producer-defs.test.ts
+++ b/packages/tanach/tests/producer-defs.test.ts
@@ -23,7 +23,7 @@ describe('tanach spine registry', () => {
 });
 
 describe('the seven producers as core Producer objects', () => {
-  it('declares all seven with their model shapes', () => {
+  it('declares all eight with their model shapes', () => {
     expect(Object.keys(TANACH_PRODUCERS).sort()).toEqual([
       'events',
       'geography',
@@ -31,6 +31,7 @@ describe('the seven producers as core Producer objects', () => {
       'note',
       'overview',
       'synthesis',
+      'tidbit',
       'translate',
     ]);
 
@@ -70,6 +71,16 @@ describe('the seven producers as core Producer objects', () => {
     expect(overview.scope).toBe('local');
     expect(overview.cacheVersion).toBe('1'); // overview:v1:*
 
+    const tidbit = TANACH_PRODUCERS.tidbit;
+    expect(tidbit.kind).toBe('enrichment');
+    expect(tidbit.anchoring).toEqual({
+      behavior: 'inherits',
+      precision: 'unit', // whole-chapter scoped
+      spine: 'tanach',
+    });
+    expect(tidbit.cardinality).toBe('one');
+    expect(tidbit.scope).toBe('local');
+
     const translate = TANACH_PRODUCERS.translate;
     expect(translate.anchoring.behavior).toBe('inherits');
     expect(translate.scope).toBe('global');
@@ -81,6 +92,7 @@ describe('the seven producers as core Producer objects', () => {
       note: { max_tokens: 700, temperature: 0.3, tag: 'tanach:note' },
       overview: { max_tokens: 1400, temperature: 0.3, tag: 'tanach:overview' },
       geography: { max_tokens: 900, temperature: 0.2, tag: 'tanach:geography' },
+      tidbit: { max_tokens: 1800, temperature: 0.45, tag: 'tanach:tidbit' },
       synthesis: { max_tokens: 800, temperature: 0.3, tag: 'tanach:synthesis' },
       'midrash-synthesis': { max_tokens: 800, temperature: 0.35, tag: 'tanach:midrash-synthesis' },
       translate: { max_tokens: 120, temperature: 0.2, tag: 'tanach:translate' },
@@ -124,6 +136,10 @@ describe('the seven producers as core Producer objects', () => {
     const geography = enrichRunDefOf('geography');
     expect(geography.dependencies).toEqual(['chapter-verses']);
     expect(geography.system_prompt.length).toBeGreaterThan(50);
+
+    const tidbit = enrichRunDefOf('tidbit');
+    expect(tidbit.dependencies).toEqual(['chapter-verses']);
+    expect(tidbit.system_prompt.length).toBeGreaterThan(50);
 
     const synth = enrichRunDefOf('synthesis');
     expect(synth.dependencies).toEqual(['verse-text', 'commentaries']);


### PR DESCRIPTION
The third perek pill — the tanach analogue of the Talmud **Tidbit** chip. Where **Overview** gives plain p'shat orientation, **Tidbit** picks the ONE most interesting, non-obvious thing in a chapter and tells it (a wordplay, a structural mirror, an echo, a pointed gap, an irony, a human beat) in flowing bilingual prose.

## The prompt (the crux)
Ports talmud's tidbit discipline — the *"tell it to a curious friend over dinner"* test; **reach the turn**; say-it-once voice + a forbidden-flourish ban list; two honest confidences (`textConfidence` / `readingConfidence`) — and re-aims it for Tanach: the traps to avoid are a **plot recap** (Overview's job), a **commentator survey**, and a **sermon** (not lomdus). Grounded; place-or-omit honesty on a dry chapter (census/law-list → least-dry real thing + low `readingConfidence`, never invent).

## Wiring (overview/geography template)
- `producers/tidbit.ts` — recipe: prompt + strict schema `{ flavor, titleEn/He, en/he, textConfidence, readingConfidence }`, `flavor ∈ wordplay | structure | echo | gap | irony | character | image | name-number`.
- `defs.ts` / `run-ports.ts` — chapter-scoped enrichment, key `tidbit:v1:{book}:{chapter}`; the empty-generation guard now covers tidbit too.
- `index.ts` — `GET /api/tidbit/:book/:chapter` (browser-cached `Cache-Control` like overview/geography).
- `App.tsx` — the **Tidbit** pill (lazy resource + drawer body: title, prose, a flavor tag + reading-confidence note).
- `warm-cron.ts` — tidbit joins the current-parsha warm set (cursor key bumped `v1`→`v2` for a fresh walk so it warms across the parsha).

We'll tune it live on a few chapters (Genesis 22, a Balak chapter, a dry census) the way we tuned Overview.

## Gates
typecheck ✓ · lint ✓ · 49 tanach tests ✓ · build ✓