### PR TITLE
Cron: one heavy phase per tick (rotating) + trim spine window

### DIFF
--- a/packages/talmud/src/worker/cron-schedule.ts
+++ b/packages/talmud/src/worker/cron-schedule.ts
@@ -1,0 +1,27 @@
+/**
+ * Cron phase scheduling.
+ *
+ * The 5-minute warm cron used to run THREE heavy phases in one invocation —
+ * connect-sweep, the warm cron (observations + dafyomi + source warming), and
+ * the spine-view snapshot (which holds a growing per-tractate accumulator and
+ * builds a window of dapim concurrently). Stacked in one 128 MB isolate, that
+ * cumulative footprint was the suspected source of the sporadic `exceededMemory`
+ * cron OOMs.
+ *
+ * Fix: run ONE heavy phase per tick, rotating. Each phase is cursor-resumable,
+ * so running it every 3rd tick (~15 min) just paces the background warming —
+ * nothing is skipped — while a single invocation only ever holds one phase's
+ * memory. Pure + tested so the rotation can't silently regress.
+ */
+
+export type CronHeavyPhase = 'connect' | 'warm' | 'spine';
+
+const ROTATION: readonly CronHeavyPhase[] = ['connect', 'warm', 'spine'];
+const TICK_MS = 300_000; // the */5 cron interval
+
+/** Which heavy phase this 5-min tick should run. Derived from the scheduled
+ *  time so it's deterministic across the fleet (no shared counter needed). */
+export function cronHeavyPhase(scheduledTimeMs: number): CronHeavyPhase {
+  const tick = Math.floor(scheduledTimeMs / TICK_MS);
+  return ROTATION[((tick % ROTATION.length) + ROTATION.length) % ROTATION.length];
+}

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -170,6 +170,7 @@ import {
 import { fetchCommentaryWorks, registerCommentaryRoutes } from './commentary';
 import { aiMatchToSegments } from './context-match';
 import { collectContext, type SourceTiming } from './context-providers';
+import { cronHeavyPhase } from './cron-schedule';
 import { dafCostReport } from './daf-cost';
 import { recordEnrichmentDafIndex, recordMarkDafIndex } from './daf-index';
 import {
@@ -1899,7 +1900,11 @@ app.get('/api/derived-flow/:tractate/:page', async (c) => {
 // pass, so newly-warmed dapim + human edits flow in on the next lap. Gated by
 // SPINE_VIEW_WARM_SHAS.
 const SPINE_VIEW_CURSOR_KEY = 'spine-view-cursor:v1';
-const SPINE_VIEW_WINDOW = 20; // warmed dapim built per tick (~240 KV reads)
+// Dapim built per tick. Each build loads a daf's pieces, and they run
+// concurrently, so this is the spine-snapshot's peak-memory knob. 10 (was 20)
+// keeps the build spike well within the isolate even though the phase now also
+// runs alone on its own rotated tick (see cron-schedule.ts).
+const SPINE_VIEW_WINDOW = 10;
 interface SpineViewCursor {
   tractateIdx: number;
   amudIdx: number; // index into the WARMED-pages list of the current tractate
@@ -11302,13 +11307,16 @@ export default {
         runBacklogBackfill(wrapped, (n, nHe, g) => enrichRabbi(n, nHe, g as GenerationId)).then(
           async (r) => {
             if (r) return; // backfill ran this tick — give it the full budget
-            // Connect-only cross-daf sweep first (bounded + cheap, so it always
-            // makes a little progress), then the source warm cron uses the rest.
-            await runConnectSweep(wrapped).catch(() => {});
-            await runWarmCron(wrapped);
-            // Last (and self-gated by SPINE_VIEW_WARM_SHAS): build a window of the
-            // per-tractate spine-view snapshot shelf from the now-warmed pieces.
-            await runSpineViewSnapshot(wrapped);
+            // Run ONE heavy phase per tick, rotating, so a single 5-min
+            // invocation never holds connect-sweep + warm-cron + spine-snapshot
+            // memory at once (their stacked footprint was the suspected source of
+            // the sporadic exceededMemory cron OOMs). Each phase is
+            // cursor-resumable, so every-3rd-tick just paces the background
+            // warming — nothing is skipped. See cron-schedule.ts.
+            const phase = cronHeavyPhase(controller.scheduledTime || Date.now());
+            if (phase === 'connect') await runConnectSweep(wrapped).catch(() => {});
+            else if (phase === 'warm') await runWarmCron(wrapped);
+            else await runSpineViewSnapshot(wrapped);
           },
         ),
       );

--- a/packages/talmud/tests/cron-schedule.test.ts
+++ b/packages/talmud/tests/cron-schedule.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { type CronHeavyPhase, cronHeavyPhase } from '../src/worker/cron-schedule';
+
+// Guards the memory fix: the three heavy cron phases must run on SEPARATE ticks
+// (rotating), so one 5-min invocation never stacks all three in a 128 MB isolate.
+describe('cronHeavyPhase', () => {
+  const TICK = 300_000;
+
+  it('rotates connect -> warm -> spine across consecutive ticks', () => {
+    const seq: CronHeavyPhase[] = [0, 1, 2, 3, 4, 5].map((k) => cronHeavyPhase(k * TICK));
+    expect(seq).toEqual(['connect', 'warm', 'spine', 'connect', 'warm', 'spine']);
+  });
+
+  it('only ever returns one phase (never runs two heavy phases the same tick)', () => {
+    for (let k = 0; k < 30; k++) {
+      expect(['connect', 'warm', 'spine']).toContain(cronHeavyPhase(k * TICK));
+    }
+  });
+
+  it('is stable within a tick and changes across the 5-min boundary', () => {
+    const t = 1_000_000 * TICK;
+    expect(cronHeavyPhase(t)).toBe(cronHeavyPhase(t + TICK - 1)); // same tick
+    expect(cronHeavyPhase(t)).not.toBe(cronHeavyPhase(t + TICK)); // next tick rotates
+  });
+
+  it('handles t=0 and never throws on the modulo (no negative-index gap)', () => {
+    expect(cronHeavyPhase(0)).toBe('connect');
+  });
+});


### PR DESCRIPTION
**Fixes the source of the worker-health OOM alert emails.**

The 5-min warm cron ran **all three** heavy phases in one invocation: connect-sweep + warm-cron (observations + dafyomi + source warm) + the spine-view snapshot. The spine-snapshot holds a **growing per-tractate accumulator** and built **20 dapim concurrently** — stacked with the other phases in one 128 MB isolate, that cumulative footprint is the suspected source of the sporadic `exceededMemory` cron OOMs.

## Fix
- **Rotate**: run ONE heavy phase per tick (`cron-schedule.ts`: connect → warm → spine by 5-min tick number). Each phase is cursor-resumable, so running it every 3rd tick (~15 min) just paces the background warming — **nothing is skipped** — while a single invocation only ever holds **one** phase's memory.
- **Trim** `SPINE_VIEW_WINDOW` 20 → 10 so even that phase's concurrent-build spike is comfortably within the isolate.

Pairs with #467 (alert dedupe hourly → daily) — that quiets the inbox, this removes the root. The daily yomi-cron (separate) still pre-warms tomorrow's daf, so daf-yomi readiness is unaffected.

`tests/cron-schedule.test.ts` pins the rotation. typecheck / biome / full suite green.