### PR TITLE
Add #howitworks: interactive walkthrough of the framework + every enrichment

### DIFF
--- a/packages/talmud/src/client/App.tsx
+++ b/packages/talmud/src/client/App.tsx
@@ -3,6 +3,7 @@ import { AlignPage } from './AlignPage';
 import { AttributionsPage } from './AttributionsPage';
 import Compare from './Compare';
 import DafViewer from './DafViewer';
+import { HowItWorksPage } from './HowItWorksPage';
 import { McpPage } from './McpPage';
 import PretextSpike from './PretextSpike';
 import { SagesPage } from './SagesPage';
@@ -78,7 +79,14 @@ export default function App() {
                                             when={
                                               route() === 'spine' || route().startsWith('spine/')
                                             }
-                                            fallback={<DafViewer />}
+                                            fallback={
+                                              <Show
+                                                when={route() === 'howitworks'}
+                                                fallback={<DafViewer />}
+                                              >
+                                                <HowItWorksPage />
+                                              </Show>
+                                            }
                                           >
                                             <SpineCoveragePage />
                                           </Show>

--- a/packages/talmud/src/client/HowItWorksGraph.tsx
+++ b/packages/talmud/src/client/HowItWorksGraph.tsx
@@ -1,0 +1,282 @@
+/**
+ * The #howitworks centerpiece: the live registry DAG as an interactive SVG.
+ * Columns are dependency depth (sources -> marks -> enrichments -> synthesis);
+ * connectors are declared `dependencies`, routed orthogonally (never diagonal)
+ * with the shared edge router. Hovering or selecting a node lights its whole
+ * dependency chain and dims the rest; clicking opens its deep-dive in the
+ * parent. A focus-by-family chip row narrows the ~60-node "everything" view to
+ * one mark family at a time.
+ *
+ * This renders DEFINITIONS (what connects to what), not cached instances — it
+ * never calls /api/run.
+ */
+import { createMemo, createSignal, For, type JSX, Show } from 'solid-js';
+import { orthogonalEdgePath } from './flow/orthogonalEdge';
+import { ancestorsOf, connectedClosure, type Graph, type GraphNode } from './howItWorks/graphModel';
+import { ACCENTS } from './sidebar/primitives';
+
+const NODE_W = 184;
+const NODE_H = 30;
+const ROW_GAP = 9;
+const COL_GAP = 118;
+const PAD = 16;
+
+// Mark ids whose accent lives under a slightly different key in ACCENTS.
+const FAMILY_ALIAS: Record<string, string> = { pesukim: 'pesuk', places: 'place' };
+
+export function familyColor(family: string): string {
+  if (family === 'source') return '#6b7280';
+  const key = FAMILY_ALIAS[family] ?? family;
+  return (ACCENTS as Record<string, string>)[key] ?? '#64748b';
+}
+
+const arrowId = (color: string): string => `hiw-arrow-${color.replace('#', '')}`;
+const truncate = (s: string, n: number): string => (s.length > n ? `${s.slice(0, n - 1)}…` : s);
+
+interface Props {
+  graph: Graph;
+  selectedId: string | null;
+  onSelect: (id: string | null) => void;
+  /** Mark family to focus, or null for the whole graph. */
+  focusFamily: string | null;
+}
+
+interface Placed {
+  node: GraphNode;
+  x: number;
+  y: number;
+}
+
+export function HowItWorksGraph(props: Props): JSX.Element {
+  const [hovered, setHovered] = createSignal<string | null>(null);
+
+  // Nodes to show: everything, or one family plus the inputs it's built from.
+  const shownNodes = createMemo<GraphNode[]>(() => {
+    const f = props.focusFamily;
+    if (!f) return props.graph.nodes;
+    const keep = new Set<string>();
+    for (const n of props.graph.nodes) {
+      if (n.family !== f) continue;
+      keep.add(n.id);
+      for (const a of ancestorsOf(props.graph, n.id)) keep.add(a);
+    }
+    return props.graph.nodes.filter((n) => keep.has(n.id));
+  });
+
+  // Column layout by dependency depth; compact x so empty layers leave no gap.
+  const layout = createMemo(() => {
+    const nodes = shownNodes();
+    const shownSet = new Set(nodes.map((n) => n.id));
+    const byLayer = new Map<number, GraphNode[]>();
+    for (const n of nodes) {
+      const arr = byLayer.get(n.layer);
+      if (arr) arr.push(n);
+      else byLayer.set(n.layer, [n]);
+    }
+    const layers = [...byLayer.keys()].sort((a, b) => a - b);
+    const placed = new Map<string, Placed>();
+    let maxRows = 0;
+    layers.forEach((L, col) => {
+      const arr = (byLayer.get(L) as GraphNode[]).slice().sort((a, b) => {
+        if (a.kind !== b.kind) return a.kind === 'source' ? -1 : 1;
+        if (a.family !== b.family) return a.family < b.family ? -1 : 1;
+        return a.id < b.id ? -1 : 1;
+      });
+      maxRows = Math.max(maxRows, arr.length);
+      arr.forEach((node, row) => {
+        placed.set(node.id, {
+          node,
+          x: PAD + col * (NODE_W + COL_GAP),
+          y: PAD + row * (NODE_H + ROW_GAP),
+        });
+      });
+    });
+    const edges = props.graph.edges.filter((e) => shownSet.has(e.from) && shownSet.has(e.to));
+    const width = PAD * 2 + layers.length * NODE_W + Math.max(0, layers.length - 1) * COL_GAP;
+    const height = PAD * 2 + maxRows * (NODE_H + ROW_GAP);
+    const colors = new Set<string>();
+    for (const e of edges) colors.add(familyColor((placed.get(e.to) as Placed).node.family));
+    return { placed, edges, width, height: Math.max(height, 120), colors: [...colors] };
+  });
+
+  // What stays lit: the connected chain through the active (hovered|selected)
+  // node. Null = nothing active, everything full-strength.
+  const litSet = createMemo<Set<string> | null>(() => {
+    const active = hovered() ?? props.selectedId;
+    return active ? connectedClosure(props.graph, active) : null;
+  });
+  const nodeLit = (id: string): boolean => {
+    const lit = litSet();
+    return !lit || lit.has(id);
+  };
+  const edgeLit = (from: string, to: string): boolean => {
+    const lit = litSet();
+    return !lit || (lit.has(from) && lit.has(to));
+  };
+
+  return (
+    <div
+      style={{
+        border: '1px solid var(--line)',
+        'border-radius': '10px',
+        background: '#fcfbf8',
+        overflow: 'auto',
+        'max-height': '74vh',
+      }}
+    >
+      <svg
+        width={layout().width}
+        height={layout().height}
+        viewBox={`0 0 ${layout().width} ${layout().height}`}
+        role="img"
+        aria-label="Producer dependency graph"
+        style={{ display: 'block', 'min-width': '100%' }}
+      >
+        <defs>
+          <For each={layout().colors}>
+            {(color) => (
+              <marker
+                id={arrowId(color)}
+                viewBox="0 0 6 6"
+                refX="5"
+                refY="3"
+                markerWidth="5"
+                markerHeight="5"
+                orient="auto-start-reverse"
+              >
+                <path d="M 0 0 L 6 3 L 0 6 z" fill={color} />
+              </marker>
+            )}
+          </For>
+        </defs>
+
+        {/* Connectors behind the nodes. */}
+        <For each={layout().edges}>
+          {(e) => {
+            const a = (): Placed => layout().placed.get(e.from) as Placed;
+            const b = (): Placed => layout().placed.get(e.to) as Placed;
+            const color = (): string => familyColor(b().node.family);
+            const lit = (): boolean => edgeLit(e.from, e.to);
+            return (
+              <Show when={a() && b()}>
+                <path
+                  d={orthogonalEdgePath(
+                    { x: a().x, y: a().y, w: NODE_W, h: NODE_H },
+                    { x: b().x, y: b().y, w: NODE_W, h: NODE_H },
+                  )}
+                  fill="none"
+                  stroke={color()}
+                  stroke-width={lit() ? 1.8 : 1.1}
+                  stroke-dasharray={e.target ? '3 3' : undefined}
+                  marker-end={`url(#${arrowId(color())})`}
+                  opacity={lit() ? (litSet() ? 0.95 : 0.5) : 0.08}
+                />
+              </Show>
+            );
+          }}
+        </For>
+
+        {/* Nodes. */}
+        <For each={[...layout().placed.values()]}>
+          {(p) => {
+            const n = p.node;
+            const color = familyColor(n.family);
+            const isSel = (): boolean => props.selectedId === n.id;
+            const lit = (): boolean => nodeLit(n.id);
+            const fill = (): string =>
+              n.kind === 'source' ? '#eef1ee' : isSel() ? color : '#ffffff';
+            const textColor = (): string =>
+              n.kind === 'source' ? '#475569' : isSel() ? '#fff' : '#1f2937';
+            return (
+              // biome-ignore lint/a11y/useSemanticElements: native <button> cannot be used inside an SVG diagram
+              <g
+                role="button"
+                tabindex={0}
+                aria-pressed={isSel()}
+                aria-label={`${n.kind} ${n.id}`}
+                style={{ cursor: 'pointer', opacity: lit() ? 1 : 0.22 }}
+                onMouseEnter={() => setHovered(n.id)}
+                onMouseLeave={() => setHovered(null)}
+                onFocus={() => setHovered(n.id)}
+                onBlur={() => setHovered(null)}
+                onClick={() => props.onSelect(isSel() ? null : n.id)}
+                onKeyDown={(ev) => {
+                  if (ev.key === 'Enter' || ev.key === ' ') {
+                    ev.preventDefault();
+                    props.onSelect(isSel() ? null : n.id);
+                  }
+                }}
+              >
+                <title>{n.id}</title>
+                <rect
+                  x={p.x}
+                  y={p.y}
+                  width={NODE_W}
+                  height={NODE_H}
+                  rx={n.kind === 'source' ? 14 : 6}
+                  fill={fill()}
+                  stroke={color}
+                  stroke-width={isSel() ? 2 : n.kind === 'enrichment' ? 1 : 1.4}
+                  stroke-dasharray={n.kind === 'enrichment' && !isSel() ? '4 2' : undefined}
+                />
+                <text
+                  x={p.x + NODE_W / 2}
+                  y={p.y + NODE_H / 2}
+                  text-anchor="middle"
+                  dominant-baseline="central"
+                  font-size="11.5"
+                  font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+                  fill={textColor()}
+                >
+                  {truncate(n.id, 24)}
+                </text>
+              </g>
+            );
+          }}
+        </For>
+      </svg>
+    </div>
+  );
+}
+
+/** Legend: what the node shapes/colors mean. Rendered once beside the graph. */
+export function GraphLegend(): JSX.Element {
+  const item = (swatch: JSX.Element, label: string): JSX.Element => (
+    <span style={{ display: 'inline-flex', 'align-items': 'center', gap: '0.35rem' }}>
+      {swatch}
+      {label}
+    </span>
+  );
+  const box = (style: JSX.CSSProperties): JSX.Element => (
+    <span
+      style={{
+        width: '16px',
+        height: '11px',
+        'border-radius': '3px',
+        display: 'inline-block',
+        ...style,
+      }}
+    />
+  );
+  return (
+    <div
+      style={{
+        display: 'flex',
+        'flex-wrap': 'wrap',
+        gap: '0.45rem 1rem',
+        'font-size': '0.7rem',
+        color: 'var(--muted)',
+        'margin-top': '0.5rem',
+      }}
+    >
+      {item(box({ background: '#eef1ee', border: '1px solid #6b7280' }), 'source input')}
+      {item(box({ background: '#fff', border: '1.4px solid #8a2a2b' }), 'mark (discovers anchors)')}
+      {item(
+        box({ background: '#fff', border: '1px dashed #8a2a2b' }),
+        'enrichment (inherits / aggregates)',
+      )}
+      {item(<span style={{ color: 'var(--muted)' }}>– – –</span>, 'edge to its target mark')}
+      <span>hover a node to trace its dependency chain · click for the deep-dive</span>
+    </div>
+  );
+}

--- a/packages/talmud/src/client/HowItWorksPage.tsx
+++ b/packages/talmud/src/client/HowItWorksPage.tsx
@@ -1,0 +1,1035 @@
+/**
+ * #howitworks — a guided walkthrough of how this app is built, for a colleague.
+ * Reads like an interactive presentation: a sticky chapter rail down the side,
+ * the four-primitive vocabulary, the producer lifecycle, then the live build
+ * graph as the centerpiece, a deep dive into every enrichment, and the
+ * caching/freshness story.
+ *
+ * Everything about producers is pulled LIVE from the running registry
+ * (GET /api/marks + /api/enrichments) so the page documents what is actually
+ * deployed. The conceptual prose follows docs/framework.md ("the framework:
+ * four primitives").
+ */
+import { createMemo, createSignal, For, type JSX, onCleanup, onMount, Show } from 'solid-js';
+import { familyColor, GraphLegend, HowItWorksGraph } from './HowItWorksGraph';
+import { assignLayers, buildGraph, type Graph, type GraphNode } from './howItWorks/graphModel';
+import { useRegistry } from './howItWorks/registry';
+
+// ── small presentational atoms ────────────────────────────────────────────
+
+function Badge(props: { children: JSX.Element; color?: string; title?: string }): JSX.Element {
+  return (
+    <span
+      title={props.title}
+      style={{
+        display: 'inline-block',
+        'font-size': '0.66rem',
+        'font-weight': 600,
+        'letter-spacing': '0.02em',
+        padding: '0.12rem 0.4rem',
+        'border-radius': '4px',
+        background: props.color ? `${props.color}1a` : '#eceae3',
+        color: props.color ?? '#555',
+        border: `1px solid ${props.color ? `${props.color}55` : '#dcd9cf'}`,
+        'white-space': 'nowrap',
+      }}
+    >
+      {props.children}
+    </span>
+  );
+}
+
+function Mono(props: { children: JSX.Element }): JSX.Element {
+  return (
+    <code
+      style={{
+        'font-family': 'ui-monospace, SFMono-Regular, Menlo, monospace',
+        'font-size': '0.82em',
+        background: '#f1efe8',
+        padding: '0.05rem 0.3rem',
+        'border-radius': '4px',
+      }}
+    >
+      {props.children}
+    </code>
+  );
+}
+
+function Disclosure(props: { title: string; children: JSX.Element }): JSX.Element {
+  const [open, setOpen] = createSignal(false);
+  return (
+    <div style={{ 'margin-top': '0.5rem' }}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        style={{
+          display: 'flex',
+          'align-items': 'center',
+          gap: '0.4rem',
+          width: '100%',
+          'text-align': 'left',
+          background: 'none',
+          border: 'none',
+          cursor: 'pointer',
+          padding: '0.2rem 0',
+          color: 'var(--muted)',
+          'font-size': '0.72rem',
+          'text-transform': 'uppercase',
+          'letter-spacing': '0.06em',
+        }}
+        aria-expanded={open()}
+      >
+        <span
+          style={{ transform: open() ? 'rotate(90deg)' : 'none', transition: 'transform .12s' }}
+        >
+          ▸
+        </span>
+        {props.title}
+      </button>
+      <Show when={open()}>{props.children}</Show>
+    </div>
+  );
+}
+
+function Code(props: { text: string }): JSX.Element {
+  return (
+    <pre
+      style={{
+        margin: '0.4rem 0 0',
+        padding: '0.6rem 0.7rem',
+        background: '#2b2a26',
+        color: '#e8e6df',
+        'border-radius': '6px',
+        'font-size': '0.74rem',
+        'line-height': 1.5,
+        'white-space': 'pre-wrap',
+        'word-break': 'break-word',
+        'max-height': '320px',
+        overflow: 'auto',
+      }}
+    >
+      {props.text}
+    </pre>
+  );
+}
+
+// ── the deep-dive card, reused by the graph and the directory ──────────────
+
+function neighbors(graph: Graph, id: string, dir: 'in' | 'out'): GraphNode[] {
+  const ids: string[] = [];
+  for (const e of graph.edges) {
+    if (dir === 'in' && e.to === id) ids.push(e.from);
+    if (dir === 'out' && e.from === id) ids.push(e.to);
+  }
+  const seen = new Set<string>();
+  const out: GraphNode[] = [];
+  for (const nid of ids) {
+    if (seen.has(nid)) continue;
+    seen.add(nid);
+    const n = graph.byId.get(nid);
+    if (n) out.push(n);
+  }
+  return out.sort((a, b) => (a.id < b.id ? -1 : 1));
+}
+
+function ChipRow(props: {
+  label: string;
+  nodes: GraphNode[];
+  onSelect: (id: string) => void;
+}): JSX.Element {
+  return (
+    <Show when={props.nodes.length}>
+      <div style={{ 'margin-top': '0.55rem' }}>
+        <div
+          style={{
+            'font-size': '0.66rem',
+            'text-transform': 'uppercase',
+            'letter-spacing': '0.06em',
+            color: '#9a958a',
+            'margin-bottom': '0.3rem',
+          }}
+        >
+          {props.label}
+        </div>
+        <div style={{ display: 'flex', 'flex-wrap': 'wrap', gap: '0.3rem' }}>
+          <For each={props.nodes}>
+            {(n) => (
+              <button
+                type="button"
+                onClick={() => props.onSelect(n.id)}
+                style={{
+                  'font-family': 'ui-monospace, SFMono-Regular, Menlo, monospace',
+                  'font-size': '0.72rem',
+                  padding: '0.15rem 0.45rem',
+                  'border-radius': '5px',
+                  cursor: 'pointer',
+                  background: '#fff',
+                  color: '#374151',
+                  border: `1px solid ${familyColor(n.family)}66`,
+                  'border-left': `3px solid ${familyColor(n.family)}`,
+                }}
+              >
+                {n.id}
+              </button>
+            )}
+          </For>
+        </div>
+      </div>
+    </Show>
+  );
+}
+
+function MetaList(props: { rows: [string, JSX.Element | string | undefined][] }): JSX.Element {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        'flex-wrap': 'wrap',
+        gap: '0.35rem 0.5rem',
+        'margin-top': '0.5rem',
+      }}
+    >
+      <For each={props.rows.filter(([, v]) => v != null && v !== '')}>
+        {([k, v]) => (
+          <div
+            style={{
+              'font-size': '0.74rem',
+              color: '#444',
+              background: '#faf8f2',
+              border: '1px solid #ece9e0',
+              'border-radius': '5px',
+              padding: '0.2rem 0.45rem',
+            }}
+          >
+            <span style={{ color: '#9a958a' }}>{k}: </span>
+            {v}
+          </div>
+        )}
+      </For>
+    </div>
+  );
+}
+
+export function DeepDive(props: {
+  node: GraphNode;
+  graph: Graph;
+  onSelect: (id: string) => void;
+}): JSX.Element {
+  const color = (): string => familyColor(props.node.family);
+  const m = (): GraphNode['mark'] => props.node.mark;
+  const e = (): GraphNode['enrichment'] => props.node.enrichment;
+
+  const kindLabel = (): string =>
+    props.node.kind === 'mark'
+      ? 'mark · discovers anchors'
+      : props.node.kind === 'enrichment'
+        ? 'enrichment · builds on a mark'
+        : 'source input';
+
+  const modelLabel = (): string => {
+    const model = m()?.extractor?.model ?? e()?.model;
+    return model || 'default model';
+  };
+  const reasoningLabel = (): string | undefined => {
+    const ex = m()?.extractor;
+    const thinkingOff = ex?.thinking_off ?? e()?.thinking_off;
+    const effort = ex?.reasoning_effort ?? e()?.reasoning_effort;
+    if (effort) return `reasoning: ${effort}`;
+    if (thinkingOff) return 'thinking off';
+    return undefined;
+  };
+
+  return (
+    <div
+      style={{
+        border: `1px solid ${color()}55`,
+        'border-left': `4px solid ${color()}`,
+        'border-radius': '8px',
+        background: '#fff',
+        padding: '0.85rem 1rem',
+      }}
+    >
+      <div
+        style={{ display: 'flex', 'align-items': 'baseline', gap: '0.5rem', 'flex-wrap': 'wrap' }}
+      >
+        <span
+          style={{
+            'font-family': 'ui-monospace, SFMono-Regular, Menlo, monospace',
+            'font-size': '0.95rem',
+            'font-weight': 700,
+            color: color(),
+          }}
+        >
+          {props.node.id}
+        </span>
+        <Badge color={color()}>{kindLabel()}</Badge>
+        <Show when={m()?.experimental || m()?.status === 'draft'}>
+          <Badge title="not promoted to readers">experimental</Badge>
+        </Show>
+      </div>
+
+      <Show when={m()?.label && m()?.label !== props.node.id}>
+        <div style={{ 'font-weight': 600, 'margin-top': '0.3rem' }}>{m()?.label}</div>
+      </Show>
+      <Show when={e()?.label && e()?.label !== props.node.id}>
+        <div style={{ 'font-weight': 600, 'margin-top': '0.3rem' }}>{e()?.label}</div>
+      </Show>
+
+      <Show when={m()?.description || e()?.description}>
+        <p
+          style={{
+            margin: '0.3rem 0 0',
+            'font-size': '0.88rem',
+            'line-height': 1.5,
+            color: '#333',
+          }}
+        >
+          {m()?.description ?? e()?.description}
+        </p>
+      </Show>
+
+      <Show when={props.node.kind === 'source'}>
+        <p style={{ margin: '0.3rem 0 0', 'font-size': '0.85rem', color: '#555' }}>
+          A source input — a cached slice of text the runtime feeds into a producer's prompt (it
+          isn't itself produced). Everything to its right is built, ultimately, from inputs like
+          this.
+        </p>
+      </Show>
+
+      {/* metadata */}
+      <Show when={props.node.kind !== 'source'}>
+        <MetaList
+          rows={
+            props.node.kind === 'mark'
+              ? [
+                  ['anchor', m()?.anchor],
+                  ['render', m()?.render?.kind],
+                  ['extractor', m()?.extractor?.kind],
+                  ['model', modelLabel()],
+                  ['reasoning', reasoningLabel()],
+                  ['cache', m()?.cache_version ? `v${m()?.cache_version}` : undefined],
+                ]
+              : [
+                  ['target mark', e()?.mark],
+                  ['mode', e()?.mode],
+                  ['scope', e()?.scope],
+                  ['model', modelLabel()],
+                  ['reasoning', reasoningLabel()],
+                  ['cache', e()?.cache_version ? `v${e()?.cache_version}` : undefined],
+                ]
+          }
+        />
+      </Show>
+
+      <ChipRow
+        label="built from"
+        nodes={neighbors(props.graph, props.node.id, 'in')}
+        onSelect={props.onSelect}
+      />
+      <ChipRow
+        label="feeds into"
+        nodes={neighbors(props.graph, props.node.id, 'out')}
+        onSelect={props.onSelect}
+      />
+
+      <Show when={e()?.output_schema}>
+        <Disclosure title="output schema">
+          <Code text={JSON.stringify(e()?.output_schema, null, 2)} />
+        </Disclosure>
+      </Show>
+      <Show when={e()?.system_prompt}>
+        <Disclosure title="system prompt">
+          <Code text={e()?.system_prompt ?? ''} />
+        </Disclosure>
+      </Show>
+      <Show when={e()?.user_prompt_template}>
+        <Disclosure title="user prompt template">
+          <Code text={e()?.user_prompt_template ?? ''} />
+        </Disclosure>
+      </Show>
+    </div>
+  );
+}
+
+// ── conceptual chapter content ─────────────────────────────────────────────
+
+function PrimitiveCard(props: {
+  name: string;
+  module: string;
+  oneLine: string;
+  children: JSX.Element;
+}): JSX.Element {
+  return (
+    <div
+      style={{
+        border: '1px solid var(--line)',
+        'border-radius': '8px',
+        background: '#fff',
+        padding: '0.85rem 1rem',
+      }}
+    >
+      <div
+        style={{ display: 'flex', 'align-items': 'baseline', gap: '0.5rem', 'flex-wrap': 'wrap' }}
+      >
+        <span style={{ 'font-size': '1.05rem', 'font-weight': 700, color: 'var(--accent)' }}>
+          {props.name}
+        </span>
+        <Mono>{props.module}</Mono>
+      </div>
+      <p style={{ margin: '0.35rem 0 0.2rem', 'font-weight': 600, 'font-size': '0.9rem' }}>
+        {props.oneLine}
+      </p>
+      <div style={{ 'font-size': '0.85rem', 'line-height': 1.55, color: '#333' }}>
+        {props.children}
+      </div>
+    </div>
+  );
+}
+
+/** A tiny "note pinned to a span of a spine" illustration for the Anchor card. */
+function AnchorDiagram(): JSX.Element {
+  const segs = [0, 1, 2, 3, 4, 5, 6];
+  const W = 44;
+  return (
+    <svg
+      width="100%"
+      height="92"
+      viewBox="0 0 340 92"
+      role="img"
+      aria-label="An anchor spans segments 3 to 5 of a spine"
+    >
+      <text x="2" y="14" font-size="10" fill="#9a958a">
+        spine: bavli · Berakhot 2a
+      </text>
+      <For each={segs}>
+        {(s, i) => (
+          <g>
+            <rect
+              x={6 + i() * W}
+              y={24}
+              width={W - 6}
+              height={26}
+              rx={4}
+              fill={s >= 3 && s <= 5 ? '#8a2a2b22' : '#f1efe8'}
+              stroke={s >= 3 && s <= 5 ? '#8a2a2b' : '#ddd9cf'}
+            />
+            <text
+              x={6 + i() * W + (W - 6) / 2}
+              y={41}
+              text-anchor="middle"
+              font-size="10"
+              fill="#666"
+            >
+              {`seg ${s}`}
+            </text>
+          </g>
+        )}
+      </For>
+      <path d={`M ${6 + 3 * W} 56 L ${6 + 6 * W - 6} 56`} stroke="#8a2a2b" stroke-width="2" />
+      <text x={6 + 3 * W} y={78} font-size="11" fill="#8a2a2b" font-weight="600">
+        Anchor · span [3..5] · precision: segment
+      </text>
+    </svg>
+  );
+}
+
+const STEPS: { n: string; title: string; body: string }[] = [
+  {
+    n: '1',
+    title: 'Resolve inputs',
+    body: 'Walk the dependency DAG — source slices, mark instances, other enrichments — into template vars. One bad dep degrades to an {error}, never throws.',
+  },
+  {
+    n: '2',
+    title: 'Render + call',
+    body: "Fill the recipe's prompt template, pick the model (Hebrew prompt selected when present), and call the model — or run a deterministic computed/lookup branch.",
+  },
+  {
+    n: '3',
+    title: 'Parse + check',
+    body: 'JSON-parse the output, then run the post-LLM passes: transforms repair/re-anchor, validators raise issues. Hard issues gate the write behind a bounded retry.',
+  },
+  {
+    n: '4',
+    title: 'Stamp provenance',
+    body: 'Record the build manifest: authority (human | rule | ai), the inputs with content hashes, model, transport, cost, recipe hash.',
+  },
+  {
+    n: '5',
+    title: 'Store (no TTL)',
+    body: 'Write to the ArtifactStore under the frozen mark:/enrich: key. The human-edit guard refuses to clobber a human-authored entry with AI output.',
+  },
+  {
+    n: '6',
+    title: 'Render the view',
+    body: 'The reader composes from the cached artifact. Re-opening is instant; a cache_version bump serves the previous value while the new one recomputes (SWR).',
+  },
+];
+
+// ── the page ───────────────────────────────────────────────────────────────
+
+const CHAPTERS: { id: string; title: string }[] = [
+  { id: 'thesis', title: 'The idea' },
+  { id: 'primitives', title: 'Four primitives' },
+  { id: 'producers', title: 'Marks & enrichments' },
+  { id: 'lifecycle', title: 'How a piece is built' },
+  { id: 'graph', title: 'The build graph' },
+  { id: 'enrichments', title: 'Every enrichment' },
+  { id: 'freshness', title: 'Caching & freshness' },
+];
+
+export function HowItWorksPage(): JSX.Element {
+  const registry = useRegistry();
+  const [selected, setSelected] = createSignal<string | null>(null);
+  const [focus, setFocus] = createSignal<string | null>(null);
+  const [active, setActive] = createSignal<string>('thesis');
+  const [openEntries, setOpenEntries] = createSignal<Set<string>>(new Set());
+
+  const graph = createMemo<Graph>(() => {
+    const r = registry();
+    if (!r) return { nodes: [], edges: [], byId: new Map() };
+    return assignLayers(buildGraph(r.marks, r.enrichments));
+  });
+
+  const selectedNode = createMemo<GraphNode | null>(() => {
+    const id = selected();
+    return id ? (graph().byId.get(id) ?? null) : null;
+  });
+
+  // Families (mark ids) for the focus chips + directory grouping, canon first.
+  const families = createMemo<GraphNode[]>(() =>
+    graph()
+      .nodes.filter((n) => n.kind === 'mark')
+      .sort((a, b) => {
+        const ca = a.mark?.category === 'canon' ? 0 : 1;
+        const cb = b.mark?.category === 'canon' ? 0 : 1;
+        if (ca !== cb) return ca - cb;
+        return a.id < b.id ? -1 : 1;
+      }),
+  );
+
+  const enrichmentsByFamily = (family: string): GraphNode[] =>
+    graph()
+      .nodes.filter((n) => n.kind === 'enrichment' && n.family === family)
+      .sort((a, b) => (a.id < b.id ? -1 : 1));
+
+  const sectionEls = new Map<string, HTMLElement>();
+  const registerSection = (id: string) => (el: HTMLElement) => {
+    sectionEls.set(id, el);
+  };
+  const scrollTo = (id: string): void => {
+    sectionEls.get(id)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+  const selectAndReveal = (id: string): void => {
+    setSelected(id);
+    scrollTo('graph');
+  };
+
+  onMount(() => {
+    const obs = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((en) => en.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+        if (visible.length) setActive((visible[0].target as HTMLElement).id);
+      },
+      { rootMargin: '-15% 0px -75% 0px', threshold: 0 },
+    );
+    for (const el of sectionEls.values()) obs.observe(el);
+    onCleanup(() => obs.disconnect());
+  });
+
+  const toggleEntry = (id: string): void => {
+    setOpenEntries((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else {
+        next.add(id);
+        setSelected(id);
+      }
+      return next;
+    });
+  };
+
+  const h2: JSX.CSSProperties = {
+    'font-size': '0.85rem',
+    'text-transform': 'uppercase',
+    'letter-spacing': '0.1em',
+    color: 'var(--muted)',
+    margin: '0 0 0.75rem',
+  };
+  const sectionStyle: JSX.CSSProperties = { 'margin-bottom': '3rem', 'scroll-margin-top': '1rem' };
+  const lead: JSX.CSSProperties = { 'font-size': '0.95rem', 'line-height': 1.6, color: '#2a2a2a' };
+
+  return (
+    <div class="page-shell" style={{ '--page-max': '1180px' }}>
+      <header>
+        <h1>How it works</h1>
+        <p style={{ color: 'var(--muted)', 'max-width': '60ch' }}>
+          A walkthrough of how this app turns a page of Talmud into smart notes — the four
+          primitives the engine is built on, how a single note is produced, and a deep dive into
+          every enrichment, drawn live from the running registry.
+        </p>
+      </header>
+
+      <div class="hiw-layout">
+        <nav class="hiw-rail" aria-label="Sections">
+          <ol>
+            <For each={CHAPTERS}>
+              {(ch) => (
+                <li>
+                  <button
+                    type="button"
+                    classList={{ 'is-active': active() === ch.id }}
+                    onClick={() => scrollTo(ch.id)}
+                  >
+                    {ch.title}
+                  </button>
+                </li>
+              )}
+            </For>
+          </ol>
+        </nav>
+
+        <div>
+          {/* 1 — the idea */}
+          <section id="thesis" ref={registerSection('thesis')} style={sectionStyle}>
+            <h2 style={h2}>The idea</h2>
+            <p style={lead}>
+              The plain-English version is: <strong>the text, covered in smart notes</strong>. A
+              note knows <em>where</em> it sits on the text, <em>what</em> it's built from,{' '}
+              <em>how</em> it was made, and <em>how sure</em> we are. Notes compose — a synthesis is
+              a note built from other notes — and the views you read (sidebar cards, maps, the
+              argument flow) are all generated from notes, never authored by hand.
+            </p>
+            <p style={lead}>
+              Under that plain story sits one small engine, shared by both this app and its sister
+              Tanach app, made of exactly four primitives.
+            </p>
+          </section>
+
+          {/* 2 — four primitives */}
+          <section id="primitives" ref={registerSection('primitives')} style={sectionStyle}>
+            <h2 style={h2}>Four primitives</h2>
+            <div class="hiw-cards">
+              <PrimitiveCard
+                name="Spine"
+                module="@corpus/core/model/spine"
+                oneLine="An addressable text (or entity space) that notes pin to."
+              >
+                A reference into a spine is a path that <strong>may stop early</strong>:{' '}
+                <Mono>[Berakhot, 2a]</Mono> is the whole daf, <Mono>[Berakhot, 2a, 3]</Mono> one
+                segment. Bavli is the implicit default spine; Tanach is book / chapter / verse.
+              </PrimitiveCard>
+              <PrimitiveCard
+                name="Anchor"
+                module="@corpus/core/model/anchor"
+                oneLine="THE one shape for “where a piece sits.”"
+              >
+                A span plus a <strong>precision</strong> (token &gt; segment &gt; division &gt; unit
+                &gt; work &gt; external) and how it was earned (<Mono>via</Mono>,{' '}
+                <Mono>confidence</Mono>). “Cross-daf” isn't a precision — it's derived at render
+                time.
+                <AnchorDiagram />
+              </PrimitiveCard>
+              <PrimitiveCard
+                name="Artifact"
+                module="@corpus/core/model/artifact"
+                oneLine="One produced piece: a typed body + anchors + provenance."
+              >
+                Mark instances, enrichment outputs, context items, links, and anchor refinements are{' '}
+                <em>all</em> artifacts. Provenance is the <strong>build manifest</strong>: who
+                decided (<Mono>human | rule | ai</Mono>), the inputs with content hashes, the model,
+                the cost.
+              </PrimitiveCard>
+              <PrimitiveCard
+                name="Producer"
+                module="@corpus/core/model/producer"
+                oneLine="The registry entry that makes artifacts."
+              >
+                Declares its inputs, its recipe, where outputs sit, and how they cache. Its{' '}
+                <Mono>anchoring.behavior</Mono> unifies the old split: <strong>discovers</strong>{' '}
+                (finds anchors — a mark), <strong>inherits</strong> (sits where its input sits — a
+                per-instance enrichment), <strong>aggregates</strong> (one output over many — a
+                synthesis).
+              </PrimitiveCard>
+            </div>
+            <p
+              style={{
+                ...lead,
+                'margin-top': '0.85rem',
+                color: 'var(--muted)',
+                'font-size': '0.85rem',
+              }}
+            >
+              Placement is a <em>lifecycle</em>, not a fifth primitive: an anchor is earned coarse →
+              deterministic → AI → human, and a human-earned anchor is never silently overwritten.
+            </p>
+          </section>
+
+          {/* 3 — marks & enrichments */}
+          <section id="producers" ref={registerSection('producers')} style={sectionStyle}>
+            <h2 style={h2}>Two flavors of producer: marks & enrichments</h2>
+            <p style={lead}>
+              Every producer is one <Mono>Producer</Mono> under the hood, but it wears one of two
+              familiar faces. A <strong>mark</strong> reads the raw daf and{' '}
+              <strong>discovers</strong> instances — a rabbi name, an argument section, a biblical
+              citation — each anchored to where it sits. An <strong>enrichment</strong> takes a
+              mark's instances and builds on them: it either <strong>inherits</strong> the
+              instance's anchor (a per-instance note like a rabbi's biography) or{' '}
+              <strong>aggregates</strong> many instances into one whole-daf note (a synthesis).
+            </p>
+            <p style={lead}>
+              Enrichments chain: a synthesis depends on the leaf enrichments beneath it, which
+              depend on the mark, which depends on the raw text. That chain is exactly what the
+              build graph below draws.
+            </p>
+          </section>
+
+          {/* 4 — lifecycle */}
+          <section id="lifecycle" ref={registerSection('lifecycle')} style={sectionStyle}>
+            <h2 style={h2}>How a single piece is built</h2>
+            <p style={{ ...lead, 'margin-bottom': '0.9rem' }}>
+              One function — <Mono>runProducer</Mono> — runs every producer, mark or enrichment, the
+              same way:
+            </p>
+            <div
+              style={{
+                display: 'grid',
+                'grid-template-columns': 'repeat(auto-fit, minmax(160px, 1fr))',
+                gap: '0.6rem',
+              }}
+            >
+              <For each={STEPS}>
+                {(step) => (
+                  <div
+                    style={{
+                      border: '1px solid var(--line)',
+                      'border-radius': '8px',
+                      background: '#fff',
+                      padding: '0.7rem 0.8rem',
+                    }}
+                  >
+                    <div style={{ display: 'flex', 'align-items': 'center', gap: '0.4rem' }}>
+                      <span
+                        style={{
+                          width: '1.4rem',
+                          height: '1.4rem',
+                          'border-radius': '50%',
+                          background: 'var(--accent)',
+                          color: '#fff',
+                          display: 'inline-flex',
+                          'align-items': 'center',
+                          'justify-content': 'center',
+                          'font-size': '0.78rem',
+                          'font-weight': 700,
+                        }}
+                      >
+                        {step.n}
+                      </span>
+                      <strong style={{ 'font-size': '0.88rem' }}>{step.title}</strong>
+                    </div>
+                    <p
+                      style={{
+                        margin: '0.4rem 0 0',
+                        'font-size': '0.8rem',
+                        'line-height': 1.5,
+                        color: '#444',
+                      }}
+                    >
+                      {step.body}
+                    </p>
+                  </div>
+                )}
+              </For>
+            </div>
+          </section>
+
+          {/* 5 — the build graph */}
+          <section id="graph" ref={registerSection('graph')} style={sectionStyle}>
+            <h2 style={h2}>The build graph</h2>
+            <p style={{ ...lead, 'margin-bottom': '0.6rem' }}>
+              The live registry, as a dependency graph. Columns are dependency depth: source inputs
+              on the left, then the marks built from them, then the enrichments built on the marks.
+              Hover any node to trace its chain; click it for the full deep dive.
+            </p>
+
+            <Show when={registry.loading}>
+              <p style={{ color: 'var(--muted)' }}>Loading the registry…</p>
+            </Show>
+            <Show when={registry.error}>
+              <p style={{ color: '#b91c1c' }}>Couldn't load the registry from /api.</p>
+            </Show>
+
+            <Show when={!registry.loading && !registry.error}>
+              {/* focus-by-family chips */}
+              <div
+                style={{
+                  display: 'flex',
+                  'flex-wrap': 'wrap',
+                  gap: '0.3rem',
+                  'margin-bottom': '0.55rem',
+                }}
+              >
+                <button
+                  type="button"
+                  onClick={() => setFocus(null)}
+                  classList={{ 'is-active': focus() === null }}
+                  style={chip(focus() === null, '#444')}
+                >
+                  all
+                </button>
+                <For each={families()}>
+                  {(f) => (
+                    <button
+                      type="button"
+                      onClick={() => setFocus(focus() === f.id ? null : f.id)}
+                      style={chip(focus() === f.id, familyColor(f.id))}
+                    >
+                      {f.id}
+                    </button>
+                  )}
+                </For>
+              </div>
+
+              <HowItWorksGraph
+                graph={graph()}
+                selectedId={selected()}
+                onSelect={setSelected}
+                focusFamily={focus()}
+              />
+              <GraphLegend />
+
+              <Show
+                when={selectedNode()}
+                fallback={
+                  <p
+                    style={{
+                      'margin-top': '0.8rem',
+                      color: 'var(--muted)',
+                      'font-size': '0.85rem',
+                    }}
+                  >
+                    Select a node to see how it's built and what it feeds.
+                  </p>
+                }
+              >
+                {(n) => (
+                  <div style={{ 'margin-top': '0.9rem' }}>
+                    <button
+                      type="button"
+                      onClick={() => setSelected(null)}
+                      style={{
+                        float: 'right',
+                        background: 'none',
+                        border: 'none',
+                        cursor: 'pointer',
+                        color: 'var(--muted)',
+                        'font-size': '1.1rem',
+                        'line-height': 1,
+                      }}
+                      aria-label="Close deep dive"
+                    >
+                      ×
+                    </button>
+                    <DeepDive node={n()} graph={graph()} onSelect={selectAndReveal} />
+                  </div>
+                )}
+              </Show>
+            </Show>
+          </section>
+
+          {/* 6 — every enrichment */}
+          <section id="enrichments" ref={registerSection('enrichments')} style={sectionStyle}>
+            <h2 style={h2}>Every enrichment</h2>
+            <p style={{ ...lead, 'margin-bottom': '0.8rem' }}>
+              Grouped under the mark each one builds on. Click any row to expand its full deep dive
+              — dependencies, model, scope, output schema, and the prompts behind it.
+            </p>
+
+            <Show when={!registry.loading && !registry.error}>
+              <For each={families()}>
+                {(fam) => (
+                  <div style={{ 'margin-bottom': '1.1rem' }}>
+                    <div
+                      style={{
+                        display: 'flex',
+                        'align-items': 'center',
+                        gap: '0.5rem',
+                        'border-bottom': `2px solid ${familyColor(fam.id)}`,
+                        'padding-bottom': '0.25rem',
+                        'margin-bottom': '0.5rem',
+                      }}
+                    >
+                      <span
+                        style={{
+                          'font-family': 'ui-monospace, SFMono-Regular, Menlo, monospace',
+                          'font-weight': 700,
+                          color: familyColor(fam.id),
+                        }}
+                      >
+                        {fam.id}
+                      </span>
+                      <span style={{ 'font-size': '0.8rem', color: 'var(--muted)' }}>
+                        {fam.mark?.label}
+                      </span>
+                    </div>
+                    <For
+                      each={enrichmentsByFamily(fam.id)}
+                      fallback={
+                        <p style={{ 'font-size': '0.8rem', color: 'var(--muted)', margin: 0 }}>
+                          No LLM enrichments — this mark stands on its own.
+                        </p>
+                      }
+                    >
+                      {(en) => (
+                        <DirectoryRow
+                          node={en}
+                          graph={graph()}
+                          open={openEntries().has(en.id)}
+                          onToggle={() => toggleEntry(en.id)}
+                          onSelect={selectAndReveal}
+                        />
+                      )}
+                    </For>
+                  </div>
+                )}
+              </For>
+              <p style={{ 'font-size': '0.78rem', color: 'var(--muted)', 'margin-top': '1rem' }}>
+                Note: <Mono>/api/enrichments</Mono> lists LLM enrichments only. A couple of
+                producers (e.g. <Mono>rabbi.identity</Mono>) are deterministic/computed — they're
+                real producers but resolve from data rather than a model, so they appear under their
+                mark rather than in this list.
+              </p>
+            </Show>
+          </section>
+
+          {/* 7 — caching & freshness */}
+          <section id="freshness" ref={registerSection('freshness')} style={sectionStyle}>
+            <h2 style={h2}>Caching, provenance & freshness</h2>
+            <p style={lead}>
+              Producer outputs are cached in the <Mono>ArtifactStore</Mono> under{' '}
+              <strong>byte-frozen keys</strong> (<Mono>mark:…</Mono> / <Mono>enrich:…</Mono>) with{' '}
+              <strong>no TTL</strong> — outputs are deterministic per key, and full-Shas re-warming
+              is expensive, so a stray key change would silently re-pay all of it.
+            </p>
+            <ul style={{ ...lead, 'padding-left': '1.1rem' }}>
+              <li>
+                <strong>Invalidate by version.</strong> Bump a producer's <Mono>cache_version</Mono>{' '}
+                and the old key becomes unreachable. If you bump a producer, you must bump
+                everything that depends on it — <Mono>GET /api/dependents/:id</Mono> enumerates the
+                cascade.
+              </li>
+              <li>
+                <strong>Detect by recipe hash.</strong> Each artifact stamps the hash of the recipe
+                that made it, so <Mono>/api/stale/:id/:t/:p</Mono> can tell fresh from stale without
+                re-running anything.
+              </li>
+              <li>
+                <strong>Serve stale while revalidating.</strong> Across a version bump the reader
+                gets the previous value immediately while the new one recomputes in the background.
+              </li>
+              <li>
+                <strong>Human edits win.</strong> The store refuses to overwrite a human-authored
+                artifact with rule/AI output — an enforced invariant, not a convention.
+              </li>
+            </ul>
+            <p style={{ ...lead, color: 'var(--muted)', 'font-size': '0.85rem' }}>
+              The provenance manifest on each artifact records the exact inputs it was built from
+              (with content hashes), which closes the loop: detect what's stale, enumerate what else
+              must follow, and re-warm only the cascade.
+            </p>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function chip(activeState: boolean, color: string): JSX.CSSProperties {
+  return {
+    'font-family': 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    'font-size': '0.72rem',
+    padding: '0.2rem 0.5rem',
+    'border-radius': '999px',
+    cursor: 'pointer',
+    background: activeState ? color : '#fff',
+    color: activeState ? '#fff' : color,
+    border: `1px solid ${color}66`,
+  };
+}
+
+function DirectoryRow(props: {
+  node: GraphNode;
+  graph: Graph;
+  open: boolean;
+  onToggle: () => void;
+  onSelect: (id: string) => void;
+}): JSX.Element {
+  const e = (): GraphNode['enrichment'] => props.node.enrichment;
+  return (
+    <div style={{ 'margin-bottom': '0.4rem' }}>
+      <button
+        type="button"
+        onClick={() => props.onToggle()}
+        aria-expanded={props.open}
+        style={{
+          display: 'flex',
+          'align-items': 'center',
+          gap: '0.5rem',
+          width: '100%',
+          'text-align': 'left',
+          background: props.open ? '#faf8f2' : '#fff',
+          border: '1px solid var(--line)',
+          'border-radius': '6px',
+          padding: '0.4rem 0.6rem',
+          cursor: 'pointer',
+        }}
+      >
+        <span
+          style={{
+            color: '#bbb',
+            transform: props.open ? 'rotate(90deg)' : 'none',
+            transition: 'transform .12s',
+          }}
+        >
+          ▸
+        </span>
+        <span
+          style={{
+            'font-family': 'ui-monospace, SFMono-Regular, Menlo, monospace',
+            'font-size': '0.82rem',
+            'font-weight': 600,
+            color: familyColor(props.node.family),
+          }}
+        >
+          {props.node.id}
+        </span>
+        <span
+          style={{
+            'font-size': '0.78rem',
+            color: '#555',
+            flex: 1,
+            'min-width': 0,
+            overflow: 'hidden',
+            'text-overflow': 'ellipsis',
+            'white-space': 'nowrap',
+          }}
+        >
+          {e()?.description}
+        </span>
+        <Show when={e()?.scope}>
+          <Badge>{e()?.scope}</Badge>
+        </Show>
+        <Show when={e()?.mode}>
+          <Badge>{e()?.mode}</Badge>
+        </Show>
+      </button>
+      <Show when={props.open}>
+        <div style={{ 'margin-top': '0.4rem' }}>
+          <DeepDive node={props.node} graph={props.graph} onSelect={props.onSelect} />
+        </div>
+      </Show>
+    </div>
+  );
+}

--- a/packages/talmud/src/client/howItWorks/graphModel.ts
+++ b/packages/talmud/src/client/howItWorks/graphModel.ts
@@ -1,0 +1,251 @@
+/**
+ * Pure model for the #howitworks build graph. Turns the live registry
+ * (GET /api/marks + GET /api/enrichments) into a layered dependency DAG:
+ * source inputs -> marks (producers that DISCOVER anchors) -> enrichments
+ * (producers that INHERIT/AGGREGATE over a mark's instances). This is the
+ * static "registry DAG" from docs/framework.md (the same shape depGraph.ts
+ * walks) rendered for a reader.
+ *
+ * No Solid, no fetch, no DOM — so it unit-tests cleanly
+ * (tests/how-it-works-graph.test.ts). Layout (x/y, edges) lives in the
+ * HowItWorksGraph component; this module only decides what connects to what
+ * and how deep each node sits.
+ */
+
+/** A dependency entry as the API returns it (the legacy `dependencies`
+ *  grammar). A bare string is a source input; an object names another
+ *  producer. */
+export type RawDep = string | { mark: string } | { enrichment: string; fanOut?: boolean };
+
+/** The fields we read off GET /api/marks (a MarkDefinition). Kept local +
+ *  loose so the client never imports worker types. */
+export interface RawMark {
+  id: string;
+  label?: string;
+  description?: string;
+  category?: string;
+  anchor?: string;
+  render?: { kind?: string } | null;
+  extractor?: {
+    kind?: string;
+    model?: string;
+    thinking_off?: boolean;
+    reasoning_effort?: string;
+  } | null;
+  dependencies?: RawDep[];
+  status?: string;
+  experimental?: boolean;
+  cache_version?: string;
+}
+
+/** The fields we read off GET /api/enrichments (the flattened enrichment
+ *  shape the worker emits — `mark` is the target mark). */
+export interface RawEnrichment {
+  id: string;
+  label?: string;
+  description?: string;
+  mark?: string;
+  mode?: string;
+  scope?: string;
+  dependencies?: RawDep[];
+  model?: string;
+  thinking_off?: boolean;
+  reasoning_effort?: string;
+  output_schema?: unknown;
+  system_prompt?: string;
+  user_prompt_template?: string;
+  cache_version?: string;
+}
+
+export type NodeKind = 'source' | 'mark' | 'enrichment';
+
+export interface GraphNode {
+  id: string;
+  kind: NodeKind;
+  label: string;
+  /** Mark family for grouping/coloring: a mark colors by its own id, an
+   *  enrichment by its target mark, a source by 'source'. */
+  family: string;
+  /** Dependency depth: sources 0, marks 1, enrichments 2+. Set by assignLayers. */
+  layer: number;
+  mark?: RawMark;
+  enrichment?: RawEnrichment;
+}
+
+export interface GraphEdge {
+  /** Dependency node id (the input). */
+  from: string;
+  /** Producer node id (the thing built from it). */
+  to: string;
+  /** Kind of the `from` endpoint — used to color the connector. */
+  kind: NodeKind;
+  /** True when the edge is the enrichment->its-target-mark relation rather
+   *  than a declared `dependencies` entry (drawn more softly). */
+  target?: boolean;
+}
+
+export interface Graph {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  byId: Map<string, GraphNode>;
+}
+
+/** Normalize one dependency entry to the node it points at, or null if the
+ *  shape is unrecognized. */
+export function depRef(dep: RawDep): { id: string; kind: NodeKind } | null {
+  if (typeof dep === 'string') {
+    const id = dep.trim();
+    return id ? { id, kind: 'source' } : null;
+  }
+  if (dep && typeof dep === 'object') {
+    if ('mark' in dep && typeof dep.mark === 'string') return { id: dep.mark, kind: 'mark' };
+    if ('enrichment' in dep && typeof dep.enrichment === 'string')
+      return { id: dep.enrichment, kind: 'enrichment' };
+  }
+  return null;
+}
+
+/** All resolvable dependency refs for a producer (dedup-free; caller dedups). */
+export function parseDeps(deps: RawDep[] | undefined): { id: string; kind: NodeKind }[] {
+  if (!Array.isArray(deps)) return [];
+  const out: { id: string; kind: NodeKind }[] = [];
+  for (const d of deps) {
+    const ref = depRef(d);
+    if (ref) out.push(ref);
+  }
+  return out;
+}
+
+const niceLabel = (id: string, label?: string): string => (label?.trim() ? label.trim() : id);
+
+/** Build the node/edge graph from the live registry. Source nodes are
+ *  synthesized from the union of all string dependencies, so the graph shows
+ *  exactly the inputs the registry actually declares. */
+export function buildGraph(marks: RawMark[], enrichments: RawEnrichment[]): Graph {
+  const byId = new Map<string, GraphNode>();
+  const edges: GraphEdge[] = [];
+  const seenEdge = new Set<string>();
+
+  const ensureSource = (id: string): void => {
+    if (!byId.has(id)) byId.set(id, { id, kind: 'source', label: id, family: 'source', layer: 0 });
+  };
+  const addEdge = (from: string, to: string, kind: NodeKind, target = false): void => {
+    const key = `${from}->${to}`;
+    if (seenEdge.has(key)) return;
+    seenEdge.add(key);
+    edges.push({ from, to, kind, target });
+  };
+
+  for (const m of marks) {
+    byId.set(m.id, {
+      id: m.id,
+      kind: 'mark',
+      label: niceLabel(m.id, m.label),
+      family: m.id,
+      layer: 1,
+      mark: m,
+    });
+  }
+  for (const e of enrichments) {
+    byId.set(e.id, {
+      id: e.id,
+      kind: 'enrichment',
+      label: niceLabel(e.id, e.label),
+      family: e.mark || 'other',
+      layer: 2,
+      enrichment: e,
+    });
+  }
+
+  // Declared dependency edges (sources + producer-to-producer).
+  const wireDeps = (producerId: string, deps: RawDep[] | undefined): void => {
+    for (const ref of parseDeps(deps)) {
+      if (ref.kind === 'source') ensureSource(ref.id);
+      // Only wire producer deps that actually exist in the registry; a source
+      // always exists (we just made it).
+      if (ref.kind !== 'source' && !byId.has(ref.id)) continue;
+      addEdge(ref.id, producerId, ref.kind);
+    }
+  };
+  for (const m of marks) wireDeps(m.id, m.dependencies);
+  for (const e of enrichments) wireDeps(e.id, e.dependencies);
+
+  // Every enrichment is anchored to a target mark even when the mark isn't in
+  // its declared deps (global enrichments take their instance implicitly).
+  // Draw that as a soft edge so the graph is connected and groups read.
+  for (const e of enrichments) {
+    if (e.mark && byId.has(e.mark)) addEdge(e.mark, e.id, 'mark', true);
+  }
+
+  return { nodes: [...byId.values()], edges, byId };
+}
+
+/** Longest-path dependency depth per node: sources sit at 0, and every other
+ *  node sits one column past its deepest input (a node with only source deps
+ *  lands at 1). Because each node is strictly deeper than everything it
+ *  depends on, EVERY edge runs left-to-right — no intra-column connectors — so
+ *  the columns read sources -> marks -> enrichments -> synthesis by depth.
+ *  Cycle-safe (the registry is acyclic — validateProducerGraph guards it — but
+ *  we never loop regardless). Mutates node.layer and returns the graph. */
+export function assignLayers(graph: Graph): Graph {
+  const memo = new Map<string, number>();
+  const visiting = new Set<string>();
+  const layerOf = (id: string): number => {
+    const node = graph.byId.get(id);
+    if (!node) return 0;
+    if (node.kind === 'source') return 0;
+    if (memo.has(id)) return memo.get(id) as number;
+    if (visiting.has(id)) return 1;
+    visiting.add(id);
+    let layer = 1;
+    for (const e of graph.edges) {
+      if (e.to === id) layer = Math.max(layer, layerOf(e.from) + 1);
+    }
+    visiting.delete(id);
+    memo.set(id, layer);
+    return layer;
+  };
+  for (const n of graph.nodes) n.layer = layerOf(n.id);
+  return graph;
+}
+
+/** Everything `id` is (transitively) built from — its upstream inputs. */
+export function ancestorsOf(graph: Graph, id: string): Set<string> {
+  const out = new Set<string>();
+  const stack = [id];
+  while (stack.length) {
+    const cur = stack.pop() as string;
+    for (const e of graph.edges) {
+      if (e.to === cur && !out.has(e.from)) {
+        out.add(e.from);
+        stack.push(e.from);
+      }
+    }
+  }
+  return out;
+}
+
+/** Everything (transitively) built from `id` — its downstream consumers. */
+export function descendantsOf(graph: Graph, id: string): Set<string> {
+  const out = new Set<string>();
+  const stack = [id];
+  while (stack.length) {
+    const cur = stack.pop() as string;
+    for (const e of graph.edges) {
+      if (e.from === cur && !out.has(e.to)) {
+        out.add(e.to);
+        stack.push(e.to);
+      }
+    }
+  }
+  return out;
+}
+
+/** The full connected chain through a node (inputs + consumers + itself) —
+ *  what to keep lit when the node is hovered/selected. */
+export function connectedClosure(graph: Graph, id: string): Set<string> {
+  const out = ancestorsOf(graph, id);
+  for (const d of descendantsOf(graph, id)) out.add(d);
+  out.add(id);
+  return out;
+}

--- a/packages/talmud/src/client/howItWorks/registry.ts
+++ b/packages/talmud/src/client/howItWorks/registry.ts
@@ -1,0 +1,34 @@
+/**
+ * Live registry fetch for #howitworks. Pulls the actual producer definitions
+ * the running worker serves (GET /api/marks + GET /api/enrichments) so the
+ * page never drifts from the code — it documents whatever is deployed.
+ *
+ * NOTE: /api/enrichments only emits LLM enrichments (the worker filters to
+ * extractor.kind === 'llm'), so deterministic/computed producers like
+ * rabbi.identity surface as marks/derived rather than in the enrichment list.
+ * The page states this honestly rather than fabricating entries.
+ */
+import { createResource, type Resource } from 'solid-js';
+import type { RawEnrichment, RawMark } from './graphModel';
+
+export interface Registry {
+  marks: RawMark[];
+  enrichments: RawEnrichment[];
+}
+
+async function fetchRegistry(): Promise<Registry> {
+  const [marksRes, enrichRes] = await Promise.all([fetch('/api/marks'), fetch('/api/enrichments')]);
+  if (!marksRes.ok) throw new Error(`/api/marks ${marksRes.status}`);
+  if (!enrichRes.ok) throw new Error(`/api/enrichments ${enrichRes.status}`);
+  const marksJson = (await marksRes.json()) as { marks?: RawMark[] };
+  const enrichJson = (await enrichRes.json()) as { enrichments?: RawEnrichment[] };
+  return {
+    marks: Array.isArray(marksJson.marks) ? marksJson.marks : [],
+    enrichments: Array.isArray(enrichJson.enrichments) ? enrichJson.enrichments : [],
+  };
+}
+
+export function useRegistry(): Resource<Registry> {
+  const [registry] = createResource(fetchRegistry);
+  return registry;
+}

--- a/packages/talmud/src/client/styles.css
+++ b/packages/talmud/src/client/styles.css
@@ -126,6 +126,78 @@ main {
   }
 }
 
+/* #howitworks guided walkthrough: sticky chapter rail beside the content. */
+.hiw-layout {
+  display: grid;
+  grid-template-columns: 184px minmax(0, 1fr);
+  gap: 2.5rem;
+  align-items: start;
+}
+.hiw-rail {
+  position: sticky;
+  top: 1rem;
+  align-self: start;
+}
+.hiw-rail ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+.hiw-rail button {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  border-left: 2px solid transparent;
+  padding: 0.3rem 0.5rem;
+  border-radius: 0 6px 6px 0;
+  color: var(--muted);
+  font: inherit;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+.hiw-rail button.is-active {
+  color: var(--accent);
+  border-left-color: var(--accent);
+  background: #f3ede4;
+  font-weight: 600;
+}
+.hiw-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 0.8rem;
+}
+@media (max-width: 900px) {
+  .hiw-layout {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+  .hiw-rail {
+    position: static;
+    overflow-x: auto;
+    border-bottom: 1px solid var(--line);
+    padding-bottom: 0.4rem;
+  }
+  .hiw-rail ol {
+    flex-direction: row;
+    gap: 0.25rem;
+  }
+  .hiw-rail button {
+    white-space: nowrap;
+    border-left: none;
+    border-bottom: 2px solid transparent;
+    border-radius: 6px 6px 0 0;
+  }
+  .hiw-rail button.is-active {
+    border-left-color: transparent;
+    border-bottom-color: var(--accent);
+  }
+}
+
 header {
   border-bottom: 1px solid var(--line);
   padding-bottom: 1rem;

--- a/packages/talmud/tests/how-it-works-graph.test.ts
+++ b/packages/talmud/tests/how-it-works-graph.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ancestorsOf,
+  assignLayers,
+  buildGraph,
+  connectedClosure,
+  depRef,
+  descendantsOf,
+  parseDeps,
+  type RawEnrichment,
+  type RawMark,
+} from '../src/client/howItWorks/graphModel';
+
+// A small registry that exercises every edge kind:
+//  - a mark on raw text (rabbi, argument)
+//  - a mark built on another mark (argument-move)
+//  - a global enrichment with no declared deps (rabbi.bio — target edge only)
+//  - an enrichment on an enrichment (rabbi.synthesis, argument.synthesis)
+//  - an enrichment on a mark (argument.voices)
+const MARKS: RawMark[] = [
+  { id: 'rabbi', label: 'Rabbi', dependencies: ['gemara'] },
+  { id: 'argument', label: 'Argument', dependencies: ['gemara'] },
+  { id: 'argument-move', label: 'Move', dependencies: ['gemara', { mark: 'argument' }] },
+];
+const ENRICHMENTS: RawEnrichment[] = [
+  { id: 'rabbi.bio', mark: 'rabbi', mode: 'augment-content', scope: 'global' },
+  {
+    id: 'rabbi.synthesis',
+    mark: 'rabbi',
+    mode: 'aggregate',
+    scope: 'local',
+    dependencies: ['gemara', { enrichment: 'rabbi.bio' }, { mark: 'rabbi' }],
+  },
+  {
+    id: 'argument.voices',
+    mark: 'argument',
+    mode: 'augment-content',
+    scope: 'local',
+    dependencies: [{ mark: 'argument-move' }],
+  },
+  {
+    id: 'argument.synthesis',
+    mark: 'argument',
+    mode: 'aggregate',
+    scope: 'local',
+    dependencies: [{ enrichment: 'argument.voices' }],
+  },
+];
+
+const built = () => assignLayers(buildGraph(MARKS, ENRICHMENTS));
+
+describe('depRef / parseDeps', () => {
+  it('classifies each dependency shape', () => {
+    expect(depRef('gemara')).toEqual({ id: 'gemara', kind: 'source' });
+    expect(depRef({ mark: 'rabbi' })).toEqual({ id: 'rabbi', kind: 'mark' });
+    expect(depRef({ enrichment: 'rabbi.bio' })).toEqual({ id: 'rabbi.bio', kind: 'enrichment' });
+    expect(depRef({} as never)).toBeNull();
+    expect(depRef('')).toBeNull();
+  });
+  it('drops unrecognized entries', () => {
+    expect(parseDeps(['gemara', {} as never, { mark: 'x' }])).toEqual([
+      { id: 'gemara', kind: 'source' },
+      { id: 'x', kind: 'mark' },
+    ]);
+    expect(parseDeps(undefined)).toEqual([]);
+  });
+});
+
+describe('buildGraph', () => {
+  it('synthesizes a source node for string deps and keeps producer nodes', () => {
+    const g = built();
+    expect(g.byId.get('gemara')?.kind).toBe('source');
+    expect(g.byId.get('rabbi')?.kind).toBe('mark');
+    expect(g.byId.get('rabbi.bio')?.kind).toBe('enrichment');
+    // enrichment family is its target mark
+    expect(g.byId.get('argument.voices')?.family).toBe('argument');
+  });
+
+  it('wires declared deps and a soft edge to each enrichment target mark', () => {
+    const g = built();
+    const has = (from: string, to: string) => g.edges.some((e) => e.from === from && e.to === to);
+    expect(has('gemara', 'rabbi')).toBe(true);
+    expect(has('argument', 'argument-move')).toBe(true);
+    expect(has('rabbi.bio', 'rabbi.synthesis')).toBe(true);
+    // rabbi.bio declares no deps, so the only edge into it is the target-mark edge
+    const intoBio = g.edges.filter((e) => e.to === 'rabbi.bio');
+    expect(intoBio).toHaveLength(1);
+    expect(intoBio[0]).toMatchObject({ from: 'rabbi', target: true });
+  });
+
+  it('does not double-count a target edge already declared as a dep', () => {
+    const g = built();
+    const rabbiToSynthesis = g.edges.filter(
+      (e) => e.from === 'rabbi' && e.to === 'rabbi.synthesis',
+    );
+    expect(rabbiToSynthesis).toHaveLength(1);
+    // declared {mark:'rabbi'} wins, so it is NOT flagged as a soft target edge
+    expect(rabbiToSynthesis[0].target).toBe(false);
+  });
+});
+
+describe('assignLayers — longest-path depth', () => {
+  it('places every node one column past its deepest input', () => {
+    const g = built();
+    const layer = (id: string) => g.byId.get(id)?.layer;
+    expect(layer('gemara')).toBe(0);
+    expect(layer('rabbi')).toBe(1);
+    expect(layer('argument')).toBe(1);
+    expect(layer('argument-move')).toBe(2);
+    expect(layer('rabbi.bio')).toBe(2);
+    expect(layer('rabbi.synthesis')).toBe(3);
+    expect(layer('argument.voices')).toBe(3);
+    expect(layer('argument.synthesis')).toBe(4);
+  });
+
+  it('guarantees every edge runs strictly left to right', () => {
+    const g = built();
+    for (const e of g.edges) {
+      const from = g.byId.get(e.from)?.layer ?? 0;
+      const to = g.byId.get(e.to)?.layer ?? 0;
+      expect(to).toBeGreaterThan(from);
+    }
+  });
+});
+
+describe('closures', () => {
+  it('ancestorsOf returns the full upstream chain', () => {
+    const g = built();
+    expect(ancestorsOf(g, 'rabbi.synthesis')).toEqual(new Set(['gemara', 'rabbi', 'rabbi.bio']));
+  });
+  it('descendantsOf returns everything downstream', () => {
+    const g = built();
+    const d = descendantsOf(g, 'gemara');
+    expect(d.size).toBe(7);
+    expect(d.has('argument.synthesis')).toBe(true);
+  });
+  it('connectedClosure includes the node itself plus both directions', () => {
+    const g = built();
+    const c = connectedClosure(g, 'rabbi.bio');
+    expect(c.has('rabbi.bio')).toBe(true);
+    expect(c.has('rabbi')).toBe(true); // ancestor
+    expect(c.has('rabbi.synthesis')).toBe(true); // descendant
+  });
+});

--- a/packages/talmud/tests/how-it-works-page.test.tsx
+++ b/packages/talmud/tests/how-it-works-page.test.tsx
@@ -1,0 +1,57 @@
+import { render } from 'solid-js/web';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { HowItWorksPage } from '../src/client/HowItWorksPage';
+
+// A jsdom mount smoke test: proves the page renders without throwing through
+// its real lifecycle (onMount + IntersectionObserver + the registry resource),
+// and that the static walkthrough scaffold is present. The interactive graph
+// itself is covered by how-it-works-graph.test.ts (the pure model).
+
+describe('HowItWorksPage', () => {
+  let dispose: (() => void) | undefined;
+
+  beforeEach(() => {
+    // jsdom has no IntersectionObserver; the scroll-spy onMount needs one.
+    vi.stubGlobal(
+      'IntersectionObserver',
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        const body = String(url).includes('enrichments')
+          ? {
+              enrichments: [
+                { id: 'rabbi.bio', mark: 'rabbi', mode: 'augment-content', scope: 'global' },
+              ],
+            }
+          : { marks: [{ id: 'rabbi', label: 'Rabbi', dependencies: ['gemara'] }] };
+        return { ok: true, json: async () => body } as Response;
+      }),
+    );
+  });
+
+  afterEach(() => {
+    dispose?.();
+    dispose = undefined;
+    vi.unstubAllGlobals();
+  });
+
+  it('mounts and renders the walkthrough scaffold', () => {
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    dispose = render(() => <HowItWorksPage />, root);
+    const text = root.textContent ?? '';
+    expect(text).toContain('How it works');
+    expect(text).toContain('Four primitives');
+    // a lifecycle step (renders synchronously, independent of the fetch)
+    expect(text).toContain('Resolve inputs');
+    // the chapter rail is present
+    expect(root.querySelector('.hiw-rail')).toBeTruthy();
+    root.remove();
+  });
+});


### PR DESCRIPTION
## What

A new guided, presentation-style page at the **`#howitworks`** route that explains how the app is built — for walking a colleague through the system — and does a deep dive into **every enrichment**. All producer data is pulled **live** from the running registry (`GET /api/marks` + `GET /api/enrichments`), so the page documents whatever is actually deployed and never drifts from the code.

## The page (chapter walkthrough with a sticky rail + scroll-spy)

1. **The idea** — the text covered in smart notes.
2. **Four primitives** — Spine / Anchor / Artifact / Producer (grounded in `docs/framework.md`), with a small "note pinned to a span" diagram for Anchor.
3. **Marks & enrichments** — the two producer faces: `discovers` vs `inherits`/`aggregates`.
4. **How a piece is built** — the `runProducer` lifecycle as a stepper (resolve inputs → render+call → parse+check → stamp provenance → store no-TTL → render).
5. **The build graph** — the centerpiece: the live registry as a layered dependency DAG (sources → marks → enrichments). Hover any node to trace its whole dependency chain; click for the deep dive; focus-by-mark chips narrow the view.
6. **Every enrichment** — a directory grouped by mark; each row expands to the full deep dive (deps, model, scope, mode, cache version, output schema, and the system/user prompts).
7. **Caching & freshness** — byte-frozen keys, version-bump cascade, recipe-hash staleness, SWR, the human-edit guard.

## Implementation

- `src/client/howItWorks/graphModel.ts` — pure, unit-tested model (`depRef`/`parseDeps`/`buildGraph`/`assignLayers` + `ancestorsOf`/`descendantsOf`/`connectedClosure`). Longest-path layering guarantees every edge runs strictly left-to-right.
- `src/client/howItWorks/registry.ts` — the live `createResource` fetch.
- `src/client/HowItWorksGraph.tsx` — the interactive SVG, reusing the shared `orthogonalEdge` router and the `ACCENTS` palette; SVG nodes are keyboard-accessible (matches the repo's a11y pass).
- `src/client/HowItWorksPage.tsx` — the walkthrough + the shared `DeepDive` card (reused by the graph and the directory).
- `src/client/App.tsx` — hash route `#howitworks`. `styles.css` — `.hiw-*` rail layout.

## Notes / honest gaps

- `/api/enrichments` emits LLM enrichments only, so deterministic/computed producers (e.g. `rabbi.identity`) appear under their mark rather than in the enrichment list — the page states this rather than fabricating entries.
- Page prose is English (a systems guide); the floating EN/HE toggle still renders but the walkthrough copy isn't translated.

## Verification

- `pnpm typecheck`, `pnpm lint` (Biome, 630 files), and the full suite (**2535 tests**) all green.
- New tests: `tests/how-it-works-graph.test.ts` (10, the model) + `tests/how-it-works-page.test.tsx` (jsdom mount smoke test — first `.test.tsx` in the repo).
- Clean production `vite build`. Live endpoints confirmed returning 15 marks + 47 enrichments.
- In-browser screenshot couldn't be captured this run: the shared chrome-devtools profile was locked by another agent's session. Reachable at `#howitworks`.