### PR TITLE
howitworks: show the model on a real daf, bigger graph, searchable directory

### DIFF
--- a/packages/talmud/src/client/HowItWorksGraph.tsx
+++ b/packages/talmud/src/client/HowItWorksGraph.tsx
@@ -10,7 +10,7 @@
  * This renders DEFINITIONS (what connects to what), not cached instances — it
  * never calls /api/run.
  */
-import { createMemo, createSignal, For, type JSX, Show } from 'solid-js';
+import { createMemo, createSignal, For, type JSX, onCleanup, onMount, Show } from 'solid-js';
 import { orthogonalEdgePath } from './flow/orthogonalEdge';
 import { ancestorsOf, connectedClosure, type Graph, type GraphNode } from './howItWorks/graphModel';
 import { ACCENTS } from './sidebar/primitives';
@@ -114,127 +114,248 @@ export function HowItWorksGraph(props: Props): JSX.Element {
     return !lit || (lit.has(from) && lit.has(to));
   };
 
+  // Zoom + pan. userZoom null = "fit to width" (the default, so the whole
+  // graph is visible on open). Grab-to-pan drags the scroll container.
+  let containerEl: HTMLDivElement | undefined;
+  const [containerW, setContainerW] = createSignal(0);
+  const [userZoom, setUserZoom] = createSignal<number | null>(null);
+  const fitScale = (): number => {
+    const cw = containerW();
+    const bw = layout().width;
+    if (!cw || !bw) return 1;
+    return Math.min(1, Math.max(0.3, (cw - 4) / bw));
+  };
+  const k = (): number => userZoom() ?? fitScale();
+  const bump = (factor: number): void => {
+    const next = Math.min(2, Math.max(0.3, k() * factor));
+    setUserZoom(Number(next.toFixed(2)));
+  };
+
+  onMount(() => {
+    if (!containerEl) return;
+    setContainerW(containerEl.clientWidth);
+    if (typeof ResizeObserver === 'undefined') return; // e.g. jsdom
+    const ro = new ResizeObserver(() => setContainerW(containerEl?.clientWidth ?? 0));
+    ro.observe(containerEl);
+    onCleanup(() => ro.disconnect());
+  });
+
+  // Pan only when the drag starts on empty SVG canvas (target is the <svg>),
+  // so node clicks/hovers are untouched.
+  let panning = false;
+  let sx = 0;
+  let sy = 0;
+  let sl = 0;
+  let st = 0;
+  const onPointerDown = (e: PointerEvent): void => {
+    if ((e.target as Element)?.tagName?.toLowerCase() !== 'svg' || !containerEl) return;
+    panning = true;
+    sx = e.clientX;
+    sy = e.clientY;
+    sl = containerEl.scrollLeft;
+    st = containerEl.scrollTop;
+    containerEl.setPointerCapture?.(e.pointerId);
+  };
+  const onPointerMove = (e: PointerEvent): void => {
+    if (!panning || !containerEl) return;
+    containerEl.scrollLeft = sl - (e.clientX - sx);
+    containerEl.scrollTop = st - (e.clientY - sy);
+  };
+  const endPan = (): void => {
+    panning = false;
+  };
+
+  const toolBtn: JSX.CSSProperties = {
+    border: '1px solid var(--line)',
+    background: '#fff',
+    'border-radius': '6px',
+    width: '1.8rem',
+    height: '1.8rem',
+    cursor: 'pointer',
+    'font-size': '0.95rem',
+    'line-height': 1,
+    color: 'var(--fg)',
+  };
+
   return (
-    <div
-      style={{
-        border: '1px solid var(--line)',
-        'border-radius': '10px',
-        background: '#fcfbf8',
-        overflow: 'auto',
-        'max-height': '74vh',
-      }}
-    >
-      <svg
-        width={layout().width}
-        height={layout().height}
-        viewBox={`0 0 ${layout().width} ${layout().height}`}
-        role="img"
-        aria-label="Producer dependency graph"
-        style={{ display: 'block', 'min-width': '100%' }}
+    <div>
+      {/* zoom toolbar */}
+      <div
+        style={{
+          display: 'flex',
+          'align-items': 'center',
+          gap: '0.3rem',
+          'margin-bottom': '0.4rem',
+        }}
       >
-        <defs>
-          <For each={layout().colors}>
-            {(color) => (
-              <marker
-                id={arrowId(color)}
-                viewBox="0 0 6 6"
-                refX="5"
-                refY="3"
-                markerWidth="5"
-                markerHeight="5"
-                orient="auto-start-reverse"
-              >
-                <path d="M 0 0 L 6 3 L 0 6 z" fill={color} />
-              </marker>
-            )}
-          </For>
-        </defs>
-
-        {/* Connectors behind the nodes. */}
-        <For each={layout().edges}>
-          {(e) => {
-            const a = (): Placed => layout().placed.get(e.from) as Placed;
-            const b = (): Placed => layout().placed.get(e.to) as Placed;
-            const color = (): string => familyColor(b().node.family);
-            const lit = (): boolean => edgeLit(e.from, e.to);
-            return (
-              <Show when={a() && b()}>
-                <path
-                  d={orthogonalEdgePath(
-                    { x: a().x, y: a().y, w: NODE_W, h: NODE_H },
-                    { x: b().x, y: b().y, w: NODE_W, h: NODE_H },
-                  )}
-                  fill="none"
-                  stroke={color()}
-                  stroke-width={lit() ? 1.8 : 1.1}
-                  stroke-dasharray={e.target ? '3 3' : undefined}
-                  marker-end={`url(#${arrowId(color())})`}
-                  opacity={lit() ? (litSet() ? 0.95 : 0.5) : 0.08}
-                />
-              </Show>
-            );
+        <button type="button" style={toolBtn} onClick={() => bump(1 / 1.25)} aria-label="Zoom out">
+          −
+        </button>
+        <button type="button" style={toolBtn} onClick={() => bump(1.25)} aria-label="Zoom in">
+          +
+        </button>
+        <span
+          style={{
+            'font-size': '0.72rem',
+            color: 'var(--muted)',
+            'font-variant-numeric': 'tabular-nums',
+            'min-width': '2.6rem',
+            'text-align': 'center',
           }}
-        </For>
+        >
+          {Math.round(k() * 100)}%
+        </span>
+        <button
+          type="button"
+          style={{ ...toolBtn, width: 'auto', padding: '0 0.55rem' }}
+          onClick={() => setUserZoom(null)}
+          aria-label="Fit to width"
+        >
+          Fit
+        </button>
+        <button
+          type="button"
+          style={{ ...toolBtn, width: 'auto', padding: '0 0.55rem' }}
+          onClick={() => setUserZoom(1)}
+          aria-label="Reset zoom to 100%"
+        >
+          100%
+        </button>
+        <span
+          style={{ 'font-size': '0.7rem', color: 'var(--muted)', 'margin-inline-start': 'auto' }}
+        >
+          drag the canvas to pan
+        </span>
+      </div>
 
-        {/* Nodes. */}
-        <For each={[...layout().placed.values()]}>
-          {(p) => {
-            const n = p.node;
-            const color = familyColor(n.family);
-            const isSel = (): boolean => props.selectedId === n.id;
-            const lit = (): boolean => nodeLit(n.id);
-            const fill = (): string =>
-              n.kind === 'source' ? '#eef1ee' : isSel() ? color : '#ffffff';
-            const textColor = (): string =>
-              n.kind === 'source' ? '#475569' : isSel() ? '#fff' : '#1f2937';
-            return (
-              // biome-ignore lint/a11y/useSemanticElements: native <button> cannot be used inside an SVG diagram
-              <g
-                role="button"
-                tabindex={0}
-                aria-pressed={isSel()}
-                aria-label={`${n.kind} ${n.id}`}
-                style={{ cursor: 'pointer', opacity: lit() ? 1 : 0.22 }}
-                onMouseEnter={() => setHovered(n.id)}
-                onMouseLeave={() => setHovered(null)}
-                onFocus={() => setHovered(n.id)}
-                onBlur={() => setHovered(null)}
-                onClick={() => props.onSelect(isSel() ? null : n.id)}
-                onKeyDown={(ev) => {
-                  if (ev.key === 'Enter' || ev.key === ' ') {
-                    ev.preventDefault();
-                    props.onSelect(isSel() ? null : n.id);
-                  }
-                }}
-              >
-                <title>{n.id}</title>
-                <rect
-                  x={p.x}
-                  y={p.y}
-                  width={NODE_W}
-                  height={NODE_H}
-                  rx={n.kind === 'source' ? 14 : 6}
-                  fill={fill()}
-                  stroke={color}
-                  stroke-width={isSel() ? 2 : n.kind === 'enrichment' ? 1 : 1.4}
-                  stroke-dasharray={n.kind === 'enrichment' && !isSel() ? '4 2' : undefined}
-                />
-                <text
-                  x={p.x + NODE_W / 2}
-                  y={p.y + NODE_H / 2}
-                  text-anchor="middle"
-                  dominant-baseline="central"
-                  font-size="11.5"
-                  font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
-                  fill={textColor()}
+      <div
+        ref={containerEl}
+        style={{
+          border: '1px solid var(--line)',
+          'border-radius': '10px',
+          background: '#fcfbf8',
+          overflow: 'auto',
+          'max-height': '82vh',
+          cursor: 'grab',
+          'touch-action': 'none',
+        }}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={endPan}
+        onPointerLeave={endPan}
+      >
+        <svg
+          width={layout().width * k()}
+          height={layout().height * k()}
+          viewBox={`0 0 ${layout().width} ${layout().height}`}
+          role="img"
+          aria-label="Producer dependency graph"
+          style={{ display: 'block' }}
+        >
+          <defs>
+            <For each={layout().colors}>
+              {(color) => (
+                <marker
+                  id={arrowId(color)}
+                  viewBox="0 0 6 6"
+                  refX="5"
+                  refY="3"
+                  markerWidth="5"
+                  markerHeight="5"
+                  orient="auto-start-reverse"
                 >
-                  {truncate(n.id, 24)}
-                </text>
-              </g>
-            );
-          }}
-        </For>
-      </svg>
+                  <path d="M 0 0 L 6 3 L 0 6 z" fill={color} />
+                </marker>
+              )}
+            </For>
+          </defs>
+
+          {/* Connectors behind the nodes. */}
+          <For each={layout().edges}>
+            {(e) => {
+              const a = (): Placed => layout().placed.get(e.from) as Placed;
+              const b = (): Placed => layout().placed.get(e.to) as Placed;
+              const color = (): string => familyColor(b().node.family);
+              const lit = (): boolean => edgeLit(e.from, e.to);
+              return (
+                <Show when={a() && b()}>
+                  <path
+                    d={orthogonalEdgePath(
+                      { x: a().x, y: a().y, w: NODE_W, h: NODE_H },
+                      { x: b().x, y: b().y, w: NODE_W, h: NODE_H },
+                    )}
+                    fill="none"
+                    stroke={color()}
+                    stroke-width={lit() ? 1.8 : 1.1}
+                    stroke-dasharray={e.target ? '3 3' : undefined}
+                    marker-end={`url(#${arrowId(color())})`}
+                    opacity={lit() ? (litSet() ? 0.95 : 0.5) : 0.08}
+                  />
+                </Show>
+              );
+            }}
+          </For>
+
+          {/* Nodes. */}
+          <For each={[...layout().placed.values()]}>
+            {(p) => {
+              const n = p.node;
+              const color = familyColor(n.family);
+              const isSel = (): boolean => props.selectedId === n.id;
+              const lit = (): boolean => nodeLit(n.id);
+              const fill = (): string =>
+                n.kind === 'source' ? '#eef1ee' : isSel() ? color : '#ffffff';
+              const textColor = (): string =>
+                n.kind === 'source' ? '#475569' : isSel() ? '#fff' : '#1f2937';
+              return (
+                // biome-ignore lint/a11y/useSemanticElements: native <button> cannot be used inside an SVG diagram
+                <g
+                  role="button"
+                  tabindex={0}
+                  aria-pressed={isSel()}
+                  aria-label={`${n.kind} ${n.id}`}
+                  style={{ cursor: 'pointer', opacity: lit() ? 1 : 0.22 }}
+                  onMouseEnter={() => setHovered(n.id)}
+                  onMouseLeave={() => setHovered(null)}
+                  onFocus={() => setHovered(n.id)}
+                  onBlur={() => setHovered(null)}
+                  onClick={() => props.onSelect(isSel() ? null : n.id)}
+                  onKeyDown={(ev) => {
+                    if (ev.key === 'Enter' || ev.key === ' ') {
+                      ev.preventDefault();
+                      props.onSelect(isSel() ? null : n.id);
+                    }
+                  }}
+                >
+                  <title>{n.id}</title>
+                  <rect
+                    x={p.x}
+                    y={p.y}
+                    width={NODE_W}
+                    height={NODE_H}
+                    rx={n.kind === 'source' ? 14 : 6}
+                    fill={fill()}
+                    stroke={color}
+                    stroke-width={isSel() ? 2 : n.kind === 'enrichment' ? 1 : 1.4}
+                    stroke-dasharray={n.kind === 'enrichment' && !isSel() ? '4 2' : undefined}
+                  />
+                  <text
+                    x={p.x + NODE_W / 2}
+                    y={p.y + NODE_H / 2}
+                    text-anchor="middle"
+                    dominant-baseline="central"
+                    font-size="11.5"
+                    font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+                    fill={textColor()}
+                  >
+                    {truncate(n.id, 24)}
+                  </text>
+                </g>
+              );
+            }}
+          </For>
+        </svg>
+      </div>
     </div>
   );
 }

--- a/packages/talmud/src/client/HowItWorksPage.tsx
+++ b/packages/talmud/src/client/HowItWorksPage.tsx
@@ -1,19 +1,19 @@
 /**
- * #howitworks — a guided walkthrough of how this app is built, for a colleague.
- * Reads like an interactive presentation: a sticky chapter rail down the side,
- * the four-primitive vocabulary, the producer lifecycle, then the live build
- * graph as the centerpiece, a deep dive into every enrichment, and the
- * caching/freshness story.
+ * #howitworks — a show-don't-tell walkthrough of how this app is built. A
+ * sticky chapter rail; the four primitives DEMONSTRATED on a real daf (the
+ * worked example); how a piece is built; the live build graph (zoom/pan); a
+ * searchable deep dive into every enrichment; and the caching story.
  *
  * Everything about producers is pulled LIVE from the running registry
- * (GET /api/marks + /api/enrichments) so the page documents what is actually
- * deployed. The conceptual prose follows docs/framework.md ("the framework:
- * four primitives").
+ * (GET /api/marks + /api/enrichments) and the worked example from a real daf
+ * (GET /api/daf + /api/daf-view), so the page documents what is deployed.
  */
 import { createMemo, createSignal, For, type JSX, onCleanup, onMount, Show } from 'solid-js';
 import { familyColor, GraphLegend, HowItWorksGraph } from './HowItWorksGraph';
+import { useWorkedExample } from './howItWorks/example';
 import { assignLayers, buildGraph, type Graph, type GraphNode } from './howItWorks/graphModel';
 import { useRegistry } from './howItWorks/registry';
+import { WorkedExample } from './WorkedExample';
 
 // ── small presentational atoms ────────────────────────────────────────────
 
@@ -290,13 +290,10 @@ export function DeepDive(props: {
 
       <Show when={props.node.kind === 'source'}>
         <p style={{ margin: '0.3rem 0 0', 'font-size': '0.85rem', color: '#555' }}>
-          A source input — a cached slice of text the runtime feeds into a producer's prompt (it
-          isn't itself produced). Everything to its right is built, ultimately, from inputs like
-          this.
+          A cached slice of text fed into a producer's prompt — an input, not itself produced.
         </p>
       </Show>
 
-      {/* metadata */}
       <Show when={props.node.kind !== 'source'}>
         <MetaList
           rows={
@@ -351,139 +348,79 @@ export function DeepDive(props: {
   );
 }
 
-// ── conceptual chapter content ─────────────────────────────────────────────
-
-function PrimitiveCard(props: {
-  name: string;
-  module: string;
-  oneLine: string;
-  children: JSX.Element;
-}): JSX.Element {
-  return (
-    <div
-      style={{
-        border: '1px solid var(--line)',
-        'border-radius': '8px',
-        background: '#fff',
-        padding: '0.85rem 1rem',
-      }}
-    >
-      <div
-        style={{ display: 'flex', 'align-items': 'baseline', gap: '0.5rem', 'flex-wrap': 'wrap' }}
-      >
-        <span style={{ 'font-size': '1.05rem', 'font-weight': 700, color: 'var(--accent)' }}>
-          {props.name}
-        </span>
-        <Mono>{props.module}</Mono>
-      </div>
-      <p style={{ margin: '0.35rem 0 0.2rem', 'font-weight': 600, 'font-size': '0.9rem' }}>
-        {props.oneLine}
-      </p>
-      <div style={{ 'font-size': '0.85rem', 'line-height': 1.55, color: '#333' }}>
-        {props.children}
-      </div>
-    </div>
-  );
-}
-
-/** A tiny "note pinned to a span of a spine" illustration for the Anchor card. */
-function AnchorDiagram(): JSX.Element {
-  const segs = [0, 1, 2, 3, 4, 5, 6];
-  const W = 44;
-  return (
-    <svg
-      width="100%"
-      height="92"
-      viewBox="0 0 340 92"
-      role="img"
-      aria-label="An anchor spans segments 3 to 5 of a spine"
-    >
-      <text x="2" y="14" font-size="10" fill="#9a958a">
-        spine: bavli · Berakhot 2a
-      </text>
-      <For each={segs}>
-        {(s, i) => (
-          <g>
-            <rect
-              x={6 + i() * W}
-              y={24}
-              width={W - 6}
-              height={26}
-              rx={4}
-              fill={s >= 3 && s <= 5 ? '#8a2a2b22' : '#f1efe8'}
-              stroke={s >= 3 && s <= 5 ? '#8a2a2b' : '#ddd9cf'}
-            />
-            <text
-              x={6 + i() * W + (W - 6) / 2}
-              y={41}
-              text-anchor="middle"
-              font-size="10"
-              fill="#666"
-            >
-              {`seg ${s}`}
-            </text>
-          </g>
-        )}
-      </For>
-      <path d={`M ${6 + 3 * W} 56 L ${6 + 6 * W - 6} 56`} stroke="#8a2a2b" stroke-width="2" />
-      <text x={6 + 3 * W} y={78} font-size="11" fill="#8a2a2b" font-weight="600">
-        Anchor · span [3..5] · precision: segment
-      </text>
-    </svg>
-  );
-}
+// ── content ────────────────────────────────────────────────────────────────
 
 const STEPS: { n: string; title: string; body: string }[] = [
-  {
-    n: '1',
-    title: 'Resolve inputs',
-    body: 'Walk the dependency DAG — source slices, mark instances, other enrichments — into template vars. One bad dep degrades to an {error}, never throws.',
-  },
+  { n: '1', title: 'Resolve inputs', body: 'Walk the dependency graph into prompt variables.' },
   {
     n: '2',
     title: 'Render + call',
-    body: "Fill the recipe's prompt template, pick the model (Hebrew prompt selected when present), and call the model — or run a deterministic computed/lookup branch.",
+    body: 'Fill the prompt, pick the model, call it (or run a computed branch).',
   },
   {
     n: '3',
     title: 'Parse + check',
-    body: 'JSON-parse the output, then run the post-LLM passes: transforms repair/re-anchor, validators raise issues. Hard issues gate the write behind a bounded retry.',
+    body: 'Parse JSON; transforms repair, validators gate the write.',
   },
-  {
-    n: '4',
-    title: 'Stamp provenance',
-    body: 'Record the build manifest: authority (human | rule | ai), the inputs with content hashes, model, transport, cost, recipe hash.',
-  },
+  { n: '4', title: 'Stamp provenance', body: 'Record authority, inputs (hashed), model, cost.' },
   {
     n: '5',
-    title: 'Store (no TTL)',
-    body: 'Write to the ArtifactStore under the frozen mark:/enrich: key. The human-edit guard refuses to clobber a human-authored entry with AI output.',
+    title: 'Store',
+    body: 'Write under a frozen key, no TTL. Human edits are never clobbered.',
+  },
+  { n: '6', title: 'Render', body: 'The view composes from the cached artifact.' },
+];
+
+const CACHE_FACTS: { title: string; body: JSX.Element }[] = [
+  {
+    title: 'Frozen keys',
+    body: (
+      <>
+        <Mono>mark:…</Mono> / <Mono>enrich:…</Mono>, no TTL — deterministic per key.
+      </>
+    ),
   },
   {
-    n: '6',
-    title: 'Render the view',
-    body: 'The reader composes from the cached artifact. Re-opening is instant; a cache_version bump serves the previous value while the new one recomputes (SWR).',
+    title: 'Invalidate by version',
+    body: (
+      <>
+        Bump <Mono>cache_version</Mono>; <Mono>/api/dependents</Mono> gives the cascade.
+      </>
+    ),
+  },
+  {
+    title: 'Detect by recipe hash',
+    body: (
+      <>
+        <Mono>/api/stale</Mono> tells fresh from stale without re-running.
+      </>
+    ),
+  },
+  {
+    title: 'Human edits win',
+    body: <>The store refuses to overwrite a human-authored artifact.</>,
   },
 ];
 
-// ── the page ───────────────────────────────────────────────────────────────
-
 const CHAPTERS: { id: string; title: string }[] = [
   { id: 'thesis', title: 'The idea' },
-  { id: 'primitives', title: 'Four primitives' },
-  { id: 'producers', title: 'Marks & enrichments' },
+  { id: 'model', title: 'The model, shown' },
   { id: 'lifecycle', title: 'How a piece is built' },
   { id: 'graph', title: 'The build graph' },
   { id: 'enrichments', title: 'Every enrichment' },
   { id: 'freshness', title: 'Caching & freshness' },
 ];
 
+// ── the page ───────────────────────────────────────────────────────────────
+
 export function HowItWorksPage(): JSX.Element {
   const registry = useRegistry();
+  const example = useWorkedExample();
   const [selected, setSelected] = createSignal<string | null>(null);
   const [focus, setFocus] = createSignal<string | null>(null);
   const [active, setActive] = createSignal<string>('thesis');
   const [openEntries, setOpenEntries] = createSignal<Set<string>>(new Set());
+  const [query, setQuery] = createSignal('');
 
   const graph = createMemo<Graph>(() => {
     const r = registry();
@@ -496,7 +433,6 @@ export function HowItWorksPage(): JSX.Element {
     return id ? (graph().byId.get(id) ?? null) : null;
   });
 
-  // Families (mark ids) for the focus chips + directory grouping, canon first.
   const families = createMemo<GraphNode[]>(() =>
     graph()
       .nodes.filter((n) => n.kind === 'mark')
@@ -508,17 +444,33 @@ export function HowItWorksPage(): JSX.Element {
       }),
   );
 
-  const enrichmentsByFamily = (family: string): GraphNode[] =>
+  const matchEnr = (n: GraphNode, q: string): boolean => {
+    if (!q) return true;
+    const s = q.toLowerCase();
+    return (
+      n.id.toLowerCase().includes(s) || (n.enrichment?.description ?? '').toLowerCase().includes(s)
+    );
+  };
+  const enrFor = (family: string): GraphNode[] =>
     graph()
-      .nodes.filter((n) => n.kind === 'enrichment' && n.family === family)
+      .nodes.filter((n) => n.kind === 'enrichment' && n.family === family && matchEnr(n, query()))
       .sort((a, b) => (a.id < b.id ? -1 : 1));
+  const visibleFamilies = createMemo<GraphNode[]>(() =>
+    query() ? families().filter((f) => enrFor(f.id).length > 0) : families(),
+  );
+  const allVisibleEnrIds = (): string[] =>
+    visibleFamilies().flatMap((f) => enrFor(f.id).map((n) => n.id));
 
   const sectionEls = new Map<string, HTMLElement>();
   const registerSection = (id: string) => (el: HTMLElement) => {
     sectionEls.set(id, el);
   };
+  const familyEls = new Map<string, HTMLElement>();
   const scrollTo = (id: string): void => {
     sectionEls.get(id)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+  const jumpToFamily = (id: string): void => {
+    familyEls.get(id)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   };
   const selectAndReveal = (id: string): void => {
     setSelected(id);
@@ -556,19 +508,23 @@ export function HowItWorksPage(): JSX.Element {
     'text-transform': 'uppercase',
     'letter-spacing': '0.1em',
     color: 'var(--muted)',
-    margin: '0 0 0.75rem',
+    margin: '0 0 0.6rem',
   };
   const sectionStyle: JSX.CSSProperties = { 'margin-bottom': '3rem', 'scroll-margin-top': '1rem' };
-  const lead: JSX.CSSProperties = { 'font-size': '0.95rem', 'line-height': 1.6, color: '#2a2a2a' };
+  const lead: JSX.CSSProperties = {
+    'font-size': '0.95rem',
+    'line-height': 1.6,
+    color: '#2a2a2a',
+    margin: '0 0 0.7rem',
+  };
 
   return (
     <div class="page-shell" style={{ '--page-max': '1180px' }}>
       <header>
         <h1>How it works</h1>
-        <p style={{ color: 'var(--muted)', 'max-width': '60ch' }}>
-          A walkthrough of how this app turns a page of Talmud into smart notes — the four
-          primitives the engine is built on, how a single note is produced, and a deep dive into
-          every enrichment, drawn live from the running registry.
+        <p style={{ color: 'var(--muted)', 'max-width': '60ch', margin: '0.4rem 0 0' }}>
+          The text, covered in smart notes — shown on a real daf, then the whole machine that makes
+          them.
         </p>
       </header>
 
@@ -596,162 +552,105 @@ export function HowItWorksPage(): JSX.Element {
           <section id="thesis" ref={registerSection('thesis')} style={sectionStyle}>
             <h2 style={h2}>The idea</h2>
             <p style={lead}>
-              The plain-English version is: <strong>the text, covered in smart notes</strong>. A
-              note knows <em>where</em> it sits on the text, <em>what</em> it's built from,{' '}
-              <em>how</em> it was made, and <em>how sure</em> we are. Notes compose — a synthesis is
-              a note built from other notes — and the views you read (sidebar cards, maps, the
-              argument flow) are all generated from notes, never authored by hand.
-            </p>
-            <p style={lead}>
-              Under that plain story sits one small engine, shared by both this app and its sister
-              Tanach app, made of exactly four primitives.
+              A <strong>note</strong> knows where it sits, what it's built from, how it was made,
+              and how sure we are. Notes compose; every view is generated from them. Underneath sits
+              one engine of four primitives — here it is on a real page.
             </p>
           </section>
 
-          {/* 2 — four primitives */}
-          <section id="primitives" ref={registerSection('primitives')} style={sectionStyle}>
-            <h2 style={h2}>Four primitives</h2>
-            <div class="hiw-cards">
-              <PrimitiveCard
-                name="Spine"
-                module="@corpus/core/model/spine"
-                oneLine="An addressable text (or entity space) that notes pin to."
-              >
-                A reference into a spine is a path that <strong>may stop early</strong>:{' '}
-                <Mono>[Berakhot, 2a]</Mono> is the whole daf, <Mono>[Berakhot, 2a, 3]</Mono> one
-                segment. Bavli is the implicit default spine; Tanach is book / chapter / verse.
-              </PrimitiveCard>
-              <PrimitiveCard
-                name="Anchor"
-                module="@corpus/core/model/anchor"
-                oneLine="THE one shape for “where a piece sits.”"
-              >
-                A span plus a <strong>precision</strong> (token &gt; segment &gt; division &gt; unit
-                &gt; work &gt; external) and how it was earned (<Mono>via</Mono>,{' '}
-                <Mono>confidence</Mono>). “Cross-daf” isn't a precision — it's derived at render
-                time.
-                <AnchorDiagram />
-              </PrimitiveCard>
-              <PrimitiveCard
-                name="Artifact"
-                module="@corpus/core/model/artifact"
-                oneLine="One produced piece: a typed body + anchors + provenance."
-              >
-                Mark instances, enrichment outputs, context items, links, and anchor refinements are{' '}
-                <em>all</em> artifacts. Provenance is the <strong>build manifest</strong>: who
-                decided (<Mono>human | rule | ai</Mono>), the inputs with content hashes, the model,
-                the cost.
-              </PrimitiveCard>
-              <PrimitiveCard
-                name="Producer"
-                module="@corpus/core/model/producer"
-                oneLine="The registry entry that makes artifacts."
-              >
-                Declares its inputs, its recipe, where outputs sit, and how they cache. Its{' '}
-                <Mono>anchoring.behavior</Mono> unifies the old split: <strong>discovers</strong>{' '}
-                (finds anchors — a mark), <strong>inherits</strong> (sits where its input sits — a
-                per-instance enrichment), <strong>aggregates</strong> (one output over many — a
-                synthesis).
-              </PrimitiveCard>
-            </div>
-            <p
-              style={{
-                ...lead,
-                'margin-top': '0.85rem',
-                color: 'var(--muted)',
-                'font-size': '0.85rem',
-              }}
+          {/* 2 — the model, shown */}
+          <section id="model" ref={registerSection('model')} style={sectionStyle}>
+            <h2 style={h2}>The model, on a real daf</h2>
+            <Show
+              when={example()}
+              fallback={<p style={{ color: 'var(--muted)' }}>Loading Berakhot 2a…</p>}
             >
-              Placement is a <em>lifecycle</em>, not a fifth primitive: an anchor is earned coarse →
-              deterministic → AI → human, and a human-earned anchor is never silently overwritten.
-            </p>
+              {(ex) => (
+                <WorkedExample example={ex()} graph={graph()} onOpenInGraph={selectAndReveal} />
+              )}
+            </Show>
           </section>
 
-          {/* 3 — marks & enrichments */}
-          <section id="producers" ref={registerSection('producers')} style={sectionStyle}>
-            <h2 style={h2}>Two flavors of producer: marks & enrichments</h2>
-            <p style={lead}>
-              Every producer is one <Mono>Producer</Mono> under the hood, but it wears one of two
-              familiar faces. A <strong>mark</strong> reads the raw daf and{' '}
-              <strong>discovers</strong> instances — a rabbi name, an argument section, a biblical
-              citation — each anchored to where it sits. An <strong>enrichment</strong> takes a
-              mark's instances and builds on them: it either <strong>inherits</strong> the
-              instance's anchor (a per-instance note like a rabbi's biography) or{' '}
-              <strong>aggregates</strong> many instances into one whole-daf note (a synthesis).
-            </p>
-            <p style={lead}>
-              Enrichments chain: a synthesis depends on the leaf enrichments beneath it, which
-              depend on the mark, which depends on the raw text. That chain is exactly what the
-              build graph below draws.
-            </p>
-          </section>
-
-          {/* 4 — lifecycle */}
+          {/* 3 — lifecycle */}
           <section id="lifecycle" ref={registerSection('lifecycle')} style={sectionStyle}>
-            <h2 style={h2}>How a single piece is built</h2>
-            <p style={{ ...lead, 'margin-bottom': '0.9rem' }}>
-              One function — <Mono>runProducer</Mono> — runs every producer, mark or enrichment, the
-              same way:
+            <h2 style={h2}>How a piece is built</h2>
+            <p style={{ ...lead, color: 'var(--muted)', 'font-size': '0.85rem' }}>
+              One function — <Mono>runProducer</Mono> — runs every producer the same way.
             </p>
             <div
               style={{
-                display: 'grid',
-                'grid-template-columns': 'repeat(auto-fit, minmax(160px, 1fr))',
-                gap: '0.6rem',
+                display: 'flex',
+                'flex-wrap': 'wrap',
+                gap: '0.5rem',
+                'align-items': 'stretch',
               }}
             >
               <For each={STEPS}>
-                {(step) => (
-                  <div
-                    style={{
-                      border: '1px solid var(--line)',
-                      'border-radius': '8px',
-                      background: '#fff',
-                      padding: '0.7rem 0.8rem',
-                    }}
-                  >
-                    <div style={{ display: 'flex', 'align-items': 'center', gap: '0.4rem' }}>
-                      <span
-                        style={{
-                          width: '1.4rem',
-                          height: '1.4rem',
-                          'border-radius': '50%',
-                          background: 'var(--accent)',
-                          color: '#fff',
-                          display: 'inline-flex',
-                          'align-items': 'center',
-                          'justify-content': 'center',
-                          'font-size': '0.78rem',
-                          'font-weight': 700,
-                        }}
-                      >
-                        {step.n}
-                      </span>
-                      <strong style={{ 'font-size': '0.88rem' }}>{step.title}</strong>
-                    </div>
-                    <p
+                {(step, i) => (
+                  <>
+                    <div
                       style={{
-                        margin: '0.4rem 0 0',
-                        'font-size': '0.8rem',
-                        'line-height': 1.5,
-                        color: '#444',
+                        flex: '1 1 150px',
+                        border: '1px solid var(--line)',
+                        'border-radius': '8px',
+                        background: '#fff',
+                        padding: '0.6rem 0.7rem',
                       }}
                     >
-                      {step.body}
-                    </p>
-                  </div>
+                      <div
+                        style={{
+                          display: 'flex',
+                          'align-items': 'center',
+                          gap: '0.4rem',
+                          'margin-bottom': '0.25rem',
+                        }}
+                      >
+                        <span
+                          style={{
+                            width: '1.3rem',
+                            height: '1.3rem',
+                            'border-radius': '50%',
+                            background: 'var(--accent)',
+                            color: '#fff',
+                            display: 'inline-flex',
+                            'align-items': 'center',
+                            'justify-content': 'center',
+                            'font-size': '0.74rem',
+                            'font-weight': 700,
+                          }}
+                        >
+                          {step.n}
+                        </span>
+                        <strong style={{ 'font-size': '0.85rem' }}>{step.title}</strong>
+                      </div>
+                      <p
+                        style={{
+                          margin: 0,
+                          'font-size': '0.78rem',
+                          'line-height': 1.45,
+                          color: '#555',
+                        }}
+                      >
+                        {step.body}
+                      </p>
+                    </div>
+                    <Show when={i() < STEPS.length - 1}>
+                      <span style={{ 'align-self': 'center', color: '#cbb', 'font-size': '1rem' }}>
+                        →
+                      </span>
+                    </Show>
+                  </>
                 )}
               </For>
             </div>
           </section>
 
-          {/* 5 — the build graph */}
+          {/* 4 — the build graph */}
           <section id="graph" ref={registerSection('graph')} style={sectionStyle}>
             <h2 style={h2}>The build graph</h2>
-            <p style={{ ...lead, 'margin-bottom': '0.6rem' }}>
-              The live registry, as a dependency graph. Columns are dependency depth: source inputs
-              on the left, then the marks built from them, then the enrichments built on the marks.
-              Hover any node to trace its chain; click it for the full deep dive.
+            <p style={{ ...lead, color: 'var(--muted)', 'font-size': '0.85rem' }}>
+              The whole live registry. Source inputs → marks → enrichments, left to right. Hover to
+              trace a chain; click for the deep dive.
             </p>
 
             <Show when={registry.loading}>
@@ -762,7 +661,6 @@ export function HowItWorksPage(): JSX.Element {
             </Show>
 
             <Show when={!registry.loading && !registry.error}>
-              {/* focus-by-family chips */}
               <div
                 style={{
                   display: 'flex',
@@ -774,7 +672,6 @@ export function HowItWorksPage(): JSX.Element {
                 <button
                   type="button"
                   onClick={() => setFocus(null)}
-                  classList={{ 'is-active': focus() === null }}
                   style={chip(focus() === null, '#444')}
                 >
                   all
@@ -839,18 +736,75 @@ export function HowItWorksPage(): JSX.Element {
             </Show>
           </section>
 
-          {/* 6 — every enrichment */}
+          {/* 5 — every enrichment */}
           <section id="enrichments" ref={registerSection('enrichments')} style={sectionStyle}>
             <h2 style={h2}>Every enrichment</h2>
-            <p style={{ ...lead, 'margin-bottom': '0.8rem' }}>
-              Grouped under the mark each one builds on. Click any row to expand its full deep dive
-              — dependencies, model, scope, output schema, and the prompts behind it.
-            </p>
 
             <Show when={!registry.loading && !registry.error}>
-              <For each={families()}>
+              {/* search + controls */}
+              <div
+                style={{
+                  display: 'flex',
+                  'flex-wrap': 'wrap',
+                  gap: '0.5rem',
+                  'align-items': 'center',
+                  'margin-bottom': '0.5rem',
+                }}
+              >
+                <input
+                  type="search"
+                  placeholder="Filter enrichments…"
+                  value={query()}
+                  onInput={(e) => setQuery(e.currentTarget.value)}
+                  style={{
+                    flex: '1 1 220px',
+                    padding: '0.4rem 0.6rem',
+                    border: '1px solid var(--line)',
+                    'border-radius': '6px',
+                    'font-size': '0.85rem',
+                    background: '#fff',
+                  }}
+                />
+                <button
+                  type="button"
+                  style={miniBtn}
+                  onClick={() => setOpenEntries(new Set(allVisibleEnrIds()))}
+                >
+                  expand all
+                </button>
+                <button type="button" style={miniBtn} onClick={() => setOpenEntries(new Set())}>
+                  collapse all
+                </button>
+              </div>
+
+              {/* family jump chips */}
+              <div
+                style={{
+                  display: 'flex',
+                  'flex-wrap': 'wrap',
+                  gap: '0.3rem',
+                  'margin-bottom': '0.8rem',
+                }}
+              >
+                <For each={visibleFamilies()}>
+                  {(f) => (
+                    <button
+                      type="button"
+                      onClick={() => jumpToFamily(f.id)}
+                      style={chip(false, familyColor(f.id))}
+                    >
+                      {f.id} <span style={{ opacity: 0.7 }}>{enrFor(f.id).length}</span>
+                    </button>
+                  )}
+                </For>
+              </div>
+
+              <For each={visibleFamilies()}>
                 {(fam) => (
-                  <div style={{ 'margin-bottom': '1.1rem' }}>
+                  <div
+                    ref={(el) => familyEls.set(fam.id, el)}
+                    style={{ 'margin-bottom': '1.1rem', 'scroll-margin-top': '1rem' }}
+                  >
                     <div
                       style={{
                         display: 'flex',
@@ -875,7 +829,7 @@ export function HowItWorksPage(): JSX.Element {
                       </span>
                     </div>
                     <For
-                      each={enrichmentsByFamily(fam.id)}
+                      each={enrFor(fam.id)}
                       fallback={
                         <p style={{ 'font-size': '0.8rem', color: 'var(--muted)', margin: 0 }}>
                           No LLM enrichments — this mark stands on its own.
@@ -895,50 +849,48 @@ export function HowItWorksPage(): JSX.Element {
                   </div>
                 )}
               </For>
-              <p style={{ 'font-size': '0.78rem', color: 'var(--muted)', 'margin-top': '1rem' }}>
-                Note: <Mono>/api/enrichments</Mono> lists LLM enrichments only. A couple of
-                producers (e.g. <Mono>rabbi.identity</Mono>) are deterministic/computed — they're
-                real producers but resolve from data rather than a model, so they appear under their
-                mark rather than in this list.
+              <p style={{ 'font-size': '0.78rem', color: 'var(--muted)', 'margin-top': '0.5rem' }}>
+                <Mono>/api/enrichments</Mono> lists LLM enrichments; a few deterministic producers
+                (e.g. <Mono>rabbi.identity</Mono>) appear under their mark instead.
               </p>
             </Show>
           </section>
 
-          {/* 7 — caching & freshness */}
+          {/* 6 — caching & freshness */}
           <section id="freshness" ref={registerSection('freshness')} style={sectionStyle}>
-            <h2 style={h2}>Caching, provenance & freshness</h2>
-            <p style={lead}>
-              Producer outputs are cached in the <Mono>ArtifactStore</Mono> under{' '}
-              <strong>byte-frozen keys</strong> (<Mono>mark:…</Mono> / <Mono>enrich:…</Mono>) with{' '}
-              <strong>no TTL</strong> — outputs are deterministic per key, and full-Shas re-warming
-              is expensive, so a stray key change would silently re-pay all of it.
-            </p>
-            <ul style={{ ...lead, 'padding-left': '1.1rem' }}>
-              <li>
-                <strong>Invalidate by version.</strong> Bump a producer's <Mono>cache_version</Mono>{' '}
-                and the old key becomes unreachable. If you bump a producer, you must bump
-                everything that depends on it — <Mono>GET /api/dependents/:id</Mono> enumerates the
-                cascade.
-              </li>
-              <li>
-                <strong>Detect by recipe hash.</strong> Each artifact stamps the hash of the recipe
-                that made it, so <Mono>/api/stale/:id/:t/:p</Mono> can tell fresh from stale without
-                re-running anything.
-              </li>
-              <li>
-                <strong>Serve stale while revalidating.</strong> Across a version bump the reader
-                gets the previous value immediately while the new one recomputes in the background.
-              </li>
-              <li>
-                <strong>Human edits win.</strong> The store refuses to overwrite a human-authored
-                artifact with rule/AI output — an enforced invariant, not a convention.
-              </li>
-            </ul>
-            <p style={{ ...lead, color: 'var(--muted)', 'font-size': '0.85rem' }}>
-              The provenance manifest on each artifact records the exact inputs it was built from
-              (with content hashes), which closes the loop: detect what's stale, enumerate what else
-              must follow, and re-warm only the cascade.
-            </p>
+            <h2 style={h2}>Caching & freshness</h2>
+            <div
+              style={{
+                display: 'grid',
+                'grid-template-columns': 'repeat(auto-fit, minmax(220px, 1fr))',
+                gap: '0.6rem',
+              }}
+            >
+              <For each={CACHE_FACTS}>
+                {(f) => (
+                  <div
+                    style={{
+                      border: '1px solid var(--line)',
+                      'border-radius': '8px',
+                      background: '#fff',
+                      padding: '0.7rem 0.8rem',
+                    }}
+                  >
+                    <strong style={{ 'font-size': '0.85rem' }}>{f.title}</strong>
+                    <p
+                      style={{
+                        margin: '0.3rem 0 0',
+                        'font-size': '0.8rem',
+                        'line-height': 1.45,
+                        color: '#555',
+                      }}
+                    >
+                      {f.body}
+                    </p>
+                  </div>
+                )}
+              </For>
+            </div>
           </section>
         </div>
       </div>
@@ -958,6 +910,16 @@ function chip(activeState: boolean, color: string): JSX.CSSProperties {
     border: `1px solid ${color}66`,
   };
 }
+
+const miniBtn: JSX.CSSProperties = {
+  border: '1px solid var(--line)',
+  background: '#fff',
+  'border-radius': '6px',
+  padding: '0.35rem 0.6rem',
+  cursor: 'pointer',
+  'font-size': '0.78rem',
+  color: 'var(--fg)',
+};
 
 function DirectoryRow(props: {
   node: GraphNode;

--- a/packages/talmud/src/client/WorkedExample.tsx
+++ b/packages/talmud/src/client/WorkedExample.tsx
@@ -1,0 +1,454 @@
+/**
+ * "Show, don't tell": the four primitives demonstrated on a real daf. The
+ * reader steps spine -> anchor -> artifact -> producer and each step layers
+ * onto the SAME live spine (Berakhot 2a, fetched). The anchored piece is a real
+ * cached `pesukim` instance — a biblical citation sitting on one segment.
+ */
+import { createMemo, createSignal, For, type JSX, Show } from 'solid-js';
+import { familyColor } from './HowItWorksGraph';
+import type { WorkedExample as Example } from './howItWorks/example';
+import type { Graph } from './howItWorks/graphModel';
+
+type StepKey = 'spine' | 'anchor' | 'artifact' | 'producer';
+
+const STEPS: { key: StepKey; label: string; caption: string }[] = [
+  {
+    key: 'spine',
+    label: 'Spine',
+    caption:
+      'A spine is an addressable text. This daf is a path of segments — each one has an address.',
+  },
+  {
+    key: 'anchor',
+    label: 'Anchor',
+    caption: 'An anchor says where a piece sits: a span of the spine, at some precision.',
+  },
+  {
+    key: 'artifact',
+    label: 'Artifact',
+    caption: 'An artifact is one produced piece — a typed body, its anchor, and provenance.',
+  },
+  {
+    key: 'producer',
+    label: 'Producer',
+    caption: 'A producer is the recipe that makes artifacts. Every one is in the graph below.',
+  },
+];
+
+function chipStyle(active: boolean, color: string): JSX.CSSProperties {
+  return {
+    'font-size': '0.7rem',
+    'font-weight': 600,
+    padding: '0.1rem 0.45rem',
+    'border-radius': '4px',
+    background: active ? color : `${color}14`,
+    color: active ? '#fff' : color,
+    border: `1px solid ${color}55`,
+    'white-space': 'nowrap',
+  };
+}
+
+const PRECISION = ['token', 'segment', 'division', 'unit', 'work'];
+
+export function WorkedExample(props: {
+  example: Example;
+  graph: Graph;
+  onOpenInGraph: (id: string) => void;
+}): JSX.Element {
+  const [step, setStep] = createSignal<StepKey>('spine');
+  const art = () => props.example.artifact;
+  const lit = () => step() !== 'spine' && !!art();
+
+  // Real producer facts, derived from the registry (no hardcoding).
+  const producerNode = createMemo(() => props.graph.byId.get(art()?.producerId ?? ''));
+  const authority = (): string =>
+    producerNode()?.mark?.extractor?.kind === 'computed' ? 'rule' : 'ai';
+  const feedsInto = createMemo(() => {
+    const id = art()?.producerId;
+    if (!id) return [] as string[];
+    return props.graph.edges.filter((e) => e.from === id).map((e) => e.to);
+  });
+
+  const segCount = () => Math.max(props.example.segsEn.length, props.example.segsHe.length);
+  const inRange = (i: number): boolean => {
+    const a = art();
+    return !!a && lit() && i >= a.startSeg && i <= a.endSeg;
+  };
+  const accent = (): string => familyColor(art()?.producerId ?? 'pesuk');
+
+  return (
+    <div>
+      {/* stepper */}
+      <div
+        style={{ display: 'flex', 'flex-wrap': 'wrap', gap: '0.35rem', 'margin-bottom': '0.5rem' }}
+      >
+        <For each={STEPS}>
+          {(s, i) => (
+            <button
+              type="button"
+              onClick={() => setStep(s.key)}
+              style={{
+                display: 'inline-flex',
+                'align-items': 'center',
+                gap: '0.4rem',
+                padding: '0.3rem 0.7rem',
+                'border-radius': '999px',
+                cursor: 'pointer',
+                border: `1px solid ${step() === s.key ? 'var(--accent)' : 'var(--line)'}`,
+                background: step() === s.key ? 'var(--accent)' : '#fff',
+                color: step() === s.key ? '#fff' : 'var(--fg)',
+                'font-size': '0.82rem',
+                'font-weight': 600,
+              }}
+            >
+              <span style={{ opacity: 0.7, 'font-variant-numeric': 'tabular-nums' }}>
+                {i() + 1}
+              </span>
+              {s.label}
+            </button>
+          )}
+        </For>
+      </div>
+
+      {/* caption — the only prose, one line */}
+      <p
+        style={{
+          margin: '0 0 0.7rem',
+          color: '#333',
+          'font-size': '0.9rem',
+          'min-height': '1.4rem',
+        }}
+      >
+        {STEPS.find((s) => s.key === step())?.caption}
+      </p>
+
+      <div
+        style={{
+          display: 'grid',
+          gap: '1rem',
+          'align-items': 'start',
+        }}
+        class="hiw-example"
+      >
+        {/* the spine */}
+        <div
+          style={{
+            border: '1px solid var(--line)',
+            'border-radius': '8px',
+            background: '#fff',
+            overflow: 'hidden',
+          }}
+        >
+          <div
+            style={{
+              padding: '0.4rem 0.7rem',
+              background: '#f3ede4',
+              'font-size': '0.72rem',
+              'font-family': 'ui-monospace, SFMono-Regular, Menlo, monospace',
+              color: 'var(--accent)',
+              'border-bottom': '1px solid var(--line)',
+            }}
+          >
+            spine: bavli · {props.example.tractate} {props.example.page}
+          </div>
+          <div style={{ 'max-height': '380px', overflow: 'auto' }}>
+            <Show
+              when={segCount() > 0}
+              fallback={
+                <For each={[0, 1, 2, 3, 4, 5, 6]}>
+                  {(i) => <SegRow index={i} en="" he="" highlight={inRange(i)} accent={accent()} />}
+                </For>
+              }
+            >
+              <For each={Array.from({ length: segCount() }, (_, i) => i)}>
+                {(i) => (
+                  <SegRow
+                    index={i}
+                    en={props.example.segsEn[i] ?? ''}
+                    he={props.example.segsHe[i] ?? ''}
+                    highlight={inRange(i)}
+                    accent={accent()}
+                  />
+                )}
+              </For>
+            </Show>
+          </div>
+        </div>
+
+        {/* the contextual panel per step */}
+        <div>
+          <Show when={step() === 'spine'}>
+            <Panel title="Spine" accent="var(--accent)">
+              <Row k="kind" v="text (ordered)" />
+              <Row k="address" v={`[${props.example.tractate}, ${props.example.page}, n]`} mono />
+              <p style={note}>
+                Each segment is independently addressable. A reference may stop early — the whole
+                daf is just the path with the segment left off.
+              </p>
+            </Panel>
+          </Show>
+
+          <Show when={step() === 'anchor'}>
+            <Panel title="Anchor" accent="var(--accent)">
+              <Row k="spine" v="bavli" mono />
+              <Row
+                k="span"
+                v={art() ? `[${props.example.page}, seg ${art()?.startSeg}]` : '[2a, seg n]'}
+                mono
+              />
+              <Row k="precision" v="segment" mono />
+              <div
+                style={{
+                  display: 'flex',
+                  'flex-wrap': 'wrap',
+                  gap: '0.3rem',
+                  'margin-top': '0.5rem',
+                }}
+              >
+                <For each={PRECISION}>
+                  {(p) => <span style={chipStyle(p === 'segment', 'var(--accent)')}>{p}</span>}
+                </For>
+              </div>
+            </Panel>
+          </Show>
+
+          <Show when={step() === 'artifact'}>
+            <Show
+              when={art()}
+              fallback={
+                <Panel title="Artifact" accent={accent()}>
+                  <p style={note}>
+                    An artifact is a typed body pinned to an anchor, with provenance. (No cached
+                    piece to show right now.)
+                  </p>
+                </Panel>
+              }
+            >
+              {(a) => (
+                <div
+                  style={{
+                    border: `1px solid ${accent()}55`,
+                    'border-left': `4px solid ${accent()}`,
+                    'border-radius': '8px',
+                    background: '#fff',
+                    padding: '0.85rem 1rem',
+                  }}
+                >
+                  <div
+                    style={{
+                      display: 'flex',
+                      'align-items': 'baseline',
+                      gap: '0.5rem',
+                      'flex-wrap': 'wrap',
+                    }}
+                  >
+                    <strong style={{ color: accent() }}>{a().title}</strong>
+                    <span style={chipStyle(false, accent())}>{a().kind}</span>
+                  </div>
+                  <Show when={a().excerpt}>
+                    <p
+                      dir="rtl"
+                      lang="he"
+                      style={{
+                        margin: '0.4rem 0 0',
+                        'font-family': '"Mekorot Vilna", serif',
+                        color: '#555',
+                      }}
+                    >
+                      {a().excerpt}
+                    </p>
+                  </Show>
+                  <Show when={a().body}>
+                    <p
+                      style={{
+                        margin: '0.45rem 0 0',
+                        'font-size': '0.88rem',
+                        'line-height': 1.5,
+                        color: '#333',
+                      }}
+                    >
+                      {a().body}
+                    </p>
+                  </Show>
+                  <div
+                    style={{
+                      'margin-top': '0.6rem',
+                      'border-top': '1px dashed #e3e0d7',
+                      'padding-top': '0.5rem',
+                    }}
+                  >
+                    <div
+                      style={{
+                        'font-size': '0.64rem',
+                        'text-transform': 'uppercase',
+                        'letter-spacing': '0.06em',
+                        color: '#9a958a',
+                        'margin-bottom': '0.3rem',
+                      }}
+                    >
+                      provenance
+                    </div>
+                    <div style={{ display: 'flex', 'flex-wrap': 'wrap', gap: '0.3rem' }}>
+                      <span style={chipStyle(false, authority() === 'ai' ? '#7c3aed' : '#0f766e')}>
+                        authority: {authority()}
+                      </span>
+                      <span style={chipStyle(false, accent())}>producer: {a().producerId}</span>
+                      <span style={chipStyle(false, '#6b7280')}>
+                        anchor: [{props.example.page}, seg {a().startSeg}]
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </Show>
+          </Show>
+
+          <Show when={step() === 'producer'}>
+            <Panel title={art()?.producerId ?? 'producer'} accent={accent()} mono>
+              <Row k="behavior" v="discovers (finds the anchors)" />
+              <Row k="built from" v="gemara" mono />
+              <Show when={feedsInto().length}>
+                <div style={{ 'margin-top': '0.4rem' }}>
+                  <div
+                    style={{
+                      'font-size': '0.64rem',
+                      'text-transform': 'uppercase',
+                      'letter-spacing': '0.06em',
+                      color: '#9a958a',
+                      'margin-bottom': '0.3rem',
+                    }}
+                  >
+                    feeds into
+                  </div>
+                  <div style={{ display: 'flex', 'flex-wrap': 'wrap', gap: '0.3rem' }}>
+                    <For each={feedsInto()}>
+                      {(id) => <span style={chipStyle(false, accent())}>{id}</span>}
+                    </For>
+                  </div>
+                </div>
+              </Show>
+              <button
+                type="button"
+                onClick={() => props.onOpenInGraph(art()?.producerId ?? '')}
+                style={{
+                  'margin-top': '0.7rem',
+                  background: 'var(--accent)',
+                  color: '#fff',
+                  border: 'none',
+                  'border-radius': '6px',
+                  padding: '0.4rem 0.7rem',
+                  cursor: 'pointer',
+                  'font-size': '0.8rem',
+                  'font-weight': 600,
+                }}
+              >
+                See it in the graph ↓
+              </button>
+            </Panel>
+          </Show>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const note: JSX.CSSProperties = {
+  margin: '0.5rem 0 0',
+  'font-size': '0.8rem',
+  'line-height': 1.5,
+  color: '#666',
+};
+
+function Panel(props: {
+  title: string;
+  accent: string;
+  mono?: boolean;
+  children: JSX.Element;
+}): JSX.Element {
+  return (
+    <div
+      style={{
+        border: '1px solid var(--line)',
+        'border-radius': '8px',
+        background: '#fff',
+        padding: '0.85rem 1rem',
+      }}
+    >
+      <div
+        style={{
+          'font-weight': 700,
+          color: props.accent,
+          'margin-bottom': '0.4rem',
+          'font-family': props.mono ? 'ui-monospace, SFMono-Regular, Menlo, monospace' : undefined,
+        }}
+      >
+        {props.title}
+      </div>
+      {props.children}
+    </div>
+  );
+}
+
+function Row(props: { k: string; v: string; mono?: boolean }): JSX.Element {
+  return (
+    <div style={{ 'font-size': '0.82rem', margin: '0.15rem 0', color: '#333' }}>
+      <span style={{ color: '#9a958a' }}>{props.k}: </span>
+      <span
+        style={{
+          'font-family': props.mono ? 'ui-monospace, SFMono-Regular, Menlo, monospace' : undefined,
+        }}
+      >
+        {props.v}
+      </span>
+    </div>
+  );
+}
+
+function SegRow(props: {
+  index: number;
+  en: string;
+  he: string;
+  highlight: boolean;
+  accent: string;
+}): JSX.Element {
+  const preview = (): string => {
+    const t = props.en || props.he;
+    return t.length > 88 ? `${t.slice(0, 87)}…` : t || '—';
+  };
+  return (
+    <div
+      style={{
+        display: 'flex',
+        gap: '0.5rem',
+        padding: '0.3rem 0.6rem',
+        'border-bottom': '1px solid #f1efe8',
+        background: props.highlight ? `${props.accent}14` : 'transparent',
+        'border-left': props.highlight ? `3px solid ${props.accent}` : '3px solid transparent',
+      }}
+    >
+      <span
+        style={{
+          'font-family': 'ui-monospace, SFMono-Regular, Menlo, monospace',
+          'font-size': '0.68rem',
+          color: props.highlight ? props.accent : '#aaa',
+          'min-width': '1.6rem',
+          'font-weight': props.highlight ? 700 : 400,
+        }}
+      >
+        {props.index}
+      </span>
+      <span
+        style={{
+          'font-size': '0.78rem',
+          color: '#444',
+          overflow: 'hidden',
+          'text-overflow': 'ellipsis',
+          'white-space': 'nowrap',
+        }}
+        dir={props.en ? 'ltr' : 'rtl'}
+      >
+        {preview()}
+      </span>
+    </div>
+  );
+}

--- a/packages/talmud/src/client/howItWorks/example.ts
+++ b/packages/talmud/src/client/howItWorks/example.ts
@@ -1,0 +1,95 @@
+/**
+ * Real data for the "show, don't tell" worked example on #howitworks. Pulls an
+ * actual daf (Berakhot 2a) and one real piece anchored to it, so the page
+ * demonstrates spine -> anchor -> artifact -> producer on live content rather
+ * than describing it.
+ *
+ *  - /api/daf       -> the spine: the daf's ordered segments (real text)
+ *  - /api/daf-view  -> a real cached `pesukim` instance: a biblical citation
+ *                      anchored to one segment (body + segment range)
+ */
+import { createResource, type Resource } from 'solid-js';
+
+const TRACTATE = 'berakhot';
+const PAGE = '2a';
+
+/** Strip Sefaria/HebrewBooks markup so a segment preview is plain text. */
+export function stripHtml(s: string): string {
+  return s
+    .replace(/<[^>]*>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&[a-z]+;/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export interface WorkedArtifact {
+  producerId: string; // the producer that made it, e.g. 'pesukim'
+  kind: string; // 'mark-instance'
+  title: string; // e.g. 'Deuteronomy 6:7'
+  body: string; // the produced summary
+  excerpt?: string; // the Hebrew phrase it cites
+  startSeg: number;
+  endSeg: number;
+}
+
+export interface WorkedExample {
+  tractate: string;
+  page: string;
+  segsEn: string[];
+  segsHe: string[];
+  artifact: WorkedArtifact | null;
+}
+
+interface RawInstance {
+  startSegIdx?: number;
+  endSegIdx?: number;
+  fields?: Record<string, unknown>;
+}
+
+const str = (v: unknown): string => (typeof v === 'string' ? v : '');
+
+function pickPesukim(view: unknown): WorkedArtifact | null {
+  const pieces = (view as { pieces?: Record<string, { parsed?: unknown }> })?.pieces;
+  const parsed = pieces?.pesukim?.parsed as { instances?: RawInstance[] } | undefined;
+  const inst = parsed?.instances?.find((i) => typeof i.startSegIdx === 'number');
+  if (!inst) return null;
+  const f = inst.fields ?? {};
+  return {
+    producerId: 'pesukim',
+    kind: 'mark-instance',
+    title: str(f.verseRef) || 'a biblical citation',
+    body: str(f.summary),
+    excerpt: str(f.excerpt) || undefined,
+    startSeg: inst.startSegIdx ?? 0,
+    endSeg: inst.endSegIdx ?? inst.startSegIdx ?? 0,
+  };
+}
+
+async function fetchExample(): Promise<WorkedExample> {
+  const [dafR, viewR] = await Promise.allSettled([
+    fetch(`/api/daf/${TRACTATE}/${PAGE}?source=sefaria`),
+    fetch(`/api/daf-view/${TRACTATE}/${PAGE}`),
+  ]);
+
+  let segsEn: string[] = [];
+  let segsHe: string[] = [];
+  if (dafR.status === 'fulfilled' && dafR.value.ok) {
+    const j = (await dafR.value.json()) as { mainSegmentsEn?: string[]; mainSegmentsHe?: string[] };
+    segsEn = (j.mainSegmentsEn ?? []).map(stripHtml);
+    segsHe = (j.mainSegmentsHe ?? []).map(stripHtml);
+  }
+
+  let artifact: WorkedArtifact | null = null;
+  if (viewR.status === 'fulfilled' && viewR.value.ok) {
+    artifact = pickPesukim(await viewR.value.json());
+  }
+
+  return { tractate: TRACTATE, page: PAGE, segsEn, segsHe, artifact };
+}
+
+export function useWorkedExample(): Resource<WorkedExample> {
+  const [example] = createResource(fetchExample);
+  return example;
+}

--- a/packages/talmud/src/client/styles.css
+++ b/packages/talmud/src/client/styles.css
@@ -171,6 +171,15 @@ main {
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap: 0.8rem;
 }
+/* The worked example's spine | panel split; stacks on phones. */
+.hiw-example {
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+}
+@media (max-width: 700px) {
+  .hiw-example {
+    grid-template-columns: 1fr;
+  }
+}
 @media (max-width: 900px) {
   .hiw-layout {
     grid-template-columns: 1fr;

--- a/packages/talmud/tests/how-it-works-example.test.ts
+++ b/packages/talmud/tests/how-it-works-example.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { stripHtml } from '../src/client/howItWorks/example';
+
+describe('stripHtml', () => {
+  it('removes tags and collapses whitespace', () => {
+    expect(stripHtml('<big><strong>מֵאֵימָתַי</strong></big> קוֹרִין')).toBe('מֵאֵימָתַי קוֹרִין');
+    expect(stripHtml('The <i>Berakhot</i> tractate')).toBe('The Berakhot tractate');
+  });
+  it('decodes the common entities and trims', () => {
+    expect(stripHtml('a&nbsp;&amp;&nbsp;b   ')).toBe('a & b');
+  });
+  it('is a no-op on plain text', () => {
+    expect(stripHtml('plain text')).toBe('plain text');
+  });
+});

--- a/packages/talmud/tests/how-it-works-page.test.tsx
+++ b/packages/talmud/tests/how-it-works-page.test.tsx
@@ -12,24 +12,32 @@ describe('HowItWorksPage', () => {
 
   beforeEach(() => {
     // jsdom has no IntersectionObserver; the scroll-spy onMount needs one.
-    vi.stubGlobal(
-      'IntersectionObserver',
-      class {
-        observe() {}
-        unobserve() {}
-        disconnect() {}
-      },
-    );
+    const NoopObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+    // jsdom lacks both; the scroll-spy and the graph's fit-to-width need them.
+    vi.stubGlobal('IntersectionObserver', NoopObserver);
+    vi.stubGlobal('ResizeObserver', NoopObserver);
     vi.stubGlobal(
       'fetch',
       vi.fn(async (url: string) => {
-        const body = String(url).includes('enrichments')
-          ? {
-              enrichments: [
-                { id: 'rabbi.bio', mark: 'rabbi', mode: 'augment-content', scope: 'global' },
-              ],
-            }
-          : { marks: [{ id: 'rabbi', label: 'Rabbi', dependencies: ['gemara'] }] };
+        const u = String(url);
+        let body: unknown = {};
+        if (u.includes('/api/enrichments')) {
+          body = {
+            enrichments: [
+              { id: 'rabbi.bio', mark: 'rabbi', mode: 'augment-content', scope: 'global' },
+            ],
+          };
+        } else if (u.includes('/api/marks')) {
+          body = { marks: [{ id: 'rabbi', label: 'Rabbi', dependencies: ['gemara'] }] };
+        } else if (u.includes('/api/daf-view')) {
+          body = { pieces: {} };
+        } else if (u.includes('/api/daf')) {
+          body = { mainSegmentsEn: ['seg zero'], mainSegmentsHe: ['שלום'] };
+        }
         return { ok: true, json: async () => body } as Response;
       }),
     );
@@ -47,10 +55,11 @@ describe('HowItWorksPage', () => {
     dispose = render(() => <HowItWorksPage />, root);
     const text = root.textContent ?? '';
     expect(text).toContain('How it works');
-    expect(text).toContain('Four primitives');
+    // chapter rail labels (render synchronously)
+    expect(text).toContain('The model, shown');
+    expect(text).toContain('The build graph');
     // a lifecycle step (renders synchronously, independent of the fetch)
     expect(text).toContain('Resolve inputs');
-    // the chapter rail is present
     expect(root.querySelector('.hiw-rail')).toBeTruthy();
     root.remove();
   });


### PR DESCRIPTION
Reworks `#howitworks` on the feedback: **show don't tell**, fewer words, a bigger/more navigable build graph, and an easier-to-navigate enrichment directory.

## Show the model on a real daf
The four primitives are now **demonstrated**, not described. A new worked example (`WorkedExample.tsx` + `howItWorks/example.ts`) pulls **real data** — Berakhot 2a's segments from `/api/daf` and a real cached `pesukim` citation (Deuteronomy 6:7, seg 7) from `/api/daf-view` — and steps **Spine → Anchor → Artifact → Producer**, each layering onto the same live spine. This replaces the prose "four primitives" and "marks vs enrichments" chapters.

## Bigger, navigable build graph
- **Fit-to-width by default** so the whole DAG is visible on open (then zoom in).
- Zoom in / out / reset (100%) buttons + a live % readout.
- **Grab-to-pan** the canvas (drag on empty space; node clicks/hovers untouched).
- Taller container.

## Searchable enrichment directory
- A **filter** box (matches id + description).
- **Expand all / collapse all**.
- Per-mark **jump chips** with counts that scroll to each group.

## Fewer words
One-line chapter intros, a compact 6-step lifecycle flow, and a 4-card caching summary instead of paragraphs + bullets.

## Verification
- `pnpm typecheck`, `pnpm lint` (Biome, 640 files), and the full suite (**2538 tests**) green. Clean production build.
- Updated the jsdom mount smoke test (stubs `ResizeObserver` + the new `/api/daf*` fetches); added a `stripHtml` unit test. The graph's `ResizeObserver` use is guarded for non-DOM envs.
- Verified live data exists for the worked example (Berakhot 2a: 14 segments; `pesukim` seg 7).
- Captured a headless screenshot of the rendered page (shared chrome-devtools profile was still locked by another agent, so used a standalone headless Chrome): worked example, lifecycle, fit-to-width graph, and directory all render with real content.