### PR TITLE
Move the run-tree primitives into @corpus/ui (shared inspector foundation)

### DIFF
--- a/packages/talmud/src/client/RunTreeDag.tsx
+++ b/packages/talmud/src/client/RunTreeDag.tsx
@@ -12,16 +12,7 @@
  * the dock is under active development; fold both onto a shared component once
  * that settles.
  */
-import {
-  createEffect,
-  createMemo,
-  createResource,
-  createSignal,
-  For,
-  type JSX,
-  Show,
-} from 'solid-js';
-import { lang } from './i18n';
+
 import {
   ACTIVE_STROKE,
   AuthorityBadge,
@@ -50,7 +41,17 @@ import {
   TOP_PAD,
   type TreeNode,
   variantOf,
-} from './runTreeShared';
+} from '@corpus/ui/RunTree';
+import {
+  createEffect,
+  createMemo,
+  createResource,
+  createSignal,
+  For,
+  type JSX,
+  Show,
+} from 'solid-js';
+import { lang } from './i18n';
 
 export function RunTreeDag(props: {
   tractate: string;

--- a/packages/talmud/src/client/RunTreeDock.tsx
+++ b/packages/talmud/src/client/RunTreeDock.tsx
@@ -17,32 +17,6 @@
  */
 
 import {
-  createEffect,
-  createMemo,
-  createResource,
-  createSignal,
-  For,
-  type JSX,
-  onCleanup,
-  Show,
-} from 'solid-js';
-import {
-  type AnchorGroup as AnchorGroupT,
-  type DafRun,
-  dafRunGroups,
-  dafRunMarks,
-  dafRunRows,
-  dafRunsLoading,
-  liveCounts,
-  liveLoading,
-  pieceToRun,
-  refetchDafRuns,
-  WHOLE_DAF_ANCHOR,
-} from './dafRunsStore';
-import { lang } from './i18n';
-import { inspectRequest } from './inspectBridge';
-import { AnchorTypeIcon, anchorTypeOf } from './inspectVocab';
-import {
   ACTIVE_STROKE,
   AuthorityBadge,
   BADGE_LLM,
@@ -72,7 +46,33 @@ import {
   TOP_PAD,
   type TreeNode,
   variantOf,
-} from './runTreeShared';
+} from '@corpus/ui/RunTree';
+import {
+  createEffect,
+  createMemo,
+  createResource,
+  createSignal,
+  For,
+  type JSX,
+  onCleanup,
+  Show,
+} from 'solid-js';
+import {
+  type AnchorGroup as AnchorGroupT,
+  type DafRun,
+  dafRunGroups,
+  dafRunMarks,
+  dafRunRows,
+  dafRunsLoading,
+  liveCounts,
+  liveLoading,
+  pieceToRun,
+  refetchDafRuns,
+  WHOLE_DAF_ANCHOR,
+} from './dafRunsStore';
+import { lang } from './i18n';
+import { inspectRequest } from './inspectBridge';
+import { AnchorTypeIcon, anchorTypeOf } from './inspectVocab';
 
 // DafRun (the shared snapshot row) is imported from dafRunsStore — the load bar
 // reads the same rows, so the two surfaces can't drift.

--- a/packages/talmud/src/client/dafRunsProgress.ts
+++ b/packages/talmud/src/client/dafRunsProgress.ts
@@ -5,7 +5,7 @@
  * Solid's SSR build under vitest). The store re-exports these.
  */
 
-import type { Authority, Staleness } from './runTreeShared';
+import type { Authority, Staleness } from '@corpus/ui/RunTree';
 
 export interface DafRun {
   id: string;

--- a/packages/talmud/tests/client/run-tree-provenance.test.tsx
+++ b/packages/talmud/tests/client/run-tree-provenance.test.tsx
@@ -1,13 +1,14 @@
 // @vitest-environment jsdom
-import { render } from '@solidjs/testing-library';
-import { describe, expect, it } from 'vitest';
+
 import {
   AuthorityBadge,
   ProvenanceSection,
   StalenessDot,
   stalenessTitle,
   type TreeNode,
-} from '../../src/client/runTreeShared';
+} from '@corpus/ui/RunTree';
+import { render } from '@solidjs/testing-library';
+import { describe, expect, it } from 'vitest';
 
 describe('stalenessTitle', () => {
   it('names WHY for each verdict', () => {

--- a/packages/talmud/tests/inspect-vocab.test.ts
+++ b/packages/talmud/tests/inspect-vocab.test.ts
@@ -1,6 +1,6 @@
+import { variantOf } from '@corpus/ui/RunTree';
 import { describe, expect, it } from 'vitest';
 import { anchorTypeOf } from '../src/client/inspectVocab';
-import { variantOf } from '../src/client/runTreeShared';
 
 describe('anchorTypeOf — traditional labels for the anchor types', () => {
   it('maps mark ids to the traditional terms (falls back to the id)', () => {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -26,7 +26,8 @@
     "./LangToggle": "./src/LangToggle.tsx",
     "./GeoMap": "./src/GeoMap.tsx",
     "./LoadProgress": "./src/LoadProgress.tsx",
-    "./InspectorRow": "./src/InspectorRow.tsx"
+    "./InspectorRow": "./src/InspectorRow.tsx",
+    "./RunTree": "./src/RunTree.tsx"
   },
   "peerDependencies": {
     "solid-js": "^1.9.0"

--- a/packages/ui/src/RunTree.tsx
+++ b/packages/ui/src/RunTree.tsx
@@ -5,8 +5,9 @@
  * node icon, and the small formatters. One source of truth so the two surfaces
  * can never drift in their graph maths or visuals.
  */
-import { fmtCost, fmtMs } from '@corpus/ui/format';
+
 import { For, type JSX, Match, Show, Switch } from 'solid-js';
+import { fmtCost, fmtMs } from './format.ts';
 
 // Display formatters now live in @corpus/ui (single source of truth, shared
 // with tanach's inspect panel); re-exported so existing run-tree imports keep


### PR DESCRIPTION
Foundation for genuinely sharing the Inspect **waterfall + DAG** (not just the row).

The build-provenance primitives — `TreeNode`/`RunTree` types, the DAG layout math (`computeLayout`/`assignLanes`/`edgePath`), the node icon, authority/staleness badges, the provenance section — lived in talmud's `runTreeShared.tsx` but are **pure** (only `@corpus/ui/format` + solid-js). Tanach can't import from talmud's package, so they move to **`@corpus/ui/RunTree`**.

- `packages/ui/src/RunTree.tsx` (moved; internal format import made relative).
- `@corpus/ui` exports `./RunTree`.
- Talmud's `RunTreeDag` / `RunTreeDock` / `dafRunsProgress` + two tests now import the shared module. **Pure move, zero behaviour change.**

Next PR: a tanach `/api/run-tree` endpoint (walk the producer dependency graph → `RunTree`) + render the shared waterfall + DAG in the tanach inspector. (Honest caveat we discussed: tanach's DAG will be shallow — its producers depend on sources, not each other — but the waterfall is fully meaningful and both apps will share one renderer.)

## Gates
typecheck ✓ · lint ✓ · 2512 talmud + 49 tanach tests ✓ · all builds ✓