### PR TITLE
@corpus/core/telemetry: derive usage + inspector run-tree from the system

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,8 @@
     "./sefaria/*": "./src/sefaria/*.ts",
     "./model/*": "./src/model/*.ts",
     "./store/*": "./src/store/*.ts",
-    "./run/*": "./src/run/*.ts"
+    "./run/*": "./src/run/*.ts",
+    "./telemetry/*": "./src/telemetry/*.ts"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260511.1",

--- a/packages/core/src/telemetry/runtree.ts
+++ b/packages/core/src/telemetry/runtree.ts
@@ -1,0 +1,99 @@
+/**
+ * @corpus/core/telemetry — run-tree derivation, pure + tested.
+ *
+ * The inspector's DAG is DERIVED, not hand-built: walk the producer registry's
+ * declared `dependencies` (via depGraph.forwardSubgraph) from a root, then drape
+ * each node with its cached telemetry. `isExpandable` falls out of the same
+ * walk — a piece is expandable iff its dependency subgraph reaches another
+ * PRODUCER (sources alone aren't a graph worth opening). So whether tanach's
+ * pieces expand isn't a per-app flag; it's a property of tanach's registry.
+ */
+
+import { forwardSubgraph, producerNodesFrom, type RawDependency } from '../registry/depGraph.ts';
+import type { Authority, RunTree, RunTreeTotals, Staleness, TreeNode } from './types.ts';
+
+/** A registry definition, as far as the run-tree cares. */
+export interface ProducerDef {
+  id: string;
+  label?: string;
+  dependencies?: ReadonlyArray<RawDependency>;
+  /** mark vs enrichment (drives the node's producer badge). */
+  producerKind?: 'mark' | 'enrichment';
+}
+
+/** Cached telemetry for one producer node (absent for source leaves + cold
+ *  producers). */
+export interface RunTelemetry {
+  cached?: boolean;
+  model?: string | null;
+  cold_ms?: number | null;
+  cost?: number | null;
+  tokens?: number | null;
+  instances?: { total: number; cached: number };
+  authority?: Authority | null;
+  staleness?: Staleness | null;
+  createdAt?: string | null;
+  recipeHash?: string | null;
+}
+
+/** True iff `rootId`'s dependency subgraph reaches another PRODUCER (not just
+ *  source inputs) — i.e. there's a real DAG to expand into. Pure. */
+export function isExpandable(defs: ReadonlyArray<ProducerDef>, rootId: string): boolean {
+  const producerIds = new Set(defs.map((d) => d.id));
+  const graph = forwardSubgraph(producerNodesFrom(defs), rootId);
+  return graph.edges.some(([, child]) => producerIds.has(child));
+}
+
+/** Build the run-tree for `rootId`: its forward dependency subgraph (producers
+ *  + source leaves) with each producer node's cached telemetry attached. Pure
+ *  over (registry, telemetry). */
+export function buildRunTree(
+  defs: ReadonlyArray<ProducerDef>,
+  telemetry: Readonly<Record<string, RunTelemetry>>,
+  rootId: string,
+  meta: { tractate: string; page: string; lang: string },
+): RunTree {
+  const defById = new Map(defs.map((d) => [d.id, d]));
+  const graph = forwardSubgraph(producerNodesFrom(defs), rootId);
+  const nodes: Record<string, TreeNode> = {};
+  const totals: RunTreeTotals = { count: 0, llm: 0, source: 0, cached: 0, cold_ms: 0, cost: 0 };
+
+  for (const id of graph.nodes) {
+    const def = defById.get(id);
+    const isSource = !def; // not a registry producer => a source-input leaf
+    const t: RunTelemetry = telemetry[id] ?? {};
+    const node: TreeNode = {
+      id,
+      label: def?.label ?? id,
+      kind: isSource ? 'source' : 'llm',
+      producer: def?.producerKind,
+      model: t.model ?? undefined,
+      cached: !!t.cached,
+      cold_ms: t.cold_ms ?? null,
+      cost: t.cost ?? null,
+      tokens: t.tokens ?? null,
+      instances: t.instances,
+      authority: t.authority ?? null,
+      staleness: t.staleness ?? null,
+      createdAt: t.createdAt ?? null,
+      recipeHash: t.recipeHash ?? null,
+    };
+    nodes[id] = node;
+    totals.count += 1;
+    if (isSource) totals.source += 1;
+    else totals.llm += 1;
+    if (node.cached) totals.cached += 1;
+    if (node.cold_ms) totals.cold_ms += node.cold_ms;
+    if (node.cost) totals.cost += node.cost;
+  }
+
+  return {
+    root: rootId,
+    tractate: meta.tractate,
+    page: meta.page,
+    lang: meta.lang,
+    nodes,
+    edges: graph.edges,
+    totals,
+  };
+}

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -1,0 +1,110 @@
+/**
+ * @corpus/core/telemetry — the canonical DATA shapes for the dev/telemetry
+ * surfaces (the inspector run-tree + the usage ledger), shared by every corpus
+ * app. The DERIVATIONS over these (aggregateUsage, buildRunTree, isExpandable)
+ * live alongside in usage.ts / runtree.ts; the RENDER lives in @corpus/ui. The
+ * point of housing them here is that both apps' usage page + inspector are
+ * PROJECTIONS of the producer registry + the run ledger — not hand-built pages.
+ */
+
+// ── Run-tree (inspector) ────────────────────────────────────────────────────
+
+export type Authority = 'human' | 'rule' | 'ai';
+export type Staleness = 'fresh' | 'stale-recipe' | 'stale-inputs' | 'unknown';
+
+/** Per-input freshness: did this dependency's content hash move since the node
+ *  was generated? */
+export interface TreeNodeInput {
+  sourceKey: string;
+  status: 'same' | 'changed' | 'unknown';
+}
+
+export interface TreeNode {
+  id: string;
+  label: string;
+  kind: 'source' | 'llm' | 'computed';
+  producer?: 'mark' | 'enrichment';
+  model?: string;
+  cached: boolean;
+  cold_ms: number | null;
+  cost: number | null;
+  tokens: number | null;
+  /** Per-instance producers report the warmed fraction; absent on whole-unit /
+   *  single-entry nodes. */
+  instances?: { total: number; cached: number };
+  // additive provenance/staleness (absent on older payloads + source leaves)
+  authority?: Authority | null;
+  staleness?: Staleness | null;
+  createdAt?: string | null;
+  recipeHash?: string | null;
+  inputs?: TreeNodeInput[];
+  inputsChanged?: string[];
+}
+
+export interface RunTreeTotals {
+  count: number;
+  llm: number;
+  source: number;
+  cached: number;
+  cold_ms: number;
+  cost: number;
+}
+
+export interface RunTree {
+  root: string;
+  /** Addressing context — the unit the tree is for (daf "tractate"/"page" or a
+   *  chapter "book"/"page"); opaque to the renderer. */
+  tractate: string;
+  page: string;
+  lang: string;
+  nodes: Record<string, TreeNode>;
+  edges: Array<[string, string]>;
+  rootInstances?: Array<{ label: string; instance: unknown }>;
+  totals: RunTreeTotals;
+}
+
+export interface RunResult {
+  content?: string;
+  model?: string;
+  usage?: { total_tokens?: number; cost?: number } | null;
+  elapsed_ms?: number;
+  cache_hit?: boolean;
+  resolved?: { system_prompt: string; user_prompt: string };
+}
+
+// ── Usage ledger ──────────────────────────────────────────────────────────
+
+/** One recorded producer call. */
+export interface UsageEntry {
+  ts: number;
+  /** The unit it was attributed to ("Genesis 22", "Berakhot 2a", "Genesis 22:4"). */
+  ref: string;
+  producer: string;
+  model: string;
+  tokensIn: number;
+  tokensOut: number;
+  /** Total cost (prefer billed; estimate fallback). */
+  costUsd: number | null;
+  /** Input/output cost split, when known (content-in / content-out). */
+  costInUsd?: number | null;
+  costOutUsd?: number | null;
+}
+
+/** A roll-up over some key (a producer, a model, a ref). */
+export interface UsageBucket {
+  calls: number;
+  tokensIn: number;
+  tokensOut: number;
+  costUsd: number;
+  costInUsd: number;
+  costOutUsd: number;
+}
+
+export interface UsageSummary {
+  totals: UsageBucket;
+  byProducer: Record<string, UsageBucket>;
+  byModel: Record<string, UsageBucket>;
+  /** Per-unit (per-daf / per-chapter) — the dimension talmud's page has and
+   *  tanach's lacked. Derived from each entry's `ref`. */
+  byRef: Record<string, UsageBucket>;
+}

--- a/packages/core/src/telemetry/usage.ts
+++ b/packages/core/src/telemetry/usage.ts
@@ -1,0 +1,56 @@
+/**
+ * @corpus/core/telemetry — usage aggregation, pure + tested.
+ *
+ * The single source of truth for how a stream of recorded producer calls rolls
+ * up into the usage summary the /usage page shows: totals + per-producer +
+ * per-model + per-ref (per-daf / per-chapter) breakdowns, each carrying the
+ * content-in / content-out cost split. Workers fold each call in with
+ * `addUsageEntry`; `aggregateUsage` re-derives a whole summary from a log (for
+ * tests + recompute). Nothing about the breakdown is hand-built per app.
+ */
+
+import type { UsageBucket, UsageEntry, UsageSummary } from './types.ts';
+
+function emptyBucket(): UsageBucket {
+  return { calls: 0, tokensIn: 0, tokensOut: 0, costUsd: 0, costInUsd: 0, costOutUsd: 0 };
+}
+
+export function emptyUsage(): UsageSummary {
+  return { totals: emptyBucket(), byProducer: {}, byModel: {}, byRef: {} };
+}
+
+function addToBucket(b: UsageBucket, e: UsageEntry): void {
+  b.calls += 1;
+  b.tokensIn += e.tokensIn;
+  b.tokensOut += e.tokensOut;
+  b.costUsd += e.costUsd ?? 0;
+  b.costInUsd += e.costInUsd ?? 0;
+  b.costOutUsd += e.costOutUsd ?? 0;
+}
+
+function bucketIn(map: Record<string, UsageBucket>, key: string, e: UsageEntry): void {
+  if (!key) return;
+  let b = map[key];
+  if (!b) {
+    b = emptyBucket();
+    map[key] = b;
+  }
+  addToBucket(b, e);
+}
+
+/** Fold one call into a summary (mutates + returns it). The canonical
+ *  incremental aggregation a worker's ledger uses on every recorded call. */
+export function addUsageEntry(summary: UsageSummary, e: UsageEntry): UsageSummary {
+  addToBucket(summary.totals, e);
+  bucketIn(summary.byProducer, e.producer, e);
+  bucketIn(summary.byModel, e.model, e);
+  bucketIn(summary.byRef, e.ref, e);
+  return summary;
+}
+
+/** Re-derive a whole summary from a log of calls (batch). Pure. */
+export function aggregateUsage(entries: ReadonlyArray<UsageEntry>): UsageSummary {
+  const summary = emptyUsage();
+  for (const e of entries) addUsageEntry(summary, e);
+  return summary;
+}

--- a/packages/core/tests/telemetry-runtree.test.ts
+++ b/packages/core/tests/telemetry-runtree.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { buildRunTree, isExpandable, type ProducerDef } from '../src/telemetry/runtree.ts';
+
+// A talmud-shaped registry: synthesis composes other PRODUCERS (a real DAG).
+const TALMUD: ProducerDef[] = [
+  {
+    id: 'rabbi.synthesis',
+    label: 'Rabbi synthesis',
+    producerKind: 'enrichment',
+    dependencies: ['gemara', { mark: 'rabbi' }, { enrichment: 'rabbi.bio' }],
+  },
+  { id: 'rabbi', label: 'Rabbis', producerKind: 'mark', dependencies: ['gemara'] },
+  { id: 'rabbi.bio', label: 'Bio', producerKind: 'enrichment', dependencies: ['gemara'] },
+];
+
+// A tanach-shaped registry: producers depend ONLY on sources, never each other.
+const TANACH: ProducerDef[] = [
+  { id: 'tidbit', label: 'Tidbit', producerKind: 'enrichment', dependencies: ['chapter-verses'] },
+  {
+    id: 'synthesis',
+    label: 'Synthesis',
+    producerKind: 'enrichment',
+    dependencies: ['verse-text', 'commentaries'],
+  },
+];
+
+const meta = { tractate: 'Berakhot', page: '2', lang: 'en' };
+
+describe('buildRunTree — DERIVED from the registry + telemetry', () => {
+  it('walks the dependency subgraph and attaches telemetry', () => {
+    const tree = buildRunTree(
+      TALMUD,
+      {
+        'rabbi.synthesis': { cached: true, cold_ms: 5000, cost: 0.015, model: 'deepseek' },
+        rabbi: { cached: true, cold_ms: 45000, cost: 0.08 },
+        'rabbi.bio': { cached: false },
+      },
+      'rabbi.synthesis',
+      meta,
+    );
+    expect(tree.root).toBe('rabbi.synthesis');
+    expect(new Set(Object.keys(tree.nodes))).toEqual(
+      new Set(['rabbi.synthesis', 'gemara', 'rabbi', 'rabbi.bio']),
+    );
+    // gemara is a SOURCE leaf (not a registry producer) — derived, not declared
+    expect(tree.nodes.gemara.kind).toBe('source');
+    expect(tree.nodes['rabbi.synthesis'].kind).toBe('llm');
+    expect(tree.nodes['rabbi.synthesis'].producer).toBe('enrichment');
+    expect(tree.nodes.rabbi.producer).toBe('mark');
+    // telemetry draped on
+    expect(tree.nodes['rabbi.synthesis'].cost).toBe(0.015);
+    expect(tree.nodes['rabbi.bio'].cached).toBe(false);
+    // edges include the fan-in to the shared source
+    expect(tree.edges).toContainEqual(['rabbi.synthesis', 'rabbi']);
+    expect(tree.edges).toContainEqual(['rabbi', 'gemara']);
+    // totals are DERIVED (3 producers + 1 source; 2 cached; cost summed)
+    expect(tree.totals).toMatchObject({ count: 4, llm: 3, source: 1, cached: 2 });
+    expect(tree.totals.cost).toBeCloseTo(0.095, 6);
+    expect(tree.totals.cold_ms).toBe(50000);
+  });
+
+  it('a tanach producer is just itself + its source leaves', () => {
+    const tree = buildRunTree(TANACH, { synthesis: { cached: true, cost: 0.0003 } }, 'synthesis', {
+      tractate: 'Genesis',
+      page: '22',
+      lang: 'en',
+    });
+    expect(new Set(Object.keys(tree.nodes))).toEqual(
+      new Set(['synthesis', 'verse-text', 'commentaries']),
+    );
+    expect(tree.nodes['verse-text'].kind).toBe('source');
+    expect(tree.totals).toMatchObject({ count: 3, llm: 1, source: 2 });
+  });
+});
+
+describe('isExpandable — DERIVED, flips with the registry (not a per-app flag)', () => {
+  it('true when the root composes other producers (talmud)', () => {
+    expect(isExpandable(TALMUD, 'rabbi.synthesis')).toBe(true);
+    expect(isExpandable(TALMUD, 'rabbi')).toBe(false); // only depends on a source
+  });
+
+  it('false when the root depends only on sources (tanach today)', () => {
+    expect(isExpandable(TANACH, 'tidbit')).toBe(false);
+    expect(isExpandable(TANACH, 'synthesis')).toBe(false);
+  });
+
+  it('flips to true the moment a tanach producer starts composing another', () => {
+    const composed: ProducerDef[] = [
+      { id: 'overview', producerKind: 'enrichment', dependencies: ['chapter-verses'] },
+      {
+        id: 'tidbit',
+        producerKind: 'enrichment',
+        // now built on the overview producer, not just a source
+        dependencies: ['chapter-verses', { enrichment: 'overview' }],
+      },
+    ];
+    expect(isExpandable(composed, 'tidbit')).toBe(true);
+  });
+});

--- a/packages/core/tests/telemetry-usage.test.ts
+++ b/packages/core/tests/telemetry-usage.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import type { UsageEntry } from '../src/telemetry/types.ts';
+import { addUsageEntry, aggregateUsage, emptyUsage } from '../src/telemetry/usage.ts';
+
+const entry = (over: Partial<UsageEntry>): UsageEntry => ({
+  ts: 1,
+  ref: 'Genesis 1',
+  producer: 'overview',
+  model: 'deepseek',
+  tokensIn: 100,
+  tokensOut: 20,
+  costUsd: 0.001,
+  costInUsd: 0.0007,
+  costOutUsd: 0.0003,
+  ...over,
+});
+
+describe('aggregateUsage — DERIVED from the entry log, nothing hard-coded', () => {
+  it('rolls totals + per-producer / per-model / per-ref + the in/out cost split', () => {
+    const s = aggregateUsage([
+      entry({ producer: 'overview', model: 'deepseek', ref: 'Genesis 1', costUsd: 0.001 }),
+      entry({ producer: 'tidbit', model: 'deepseek', ref: 'Genesis 1', costUsd: 0.002 }),
+      entry({ producer: 'overview', model: 'gpt', ref: 'Genesis 2', costUsd: 0.004 }),
+    ]);
+    expect(s.totals.calls).toBe(3);
+    expect(s.totals.tokensIn).toBe(300);
+    expect(s.totals.tokensOut).toBe(60);
+    expect(s.totals.costUsd).toBeCloseTo(0.007, 6);
+    // content-in / content-out split is summed too
+    expect(s.totals.costInUsd).toBeCloseTo(0.0021, 6);
+    expect(s.totals.costOutUsd).toBeCloseTo(0.0009, 6);
+    // breakdowns are derived from the entries' fields
+    expect(s.byProducer.overview.calls).toBe(2);
+    expect(s.byProducer.overview.costUsd).toBeCloseTo(0.005, 6);
+    expect(s.byProducer.tidbit.calls).toBe(1);
+    expect(s.byModel.deepseek.calls).toBe(2);
+    expect(s.byModel.gpt.calls).toBe(1);
+    // the per-ref (per-chapter) dimension tanach lacked
+    expect(s.byRef['Genesis 1'].calls).toBe(2);
+    expect(s.byRef['Genesis 2'].calls).toBe(1);
+  });
+
+  it('changes when the input changes (not memoised / hard-coded)', () => {
+    const a = aggregateUsage([entry({ costUsd: 0.001 })]);
+    const b = aggregateUsage([
+      entry({ costUsd: 0.001 }),
+      entry({ producer: 'tidbit', costUsd: 0.5 }),
+    ]);
+    expect(b.totals.costUsd).toBeGreaterThan(a.totals.costUsd);
+    expect(Object.keys(b.byProducer).sort()).toEqual(['overview', 'tidbit']);
+  });
+
+  it('incremental addUsageEntry equals the batch aggregate', () => {
+    const entries = [entry({ producer: 'a' }), entry({ producer: 'b' }), entry({ producer: 'a' })];
+    const batch = aggregateUsage(entries);
+    const incremental = entries.reduce((s, e) => addUsageEntry(s, e), emptyUsage());
+    expect(incremental).toEqual(batch);
+  });
+
+  it('tolerates missing cost / split fields (cold or pre-split entries)', () => {
+    const s = aggregateUsage([
+      entry({ costUsd: null, costInUsd: undefined, costOutUsd: undefined }),
+    ]);
+    expect(s.totals.costUsd).toBe(0);
+    expect(s.totals.costInUsd).toBe(0);
+    expect(s.totals.calls).toBe(1);
+  });
+
+  it('empty log → zeroed summary with empty buckets', () => {
+    const s = aggregateUsage([]);
+    expect(s.totals.calls).toBe(0);
+    expect(s.byProducer).toEqual({});
+    expect(s.byRef).toEqual({});
+  });
+});

--- a/packages/ui/src/RunTree.tsx
+++ b/packages/ui/src/RunTree.tsx
@@ -6,72 +6,25 @@
  * can never drift in their graph maths or visuals.
  */
 
+import type { Authority, RunTree, Staleness, TreeNode } from '@corpus/core/telemetry/types';
 import { For, type JSX, Match, Show, Switch } from 'solid-js';
 import { fmtCost, fmtMs } from './format.ts';
 
+// The run-tree DATA shapes are the canonical model in @corpus/core/telemetry
+// (both apps derive them); re-exported here so existing @corpus/ui/RunTree
+// consumers keep resolving. The render below uses the imported types.
+export type {
+  Authority,
+  RunResult,
+  RunTree,
+  Staleness,
+  TreeNode,
+  TreeNodeInput,
+} from '@corpus/core/telemetry/types';
 // Display formatters now live in @corpus/ui (single source of truth, shared
 // with tanach's inspect panel); re-exported so existing run-tree imports keep
 // resolving. The format is unchanged.
 export { fmtCost, fmtMs };
-
-export type Authority = 'human' | 'rule' | 'ai';
-export type Staleness = 'fresh' | 'stale-recipe' | 'stale-inputs' | 'unknown';
-/** Per-input freshness from the worker: did this dependency's content hash
- *  move since the node was generated? */
-export interface TreeNodeInput {
-  sourceKey: string;
-  status: 'same' | 'changed' | 'unknown';
-}
-export interface TreeNode {
-  id: string;
-  label: string;
-  kind: 'source' | 'llm' | 'computed';
-  producer?: 'mark' | 'enrichment';
-  model?: string;
-  cached: boolean;
-  cold_ms: number | null;
-  cost: number | null;
-  tokens: number | null;
-  /** Per-instance producers report the warmed fraction; absent on whole-daf /
-   *  single-entry nodes (which carry one cached entry, not a per-instance set). */
-  instances?: { total: number; cached: number };
-  // additive provenance/staleness fields (absent on older payloads + source
-  // leaves; null when nothing is cached) — every consumer must tolerate absence
-  authority?: Authority | null;
-  staleness?: Staleness | null;
-  createdAt?: string | null;
-  recipeHash?: string | null;
-  inputs?: TreeNodeInput[];
-  inputsChanged?: string[];
-}
-export interface RunTree {
-  root: string;
-  tractate: string;
-  page: string;
-  lang: string;
-  nodes: Record<string, TreeNode>;
-  edges: Array<[string, string]>;
-  /** For a per-instance ROOT opened without a pinned instance: its instance list
-   *  so the dock can offer a picker (each chip re-opens the piece with that
-   *  instance to inspect its content). Absent on whole-daf roots. */
-  rootInstances?: Array<{ label: string; instance: unknown }>;
-  totals: {
-    count: number;
-    llm: number;
-    source: number;
-    cached: number;
-    cold_ms: number;
-    cost: number;
-  };
-}
-export interface RunResult {
-  content?: string;
-  model?: string;
-  usage?: { total_tokens?: number; cost?: number } | null;
-  elapsed_ms?: number;
-  cache_hit?: boolean;
-  resolved?: { system_prompt: string; user_prompt: string };
-}
 
 export const prettifyId = (id: string): string =>
   id


### PR DESCRIPTION
The foundation you asked for first — make the dev surfaces (usage, inspector) **projections of the producer registry + run ledger**, in core, with tests that *prove* the derivation rather than hand-coding per app.

## What's here (pure + tested)
- **`types.ts`** — canonical data shapes: `TreeNode`/`RunTree` (moved from `@corpus/ui/RunTree`, which now re-exports them — talmud's imports unchanged) + `UsageEntry`/`UsageSummary` with a **content-in / content-out cost split**.
- **`usage.ts`** — `aggregateUsage` / `addUsageEntry` (pure): totals + per-producer + per-model + **per-ref (per-daf / per-chapter — the dimension tanach lacked)** + the in/out cost split, all derived from the entry log.
- **`runtree.ts`** — `buildRunTree` (walks `depGraph.forwardSubgraph` from a root, drapes cached telemetry → `RunTree`) + **`isExpandable`** (derived: a piece is expandable iff its dependency subgraph reaches another *producer* — so it's a property of the registry, **not a per-app flag**; tanach's source-only producers correctly don't expand, and `isExpandable` **flips to true the moment a tanach producer composes another**).

## Tests prove it's derived, not hard-coded
- Mutate the ledger → the summary changes; incremental `addUsageEntry` == batch `aggregateUsage`.
- Mutate the registry → the run-tree + `isExpandable` change (the flip test).
- 10 new tests, **113 core green**; 2516 talmud + 49 tanach unaffected.

Next PRs (this program): the shared **tabbed `UsagePage`** (Producer/Model/Page/Recent + content-in/out) on `aggregateUsage`, then the registry-derived inspector (`buildRunTree` + `isExpandable` + shared `RunDag`), then the alignment page.

## Gates
typecheck ✓ · lint ✓ · 113 core + 2516 talmud + 49 tanach tests ✓ · all builds ✓