### PR TITLE
Phase 1b (whole-daf): render whole-daf cards from the one daf-view fetch

### DIFF
--- a/packages/talmud/src/client/DafViewer.tsx
+++ b/packages/talmud/src/client/DafViewer.tsx
@@ -37,6 +37,7 @@ import DafLoadProgress from './DafLoadProgress';
 import { readDevMode, setDevModeActive } from './DevModeShelf';
 import { cancelPrefetch, prefetchDaf } from './dafPrefetch';
 import { setDafRunsTarget } from './dafRunsStore';
+import { loadDafView } from './dafViewStore';
 import { ensureMasechetIncipit } from './ensureMasechetIncipit';
 import { GutterIcons, type GutterKind } from './GutterIcons';
 import { GutterOverlay } from './GutterOverlay';
@@ -469,6 +470,14 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
 
   const ref = createMemo<Ref>(() => ({ tractate: tractate(), page: page() }));
   const [daf] = createResource(ref, fetchDaf);
+
+  // Phase 1: load the materialized daf-view (ONE fetch = all of a daf's cached
+  // pieces) as early as the daf itself, so whole-daf cards (Overview, …) render
+  // from it instead of each firing its own /api/run. Best-effort — a miss just
+  // means the card fetches as before (see dafViewStore).
+  createEffect(() => {
+    void loadDafView(tractate(), page(), lang());
+  });
 
   // Per-daf rabbi list — derived from the `rabbi` mark run (see dafRabbis()
   // below). The legacy /api/daf-context fetch + its dafContext signal were

--- a/packages/talmud/src/client/MarkEnrichmentCards.tsx
+++ b/packages/talmud/src/client/MarkEnrichmentCards.tsx
@@ -29,6 +29,7 @@ import {
 } from 'solid-js';
 import { trackAI } from './aiActivity';
 import { devModeActive } from './DevModeShelf';
+import { dafViewWholeDafResult } from './dafViewStore';
 import {
   isAbort,
   isPausedBody,
@@ -543,6 +544,19 @@ export default function MarkEnrichmentCards(props: Props) {
         );
         if (cached) {
           applyResult(d, s, cached);
+          continue;
+        }
+        // Second tier: the materialized daf-view (one fetch on daf open). Serves
+        // WHOLE-DAF pieces (keyed by producer id) so they render without their
+        // own /api/run. Best-effort + guaranteed-correct key — a miss (view not
+        // loaded, or a per-instance piece) just falls through to the fetch below.
+        const fromView = dafViewWholeDafResult(d.id, props.tractate, props.page, curLang);
+        if (fromView) {
+          runResultCache.set(
+            runCacheKey(d.id, props.tractate, props.page, props.instanceKey, curLang),
+            fromView,
+          );
+          applyResult(d, s, fromView);
           continue;
         }
         const cur = runs()[d.id];

--- a/packages/talmud/src/client/dafViewStore.ts
+++ b/packages/talmud/src/client/dafViewStore.ts
@@ -1,0 +1,99 @@
+/**
+ * Materialized daf-view store (client side of Phase 1).
+ *
+ * On daf open we fetch `GET /api/daf-view/:t/:p` ONCE — all of a daf's cached
+ * pieces in a single (edge-cached) response — and stash it here. A card then
+ * checks this store before firing its own `/api/run`: a hit renders from the
+ * one fetch, a miss falls through to the existing per-piece generate-and-poll.
+ *
+ * This pass wires only the WHOLE-DAF pieces (Overview, background, tidbit,
+ * geography, …), which the view keys by producer id alone — so the lookup is
+ * synchronous and GUARANTEED to match the server key, with no instanceIdOf
+ * bridge. Per-instance section pieces are keyed `producerId::instanceId` and are
+ * intentionally NOT served here yet (they need the async instanceIdOf bridge — a
+ * later pass). Everything here is best-effort: if the view hasn't loaded, fails,
+ * or lacks a piece, the caller just fetches as before — no behaviour change.
+ */
+
+import { createSignal } from 'solid-js';
+import type { RunResult } from './enrichmentQueue';
+
+export interface DafViewPiece {
+  producerId: string;
+  kind: 'mark' | 'enrichment';
+  label: string;
+  instanceId?: string;
+  instanceLabel?: string;
+  parsed: unknown;
+  content?: string;
+  deps_resolved?: Record<string, unknown>;
+}
+
+interface DafViewPayload {
+  complete?: boolean;
+  pieces?: Record<string, DafViewPiece>;
+}
+
+function dafKey(tractate: string, page: string, lang: 'en' | 'he'): string {
+  return `${tractate}:${page}:${lang}`;
+}
+
+// Keyed by daf so a view loaded for a previous daf is never served for the
+// current one (the user navigates while a fetch is in flight).
+const [view, setView] = createSignal<{ key: string; pieces: Record<string, DafViewPiece> } | null>(
+  null,
+);
+
+/**
+ * Fire-and-forget: load the materialized view for a daf and stash it. Called as
+ * early as possible on daf open so it's usually ready by the time a whole-daf
+ * card would otherwise fetch. Best-effort — any failure leaves the store empty
+ * and cards fetch per-piece as before.
+ */
+export async function loadDafView(
+  tractate: string,
+  page: string,
+  lang: 'en' | 'he',
+): Promise<void> {
+  const key = dafKey(tractate, page, lang);
+  try {
+    const r = await fetch(`/api/daf-view/${encodeURIComponent(tractate)}/${page}?lang=${lang}`);
+    if (!r.ok) return;
+    const j = (await r.json()) as DafViewPayload;
+    setView({ key, pieces: j.pieces ?? {} });
+  } catch {
+    /* best-effort: leave the store as-is */
+  }
+}
+
+/** Build a faithful RunResult from a stored view piece (cache_hit, so the card
+ *  renders it as an already-warm result). */
+export function synthRunResult(piece: DafViewPiece): RunResult {
+  return {
+    content: piece.content ?? '',
+    parsed: piece.parsed,
+    parse_error: null,
+    model: '',
+    total_ms: 0,
+    cache_hit: true,
+    deps_resolved: piece.deps_resolved,
+  };
+}
+
+/**
+ * A synthetic RunResult for a WHOLE-DAF piece (keyed by producer id alone), or
+ * undefined when the view isn't loaded for THIS daf or the piece is absent — in
+ * which case the caller fetches per-piece as today. Per-instance pieces
+ * (`producerId::instanceId`) never match here, so they fall through untouched.
+ */
+export function dafViewWholeDafResult(
+  producerId: string,
+  tractate: string,
+  page: string,
+  lang: 'en' | 'he',
+): RunResult | undefined {
+  const v = view();
+  if (!v || v.key !== dafKey(tractate, page, lang)) return undefined;
+  const piece = v.pieces[producerId];
+  return piece ? synthRunResult(piece) : undefined;
+}

--- a/packages/talmud/src/worker/daf-view.ts
+++ b/packages/talmud/src/worker/daf-view.ts
@@ -28,6 +28,9 @@ export interface DafViewPiece {
   instanceLabel?: string;
   /** The structured output the card renders from (RunResult.parsed). */
   parsed: unknown;
+  /** Raw model output (RunResult.content) — the generic fallback renderer reads
+   *  it; included so a client can build a faithful RunResult from the view. */
+  content?: string;
   /** Aggregate enrichments: each dependency's parsed output (RunResult.deps_resolved). */
   deps_resolved?: Record<string, unknown>;
 }

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -2788,6 +2788,7 @@ app.get('/api/daf-view/:tractate/:page', async (c) => {
                 instanceId,
                 instanceLabel: instanceLabel((inst as { fields?: Record<string, unknown> }).fields),
                 parsed: res.parsed,
+                content: res.content,
                 deps_resolved: depsOf(res),
               };
             } else {
@@ -2808,6 +2809,7 @@ app.get('/api/daf-view/:tractate/:page', async (c) => {
             kind: 'enrichment',
             label: def.label,
             parsed: res.parsed,
+            content: res.content,
             deps_resolved: depsOf(res),
           };
         }

--- a/packages/talmud/tests/daf-view-store.test.ts
+++ b/packages/talmud/tests/daf-view-store.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  type DafViewPiece,
+  dafViewWholeDafResult,
+  loadDafView,
+  synthRunResult,
+} from '../src/client/dafViewStore';
+
+function piece(over: Partial<DafViewPiece>): DafViewPiece {
+  return { producerId: 'x', kind: 'enrichment', label: 'X', parsed: {}, ...over };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('synthRunResult', () => {
+  it('builds a faithful cache-hit RunResult from a view piece', () => {
+    const r = synthRunResult(
+      piece({ parsed: { synthesis: 'hi' }, content: 'raw', deps_resolved: { a: 1 } }),
+    );
+    expect(r.cache_hit).toBe(true);
+    expect(r.parsed).toEqual({ synthesis: 'hi' });
+    expect(r.content).toBe('raw');
+    expect(r.deps_resolved).toEqual({ a: 1 });
+    expect(r.parse_error).toBeNull();
+  });
+
+  it('tolerates a piece with no content', () => {
+    expect(synthRunResult(piece({ content: undefined })).content).toBe('');
+  });
+});
+
+describe('loadDafView + dafViewWholeDafResult', () => {
+  function stubFetch(payload: unknown, ok = true) {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify(payload), { status: ok ? 200 : 500 })),
+    );
+  }
+
+  it('serves a WHOLE-DAF piece (keyed by producer id) after the view loads', async () => {
+    stubFetch({
+      pieces: {
+        'argument-overview.synthesis': piece({ producerId: 'argument-overview.synthesis' }),
+      },
+    });
+    await loadDafView('Chullin', '52a', 'en');
+    const r = dafViewWholeDafResult('argument-overview.synthesis', 'Chullin', '52a', 'en');
+    expect(r?.cache_hit).toBe(true);
+  });
+
+  it('does NOT serve per-instance pieces (keyed producerId::instanceId)', async () => {
+    stubFetch({
+      pieces: { 'pesukim.synthesis::abaye': piece({ producerId: 'pesukim.synthesis' }) },
+    });
+    await loadDafView('Chullin', '52a', 'en');
+    // Looking up by the bare producer id must miss — per-instance is a later pass.
+    expect(dafViewWholeDafResult('pesukim.synthesis', 'Chullin', '52a', 'en')).toBeUndefined();
+  });
+
+  it('never serves a view from a DIFFERENT daf or lang (key guard)', async () => {
+    stubFetch({ pieces: { tidbit: piece({ producerId: 'tidbit' }) } });
+    await loadDafView('Chullin', '52a', 'en');
+    expect(dafViewWholeDafResult('tidbit', 'Chullin', '52a', 'en')?.cache_hit).toBe(true);
+    expect(dafViewWholeDafResult('tidbit', 'Chullin', '53a', 'en')).toBeUndefined(); // other page
+    expect(dafViewWholeDafResult('tidbit', 'Chullin', '52a', 'he')).toBeUndefined(); // other lang
+  });
+
+  it('is best-effort: a failed fetch leaves nothing to serve (caller fetches as before)', async () => {
+    stubFetch({}, false);
+    await loadDafView('Berakhot', '2a', 'en');
+    expect(dafViewWholeDafResult('tidbit', 'Berakhot', '2a', 'en')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
The dedicated careful pass, starting with the **safe, guaranteed-correct** slice.

Wires the client to the materialized view (#461/#462) for **whole-daf pieces** — the **Overview (daf entry point)**, background, tidbit, geography. On daf open the client loads `GET /api/daf-view` **once**; a card checks that store before firing its own `/api/run`.

## Why this slice is safe
- Whole-daf pieces are keyed by **producer id alone**, so the lookup is **synchronous** and **guaranteed to match the server key** — none of the async `instanceIdOf` bridge that makes per-instance cards risky.
- **Fails safe:** a miss (view not loaded yet, fetch failed, or a per-instance piece) just falls through to the existing per-piece fetch. **Zero behaviour change on miss** — it's a pure additive cache tier.

## What's here
- **`dafViewStore.ts`**: `loadDafView` (fire-and-forget, keyed per daf+lang so a stale view is never served), `synthRunResult` (faithful cache-hit RunResult), `dafViewWholeDafResult` (whole-daf lookup; per-instance keys intentionally miss).
- **view + handler**: include `content` on enrichment pieces so the synthetic RunResult matches a real `/api/run` result.
- **DafViewer**: loads the view as early as the daf.
- **MarkEnrichmentCards**: a second cache tier between `runResultCache` and `/api/run`.

Per-instance section pieces (argument/pesukim/…) need the async `instanceIdOf` bridge — deliberately the **next** pass; they fall through untouched here.

`typecheck`, `biome ci`, full suite (2512), `build` all green. After deploy I'll verify in a headless browser that the whole-daf cards fire **no** `/api/run` once the view is warm.