### PR TITLE
Phase 3 (step 1): generation as a Workflow — additive whole-daf warm path

### DIFF
--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -1,3 +1,4 @@
+import { WorkflowEntrypoint, type WorkflowEvent, type WorkflowStep } from 'cloudflare:workers';
 import { slugTractate } from '@corpus/core/cache/keys';
 import { continuationLink, type FlowEdge } from '@corpus/core/context/link';
 import { coordLabel } from '@corpus/core/context/types';
@@ -302,6 +303,7 @@ import {
 } from './warm-cron';
 import { lookupGloss } from './word-glosses';
 import { checkWorkerHealthAndAlert, fetchWorkerOutcomes } from './worker-health';
+import { type DafWarmParams, wholeDafEnrichmentIds } from './workflow-warm';
 import { runYomiWarmCron } from './yomi-cron';
 
 // `Bindings` and `JobMessage` now live in ./types (a neutral module so route
@@ -3202,6 +3204,21 @@ app.get('/api/stale/:id/:tractate/:page', async (c) => {
 // served — they regenerate via a surface member's dependency resolution or on
 // their next read. Trusted + budget-gated. Intended flow: edit a prompt →
 // `/api/stale` shows `stale` → call this → the cascade regenerates.
+// Phase 3 (step 1): trigger the warm Workflow for a daf (trusted). Generates the
+// daf's whole-daf pieces as separate per-step invocations (bounded per-step
+// memory) and returns the workflow instance id. Additive — does not touch the
+// queue/run/reader paths. Inspect progress with `wrangler workflows instances`.
+app.post('/api/admin/workflow-warm/:tractate/:page', async (c) => {
+  if (!isTrustedRequest(c)) return c.json({ error: 'studio auth required' }, 403);
+  const wf = c.env.DAF_WARM_WORKFLOW;
+  if (!wf) return c.json({ error: 'DAF_WARM_WORKFLOW binding not available' }, 503);
+  const tractate = c.req.param('tractate');
+  const page = c.req.param('page');
+  const lang: 'en' | 'he' = c.req.query('lang') === 'he' ? 'he' : 'en';
+  const instance = await wf.create({ params: { tractate, page, lang } });
+  return c.json({ ok: true, id: instance.id, tractate, page, lang });
+});
+
 app.post('/api/admin/rewarm/:id/:tractate/:page', async (c) => {
   if (!isTrustedRequest(c)) return c.json({ error: 'studio auth required' }, 403);
   if (!c.env.ENRICHMENT_QUEUE)
@@ -11288,6 +11305,46 @@ async function processEnrichmentJob(
       totalMs,
       ...(enqueueTs ? { queueWaitMs: t0 - enqueueTs } : {}),
     });
+  }
+}
+
+// Phase 3 (step 1): the warm Workflow. Generates a daf's whole-daf pieces as
+// SEPARATE checkpointed steps — each step.do() is its own invocation with its own
+// 128 MB budget, so per-step memory can't pile up the way one monolithic
+// generation job does. Reuses runEnrichmentOnce (the exact fn the queue uses) so
+// it writes byte-identical cache keys — it cannot force a re-warm, and an
+// already-cached piece is a no-op (runEnrichmentOnce returns the cached value).
+// Additive: only POST /api/admin/workflow-warm reaches it; the live queue / run /
+// reader paths are untouched. Step 1 = whole-daf surface; per-instance is later.
+export class DafWarmWorkflow extends WorkflowEntrypoint<Bindings, DafWarmParams> {
+  override async run(event: WorkflowEvent<DafWarmParams>, step: WorkflowStep): Promise<void> {
+    const { tractate, page } = event.payload;
+    const lang: 'en' | 'he' = event.payload.lang === 'he' ? 'he' : 'en';
+    const wrapped = wrapEnv(this.env);
+    const ids = wholeDafEnrichmentIds(
+      CODE_MARKS.map((m) => ({ id: m.id, anchor: (m as { anchor?: string }).anchor })),
+      CODE_ENRICHMENTS.map((e) => ({ id: e.id, scope: e.scope, target_mark: e.target_mark })),
+    );
+    for (const id of ids) {
+      await step.do(`warm:${id}`, async () => {
+        const def = await loadEnrichmentDef(wrapped, id);
+        if (!def) return { id, skipped: 'no-def' };
+        // No ExecutionContext in a Workflow step — collect the generation's
+        // fire-and-forget waitUntil work (usage/cost telemetry) and await it
+        // within the step so it isn't dropped when the step returns.
+        const pending: Promise<unknown>[] = [];
+        const ctx = {
+          waitUntil: (p: Promise<unknown>) => {
+            pending.push(Promise.resolve(p));
+          },
+          passThroughOnException: () => {},
+        } as unknown as ExecutionContext;
+        const rc: RunCtx = { env: wrapped, url: 'https://localhost/internal', ctx, lang };
+        const res = await runEnrichmentOnce(rc, def, tractate, page, { fields: {} }, false);
+        await Promise.allSettled(pending);
+        return { id, cached: res.cache_hit ?? false, model: res.model };
+      });
+    }
   }
 }
 

--- a/packages/talmud/src/worker/types.ts
+++ b/packages/talmud/src/worker/types.ts
@@ -4,6 +4,7 @@
 // helper module creates a cycle — these neutral types break that.
 
 import type { EmailBinding } from './warm-cron';
+import type { DafWarmParams } from './workflow-warm';
 
 /** Queue message for one enrichment/mark run. `/api/run` enqueues a JobMessage;
  *  the queue consumer (bottom of index.ts) runs the LLM chain and writes the
@@ -62,6 +63,9 @@ export interface Bindings {
   // of index.ts. /api/run enqueues a JobMessage; the queue consumer
   // runs the LLM chain and writes the result to KV under `job:{runId}`.
   ENRICHMENT_QUEUE?: Queue<JobMessage>;
+  // Phase 3 (step 1): the warm Workflow binding — generates a daf's whole-daf
+  // pieces as per-step invocations. Triggered by POST /api/admin/workflow-warm.
+  DAF_WARM_WORKFLOW?: Workflow<DafWarmParams>;
   // When '1', the background Sefaria Shas walk also enqueues rabbi.observations
   // per amud (full reverse-index backfill). OFF by default — see WarmEnv.
   OBSERVATIONS_WARM_SHAS?: string;

--- a/packages/talmud/src/worker/workflow-warm.ts
+++ b/packages/talmud/src/worker/workflow-warm.ts
@@ -1,0 +1,48 @@
+/**
+ * Phase 3 (step 1) — generation as a Cloudflare Workflow.
+ *
+ * The cold-daf OOMs come from one invocation doing too much: a generation job
+ * resolves a producer's whole dependency tree (and regenerates cold deps) in a
+ * single 128 MB isolate. A Workflow decomposes that into checkpointed STEPS —
+ * each `step.do(...)` is its own invocation with its own memory budget, so the
+ * pile can't build up. This first step proves the model on an ADDITIVE warming
+ * path (a new admin trigger) that warms a daf's whole-daf pieces one step each,
+ * reusing the EXACT same generation function (`runEnrichmentOnce`) so it writes
+ * byte-identical cache keys — it can't force a re-warm and doesn't touch the live
+ * queue / run / reader paths.
+ *
+ * This module holds the pure, testable selection logic; the WorkflowEntrypoint
+ * class lives in index.ts (where the generation internals are in scope).
+ */
+
+export interface MarkLike {
+  id: string;
+  anchor?: string;
+}
+export interface EnrichmentLike {
+  id: string;
+  scope?: string;
+  target_mark?: string;
+}
+
+/**
+ * The whole-daf enrichment ids a warm pass generates: those whose target mark is
+ * whole-daf (or which declare no target mark). Same bucketing rule the daf-view
+ * uses to separate whole-daf from per-instance pieces, so the two stay in sync.
+ * Per-instance enrichments are intentionally excluded here (step 1 warms the
+ * whole-daf surface; per-instance fan-out is a later step).
+ */
+export function wholeDafEnrichmentIds(marks: MarkLike[], enrichments: EnrichmentLike[]): string[] {
+  const anchorById = new Map(marks.map((m) => [m.id, m.anchor]));
+  return enrichments
+    .filter((e) => e.scope === 'local')
+    .filter((e) => !e.target_mark || anchorById.get(e.target_mark) === 'whole-daf')
+    .map((e) => e.id);
+}
+
+/** Params passed to the warm Workflow. */
+export interface DafWarmParams {
+  tractate: string;
+  page: string;
+  lang: 'en' | 'he';
+}

--- a/packages/talmud/tests/stubs/cloudflare-workers.ts
+++ b/packages/talmud/tests/stubs/cloudflare-workers.ts
@@ -1,0 +1,14 @@
+// Test-only stub for the `cloudflare:workers` runtime module, which isn't
+// resolvable under node/vitest. index.ts imports `WorkflowEntrypoint` at module
+// scope to define DafWarmWorkflow; the warm Workflow isn't exercised by unit
+// tests, so a no-op base class is all that's needed for the import to resolve.
+// The REAL module is used at deploy (wrangler dry-run validates the binding) and
+// tsc types come from @cloudflare/workers-types — the alias is vitest-only.
+export class WorkflowEntrypoint {
+  ctx: unknown;
+  env: unknown;
+  constructor(ctx: unknown, env: unknown) {
+    this.ctx = ctx;
+    this.env = env;
+  }
+}

--- a/packages/talmud/tests/workflow-warm.test.ts
+++ b/packages/talmud/tests/workflow-warm.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { wholeDafEnrichmentIds } from '../src/worker/workflow-warm';
+
+// The warm Workflow's step list. It must include exactly the WHOLE-DAF
+// enrichments (target mark is whole-daf, or none) and exclude per-instance ones —
+// the same bucketing the daf-view uses, so the warm surface stays in sync.
+describe('wholeDafEnrichmentIds', () => {
+  const marks = [
+    { id: 'argument-overview', anchor: 'whole-daf' },
+    { id: 'daf-background', anchor: 'whole-daf' },
+    { id: 'tidbit', anchor: 'whole-daf' },
+    { id: 'argument', anchor: 'segment' },
+    { id: 'pesukim', anchor: 'segment' },
+    { id: 'rabbi', anchor: 'name' },
+  ];
+
+  it('includes enrichments whose target mark is whole-daf', () => {
+    const ids = wholeDafEnrichmentIds(marks, [
+      { id: 'argument-overview.synthesis', scope: 'local', target_mark: 'argument-overview' },
+      { id: 'daf-background.synthesis', scope: 'local', target_mark: 'daf-background' },
+      { id: 'tidbit.essay', scope: 'local', target_mark: 'tidbit' },
+    ]);
+    expect(ids.sort()).toEqual([
+      'argument-overview.synthesis',
+      'daf-background.synthesis',
+      'tidbit.essay',
+    ]);
+  });
+
+  it('EXCLUDES per-instance enrichments (target mark is segment/name)', () => {
+    const ids = wholeDafEnrichmentIds(marks, [
+      { id: 'pesukim.synthesis', scope: 'local', target_mark: 'pesukim' },
+      { id: 'rabbi.synthesis', scope: 'local', target_mark: 'rabbi' },
+      { id: 'argument.synthesis', scope: 'local', target_mark: 'argument' },
+    ]);
+    expect(ids).toEqual([]);
+  });
+
+  it('includes enrichments with NO target mark', () => {
+    const ids = wholeDafEnrichmentIds(marks, [{ id: 'standalone.synthesis', scope: 'local' }]);
+    expect(ids).toEqual(['standalone.synthesis']);
+  });
+
+  it('excludes non-local (global/entity) enrichments', () => {
+    const ids = wholeDafEnrichmentIds(marks, [
+      { id: 'rabbi.identity', scope: 'global', target_mark: 'rabbi' },
+      { id: 'daf-background.synthesis', scope: 'local', target_mark: 'daf-background' },
+    ]);
+    expect(ids).toEqual(['daf-background.synthesis']);
+  });
+
+  it('treats an unknown target mark as NOT whole-daf (excluded — safe default)', () => {
+    const ids = wholeDafEnrichmentIds(marks, [
+      { id: 'x.synthesis', scope: 'local', target_mark: 'does-not-exist' },
+    ]);
+    expect(ids).toEqual([]);
+  });
+
+  it('is empty for an empty registry', () => {
+    expect(wholeDafEnrichmentIds([], [])).toEqual([]);
+  });
+});

--- a/packages/talmud/vitest.config.ts
+++ b/packages/talmud/vitest.config.ts
@@ -1,5 +1,14 @@
+import { fileURLToPath } from 'node:url';
 import solid from 'vite-plugin-solid';
 import { defineConfig } from 'vitest/config';
+
+// `cloudflare:workers` (WorkflowEntrypoint, imported at index.ts module scope for
+// DafWarmWorkflow) isn't resolvable under node/vitest — alias it to a no-op stub
+// so any test that transitively imports index.ts still loads. The real module is
+// used at deploy; tsc types come from @cloudflare/workers-types.
+const cloudflareWorkersStub = fileURLToPath(
+  new URL('./tests/stubs/cloudflare-workers.ts', import.meta.url),
+);
 
 // Two isolated projects so the SolidJS render tests (jsdom + the solid JSX
 // transform + browser resolution conditions) never perturb the worker/unit
@@ -11,6 +20,7 @@ export default defineConfig({
   test: {
     projects: [
       {
+        resolve: { alias: { 'cloudflare:workers': cloudflareWorkersStub } },
         test: {
           name: 'node',
           include: ['tests/**/*.test.ts'],
@@ -20,7 +30,10 @@ export default defineConfig({
       },
       {
         plugins: [solid()],
-        resolve: { conditions: ['development', 'browser'] },
+        resolve: {
+          conditions: ['development', 'browser'],
+          alias: { 'cloudflare:workers': cloudflareWorkersStub },
+        },
         test: {
           name: 'client',
           include: ['tests/**/*.test.tsx'],

--- a/packages/talmud/wrangler.toml
+++ b/packages/talmud/wrangler.toml
@@ -109,6 +109,16 @@ HOURLY_CUSTOM_BUDGET_USD = "10"
 # the message and writes the result to KV under `job:{runId}`. Client polls
 # /api/run-status/:runId. Decouples client requests from LLM latency
 # and stops workerd from dying on parallel long-fetches in dev.
+# Phase 3 (step 1): generation as a Cloudflare Workflow. The warm Workflow
+# generates a daf's whole-daf pieces as separate checkpointed STEPS — each step
+# its own invocation with its own 128 MB budget, so the per-step memory can't pile
+# up the way one monolithic generation job does. Additive: triggered by
+# POST /api/admin/workflow-warm; the live queue/run/reader paths are untouched.
+[[workflows]]
+name = "daf-warm"
+binding = "DAF_WARM_WORKFLOW"
+class_name = "DafWarmWorkflow"
+
 [[queues.producers]]
 queue = "enrichment-jobs"
 binding = "ENRICHMENT_QUEUE"


### PR DESCRIPTION
First step of moving generation onto **Cloudflare Workflows** — per-step memory budgets are the *structural* cure for the cold-daf generation OOMs (the remaining sporadic ones). This lands the foundation as a **purely additive** warming path with **zero risk to live generation**.

## What it does
- **`[[workflows]]` binding `DAF_WARM_WORKFLOW` + `DafWarmWorkflow`** (WorkflowEntrypoint, exported from the worker). Its `run()` warms a daf's **whole-daf pieces, one `step.do()` per enrichment** — each step its own invocation with its own 128 MB budget, so per-step memory can't pile up the way a monolithic generation job does.
- **Reuses `runEnrichmentOnce`** (the *exact* function the queue uses) → writes **byte-identical cache keys**, so it **cannot force a re-warm**, and an already-cached piece is a no-op. Telemetry `waitUntil` is collected + awaited within the step (no ExecutionContext in a Workflow).
- **`POST /api/admin/workflow-warm/:t/:p`** (trusted) triggers it, returns the instance id. Inspect with `wrangler workflows instances`.

## Safety
- **Additive** — the live queue / run / reader paths are **untouched**; only the new admin trigger reaches the Workflow.
- **Cannot re-warm** — same generation fn, same keys.
- `wrangler deploy --dry-run` confirms the binding validates (`env.DAF_WARM_WORKFLOW (DafWarmWorkflow) → Workflow`).

## Tests
- `workflow-warm.ts` pure `wholeDafEnrichmentIds` — 6 cases (whole-daf included, per-instance excluded, no-target included, non-local excluded, unknown-target safe default). Same bucketing as the daf-view so the warm surface stays in sync.
- Test-infra: aliased `cloudflare:workers` → a stub so index.ts loads under vitest. Full suite **182 files / 2541 tests** green; typecheck, biome, build, dry-run all pass.

Later steps migrate the cold `/api/run` path (and per-instance fan-out) onto the Workflow — the actual generation-OOM cure. This PR proves the model end-to-end without touching the critical path.