### PR TITLE
Tanach inspector: the shared waterfall (ranked cold-build bars)

### DIFF
--- a/packages/tanach/src/client/Inspector.tsx
+++ b/packages/tanach/src/client/Inspector.tsx
@@ -1,14 +1,14 @@
 /**
- * Chapter inspector — a panel listing what's cached for the open chapter and
- * what each piece cost, the tanach analogue of the talmud reader's Inspect
- * waterfall. Reads GET /api/chapter-runs/:book/:chapter (the cache is the
- * index) and renders one row per producer piece: a hit/miss dot, its label
- * (+ verse/range), generation time, and cost. Rendered in the shared <Drawer>.
+ * Chapter inspector — the build-provenance WATERFALL for the open chapter, the
+ * tanach analogue of the talmud reader's Inspect waterfall (same shared
+ * @corpus/ui/RunWaterfall renderer). Reads GET /api/chapter-runs/:book/:chapter
+ * (the cache is the index) and ranks each producer piece by cold-build time,
+ * with its cost + cache status. Rendered in the shared <Drawer>.
  */
 
 import { Drawer } from '@corpus/ui/Drawer';
-import { fmtCost, fmtMs, InspectorRow } from '@corpus/ui/InspectorRow';
-import { createResource, For, type JSX, Show } from 'solid-js';
+import { RunWaterfall, type WaterfallRow } from '@corpus/ui/RunWaterfall';
+import { createResource, type JSX, Show } from 'solid-js';
 
 interface RunRow {
   id: string;
@@ -40,6 +40,20 @@ export function Inspector(props: {
     },
   );
 
+  // The chapter's producer runs as waterfall rows. `events` is a mark; the rest
+  // are enrichments (drives the run-tree icon).
+  const rows = (): WaterfallRow[] =>
+    (runs()?.runs ?? []).map((r) => ({
+      id: `${r.id}:${r.instance ?? ''}`,
+      label: r.label,
+      instance: r.instance,
+      cached: r.cached,
+      coldMs: r.coldMs,
+      cost: r.cost,
+      tokens: r.tokens,
+      variant: r.id === 'events' ? 'mark' : 'enrichment',
+    }));
+
   return (
     <Drawer
       title={`${props.book} ${props.chapter}`}
@@ -52,26 +66,11 @@ export function Inspector(props: {
       </Show>
       <Show when={runs()}>
         {(r) => (
-          <>
-            <div class="inspect-totals">
-              {r().totals.cached}/{r().totals.count} cached · {fmtCost(r().totals.cost)} ·{' '}
-              {fmtMs(r().totals.coldMs)}
-            </div>
-            <For
-              each={r().runs}
-              fallback={<p class="comm-muted">Nothing cached yet for this chapter.</p>}
-            >
-              {(run) => (
-                <InspectorRow
-                  cached={run.cached}
-                  label={run.label}
-                  instance={run.instance}
-                  coldMs={run.coldMs}
-                  cost={run.cost}
-                />
-              )}
-            </For>
-          </>
+          <RunWaterfall
+            rows={rows()}
+            totals={r().totals}
+            emptyLabel="Nothing cached yet for this chapter."
+          />
         )}
       </Show>
     </Drawer>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -27,7 +27,8 @@
     "./GeoMap": "./src/GeoMap.tsx",
     "./LoadProgress": "./src/LoadProgress.tsx",
     "./InspectorRow": "./src/InspectorRow.tsx",
-    "./RunTree": "./src/RunTree.tsx"
+    "./RunTree": "./src/RunTree.tsx",
+    "./RunWaterfall": "./src/RunWaterfall.tsx"
   },
   "peerDependencies": {
     "solid-js": "^1.9.0"

--- a/packages/ui/src/RunWaterfall.tsx
+++ b/packages/ui/src/RunWaterfall.tsx
@@ -1,0 +1,114 @@
+/**
+ * @corpus/ui — RunWaterfall.
+ *
+ * The build-provenance WATERFALL: every piece run for a unit (daf / chapter),
+ * ranked by cold-build time, each row a labelled bar + cost — the same view the
+ * Talmud reader's Inspect dock shows, on the shared run-tree primitives so both
+ * apps read identically. The app feeds rows (from /api/daf-runs or
+ * /api/chapter-runs); this just renders. Styling: `.runwf-*` in inspector.css.
+ */
+
+import { For, type JSX, Show } from 'solid-js';
+import { fmtCost, fmtMs, type IconVariant, NodeIcon } from './RunTree.tsx';
+
+export interface WaterfallRow {
+  id: string;
+  label: string;
+  /** Per-instance discriminator (verse / range) or null for a whole-unit piece. */
+  instance?: string | null;
+  cached: boolean;
+  coldMs: number | null;
+  cost: number | null;
+  tokens?: number | null;
+  /** Icon kind; defaults to 'enrichment'. */
+  variant?: IconVariant;
+}
+
+export interface RunWaterfallProps {
+  rows: WaterfallRow[];
+  totals?: { count: number; cached: number; cost: number; coldMs: number };
+  /** Click a row (e.g. to open its DAG). Rows become buttons when provided. */
+  onSelect?: (id: string) => void;
+  emptyLabel?: string;
+}
+
+const ICON_COLOR: Record<IconVariant, string> = {
+  source: '#6b7280',
+  mark: '#1d4ed8',
+  enrichment: '#7c3aed',
+  computed: '#0891b2',
+};
+
+export function RunWaterfall(props: RunWaterfallProps): JSX.Element {
+  // Ranked by cold-build time (the expensive pieces float up); a warm reload is
+  // all near-zero, a cold load shows the real shape.
+  const sorted = () => [...props.rows].sort((a, b) => (b.coldMs ?? 0) - (a.coldMs ?? 0));
+  const maxCold = () => Math.max(1, ...props.rows.map((r) => r.coldMs ?? 0));
+
+  return (
+    <div class="runwf">
+      <Show when={props.totals}>
+        {(t) => (
+          <div class="inspect-totals">
+            {t().cached}/{t().count} cached · {fmtCost(t().cost)} · {fmtMs(t().coldMs)}
+          </div>
+        )}
+      </Show>
+      <For
+        each={sorted()}
+        fallback={<p class="comm-muted">{props.emptyLabel ?? 'Nothing cached yet.'}</p>}
+      >
+        {(r) => {
+          const variant = r.variant ?? 'enrichment';
+          const pct = r.coldMs ? Math.max(2, Math.round((r.coldMs / maxCold()) * 100)) : 0;
+          const clickable = !!props.onSelect;
+          return (
+            // biome-ignore lint/a11y/noStaticElementInteractions: a waterfall row can't be a real <button> (it's a flex bar layout); role=button + tabindex + keydown make it keyboard-operable
+            <div
+              class="runwf-row"
+              classList={{ clickable }}
+              role={clickable ? 'button' : undefined}
+              tabindex={clickable ? 0 : undefined}
+              title={clickable ? `Inspect ${r.label}` : undefined}
+              onClick={() => props.onSelect?.(r.id)}
+              onKeyDown={(e) => {
+                if (clickable && (e.key === 'Enter' || e.key === ' ')) {
+                  e.preventDefault();
+                  props.onSelect?.(r.id);
+                }
+              }}
+            >
+              <span
+                class="inspect-dot"
+                classList={{ hit: r.cached }}
+                title={r.cached ? 'cached' : 'not cached'}
+              />
+              <span class="runwf-icon">
+                <NodeIcon variant={variant} color={ICON_COLOR[variant]} />
+              </span>
+              <span class="runwf-label">
+                {r.label}
+                <Show when={r.instance}>{(i) => <span class="inspect-inst"> · {i()}</span>}</Show>
+              </span>
+              <span class="runwf-bar">
+                <Show when={pct > 0}>
+                  <span class="runwf-fill" style={{ width: `${pct}%` }} />
+                </Show>
+              </span>
+              <span class="runwf-meta">
+                <Show when={r.cached} fallback={<span class="inspect-miss">miss</span>}>
+                  <Show when={r.coldMs}>
+                    {(ms) => <span class="inspect-ms">{fmtMs(ms())}</span>}
+                  </Show>
+                  <Show when={r.cost != null}>
+                    <span class="inspect-cost">{fmtCost(r.cost)}</span>
+                  </Show>
+                </Show>
+              </span>
+            </div>
+          );
+        }}
+      </For>
+    </div>
+  );
+}

--- a/packages/ui/src/inspector.css
+++ b/packages/ui/src/inspector.css
@@ -4,6 +4,64 @@
  * tokens. The panel shell (a Drawer / dock) and the data are the app's.
  */
 
+/* waterfall: pieces ranked by cold-build time, each a labelled bar + cost */
+.runwf-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 0;
+  font-family: var(--font-ui);
+  font-size: 13px;
+}
+.runwf-row + .runwf-row {
+  border-top: 1px dashed var(--line);
+}
+.runwf-row.clickable {
+  cursor: pointer;
+}
+.runwf-row.clickable:hover {
+  background: var(--surface-sunk);
+}
+.runwf-row.clickable:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+.runwf-icon {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+}
+.runwf-label {
+  flex: 0 0 32%;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  color: var(--fg);
+}
+.runwf-bar {
+  flex: 1;
+  height: 6px;
+  border-radius: 3px;
+  background: var(--surface-sunk);
+  overflow: hidden;
+}
+.runwf-fill {
+  display: block;
+  height: 100%;
+  border-radius: 3px;
+  background: var(--accent);
+  opacity: 0.55;
+}
+.runwf-meta {
+  flex-shrink: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
 .inspect-totals {
   font-family: var(--font-ui);
   font-size: 12px;


### PR DESCRIPTION
Tanach's `chapter-runs` already carried per-piece cost/time/cached, but the inspector rendered a **flat list** while talmud shows a ranked **waterfall**. This gives tanach the same view via a shared **`@corpus/ui/RunWaterfall`** (built on the run-tree primitives moved in #469): pieces **ranked by cold-build time**, each a labelled bar + cost + cache dot + producer icon, with the totals header.

- `packages/ui/src/RunWaterfall.tsx` — generic waterfall over `WaterfallRow[]`, with an `onSelect` hook (for opening a piece's DAG in the next stage). `.runwf-*` styling in `inspector.css`.
- Tanach `Inspector` renders `RunWaterfall` from `/api/chapter-runs` (`events` = mark, the rest enrichment, for the icon).

Next stage (the DAG you asked for): a tanach `/api/run-tree` endpoint (walk the producer dependency graph → `RunTree`) + wire the shared DAG view to `onSelect`. As discussed, tanach's DAG will be shallow (producers depend on sources, not each other), but it'll be the same renderer.

## Gates
typecheck ✓ · lint ✓ · 2512 talmud + 49 tanach tests ✓ · all builds ✓