### PR TITLE
Phase 1b (per-instance): render section cards from the daf-view

### DIFF
--- a/packages/talmud/src/client/MarkEnrichmentCards.tsx
+++ b/packages/talmud/src/client/MarkEnrichmentCards.tsx
@@ -17,6 +17,7 @@
  * falls back to a generic key/value dump of the parsed JSON.
  */
 
+import { instanceIdOf } from '@corpus/core/cache/keys';
 import {
   createEffect,
   createResource,
@@ -29,7 +30,7 @@ import {
 } from 'solid-js';
 import { trackAI } from './aiActivity';
 import { devModeActive } from './DevModeShelf';
-import { dafViewWholeDafResult } from './dafViewStore';
+import { dafViewLoaded, dafViewPieceResult, dafViewWholeDafResult } from './dafViewStore';
 import {
   isAbort,
   isPausedBody,
@@ -527,6 +528,17 @@ export default function MarkEnrichmentCards(props: Props) {
     controller.signal.addEventListener('abort', onAbort, { once: true });
   };
 
+  // Server instance id (the `instanceIdOf` hash the daf-view stores per-instance
+  // pieces under) for THIS card's instance. Computed async (recomputed if the
+  // instance changes); '' on the rare hash error so the gate below still
+  // resolves and the card fetches. `undefined` = not settled yet.
+  const [instIid, setInstIid] = createSignal<string | undefined>(undefined);
+  createEffect(() => {
+    const inst = props.instance;
+    setInstIid(undefined);
+    void instanceIdOf(inst).then(setInstIid, () => setInstIid(''));
+  });
+
   createEffect(() => {
     const list = matching();
     if (list.length === 0) return;
@@ -535,6 +547,11 @@ export default function MarkEnrichmentCards(props: Props) {
     // language the request was actually fired with (not whatever lang is active
     // when the promise resolves, which may have flipped mid-flight).
     const curLang = lang();
+    // Tracked reads (outside untrack) so this effect re-runs when the daf-view
+    // loads or the instance-id hash settles — that's what lets per-instance
+    // cards render from the view instead of fetching.
+    const iid = instIid();
+    const viewReady = dafViewLoaded(props.tractate, props.page, curLang);
     const controller = new AbortController();
     onCleanup(() => controller.abort());
     untrack(() => {
@@ -558,6 +575,26 @@ export default function MarkEnrichmentCards(props: Props) {
           );
           applyResult(d, s, fromView);
           continue;
+        }
+        // Third tier: PER-INSTANCE daf-view pieces (keyed producerId::instanceId).
+        // Only when the view is loaded (a hit is possible) — and gate on the
+        // instanceId hash: if it hasn't settled, wait (this effect re-runs when it
+        // does) rather than fetch-then-miss. The hash settles in ~1ms, so the gate
+        // is imperceptible; if the view isn't loaded we skip the gate and fetch as
+        // today. Fail-safe: any miss falls through to the fetch below.
+        if (viewReady) {
+          if (iid === undefined) continue; // hash not settled yet — re-runs on settle
+          const fromInstance = iid
+            ? dafViewPieceResult(d.id, iid, props.tractate, props.page, curLang)
+            : undefined;
+          if (fromInstance) {
+            runResultCache.set(
+              runCacheKey(d.id, props.tractate, props.page, props.instanceKey, curLang),
+              fromInstance,
+            );
+            applyResult(d, s, fromInstance);
+            continue;
+          }
         }
         const cur = runs()[d.id];
         if (cur && cur.kind !== 'idle' && cur.stamp === s) continue;

--- a/packages/talmud/src/client/dafViewStore.ts
+++ b/packages/talmud/src/client/dafViewStore.ts
@@ -97,3 +97,31 @@ export function dafViewWholeDafResult(
   const piece = v.pieces[producerId];
   return piece ? synthRunResult(piece) : undefined;
 }
+
+/** True once the view has loaded for THIS daf+lang (reactive: reads the view
+ *  signal). Per-instance card priming gates on this — only worth computing the
+ *  instanceId hash + checking the view when a hit is actually possible. */
+export function dafViewLoaded(tractate: string, page: string, lang: 'en' | 'he'): boolean {
+  const v = view();
+  return !!v && v.key === dafKey(tractate, page, lang);
+}
+
+/**
+ * A synthetic RunResult for a PER-INSTANCE piece, keyed `producerId::instanceId`
+ * (the server's pieceKey for per-instance enrichments). `instanceId` is the
+ * caller's `instanceIdOf(instance)` (the same async hash the server keyed by).
+ * Undefined → not loaded for this daf, or this instance isn't cached → the
+ * caller fetches as today.
+ */
+export function dafViewPieceResult(
+  producerId: string,
+  instanceId: string,
+  tractate: string,
+  page: string,
+  lang: 'en' | 'he',
+): RunResult | undefined {
+  const v = view();
+  if (!v || v.key !== dafKey(tractate, page, lang)) return undefined;
+  const piece = v.pieces[`${producerId}::${instanceId}`];
+  return piece ? synthRunResult(piece) : undefined;
+}

--- a/packages/talmud/tests/daf-view-store.test.ts
+++ b/packages/talmud/tests/daf-view-store.test.ts
@@ -1,10 +1,15 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   type DafViewPiece,
+  dafViewLoaded,
+  dafViewPieceResult,
   dafViewWholeDafResult,
   loadDafView,
   synthRunResult,
 } from '../src/client/dafViewStore';
+// The SERVER's key function — the client lookups must agree with it byte-for-byte
+// or the bridge silently misses every piece.
+import { pieceKey } from '../src/worker/daf-view';
 
 function piece(over: Partial<DafViewPiece>): DafViewPiece {
   return { producerId: 'x', kind: 'enrichment', label: 'X', parsed: {}, ...over };
@@ -55,7 +60,8 @@ describe('loadDafView + dafViewWholeDafResult', () => {
       pieces: { 'pesukim.synthesis::abaye': piece({ producerId: 'pesukim.synthesis' }) },
     });
     await loadDafView('Chullin', '52a', 'en');
-    // Looking up by the bare producer id must miss — per-instance is a later pass.
+    // The whole-daf lookup (bare producer id) must miss a producerId::instanceId
+    // key — the per-instance tier (below) owns those; the two must not collide.
     expect(dafViewWholeDafResult('pesukim.synthesis', 'Chullin', '52a', 'en')).toBeUndefined();
   });
 
@@ -71,5 +77,115 @@ describe('loadDafView + dafViewWholeDafResult', () => {
     stubFetch({}, false);
     await loadDafView('Berakhot', '2a', 'en');
     expect(dafViewWholeDafResult('tidbit', 'Berakhot', '2a', 'en')).toBeUndefined();
+  });
+});
+
+describe('dafViewLoaded', () => {
+  function stubFetch(payload: unknown) {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify(payload), { status: 200 })),
+    );
+  }
+
+  it('is true only after the view loads, for the SAME daf+lang', async () => {
+    stubFetch({ pieces: { tidbit: piece({ producerId: 'tidbit' }) } });
+    await loadDafView('Eruvin', '13a', 'en');
+    expect(dafViewLoaded('Eruvin', '13a', 'en')).toBe(true);
+    expect(dafViewLoaded('Eruvin', '13b', 'en')).toBe(false); // other page
+    expect(dafViewLoaded('Eruvin', '13a', 'he')).toBe(false); // other lang
+    expect(dafViewLoaded('Shabbat', '2a', 'en')).toBe(false); // other tractate
+  });
+});
+
+describe('dafViewPieceResult (per-instance tier)', () => {
+  function stubFetch(payload: unknown) {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify(payload), { status: 200 })),
+    );
+  }
+
+  it('serves a per-instance piece by producerId + instanceId (the instanceIdOf hash)', async () => {
+    stubFetch({
+      pieces: {
+        'pesukim.synthesis::abc123': piece({
+          producerId: 'pesukim.synthesis',
+          instanceId: 'abc123',
+          parsed: { synthesis: 'p' },
+        }),
+      },
+    });
+    await loadDafView('Chullin', '52a', 'en');
+    const r = dafViewPieceResult('pesukim.synthesis', 'abc123', 'Chullin', '52a', 'en');
+    expect(r?.cache_hit).toBe(true);
+    expect(r?.parsed).toEqual({ synthesis: 'p' });
+  });
+
+  it('misses for a wrong/unknown instanceId (caller fetches that instance)', async () => {
+    stubFetch({
+      pieces: { 'pesukim.synthesis::abc123': piece({ producerId: 'pesukim.synthesis' }) },
+    });
+    await loadDafView('Chullin', '52a', 'en');
+    expect(
+      dafViewPieceResult('pesukim.synthesis', 'WRONG', 'Chullin', '52a', 'en'),
+    ).toBeUndefined();
+  });
+
+  it('does NOT match a whole-daf piece (keyed by bare producer id)', async () => {
+    stubFetch({ pieces: { tidbit: piece({ producerId: 'tidbit' }) } });
+    await loadDafView('Chullin', '52a', 'en');
+    expect(dafViewPieceResult('tidbit', 'anything', 'Chullin', '52a', 'en')).toBeUndefined();
+  });
+
+  it('respects the daf+lang key guard', async () => {
+    stubFetch({
+      pieces: {
+        'halacha.synthesis::h1': piece({ producerId: 'halacha.synthesis', instanceId: 'h1' }),
+      },
+    });
+    await loadDafView('Chullin', '52a', 'en');
+    expect(dafViewPieceResult('halacha.synthesis', 'h1', 'Chullin', '52a', 'en')?.cache_hit).toBe(
+      true,
+    );
+    expect(dafViewPieceResult('halacha.synthesis', 'h1', 'Chullin', '53a', 'en')).toBeUndefined();
+    expect(dafViewPieceResult('halacha.synthesis', 'h1', 'Chullin', '52a', 'he')).toBeUndefined();
+  });
+
+  it('returns undefined before any view has loaded for this daf', () => {
+    expect(dafViewPieceResult('x.synthesis', 'i', 'Megillah', '5a', 'en')).toBeUndefined();
+  });
+});
+
+// The single most important regression guard for the bridge: the client's
+// lookups must read the EXACT key the server wrote (server `pieceKey`). Store the
+// piece under the server key, look it up via the client — if the two key formats
+// ever drift, these fail.
+describe('client lookups agree with the server pieceKey format', () => {
+  function stubFetch(payload: unknown) {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify(payload), { status: 200 })),
+    );
+  }
+
+  it('whole-daf: dafViewWholeDafResult finds a piece stored under pieceKey(producerId)', async () => {
+    const key = pieceKey('argument-overview.synthesis');
+    stubFetch({ pieces: { [key]: piece({ producerId: 'argument-overview.synthesis' }) } });
+    await loadDafView('Chullin', '52a', 'en');
+    expect(
+      dafViewWholeDafResult('argument-overview.synthesis', 'Chullin', '52a', 'en')?.cache_hit,
+    ).toBe(true);
+  });
+
+  it('per-instance: dafViewPieceResult finds a piece stored under pieceKey(producerId, instanceId)', async () => {
+    const key = pieceKey('pesukim.synthesis', 'abc123');
+    stubFetch({
+      pieces: { [key]: piece({ producerId: 'pesukim.synthesis', instanceId: 'abc123' }) },
+    });
+    await loadDafView('Chullin', '52a', 'en');
+    expect(
+      dafViewPieceResult('pesukim.synthesis', 'abc123', 'Chullin', '52a', 'en')?.cache_hit,
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
Extends the daf-view bridge (#465) to **per-instance section cards** (pesukim / halacha / aggadata / rabbi / places / argument-move) — the bulk of the per-daf `/api/run` fan-out. The server view already carries these pieces (keyed `producerId::instanceId`, since #461); this wires the client to use them.

## The bridge
The card computes `instanceIdOf(props.instance)` — the **same async hash the server keyed the piece under** (these marks round-trip cleanly per the `/api/daf-runs` note; `argument` stays excluded on both sides for its dual display/synth instance shape) — and looks the piece up as a **third cache tier** (after `runResultCache` and the whole-daf tier, before `/api/run`).

## Reactivity — kept fail-safe
- `instanceIdOf` is async → computed into a signal; the run effect reads it (+ `dafViewLoaded`) as **tracked** deps, so it re-runs when the hash settles / the view loads.
- A per-instance card only **waits** for the hash when the view is actually loaded (a hit is possible); otherwise it fetches as today. The hash settles in ~1 ms, so the gate is imperceptible.
- **Any miss falls through to the existing fetch — zero regression on miss.**

## Tests (regression-focused, per your ask)
`dafViewStore` gains `dafViewLoaded` + `dafViewPieceResult`. 14 store cases: per-instance hit/miss, daf+lang key guard, whole-daf vs per-instance **non-collision**, best-effort-on-failure, and a **client/server key-agreement guard** that stores a piece under the *server* `pieceKey` and reads it via the *client* lookups (catches key-format drift — the single most likely silent break). typecheck / biome / full suite (**2524**) / build all green.

Note: the live browser timing check is pending (dev browser profile is locked by another agent), but the path is fail-safe — a miss can only fetch-as-today, never break a card.