### PR TITLE
worker-health: widen OOM alert dedupe hourly -> daily

### DIFF
--- a/packages/talmud/src/worker/worker-health.ts
+++ b/packages/talmud/src/worker/worker-health.ts
@@ -171,11 +171,15 @@ export async function checkWorkerHealthAndAlert(env: HealthEnv, nowMs: number): 
 
     const cache = env.CACHE;
     const email = env.EMAIL;
-    const hourBucket = Math.floor(nowMs / 3_600_000);
-    const dedupeKey = `health-alert:fatal:${hourBucket}`;
+    // One alert per DAY per status class. These outcomes are sporadic (a heavy
+    // cron tick / a dense cold daf trips one occasionally), so an hourly alert
+    // just spammed the inbox without adding signal — a daily digest says "it
+    // happened again today" once, which is all the alert needs to convey.
+    const dayBucket = Math.floor(nowMs / 86_400_000);
+    const dedupeKey = `health-alert:fatal:${dayBucket}`;
     if (cache) {
       const already = await cache.get(dedupeKey);
-      if (already) return; // already alerted this hour
+      if (already) return; // already alerted today
     }
     if (email) {
       const lines = Object.entries(outcomes.byStatus ?? {})
@@ -196,7 +200,7 @@ export async function checkWorkerHealthAndAlert(env: HealthEnv, nowMs: number): 
       });
     }
     if (cache) {
-      await cache.put(dedupeKey, '1', { expirationTtl: 3_600 });
+      await cache.put(dedupeKey, '1', { expirationTtl: 86_400 });
     }
   } catch (err) {
     console.error('[health] checkWorkerHealthAndAlert failed:', err);

--- a/packages/talmud/tests/worker-health.test.ts
+++ b/packages/talmud/tests/worker-health.test.ts
@@ -83,8 +83,10 @@ describe('fetchWorkerOutcomes', () => {
 });
 
 describe('checkWorkerHealthAndAlert', () => {
-  it('emails once when an isolate-fatal outcome appears, then dedupes within the hour', async () => {
+  it('emails once per day (deduped within the day, re-alerts the next day)', async () => {
     const sent: unknown[] = [];
+    // One env → its CACHE (KV) persists across calls, so the dedupe key set on
+    // the first alert is seen by later calls.
     const { env, fetchStub } = envWith({
       groups: [
         { sum: { requests: 500 }, dimensions: { status: 'success' } },
@@ -93,11 +95,14 @@ describe('checkWorkerHealthAndAlert', () => {
       email: (m) => sent.push(m),
     });
     vi.stubGlobal('fetch', fetchStub);
-    const now = 1_000_000_000_000;
-    await checkWorkerHealthAndAlert(env, now);
-    await checkWorkerHealthAndAlert(env, now + 60_000); // same hour bucket
-    vi.unstubAllGlobals();
+    const day = 86_400_000;
+    const t0 = 1_000_000_000_000;
+    await checkWorkerHealthAndAlert(env, t0);
+    await checkWorkerHealthAndAlert(env, t0 + 3_600_000); // +1h, same day → deduped
     expect(sent).toHaveLength(1);
+    await checkWorkerHealthAndAlert(env, t0 + day); // next day → re-alerts
+    vi.unstubAllGlobals();
+    expect(sent).toHaveLength(2);
     expect((sent[0] as { subject: string }).subject).toContain('isolate-fatal');
   });
 


### PR DESCRIPTION
The isolate-fatal alerts fire ~once an hour because the outcomes are sporadic (a heavy cron tick or a dense cold daf trips one occasionally). Hourly emails are noise without added signal. Switch the dedupe to **once per day** per status class — re-alerts the next day. Pure alert-noise change; the OOM source fix is separate. Tests updated; typecheck/biome/tests green.