### PR TITLE
Tanach usage: record the provider's billed cost, not just the estimate

### DIFF
--- a/packages/tanach/src/worker/inspect.ts
+++ b/packages/tanach/src/worker/inspect.ts
@@ -68,7 +68,8 @@ export function telemetryOf(
     // pre-envelope payloads — not a real model.
     model: env.model && env.model !== 'legacy-cache' ? env.model : null,
     coldMs: env.elapsed_ms || null,
-    cost: cost ? (cost.estimatedUsd ?? cost.billedUsd ?? null) : null,
+    // Prefer the provider's billed cost; fall back to the price-table estimate.
+    cost: cost ? (cost.billedUsd ?? cost.estimatedUsd ?? null) : null,
     tokens: cost ? cost.tokensIn + cost.tokensOut : null,
   };
 }

--- a/packages/tanach/src/worker/run-ports.ts
+++ b/packages/tanach/src/worker/run-ports.ts
@@ -513,7 +513,10 @@ const RUN_PORTS: RunProducerPorts<TanachRunCtx, TanachEnrichmentDef, TanachMarkD
       model,
       in: usage?.prompt_tokens ?? 0,
       out: usage?.completion_tokens ?? 0,
-      cost: costUsd(model, usage),
+      // Prefer the provider's BILLED cost (u.cost) when the gateway returns it —
+      // the price-table estimate can diverge (it undercounts on some models). Fall
+      // back to the estimate only when no billed figure is available.
+      cost: usage && typeof usage.cost === 'number' ? usage.cost : costUsd(model, usage),
     };
     rc.ctx.waitUntil(recordUsageEntry(rc.env.CACHE, entry));
   },


### PR DESCRIPTION
**Audit finding (you asked to verify usage correctness first).** The `CostStamp` already captures **both** `billedUsd` (the gateway's actual `u.cost`) and `estimatedUsd` (the price-table estimate) — but `/usage`'s `recordUsage` and the inspector's `telemetryOf` both used the **estimate**. So both **understate** whenever the provider bills more than the table predicts (the same ~30% gap flagged for talmud).

Fix — prefer the billed cost, fall back to the estimate:
- `run-ports.ts` `recordUsage`: `cost = u.cost (billed) ?? estimate`.
- `inspect.ts` `telemetryOf`: `billedUsd ?? estimatedUsd`.

No regression when the gateway returns no cost (falls back to the estimate). Historical ledger buckets keep their already-recorded estimates; new traffic records billed.

(Separately known + documented: early ledger buckets predate the per-bucket token fields, so per-producer token totals undercount very early traffic — historical, not fixed here.)

## Gates
typecheck ✓ · lint ✓ · 49 tanach tests ✓