### PR TITLE
Tanach tidbit: tune the prompt (Hebrew script, no markdown, non-Torah example)

### DIFF
--- a/packages/tanach/src/worker/producers/defs.ts
+++ b/packages/tanach/src/worker/producers/defs.ts
@@ -226,12 +226,12 @@ export const TANACH_PRODUCERS: Record<TanachProducerId, Producer> = {
     inputs: [{ source: 'chapter-verses' }],
     recipe: { extractor: tidbitExtractor },
     // Chapter-scoped like overview/geography — one per chapter; the key template
-    // ignores the instance (tidbit:v1:{book}:{chapter}).
+    // ignores the instance (tidbit:v2:{book}:{chapter}).
     anchoring: { behavior: 'inherits', precision: 'unit', spine: 'tanach' },
     cardinality: 'one',
     scope: 'local',
-    key_shape: 'enrich', // nominal — template owns tidbit:v1:{book}:{chapter}
-    cacheVersion: '1',
+    key_shape: 'enrich', // nominal — template owns tidbit:v2:{book}:{chapter}
+    cacheVersion: '2',
     source: 'code',
   },
   synthesis: {

--- a/packages/tanach/src/worker/producers/tidbit.ts
+++ b/packages/tanach/src/worker/producers/tidbit.ts
@@ -52,9 +52,9 @@ WHAT TO LOOK FOR (the gold is textual, literary, and human):
 - a vivid, concrete image; a small, telling human beat in a character
 These are often things the tradition's close readers caught. You may surface such a reading — but in plain words ("there is a pun here: the word X also means Y"), as the OBSERVATION, never as a citation survey.
 
-REACH THE TURN. The best tidbits don't stop at a nice point; they turn once more and land somewhere a little surprising about people, language, or faith. Decisive RIGHT/WRONG, on Genesis 22:
-- RIGHT: "Before Isaac is even named, the verse stacks three phrases — 'your son, your only one, whom you love' — each one narrowing the knife. The text slows down exactly where it hurts most." (then turn once more.)
-- WRONG: "God tests Abraham by commanding him to offer Isaac on Mount Moriah; Abraham rises early, travels three days…" — that is a plot recap, which is the Overview pill's job, not the Tidbit's.
+REACH THE TURN. The best tidbits don't stop at a nice point; they turn once more and land somewhere a little surprising about people, language, or faith. Decisive RIGHT/WRONG, on the first chapter of Jonah:
+- RIGHT: "Notice who prays. The pagan sailors cry out — first each to his own god, then to the LORD — and plead not to be charged with an innocent life, while the Hebrew prophet sleeps below deck. The outsiders out-pray the insider; the one man who knows God is the one running from him." (concrete, then turns.)
+- WRONG: "Jonah flees God's command to go to Nineveh, boards a ship to Tarshish, and a great storm threatens to break the ship apart…" — that is a plot recap, which is the Overview pill's job, not the Tidbit's.
 
 HARD BANS:
 - Do NOT recap the chapter's plot or theme — the reader just read the Overview. Open straight on the interesting thing.
@@ -67,6 +67,7 @@ VOICE:
 - Say the point ONCE. Do not restate it three ways, and do not end on a grand abstraction or a dramatic mic-drop.
 - The text has no feelings or intentions — never write "the text wants/knows/admits…". State what it says, or pointedly leaves unsaid.
 - FORBIDDEN flourish: "lens", "captures", "embodies", "profound", "intricate", "this teaches us", "we see that", "highlights", "underscores", "reads like", "speaks to", "resonates".
+- Write Hebrew words/roots in HEBREW SCRIPT (e.g. the root ג־ל־ה, the word חֶסֶד), never Latin-letter transliteration ("bincha", "chesed"). Use NO markdown anywhere — no *italics*, no **bold**, no \`backticks\`; the prose renders literally, so a stray asterisk shows as punctuation.
 
 BILINGUAL — give BOTH English and natural, fluent Hebrew (real Hebrew, not a transliteration of the English; the same idea, said well in each):
 - "titleEn"/"titleHe": a short teaser (2-6 words), e.g. "Three words before the knife".

--- a/packages/tanach/src/worker/run-ports.ts
+++ b/packages/tanach/src/worker/run-ports.ts
@@ -109,7 +109,9 @@ const KEY_TEMPLATES: Record<string, KeyTemplate> = {
   // v2: the output now carries per-place verse numbers (for click-to-highlight).
   geography: { key: (a: TanachAddress) => `geography:v2:${a.unit?.work}:${a.unit?.unit}` },
   // Chapter-scoped like overview/geography (one tidbit per chapter; instance ignored).
-  tidbit: { key: (a: TanachAddress) => `tidbit:v1:${a.unit?.work}:${a.unit?.unit}` },
+  // v2: prompt tuned (Hebrew script over transliteration, no markdown, worked
+  // example swapped off a Torah chapter) — bump regenerates with the new recipe.
+  tidbit: { key: (a: TanachAddress) => `tidbit:v2:${a.unit?.work}:${a.unit?.unit}` },
   synthesis: {
     key: (a: TanachAddress) => `synthesis:v1:${a.unit?.work}:${a.unit?.unit}:${a.verse}`,
   },

--- a/packages/tanach/src/worker/warm-cron.ts
+++ b/packages/tanach/src/worker/warm-cron.ts
@@ -28,8 +28,9 @@ import {
 } from './run-ports.ts';
 import { computeSourcesIndex, readSourcesIndex } from './sources-index.ts';
 
-// v3: the work-list gained the sources index + per-verse synthesis/midrash.
-const CURSOR_KEY = 'tanach-warm-cursor:v3';
+// v4: tidbit prompt bumped to v2 — reset the done-set so the cron re-warms the
+// parsha's tidbits (regenerated under the new recipe; everything else cache-hits).
+const CURSOR_KEY = 'tanach-warm-cursor:v4';
 /** Chapter-level enrichments that power the reader's pills + section labels. */
 const CHAPTER_PRODUCERS = ['overview', 'geography', 'tidbit', 'events'] as const;
 /** Entries warmed per tick — small so one invocation stays well within the


### PR DESCRIPTION
Two fixes from the live trial of the Tidbit pill:

1. **Worked example off Genesis 22 → Jonah 1.** Gen 22 is a Torah chapter the warm-cron generates, and its tidbit echoed the in-prompt example almost verbatim. Jonah 1 teaches the same observation-vs-recap lesson (the pagan sailors out-pray the sleeping prophet) and no weekly parsha chapter mirrors it.
2. **Hebrew script + no markdown.** Added a voice rule: Hebrew words/roots in Hebrew **script** (ג־ל־ה), never Latin transliteration; and **no markdown** — the Genesis trial produced `*bincha*`, which the Prose component renders as a literal asterisk.

Bumped `tidbit` **v1 → v2** (key template + `cacheVersion`) so the parsha regenerates under the improved recipe, and the warm-cron cursor **v3 → v4** so it re-warms the parsha's tidbits (everything else cache-hits).

## Gates
typecheck ✓ · lint ✓ · 49 tanach tests ✓ · build ✓