### PR TITLE
Tanach warm-cron: also warm the parsha's per-verse deep content

### DIFF
--- a/packages/tanach/src/worker/index.ts
+++ b/packages/tanach/src/worker/index.ts
@@ -12,12 +12,11 @@
  * the built Solid client (the ASSETS binding, SPA fallback).
  */
 
-import { flattenPieces, pickV3Version } from '@corpus/core/sefaria/client';
+import { flattenPieces } from '@corpus/core/sefaria/client';
 import type { StoredArtifact } from '@corpus/core/store/envelope';
 import type { Context } from 'hono';
 import { Hono } from 'hono';
 import { isBook } from '../lib/books.ts';
-import { COMMENTATORS } from '../lib/commentators.ts';
 import { lookupPlace } from './gazetteer.ts';
 import { chapterRuns } from './inspect.ts';
 import type { EventSection } from './producers/events.ts';
@@ -25,6 +24,7 @@ import { translateHebrew } from './producers/translate.ts';
 import type { TanachEnv, TanachRunCtx } from './run-ports.ts';
 import { runTanachEnrichment, runTanachEvents, TanachSourceError } from './run-ports.ts';
 import { asVerses, fetchPassages, fetchVerseCommentaries, sefaria } from './sefaria-sources.ts';
+import { computeSourcesIndex } from './sources-index.ts';
 import { readUsage, recordUsage } from './usage.ts';
 import { runTanachWarm } from './warm-cron.ts';
 
@@ -488,95 +488,7 @@ app.get('/api/sources-index/:book/:chapter', async (c) => {
   if (!isBook(book)) return c.json({ error: `Unknown book: ${book}` }, 400);
   if (!/^\d+$/.test(chapter)) return c.json({ error: 'Bad chapter' }, 400);
 
-  const key = `srcidx:v4:${book}:${chapter}`;
-  const cached = await c.env.CACHE.get(key);
-  if (cached) return c.json(JSON.parse(cached));
-
-  // Per verse: how many commentators, and the total weight (chars of Hebrew
-  // commentary) — volume is a better "richness" signal than count, since in the
-  // Torah almost every verse has several commentators.
-  const acc = new Map<number, { n: number; w: number }>();
-  await Promise.all(
-    COMMENTATORS.map(async (cm) => {
-      try {
-        const v3 = await sefaria.getTextV3(`${cm.title} on ${book} ${chapter}`);
-        const heArr = (() => {
-          const he = pickV3Version(v3.versions, 'he');
-          return Array.isArray(he) ? (he as unknown[]) : [];
-        })();
-        for (let i = 0; i < heArr.length; i++) {
-          const segs = flattenPieces(heArr[i]).map((x) => x.replace(/<[^>]+>/g, '').trim());
-          const chars = segs.join('').length;
-          if (!chars) continue;
-          const e = acc.get(i + 1) ?? { n: 0, w: 0 };
-          e.n += 1;
-          e.w += chars;
-          acc.set(i + 1, e);
-        }
-      } catch {
-        /* commentator absent on this book */
-      }
-    }),
-  );
-  // Talmud + Midrash citation counts per verse, from one chapter-wide links
-  // fetch (Sefaria's link graph). Heavy for the busiest chapters (~6MB) —
-  // best-effort: on failure the icons just don't show, the drawers still work.
-  const gem = new Map<number, number>();
-  const mid = new Map<number, number>();
-  try {
-    const r = await fetch(
-      `https://www.sefaria.org/api/links/${encodeURIComponent(`${book} ${chapter}`)}?with_text=0`,
-    );
-    type Link = { category?: string; anchorVerse?: number; sourceRef?: string; ref?: string };
-    const links = (await r.json()) as Link[];
-    const gemSeen = new Map<number, Set<string>>();
-    const midSeen = new Map<number, Set<string>>();
-    for (const l of Array.isArray(links) ? links : []) {
-      const v = l.anchorVerse;
-      if (!v) continue;
-      const ref = l.sourceRef || l.ref;
-      if (!ref) continue;
-      if (l.category === 'Talmud') {
-        const s = gemSeen.get(v) ?? new Set<string>();
-        s.add(ref);
-        gemSeen.set(v, s);
-      } else if (l.category === 'Midrash') {
-        const s = midSeen.get(v) ?? new Set<string>();
-        s.add(ref);
-        midSeen.set(v, s);
-      }
-    }
-    gemSeen.forEach((s, v) => {
-      gem.set(v, s.size);
-    });
-    midSeen.forEach((s, v) => {
-      mid.set(v, s.size);
-    });
-  } catch {
-    /* links too heavy / unavailable — skip gemara+midrash counts */
-  }
-
-  const entries = [...acc.entries()].sort((a, b) => a[0] - b[0]);
-  // "rich" = many commentators AND in the top fraction of this chapter by volume.
-  const weights = entries.map(([, e]) => e.w).sort((a, b) => a - b);
-  const cutoff = weights.length ? weights[Math.floor(weights.length * 0.6)] : 0;
-  // union of verses that have any source so gemara/midrash-only verses still appear
-  const allVerses = new Set<number>([...acc.keys(), ...gem.keys(), ...mid.keys()]);
-  const verses = [...allVerses]
-    .sort((a, b) => a - b)
-    .map((verse) => {
-      const e = acc.get(verse) ?? { n: 0, w: 0 };
-      return {
-        verse,
-        rishonim: e.n,
-        rich: e.n >= 3 && e.w >= cutoff,
-        gemara: gem.get(verse) ?? 0,
-        midrash: mid.get(verse) ?? 0,
-      };
-    });
-  const payload = { book, chapter: Number(chapter), verses };
-  c.executionCtx.waitUntil(c.env.CACHE.put(key, JSON.stringify(payload)).then(() => undefined));
-  return c.json(payload);
+  return c.json(await computeSourcesIndex(c.env.CACHE, book, chapter));
 });
 
 // Reverse Gemara lookup: how a verse is used in the Talmud (Sefaria's link

--- a/packages/tanach/src/worker/sources-index.ts
+++ b/packages/tanach/src/worker/sources-index.ts
@@ -1,0 +1,145 @@
+/**
+ * Per-chapter sources index — for each verse, how much commentary / Talmud /
+ * Midrash points at it. Drives the reader's gutter icons (show the commentary
+ * icon only where many comment) AND the warm-cron's per-verse gating (only warm
+ * synthesis where there are commentators, midrash-synthesis where there is
+ * midrash). No LLM — Sefaria fetches only, cached under srcidx:v4:{book}:{chapter}.
+ *
+ * Extracted from the GET /api/sources-index route so the cron can call the same
+ * builder (cache-respecting) without an HTTP round trip.
+ */
+
+import { flattenPieces, pickV3Version } from '@corpus/core/sefaria/client';
+import { COMMENTATORS } from '../lib/commentators.ts';
+import { sefaria } from './sefaria-sources.ts';
+
+export interface SrcIndexVerse {
+  verse: number;
+  /** How many of the curated commentators comment on this verse. */
+  rishonim: number;
+  /** Many commentators AND in the top fraction of the chapter by volume. */
+  rich: boolean;
+  /** Distinct Talmud citations of this verse. */
+  gemara: number;
+  /** Distinct Midrash citations of this verse. */
+  midrash: number;
+}
+export interface SrcIndex {
+  book: string;
+  chapter: number;
+  verses: SrcIndexVerse[];
+}
+
+const indexKey = (book: string, chapter: string) => `srcidx:v4:${book}:${chapter}`;
+
+/** Read the cached index if present (no compute) — the cron uses this to gate
+ *  per-verse warming without paying the Sefaria fetches. */
+export async function readSourcesIndex(
+  cache: KVNamespace,
+  book: string,
+  chapter: string,
+): Promise<SrcIndex | null> {
+  const raw = await cache.get(indexKey(book, chapter));
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as SrcIndex;
+  } catch {
+    return null;
+  }
+}
+
+/** Build (or read from cache) the per-verse sources index for a chapter. */
+export async function computeSourcesIndex(
+  cache: KVNamespace,
+  book: string,
+  chapter: string,
+): Promise<SrcIndex> {
+  const cached = await readSourcesIndex(cache, book, chapter);
+  if (cached) return cached;
+
+  // Per verse: how many commentators, and the total weight (chars of Hebrew
+  // commentary) — volume is a better "richness" signal than count, since in the
+  // Torah almost every verse has several commentators.
+  const acc = new Map<number, { n: number; w: number }>();
+  await Promise.all(
+    COMMENTATORS.map(async (cm) => {
+      try {
+        const v3 = await sefaria.getTextV3(`${cm.title} on ${book} ${chapter}`);
+        const heArr = (() => {
+          const he = pickV3Version(v3.versions, 'he');
+          return Array.isArray(he) ? (he as unknown[]) : [];
+        })();
+        for (let i = 0; i < heArr.length; i++) {
+          const segs = flattenPieces(heArr[i]).map((x) => x.replace(/<[^>]+>/g, '').trim());
+          const chars = segs.join('').length;
+          if (!chars) continue;
+          const e = acc.get(i + 1) ?? { n: 0, w: 0 };
+          e.n += 1;
+          e.w += chars;
+          acc.set(i + 1, e);
+        }
+      } catch {
+        /* commentator absent on this book */
+      }
+    }),
+  );
+  // Talmud + Midrash citation counts per verse, from one chapter-wide links
+  // fetch (Sefaria's link graph). Heavy for the busiest chapters (~6MB) —
+  // best-effort: on failure the icons just don't show, the drawers still work.
+  const gem = new Map<number, number>();
+  const mid = new Map<number, number>();
+  try {
+    const r = await fetch(
+      `https://www.sefaria.org/api/links/${encodeURIComponent(`${book} ${chapter}`)}?with_text=0`,
+    );
+    type Link = { category?: string; anchorVerse?: number; sourceRef?: string; ref?: string };
+    const links = (await r.json()) as Link[];
+    const gemSeen = new Map<number, Set<string>>();
+    const midSeen = new Map<number, Set<string>>();
+    for (const l of Array.isArray(links) ? links : []) {
+      const v = l.anchorVerse;
+      if (!v) continue;
+      const ref = l.sourceRef || l.ref;
+      if (!ref) continue;
+      if (l.category === 'Talmud') {
+        const s = gemSeen.get(v) ?? new Set<string>();
+        s.add(ref);
+        gemSeen.set(v, s);
+      } else if (l.category === 'Midrash') {
+        const s = midSeen.get(v) ?? new Set<string>();
+        s.add(ref);
+        midSeen.set(v, s);
+      }
+    }
+    gemSeen.forEach((s, v) => {
+      gem.set(v, s.size);
+    });
+    midSeen.forEach((s, v) => {
+      mid.set(v, s.size);
+    });
+  } catch {
+    /* links too heavy / unavailable — skip gemara+midrash counts */
+  }
+
+  const entries = [...acc.entries()].sort((a, b) => a[0] - b[0]);
+  // "rich" = many commentators AND in the top fraction of this chapter by volume.
+  const weights = entries.map(([, e]) => e.w).sort((a, b) => a - b);
+  const cutoff = weights.length ? weights[Math.floor(weights.length * 0.6)] : 0;
+  // union of verses that have any source so gemara/midrash-only verses still appear
+  const allVerses = new Set<number>([...acc.keys(), ...gem.keys(), ...mid.keys()]);
+  const verses: SrcIndexVerse[] = [...allVerses]
+    .sort((a, b) => a - b)
+    .map((verse) => {
+      const e = acc.get(verse) ?? { n: 0, w: 0 };
+      return {
+        verse,
+        rishonim: e.n,
+        rich: e.n >= 3 && e.w >= cutoff,
+        gemara: gem.get(verse) ?? 0,
+        midrash: mid.get(verse) ?? 0,
+      };
+    });
+  const payload: SrcIndex = { book, chapter: Number(chapter), verses };
+  await cache.put(indexKey(book, chapter), JSON.stringify(payload));
+  return payload;
+}

--- a/packages/tanach/src/worker/warm-cron.ts
+++ b/packages/tanach/src/worker/warm-cron.ts
@@ -1,19 +1,22 @@
 /**
- * Tanach warm-cron — keeps THIS WEEK'S parsha's chapter-level enrichments warm
- * so the reader opens it instantly (no cold LLM on the Overview / Geography
- * pills or the section anchors).
+ * Tanach warm-cron — keeps THIS WEEK'S parsha fully warm so a reader opening
+ * the weekly portion never waits on a cold LLM, neither on the chapter pills
+ * (Overview / Geography / Tidbit) + section anchors NOR on a verse's commentary
+ * / midrash synthesis.
  *
- * Each tick: resolve the current parsha (Sefaria's calendar), expand it to its
- * chapter range, and warm a small BATCH of {chapter × producer} entries
- * (overview, geography, events), advancing a cursor. Once the whole parsha is
- * warmed the cursor latches and subsequent ticks are no-ops until the parsha
- * changes (the cursor stores the ref and resets when it moves). The producers
- * are cache-respecting (runProducer), so re-touching a warm entry costs nothing
- * — only a genuinely cold chapter pays an LLM call.
+ * Each tick resolves the current parsha (Sefaria's calendar), expands it to its
+ * chapter range, and warms a small BATCH of the not-yet-done work, tracked by a
+ * completed-set cursor:
  *
- * Gentle by design: ~21 entries per double-parsha, BATCH per tick, so a fresh
- * parsha warms over a handful of ticks and steady state is idle. To force a
- * re-warm (e.g. after a producer version bump), delete the cursor key.
+ *   1. chapter-level pills + section anchors (overview, geography, tidbit, events)
+ *   2. the per-chapter sources index (srcidx — no LLM; also gates step 3)
+ *   3. per-VERSE deep content, gated by the index: commentary `synthesis` where
+ *      there are commentators, `midrash-synthesis` where there is midrash.
+ *
+ * Cheap by design: the producers are cache-respecting, so a warmed entry never
+ * re-pays; the cursor records what's done (reset when the parsha changes). The
+ * whole double-parsha is a one-time ~$0.10-0.20 (deepseek-flash), then idle.
+ * Bump CURSOR_KEY to force a re-warm (e.g. a producer version bump).
  */
 
 import { isBook } from '../lib/books.ts';
@@ -23,22 +26,33 @@ import {
   type TanachEnv,
   type TanachRunCtx,
 } from './run-ports.ts';
+import { computeSourcesIndex, readSourcesIndex } from './sources-index.ts';
 
-// v2: the producer set gained `tidbit`; bumping forces a fresh walk so the new
-// producer warms across the current parsha (the rest cache-hit for free).
-const CURSOR_KEY = 'tanach-warm-cursor:v2';
-/** Chapter-level enrichments that power the reader's pills + section labels.
- *  Per-verse pieces (note / commentary / midrash / …) stay on-demand. */
-const PRODUCERS = ['overview', 'geography', 'tidbit', 'events'] as const;
+// v3: the work-list gained the sources index + per-verse synthesis/midrash.
+const CURSOR_KEY = 'tanach-warm-cursor:v3';
+/** Chapter-level enrichments that power the reader's pills + section labels. */
+const CHAPTER_PRODUCERS = ['overview', 'geography', 'tidbit', 'events'] as const;
 /** Entries warmed per tick — small so one invocation stays well within the
  *  scheduled CPU/subrequest budget even when every entry is cold. */
-const BATCH = 4;
+const BATCH = 8;
+
+type WarmEntry =
+  | { kind: 'chapter'; producer: (typeof CHAPTER_PRODUCERS)[number]; chapter: number }
+  | { kind: 'srcindex'; chapter: number }
+  | { kind: 'verse'; producer: 'synthesis' | 'midrash-synthesis'; chapter: number; verse: number };
+
+/** Stable id for the completed-set cursor. */
+function entryId(e: WarmEntry): string {
+  if (e.kind === 'chapter') return `c:${e.chapter}:${e.producer}`;
+  if (e.kind === 'srcindex') return `i:${e.chapter}`;
+  return `v:${e.chapter}:${e.producer}:${e.verse}`;
+}
 
 interface WarmCursor {
-  /** The parsha ref this cursor is walking; a change resets idx to 0. */
+  /** The parsha ref this cursor is for; a change wipes the done-set. */
   ref: string;
-  /** Next index into the (chapter × producer) list; >= length = fully warmed. */
-  idx: number;
+  /** Entry ids already warmed (cache-respecting, so this only grows). */
+  done: string[];
 }
 
 interface ParshaRange {
@@ -72,11 +86,64 @@ async function currentParsha(): Promise<ParshaRange | null> {
 
 async function readCursor(cache: KVNamespace): Promise<WarmCursor> {
   const raw = await cache.get(CURSOR_KEY);
-  if (!raw) return { ref: '', idx: 0 };
+  if (!raw) return { ref: '', done: [] };
   try {
     return JSON.parse(raw) as WarmCursor;
   } catch {
-    return { ref: '', idx: 0 };
+    return { ref: '', done: [] };
+  }
+}
+
+/** The ordered work-list. Pills + section anchors first (the visible surface),
+ *  then the sources indexes, then the per-verse deep content gated by whichever
+ *  indexes are already cached (an uncached chapter contributes a `srcindex`
+ *  entry instead; its verses join the list once that index warms). */
+async function buildWorkList(cache: KVNamespace, parsha: ParshaRange): Promise<WarmEntry[]> {
+  const pills: WarmEntry[] = [];
+  const indexes: WarmEntry[] = [];
+  const verses: WarmEntry[] = [];
+  for (let ch = parsha.startCh; ch <= parsha.endCh; ch++) {
+    for (const producer of CHAPTER_PRODUCERS)
+      pills.push({ kind: 'chapter', producer, chapter: ch });
+    const idx = await readSourcesIndex(cache, parsha.book, String(ch));
+    if (!idx) {
+      indexes.push({ kind: 'srcindex', chapter: ch });
+      continue;
+    }
+    for (const v of idx.verses) {
+      if (v.rishonim > 0)
+        verses.push({ kind: 'verse', producer: 'synthesis', chapter: ch, verse: v.verse });
+      if (v.midrash > 0)
+        verses.push({ kind: 'verse', producer: 'midrash-synthesis', chapter: ch, verse: v.verse });
+    }
+  }
+  return [...pills, ...indexes, ...verses];
+}
+
+async function warmEntry(
+  env: TanachEnv,
+  ctx: ExecutionContext,
+  book: string,
+  e: WarmEntry,
+): Promise<void> {
+  try {
+    if (e.kind === 'srcindex') {
+      await computeSourcesIndex(env.CACHE, book, String(e.chapter));
+      return;
+    }
+    if (e.kind === 'chapter') {
+      const rc: TanachRunCtx = { env, ctx, ref: `${book} ${e.chapter}` };
+      if (e.producer === 'events') await runTanachEvents(rc, book, String(e.chapter));
+      else await runTanachEnrichment(rc, e.producer, book, String(e.chapter), { id: 'perek' });
+      return;
+    }
+    const rc: TanachRunCtx = { env, ctx, ref: `${book} ${e.chapter}:${e.verse}` };
+    await runTanachEnrichment(rc, e.producer, book, String(e.chapter), {
+      id: String(e.verse),
+      verse: String(e.verse),
+    });
+  } catch (err) {
+    console.error(`[tanach-warm] ${entryId(e)} failed:`, err);
   }
 }
 
@@ -85,35 +152,24 @@ export async function runTanachWarm(env: TanachEnv, ctx: ExecutionContext): Prom
   const parsha = await currentParsha();
   if (!parsha) return;
 
-  // The ordered work-list: every chapter of the parsha × the chapter producers.
-  const entries: { chapter: number; producer: (typeof PRODUCERS)[number] }[] = [];
-  for (let ch = parsha.startCh; ch <= parsha.endCh; ch++) {
-    for (const producer of PRODUCERS) entries.push({ chapter: ch, producer });
-  }
-
+  const entries = await buildWorkList(env.CACHE, parsha);
   let cursor = await readCursor(env.CACHE);
-  if (cursor.ref !== parsha.ref) cursor = { ref: parsha.ref, idx: 0 };
-  if (cursor.idx >= entries.length) return; // this parsha is fully warmed
+  if (cursor.ref !== parsha.ref) cursor = { ref: parsha.ref, done: [] };
+  const done = new Set(cursor.done);
 
-  let idx = cursor.idx;
   let warmed = 0;
-  while (warmed < BATCH && idx < entries.length) {
-    const { chapter, producer } = entries[idx];
-    const chap = String(chapter);
-    const rc: TanachRunCtx = { env, ctx, ref: `${parsha.book} ${chapter}` };
-    try {
-      if (producer === 'events') {
-        await runTanachEvents(rc, parsha.book, chap);
-      } else {
-        await runTanachEnrichment(rc, producer, parsha.book, chap, { id: 'perek' });
-      }
-    } catch (e) {
-      console.error(`[tanach-warm] ${producer} ${parsha.book} ${chapter} failed:`, e);
-    }
-    idx++;
+  for (const e of entries) {
+    if (warmed >= BATCH) break;
+    const id = entryId(e);
+    if (done.has(id)) continue;
+    await warmEntry(env, ctx, parsha.book, e);
+    done.add(id);
     warmed++;
   }
 
-  await env.CACHE.put(CURSOR_KEY, JSON.stringify({ ref: parsha.ref, idx } satisfies WarmCursor));
-  console.log(`[tanach-warm] ${parsha.ref}: warmed ${warmed}, cursor ${idx}/${entries.length}`);
+  await env.CACHE.put(
+    CURSOR_KEY,
+    JSON.stringify({ ref: parsha.ref, done: [...done] } satisfies WarmCursor),
+  );
+  console.log(`[tanach-warm] ${parsha.ref}: warmed ${warmed}, done ${done.size}/${entries.length}`);
 }


### PR DESCRIPTION
The warm-cron warmed the chapter pills + section anchors. This folds in the whole parsha's **per-verse deep content** — commentary `synthesis` + `midrash-synthesis` — so every verse's drawers open instantly during the weekly portion. Cost: **~$0.10–0.20 for a double-parsha** (deepseek-flash), once, cached forever (per the live `/usage` ledger).

## How
- **`sources-index.ts`** — extracted `computeSourcesIndex` (+ a read-only `readSourcesIndex`) from the `GET /api/sources-index` route, which is now a thin wrapper (same shape, same `srcidx:v4` key). The index (no LLM, Sefaria-only) records which verses have commentators / midrash.
- **`warm-cron.ts`** — work-list is now: (1) pills + section anchors, (2) the per-chapter sources index, (3) per-verse `synthesis` (where `rishonim>0`) + `midrash-synthesis` (where `midrash>0`) — **gated by the index**, so no blind 404 attempts on empty verses. Switched to a **completed-set cursor** (id-keyed) so the list growing as indexes warm doesn't misalign a numeric cursor; reset on parsha change. `BATCH 8`, cache-respecting, sequential (memory-safe). Cursor key `v3`.

Pills warm first (the visible surface), then the deep content backfills over the next several ticks. A reader opening any verse's commentary/midrash in the parsha gets an instant cache hit.

## Gates
typecheck ✓ · lint ✓ · 49 tanach tests ✓ · build ✓