### PR TITLE
Inspector: shared registry-derived DAG (tanach gets the same waterfall + DAG)

### DIFF
--- a/packages/talmud/src/client/RunTreeDag.tsx
+++ b/packages/talmud/src/client/RunTreeDag.tsx
@@ -1,56 +1,16 @@
 /**
- * RunTreeDag — the build-provenance dependency DAG for ONE piece on a daf,
- * embeddable anywhere (flow layout, no dock chrome). A self-contained extract of
- * the Inspect panel's DAG view (RunTreeDock) so the alignment workbench can show
- * "select a generation → its whole DAG" without mounting the dock.
+ * RunTreeDag (talmud) — a thin wrapper over the shared @corpus/ui/RunTreeDag.
  *
- * Backed by the read-only GET /api/run-tree/:t/:p/:id[?instance=…]. Click a node
- * to select it (loads its prompt + generation via /api/run); click its ⊕ to
- * reveal its inputs. Arrows point dependency → consumer.
- *
- * NOTE: this duplicates RunTreeDock's DAG render + layout helpers on purpose —
- * the dock is under active development; fold both onto a shared component once
- * that settles.
+ * Owns talmud's data: the run-tree (GET /api/run-tree/:t/:p/:id[?instance=…])
+ * and, per selected node, its prompt + generation (POST /api/run). The DAG
+ * canvas, node header, and provenance render are the shared component; this
+ * supplies the per-node DETAIL BODY (generated text + the system/user prompt).
+ * Selection + expansion are controlled here so the detail fetch can key on them.
  */
 
-import {
-  ACTIVE_STROKE,
-  AuthorityBadge,
-  BADGE_LLM,
-  BADGE_PRO,
-  BADGE_SRC,
-  CANVAS,
-  CANVAS_BORDER,
-  CARD_STROKE,
-  computeLayout,
-  displayLabel,
-  edgePath,
-  fmtCost,
-  fmtMs,
-  type LaidEdge,
-  type Layout,
-  LEFT_PAD,
-  NODE_H,
-  NODE_W,
-  NodeIcon,
-  ProvenanceSection,
-  ROW_H,
-  type RunResult,
-  type RunTree,
-  StalenessDot,
-  TOP_PAD,
-  type TreeNode,
-  variantOf,
-} from '@corpus/ui/RunTree';
-import {
-  createEffect,
-  createMemo,
-  createResource,
-  createSignal,
-  For,
-  type JSX,
-  Show,
-} from 'solid-js';
+import type { RunResult, RunTree, TreeNode } from '@corpus/ui/RunTree';
+import { RunTreeDag as SharedRunTreeDag } from '@corpus/ui/RunTreeDag';
+import { createEffect, createResource, createSignal, type JSX, Show } from 'solid-js';
 import { lang } from './i18n';
 
 export function RunTreeDag(props: {
@@ -66,6 +26,12 @@ export function RunTreeDag(props: {
     setExpanded(new Set([p]));
     setSelected(p);
   });
+  const toggleExpand = (id: string) =>
+    setExpanded((prev) => {
+      const n = new Set(prev);
+      n.has(id) ? n.delete(id) : n.add(id);
+      return n;
+    });
 
   const instanceQS = (): string => {
     const inst = props.instance;
@@ -82,36 +48,7 @@ export function RunTreeDag(props: {
       return (await r.json()) as RunTree;
     },
   );
-  const layout = createMemo<Layout | null>(() => {
-    const t = tree();
-    return t ? computeLayout(t, expanded()) : null;
-  });
   const nodeOf = (id: string): TreeNode | undefined => tree()?.nodes[id];
-  const hasKids = (id: string): boolean => !!tree()?.edges.some((e) => e[0] === id);
-  const toggleExpand = (id: string) =>
-    setExpanded((prev) => {
-      const n = new Set(prev);
-      n.has(id) ? n.delete(id) : n.add(id);
-      return n;
-    });
-  const badgeColor = (n: TreeNode) =>
-    n.kind !== 'llm' ? BADGE_SRC : n.model?.includes('pro') ? BADGE_PRO : BADGE_LLM;
-  const connected = createMemo<Set<string>>(() => {
-    const sel = selected();
-    const lay = layout();
-    if (!sel || !lay) return new Set();
-    const set = new Set<string>([sel]);
-    for (const e of lay.edges) {
-      if (e.fromId === sel) set.add(e.toId);
-      if (e.toId === sel) set.add(e.fromId);
-    }
-    return set;
-  });
-  const isIncident = (e: LaidEdge) => e.fromId === selected() || e.toId === selected();
-  const nodeY = (id: string) => {
-    const r = layout()!.rowOf.get(id)!;
-    return TOP_PAD + r * ROW_H;
-  };
 
   const [detail] = createResource(
     () => {
@@ -145,413 +82,92 @@ export function RunTreeDag(props: {
     },
   );
 
-  return (
-    <div
-      style={{
-        display: 'flex',
-        'flex-direction': 'column',
-        gap: '0.5rem',
-        'font-family': 'system-ui, sans-serif',
-        'font-size': '13px',
-      }}
-    >
-      {/* DAG */}
-      <div
-        style={{
-          'max-height': '52vh',
-          overflow: 'auto',
-          background: CANVAS,
-          padding: '0.5rem',
-          border: `1px solid ${CANVAS_BORDER}`,
-          'border-radius': '8px',
-        }}
-      >
-        <Show when={tree.loading}>
-          <div style={{ padding: '0.5rem', color: '#aaa' }}>loading…</div>
-        </Show>
-        <Show when={tree() === null && !tree.loading}>
-          <div style={{ padding: '0.5rem', color: '#c00' }}>
-            no graph (unknown piece, or nothing cached)
-          </div>
-        </Show>
-        <Show when={layout()}>
-          {(lay) => (
+  // The per-node DETAIL BODY: the generated text + a system/user prompt
+  // accordion, from POST /api/run. The shared component renders the header +
+  // ProvenanceSection around it.
+  const renderDetail = (): JSX.Element => (
+    <>
+      <Show when={detail.loading}>
+        <div style={{ color: '#aaa', 'font-size': '0.78rem' }}>loading run…</div>
+      </Show>
+      <Show when={detail()}>
+        {(r) => (
+          <>
             <div
               style={{
-                position: 'relative',
-                width: `${lay().width}px`,
-                height: `${lay().height}px`,
+                'line-height': 1.5,
+                'font-size': '0.82rem',
+                color: '#222',
+                'white-space': 'pre-wrap',
               }}
             >
-              <svg
-                aria-hidden="true"
-                width={lay().width}
-                height={lay().height}
-                style={{
-                  position: 'absolute',
-                  inset: 0,
-                  'pointer-events': 'none',
-                  overflow: 'visible',
-                }}
-              >
-                <defs>
-                  <marker
-                    id="rtd-arrow"
-                    markerWidth="8"
-                    markerHeight="8"
-                    refX="6"
-                    refY="3"
-                    orient="auto"
+              {(r().content ?? '').slice(0, 1600)}
+            </div>
+            <Show when={r().resolved}>
+              {(res) => (
+                <details style={{ 'margin-top': '0.7rem' }}>
+                  <summary style={{ cursor: 'pointer', 'font-size': '0.74rem', color: '#666' }}>
+                    prompt (system + user)
+                  </summary>
+                  <div style={{ 'font-size': '0.64rem', color: '#999', 'margin-top': '0.3rem' }}>
+                    system
+                  </div>
+                  <pre
+                    style={{
+                      'white-space': 'pre-wrap',
+                      'font-family': 'ui-monospace, Menlo, monospace',
+                      'font-size': '11px',
+                      margin: 0,
+                      background: '#f8f8f8',
+                      padding: '0.5rem',
+                      'border-radius': '3px',
+                      'max-height': '24vh',
+                      overflow: 'auto',
+                    }}
                   >
-                    <path d="M0 0 L6 3 L0 6 z" fill="#c9b8b0" />
-                  </marker>
-                  <marker
-                    id="rtd-arrow-hot"
-                    markerWidth="8"
-                    markerHeight="8"
-                    refX="6"
-                    refY="3"
-                    orient="auto"
+                    {res().system_prompt}
+                  </pre>
+                  <div style={{ 'font-size': '0.64rem', color: '#999', margin: '0.3rem 0 0' }}>
+                    user
+                  </div>
+                  <pre
+                    style={{
+                      'white-space': 'pre-wrap',
+                      'font-family': 'ui-monospace, Menlo, monospace',
+                      'font-size': '11px',
+                      margin: 0,
+                      background: '#f8f8f8',
+                      padding: '0.5rem',
+                      'border-radius': '3px',
+                      'max-height': '24vh',
+                      overflow: 'auto',
+                    }}
                   >
-                    <path d="M0 0 L6 3 L0 6 z" fill="#8a2a2b" />
-                  </marker>
-                </defs>
-                <For each={lay().edges}>
-                  {(e) => {
-                    const hot = () => isIncident(e);
-                    const faded = () => !!selected() && !hot();
-                    return (
-                      <path
-                        d={edgePath(e.toRow, e.fromRow, e.lane)}
-                        fill="none"
-                        stroke={hot() ? '#8a2a2b' : '#d3c4ba'}
-                        stroke-width={hot() ? 2 : 1.5}
-                        stroke-opacity={faded() ? 0.22 : hot() ? 0.85 : 1}
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        marker-end={`url(#${hot() ? 'rtd-arrow-hot' : 'rtd-arrow'})`}
-                      />
-                    );
-                  }}
-                </For>
-              </svg>
-              <For each={lay().order}>
-                {(id) => {
-                  const n = () => nodeOf(id)!;
-                  const isLLM = () => n().kind === 'llm';
-                  const sel = () => selected() === id;
-                  const exp = () => expanded().has(id);
-                  const slow = () => (n().cold_ms ?? 0) > 10_000;
-                  const dim = () => !!selected() && !connected().has(id);
-                  const activate = () => {
-                    setSelected(id);
-                    if (hasKids(id)) toggleExpand(id);
-                  };
-                  return (
-                    // biome-ignore lint/a11y/useSemanticElements: node card contains a nested expand <button>; a native button cannot contain another button
-                    <div
-                      role="button"
-                      tabIndex={0}
-                      onClick={activate}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' || e.key === ' ') {
-                          e.preventDefault();
-                          activate();
-                        }
-                      }}
-                      style={{
-                        position: 'absolute',
-                        left: `${LEFT_PAD}px`,
-                        top: `${nodeY(id)}px`,
-                        width: `${NODE_W}px`,
-                        height: `${NODE_H}px`,
-                        display: 'flex',
-                        'align-items': 'center',
-                        gap: '0.5rem',
-                        padding: '0 0.6rem',
-                        cursor: 'pointer',
-                        'box-sizing': 'border-box',
-                        background: sel() ? '#fdf2f2' : '#fff',
-                        border: `${sel() ? 1.75 : 1}px solid ${sel() ? ACTIVE_STROKE : CARD_STROKE}`,
-                        'border-radius': '11px',
-                        'box-shadow': '0 1px 2px rgba(58,51,32,0.08)',
-                        opacity: dim() ? 0.42 : 1,
-                        transition: 'opacity 0.12s',
-                      }}
-                    >
-                      <NodeIcon variant={variantOf(n())} color={badgeColor(n())} />
-                      <div style={{ flex: 1, 'min-width': 0 }}>
-                        <div style={{ display: 'flex', 'align-items': 'baseline', gap: '0.4rem' }}>
-                          <span
-                            style={{
-                              'font-weight': 600,
-                              'font-size': '0.84rem',
-                              color: '#2a2723',
-                              'white-space': 'nowrap',
-                              overflow: 'hidden',
-                              'text-overflow': 'ellipsis',
-                            }}
-                          >
-                            {displayLabel(n().id, n().label)}
-                          </span>
-                          <span
-                            style={{
-                              'margin-left': 'auto',
-                              'font-size': '0.68rem',
-                              'font-variant-numeric': 'tabular-nums',
-                              color: slow() ? '#b45309' : '#9a857c',
-                              'flex-shrink': 0,
-                            }}
-                          >
-                            {fmtMs(n().cold_ms)}
-                          </span>
-                          <Show when={n().staleness}>
-                            {(s) => (
-                              <StalenessDot
-                                staleness={s()}
-                                inputsChanged={n().inputsChanged}
-                                isMark={n().producer === 'mark'}
-                              />
-                            )}
-                          </Show>
-                        </div>
-                        <div
-                          style={{
-                            display: 'flex',
-                            'align-items': 'center',
-                            gap: '0.3rem',
-                            'font-size': '0.66rem',
-                            'font-family': 'ui-monospace, Menlo, monospace',
-                            color: isLLM() ? '#9a8fb5' : '#9aa4ad',
-                            'white-space': 'nowrap',
-                            overflow: 'hidden',
-                            'text-overflow': 'ellipsis',
-                          }}
-                        >
-                          <Show when={n().authority}>
-                            {(a) => <AuthorityBadge authority={a()} />}
-                          </Show>
-                          {isLLM()
-                            ? `${(n().model ?? '').split('/').pop()} · ${fmtCost(n().cost)}`
-                            : 'source · $0'}
-                        </div>
-                      </div>
-                      <Show when={hasKids(id)}>
-                        <button
-                          type="button"
-                          onClick={(ev) => {
-                            ev.stopPropagation();
-                            setSelected(id);
-                            toggleExpand(id);
-                          }}
-                          title={exp() ? 'collapse inputs' : 'expand inputs'}
-                          style={{
-                            'flex-shrink': 0,
-                            width: '18px',
-                            height: '18px',
-                            'border-radius': '50%',
-                            border: '1px solid #d8c9c0',
-                            background: '#fff',
-                            color: '#8a7d74',
-                            cursor: 'pointer',
-                            'font-size': '0.8rem',
-                            'line-height': 1,
-                            display: 'inline-flex',
-                            'align-items': 'center',
-                            'justify-content': 'center',
-                            padding: 0,
-                          }}
-                        >
-                          {exp() ? '–' : '+'}
-                        </button>
-                      </Show>
-                    </div>
-                  );
-                }}
-              </For>
-            </div>
-          )}
-        </Show>
-      </div>
-
-      {/* node detail */}
-      <Show when={selected() ? nodeOf(selected()!) : null}>
-        {(n) => (
-          <div style={{ border: '1px solid #eee', 'border-radius': '8px', overflow: 'hidden' }}>
-            <div
-              style={{
-                padding: '0.45rem 0.7rem',
-                'border-bottom': '1px solid #f0f0f0',
-                display: 'flex',
-                'flex-wrap': 'wrap',
-                gap: '0.35rem',
-                'align-items': 'center',
-              }}
-            >
-              <span
-                style={{ 'font-weight': 600, 'font-size': '0.84rem', 'margin-right': '0.2rem' }}
-              >
-                {displayLabel(n().id, n().label)}
-              </span>
-              <span
-                style={{
-                  'font-size': '0.66rem',
-                  background: '#f1f1f3',
-                  'border-radius': '4px',
-                  padding: '0.05rem 0.4rem',
-                  color: '#555',
-                  'font-family': 'ui-monospace, Menlo, monospace',
-                }}
-              >
-                {n().kind === 'source' ? 'source' : (n().model ?? 'llm')}
-              </span>
-              <Show when={n().cold_ms != null}>
-                <span
-                  style={{
-                    'font-size': '0.66rem',
-                    background: '#f1f1f3',
-                    'border-radius': '4px',
-                    padding: '0.05rem 0.4rem',
-                    color: '#555',
-                    'font-family': 'ui-monospace, Menlo, monospace',
-                  }}
-                >
-                  gen {fmtMs(n().cold_ms)}
-                </span>
-              </Show>
-              <Show when={n().kind === 'llm'}>
-                <span
-                  style={{
-                    'font-size': '0.66rem',
-                    background: '#ecfdf5',
-                    'border-radius': '4px',
-                    padding: '0.05rem 0.4rem',
-                    color: '#047857',
-                    'font-family': 'ui-monospace, Menlo, monospace',
-                  }}
-                >
-                  {fmtCost(n().cost)}
-                </span>
-              </Show>
-              <span
-                style={{
-                  'font-size': '0.66rem',
-                  'border-radius': '4px',
-                  padding: '0.05rem 0.4rem',
-                  'font-family': 'ui-monospace, Menlo, monospace',
-                  ...(n().cached
-                    ? { background: '#dcfce7', color: '#15803d' }
-                    : { background: '#fef3c7', color: '#b45309' }),
-                }}
-              >
-                {n().cached ? 'cached' : 'not cached'}
-              </span>
-            </div>
-            <div style={{ 'max-height': '38vh', 'overflow-y': 'auto', padding: '0.6rem 0.7rem' }}>
-              <Show
-                when={n().kind === 'source'}
-                fallback={
-                  <>
-                    <Show when={detail.loading}>
-                      <div style={{ color: '#aaa', 'font-size': '0.78rem' }}>loading run…</div>
-                    </Show>
-                    <Show when={detail()}>
-                      {(r) => (
-                        <>
-                          <div
-                            style={{
-                              'line-height': 1.5,
-                              'font-size': '0.82rem',
-                              color: '#222',
-                              'white-space': 'pre-wrap',
-                            }}
-                          >
-                            {(r().content ?? '').slice(0, 1600)}
-                          </div>
-                          <Show when={r().resolved}>
-                            {(res) => (
-                              <details style={{ 'margin-top': '0.7rem' }}>
-                                <summary
-                                  style={{
-                                    cursor: 'pointer',
-                                    'font-size': '0.74rem',
-                                    color: '#666',
-                                  }}
-                                >
-                                  prompt (system + user)
-                                </summary>
-                                <div
-                                  style={{
-                                    'font-size': '0.64rem',
-                                    color: '#999',
-                                    'margin-top': '0.3rem',
-                                  }}
-                                >
-                                  system
-                                </div>
-                                <pre
-                                  style={{
-                                    'white-space': 'pre-wrap',
-                                    'font-family': 'ui-monospace, Menlo, monospace',
-                                    'font-size': '11px',
-                                    margin: 0,
-                                    background: '#f8f8f8',
-                                    padding: '0.5rem',
-                                    'border-radius': '3px',
-                                    'max-height': '24vh',
-                                    overflow: 'auto',
-                                  }}
-                                >
-                                  {res().system_prompt}
-                                </pre>
-                                <div
-                                  style={{
-                                    'font-size': '0.64rem',
-                                    color: '#999',
-                                    margin: '0.3rem 0 0',
-                                  }}
-                                >
-                                  user
-                                </div>
-                                <pre
-                                  style={{
-                                    'white-space': 'pre-wrap',
-                                    'font-family': 'ui-monospace, Menlo, monospace',
-                                    'font-size': '11px',
-                                    margin: 0,
-                                    background: '#f8f8f8',
-                                    padding: '0.5rem',
-                                    'border-radius': '3px',
-                                    'max-height': '24vh',
-                                    overflow: 'auto',
-                                  }}
-                                >
-                                  {res().user_prompt}
-                                </pre>
-                              </details>
-                            )}
-                          </Show>
-                        </>
-                      )}
-                    </Show>
-                    <Show when={!detail.loading && !detail()}>
-                      <div style={{ color: '#bbb', 'font-size': '0.78rem' }}>
-                        nothing cached for this node on this daf yet.
-                      </div>
-                    </Show>
-                    <ProvenanceSection node={n()} />
-                  </>
-                }
-              >
-                <div style={{ 'font-size': '0.82rem', color: '#555' }}>
-                  A <b>source</b> input — fetched/assembled, no model call (cost $0). The piece's
-                  prompt reads its text.
-                </div>
-              </Show>
-            </div>
-          </div>
+                    {res().user_prompt}
+                  </pre>
+                </details>
+              )}
+            </Show>
+          </>
         )}
       </Show>
-    </div>
+      <Show when={!detail.loading && !detail()}>
+        <div style={{ color: '#bbb', 'font-size': '0.78rem' }}>
+          nothing cached for this node on this daf yet.
+        </div>
+      </Show>
+    </>
+  );
+
+  return (
+    <SharedRunTreeDag
+      tree={tree() ?? null}
+      loading={tree.loading}
+      selected={selected()}
+      onSelect={setSelected}
+      expanded={expanded()}
+      onToggleExpand={toggleExpand}
+      renderDetail={renderDetail}
+    />
   );
 }

--- a/packages/tanach/src/client/App.tsx
+++ b/packages/tanach/src/client/App.tsx
@@ -975,6 +975,7 @@ export function App(): JSX.Element {
         <Inspector
           book={loc().book}
           chapter={loc().chapter}
+          lang={loc().lang}
           onClose={() => setInspectOpen(false)}
         />
       </Show>

--- a/packages/tanach/src/client/Inspector.tsx
+++ b/packages/tanach/src/client/Inspector.tsx
@@ -1,19 +1,27 @@
 /**
- * Chapter inspector — the build-provenance WATERFALL for the open chapter, the
- * tanach analogue of the talmud reader's Inspect waterfall (same shared
- * @corpus/ui/RunWaterfall renderer). Reads GET /api/chapter-runs/:book/:chapter
- * (the cache is the index) and ranks each producer piece by cold-build time,
- * with its cost + cache status. Rendered in the shared <Drawer>.
+ * Chapter inspector — the build-provenance surfaces for the open chapter, the
+ * tanach analogue of the talmud reader's Inspect dock, on the SAME shared
+ * renderers. A WATERFALL (every cached producer piece, ranked by cold-build
+ * time — @corpus/ui/RunWaterfall over GET /api/chapter-runs); click a piece to
+ * open its dependency DAG (@corpus/ui/RunTreeDag over GET /api/run-tree, derived
+ * by core buildRunTree from the producer registry). Tanach producers depend only
+ * on sources, so each DAG is one level (piece → its inputs) and the registry's
+ * `isExpandable` is false for all — surfaced as a note, not hidden. Shown in the
+ * shared <Drawer>.
  */
 
 import { Drawer } from '@corpus/ui/Drawer';
+import type { RunTree } from '@corpus/ui/RunTree';
+import { RunTreeDag } from '@corpus/ui/RunTreeDag';
 import { RunWaterfall, type WaterfallRow } from '@corpus/ui/RunWaterfall';
-import { createResource, type JSX, Show } from 'solid-js';
+import { createResource, createSignal, type JSX, Show } from 'solid-js';
 
 interface RunRow {
   id: string;
   label: string;
   instance: string | null;
+  instanceRaw: string | null;
+  expandable: boolean;
   cached: boolean;
   model: string | null;
   coldMs: number | null;
@@ -27,9 +35,17 @@ interface ChapterRuns {
   totals: { count: number; cached: number; cost: number; coldMs: number };
 }
 
+interface Picked {
+  id: string;
+  label: string;
+  instanceRaw: string | null;
+  expandable: boolean;
+}
+
 export function Inspector(props: {
   book: string;
   chapter: number;
+  lang?: 'en' | 'he';
   onClose: () => void;
 }): JSX.Element {
   const [runs] = createResource(
@@ -40,19 +56,57 @@ export function Inspector(props: {
     },
   );
 
-  // The chapter's producer runs as waterfall rows. `events` is a mark; the rest
-  // are enrichments (drives the run-tree icon).
+  // A unique waterfall-row id per piece+instance, so clicking maps back to the
+  // exact producer to open in the DAG.
+  const rowKey = (r: RunRow) => `${r.id}:${r.instanceRaw ?? ''}`;
   const rows = (): WaterfallRow[] =>
     (runs()?.runs ?? []).map((r) => ({
-      id: `${r.id}:${r.instance ?? ''}`,
+      id: rowKey(r),
       label: r.label,
       instance: r.instance,
       cached: r.cached,
       coldMs: r.coldMs,
       cost: r.cost,
       tokens: r.tokens,
+      // `events` is a mark; the rest are enrichments (drives the node icon).
       variant: r.id === 'events' ? 'mark' : 'enrichment',
     }));
+
+  const [picked, setPicked] = createSignal<Picked | null>(null);
+  // Node selection + expansion WITHIN the DAG (the shared component is controlled).
+  const [dagSel, setDagSel] = createSignal<string | null>(null);
+  const [dagExp, setDagExp] = createSignal<Set<string>>(new Set());
+  const toggle = (id: string) =>
+    setDagExp((prev) => {
+      const n = new Set(prev);
+      n.has(id) ? n.delete(id) : n.add(id);
+      return n;
+    });
+
+  const onSelect = (key: string) => {
+    const r = (runs()?.runs ?? []).find((x) => rowKey(x) === key);
+    if (!r) return;
+    setPicked({ id: r.id, label: r.label, instanceRaw: r.instanceRaw, expandable: r.expandable });
+    setDagSel(r.id);
+    setDagExp(new Set([r.id]));
+  };
+
+  const [tree] = createResource(
+    () => {
+      const p = picked();
+      return p
+        ? { ...p, book: props.book, chapter: props.chapter, lang: props.lang ?? 'en' }
+        : null;
+    },
+    async (k): Promise<RunTree | null> => {
+      const qs = new URLSearchParams({ lang: k.lang });
+      if (k.instanceRaw) qs.set('inst', k.instanceRaw);
+      const res = await fetch(
+        `/api/run-tree/${encodeURIComponent(k.book)}/${k.chapter}/${encodeURIComponent(k.id)}?${qs}`,
+      );
+      return res.ok ? ((await res.json()) as RunTree) : null;
+    },
+  );
 
   return (
     <Drawer
@@ -66,11 +120,35 @@ export function Inspector(props: {
       </Show>
       <Show when={runs()}>
         {(r) => (
-          <RunWaterfall
-            rows={rows()}
-            totals={r().totals}
-            emptyLabel="Nothing cached yet for this chapter."
-          />
+          <>
+            <RunWaterfall
+              rows={rows()}
+              totals={r().totals}
+              onSelect={onSelect}
+              emptyLabel="Nothing cached yet for this chapter."
+            />
+            <Show when={picked()}>
+              {(p) => (
+                <div class="inspect-dag">
+                  <div class="inspect-dag-head">
+                    Build provenance · {p().label}
+                    <Show when={!p().expandable}>
+                      <span class="comm-muted"> · depends only on sources (no sub-producers)</span>
+                    </Show>
+                  </div>
+                  <RunTreeDag
+                    tree={tree() ?? null}
+                    loading={tree.loading}
+                    selected={dagSel()}
+                    onSelect={setDagSel}
+                    expanded={dagExp()}
+                    onToggleExpand={toggle}
+                    emptyLabel="Nothing cached for this piece yet."
+                  />
+                </div>
+              )}
+            </Show>
+          </>
         )}
       </Show>
     </Drawer>

--- a/packages/tanach/src/client/styles.css
+++ b/packages/tanach/src/client/styles.css
@@ -356,6 +356,21 @@ body {
    see inspector.css. (.inspect-link below is tanach-only chrome.) */
 /* The /usage page is the shared @corpus/ui UsagePage — see usage.css. */
 
+/* the build-provenance DAG opened under a clicked waterfall row (the DAG canvas
+   itself is the shared @corpus/ui RunTreeDag) */
+.inspect-dag {
+  margin-top: 16px;
+  padding-top: 14px;
+  border-top: 1px solid var(--line);
+}
+.inspect-dag-head {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+  margin-bottom: 10px;
+}
+
 /* this-week's-parsha button + EN/HE language toggle (like the Talmud reader) */
 .parsha-btn {
   font-family: inherit;

--- a/packages/tanach/src/worker/index.ts
+++ b/packages/tanach/src/worker/index.ts
@@ -19,7 +19,7 @@ import type { Context } from 'hono';
 import { Hono } from 'hono';
 import { isBook } from '../lib/books.ts';
 import { lookupPlace } from './gazetteer.ts';
-import { chapterRuns } from './inspect.ts';
+import { chapterRuns, chapterRunTree } from './inspect.ts';
 import type { EventSection } from './producers/events.ts';
 import { translateHebrew } from './producers/translate.ts';
 import type { TanachEnv, TanachRunCtx } from './run-ports.ts';
@@ -606,6 +606,25 @@ app.get('/api/chapter-runs/:book/:chapter', async (c) => {
   if (!isBook(book)) return c.json({ error: `Unknown book: ${book}` }, 400);
   if (!/^\d+$/.test(chapter)) return c.json({ error: `Bad chapter: ${chapter}` }, 400);
   return c.json(await chapterRuns(c.env.CACHE, book, chapter));
+});
+
+// GET /api/run-tree/:book/:chapter/:id[?inst=…&lang=…] — the build PROVENANCE of
+// ONE piece as its forward dependency DAG, derived by core buildRunTree over the
+// tanach producer registry and draped with the root's cached telemetry. The same
+// shape talmud's /api/run-tree returns, so both feed the shared @corpus/ui DAG.
+// Read-only; a piece with nothing cached reports cached:false. `inst` is the raw
+// instance tail (verse / range) for a per-instance piece.
+app.get('/api/run-tree/:book/:chapter/:id', async (c) => {
+  const book = c.req.param('book');
+  const chapter = c.req.param('chapter');
+  const id = c.req.param('id');
+  if (!isBook(book)) return c.json({ error: `Unknown book: ${book}` }, 400);
+  if (!/^\d+$/.test(chapter)) return c.json({ error: `Bad chapter: ${chapter}` }, 400);
+  const inst = c.req.query('inst') ?? null;
+  const lang = c.req.query('lang') === 'he' ? 'he' : 'en';
+  const tree = await chapterRunTree(c.env.CACHE, book, chapter, id, inst, lang);
+  if (!tree) return c.json({ error: `Unknown producer: ${id}` }, 404);
+  return c.json(tree);
 });
 
 // Everything else: serve the built SPA (static assets + index.html fallback).

--- a/packages/tanach/src/worker/inspect.ts
+++ b/packages/tanach/src/worker/inspect.ts
@@ -1,28 +1,50 @@
 /**
- * Chapter inspector — what's cached for a chapter, and what it cost.
+ * Chapter inspector — what's cached for a chapter, what it cost, and HOW each
+ * piece was built.
  *
- * The tanach analogue of the talmud reader's Inspect waterfall. Like talmud,
- * there is no separate index: the CACHE *is* the index. The producers' keys are
- * deterministic, so we read the two chapter-level ones by exact key (showing
- * them even when cold = a miss), and enumerate the per-instance ones (note,
- * synthesis, midrash-synthesis) by KV prefix list. Each producer entry written
- * through runProducer is a StoredArtifact envelope carrying model + elapsed_ms
- * + the CostStamp, so the per-piece time and cost come straight off it; the
- * pre-migration raw-payload entries read as cached-but-untimed.
+ * The tanach analogue of the talmud reader's Inspect surfaces, and like talmud
+ * there is no separate index: the CACHE *is* the index. Two read shapes:
+ *
+ *  - `chapterRuns` — the WATERFALL: every producer piece + its telemetry. The
+ *    producer SET, labels, kind, and per-row expandability are DERIVED from the
+ *    registry (producers/defs.ts → tanachProducerDefs); only the literal cache-
+ *    key bytes are an explicit per-id table (KEY_SHAPES), byte-exact to the
+ *    writer in run-ports.ts — the one thing that can't be derived.
+ *  - `chapterRunTree` — the DAG: one piece's forward dependency subgraph via the
+ *    core `buildRunTree` over that same registry, draped with the root's cached
+ *    telemetry. Tanach producers depend only on SOURCES, so every tree is one
+ *    level (piece → its source inputs) and `isExpandable` is false for all — the
+ *    inspector's flat shape is a property of the registry, not a hard-coded flag.
+ *
+ * Each producer entry written through runProducer is a StoredArtifact envelope
+ * carrying model + elapsed_ms + the CostStamp (+ provenance), so the per-piece
+ * time / cost / authority come straight off it; pre-migration raw payloads read
+ * as cached-but-untimed.
  *
  * Pure over a minimal KV surface so it unit-tests without a Worker.
  */
 
 import type { CostStamp } from '@corpus/core/model/provenance';
 import type { StoredArtifact } from '@corpus/core/store/envelope';
+import { authorityOf } from '@corpus/core/store/envelope';
+import { buildRunTree, isExpandable, type RunTelemetry } from '@corpus/core/telemetry/runtree';
+import type { RunTree } from '@corpus/core/telemetry/types';
+import { TANACH_PRODUCERS, tanachProducerDefs } from './producers/defs.ts';
 import { isStoredArtifact } from './run-ports.ts';
 
 export interface RunRow {
   /** Producer id. */
   id: string;
   label: string;
-  /** The per-instance discriminator (verse / range) or null for whole-chapter. */
+  /** The per-instance discriminator for DISPLAY (verse / range) or null. */
   instance: string | null;
+  /** The raw key tail used to address this instance's cache entry (null for
+   *  whole-chapter pieces). Drives the run-tree fetch. */
+  instanceRaw: string | null;
+  /** True iff this piece's dependency subgraph reaches another PRODUCER — i.e.
+   *  there's a real DAG to drill into. Derived from the registry (false for
+   *  every tanach producer today: they depend only on sources). */
+  expandable: boolean;
   cached: boolean;
   model: string | null;
   /** Generation wall-time (ms) from the cached envelope, when known. */
@@ -45,22 +67,77 @@ export interface RunsCache {
   list(opts: { prefix: string }): Promise<{ keys: { name: string }[] }>;
 }
 
+// ── per-producer cache-key bytes (the one thing not derivable) ────────────────
+// Byte-exact to the writer (run-ports.ts KEY_TEMPLATES). A `chapter` producer is
+// addressed by exact key; an `instance` producer is enumerated by prefix, each
+// found key's tail giving the instance.
+interface ChapterShape {
+  kind: 'chapter';
+  key: (b: string, c: string) => string;
+}
+interface InstanceShape {
+  kind: 'instance';
+  prefix: (b: string, c: string) => string;
+  key: (b: string, c: string, raw: string) => string;
+  /** Display form of the instance tail (e.g. a verse number → "v3"). */
+  label: (raw: string) => string;
+}
+const KEY_SHAPES: Record<string, ChapterShape | InstanceShape> = {
+  events: { kind: 'chapter', key: (b, c) => `events:v2:${b}:${c}` },
+  overview: { kind: 'chapter', key: (b, c) => `overview:v1:${b}:${c}` },
+  geography: { kind: 'chapter', key: (b, c) => `geography:v2:${b}:${c}` },
+  tidbit: { kind: 'chapter', key: (b, c) => `tidbit:v2:${b}:${c}` },
+  note: {
+    kind: 'instance',
+    prefix: (b, c) => `note:v1:${b}:${c}:`,
+    key: (b, c, raw) => `note:v1:${b}:${c}:${raw}`,
+    label: (raw) => raw,
+  },
+  synthesis: {
+    kind: 'instance',
+    prefix: (b, c) => `synthesis:v1:${b}:${c}:`,
+    key: (b, c, raw) => `synthesis:v1:${b}:${c}:${raw}`,
+    label: (raw) => `v${raw}`,
+  },
+  'midrash-synthesis': {
+    kind: 'instance',
+    prefix: (b, c) => `midrash-synth:v1:${b}:${c}:`,
+    key: (b, c, raw) => `midrash-synth:v1:${b}:${c}:${raw}`,
+    label: (raw) => `v${raw}`,
+  },
+};
+// The chapter-addressable producers, in waterfall order (KEY_SHAPES is declared
+// chapter-pieces-first, then per-instance; object key order is preserved). This
+// is exactly the set with a cache-key shape — `translate` is selection-keyed
+// (no chapter address), so it has no KEY_SHAPE and is never inspected here.
+const INSPECTED_IDS = Object.keys(KEY_SHAPES);
+
+const labelOf = (id: string): string =>
+  TANACH_PRODUCERS[id as keyof typeof TANACH_PRODUCERS]?.label ?? id;
+
 const NO_TELEMETRY = { model: null, coldMs: null, cost: null, tokens: null };
 
-/** Project a stored cache value into a row's cache/telemetry fields. A null raw
- *  means a miss; a non-envelope (legacy raw payload) is cached-but-untimed. */
-export function telemetryOf(
-  raw: string | null,
-): Pick<RunRow, 'cached' | 'model' | 'coldMs' | 'cost' | 'tokens'> {
-  if (raw === null) return { cached: false, ...NO_TELEMETRY };
+/** Parse a stored cache value into the envelope (or null for miss / non-envelope). */
+function envelopeOf(raw: string | null): StoredArtifact | null {
+  if (raw === null) return null;
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
   } catch {
-    return { cached: true, ...NO_TELEMETRY };
+    return null;
   }
-  if (!isStoredArtifact(parsed)) return { cached: true, ...NO_TELEMETRY };
-  const env = parsed as StoredArtifact;
+  return isStoredArtifact(parsed) ? (parsed as StoredArtifact) : null;
+}
+
+/** Project a stored cache value into a waterfall row's cache/telemetry fields. A
+ *  null raw means a miss; a non-envelope (legacy raw payload) is
+ *  cached-but-untimed. */
+export function telemetryOf(
+  raw: string | null,
+): Pick<RunRow, 'cached' | 'model' | 'coldMs' | 'cost' | 'tokens'> {
+  if (raw === null) return { cached: false, ...NO_TELEMETRY };
+  const env = envelopeOf(raw);
+  if (!env) return { cached: true, ...NO_TELEMETRY };
   const cost = (env.cost ?? null) as CostStamp | null;
   return {
     cached: true,
@@ -74,34 +151,23 @@ export function telemetryOf(
   };
 }
 
-/** The two whole-chapter producers, addressed by exact key. */
-const CHAPTER_PRODUCERS = [
-  { id: 'events', label: 'Sections', key: (b: string, c: string) => `events:v2:${b}:${c}` },
-  { id: 'overview', label: 'Overview', key: (b: string, c: string) => `overview:v1:${b}:${c}` },
-];
-
-/** The per-instance producers, enumerated by KV prefix; `inst` labels the row
- *  from the key tail (the range for note, the verse for the per-verse ones). */
-const INSTANCE_PRODUCERS = [
-  {
-    id: 'note',
-    label: 'Section note',
-    prefix: (b: string, c: string) => `note:v1:${b}:${c}:`,
-    inst: (tail: string) => tail,
-  },
-  {
-    id: 'synthesis',
-    label: 'Commentary synthesis',
-    prefix: (b: string, c: string) => `synthesis:v1:${b}:${c}:`,
-    inst: (tail: string) => `v${tail}`,
-  },
-  {
-    id: 'midrash-synthesis',
-    label: 'Midrash synthesis',
-    prefix: (b: string, c: string) => `midrash-synth:v1:${b}:${c}:`,
-    inst: (tail: string) => `v${tail}`,
-  },
-];
+/** Project a stored envelope into a run-tree node's RunTelemetry — the richer
+ *  shape (adds authority / createdAt / recipeHash for the provenance pane). */
+function treeTelemetryOf(raw: string | null): RunTelemetry {
+  const env = envelopeOf(raw);
+  if (!env) return { cached: raw !== null };
+  const cost = (env.cost ?? null) as CostStamp | null;
+  return {
+    cached: true,
+    model: env.model && env.model !== 'legacy-cache' ? env.model : null,
+    cold_ms: env.elapsed_ms || null,
+    cost: cost ? (cost.billedUsd ?? cost.estimatedUsd ?? null) : null,
+    tokens: cost ? cost.tokensIn + cost.tokensOut : null,
+    authority: authorityOf(env),
+    createdAt: cost?.computedAt ? new Date(cost.computedAt).toISOString() : null,
+    recipeHash: env.recipe_hash ?? null,
+  };
+}
 
 /** Enumerate every cached producer piece for a chapter + its telemetry. */
 export async function chapterRuns(
@@ -109,39 +175,80 @@ export async function chapterRuns(
   book: string,
   chapter: string,
 ): Promise<ChapterRuns> {
-  // Chapter-level: exact reads in parallel (shown even on a miss).
-  const chapterRows = await Promise.all(
-    CHAPTER_PRODUCERS.map(async (p): Promise<RunRow> => {
-      const raw = await cache.get(p.key(book, chapter));
-      return { id: p.id, label: p.label, instance: null, ...telemetryOf(raw) };
-    }),
-  );
+  const defs = tanachProducerDefs();
+  const expandableOf = (id: string) => isExpandable(defs, id);
 
-  // Per-instance: list each prefix, then read the found keys in parallel.
-  const instanceRows: RunRow[] = [];
-  for (const p of INSTANCE_PRODUCERS) {
-    const prefix = p.prefix(book, chapter);
-    const { keys } = await cache.list({ prefix });
-    const rows = await Promise.all(
-      keys.map(async (k): Promise<RunRow> => {
-        const raw = await cache.get(k.name);
-        return {
-          id: p.id,
-          label: p.label,
-          instance: p.inst(k.name.slice(prefix.length)),
-          ...telemetryOf(raw),
-        };
-      }),
-    );
-    instanceRows.push(...rows);
+  const rows: RunRow[] = [];
+  for (const id of INSPECTED_IDS) {
+    const shape = KEY_SHAPES[id];
+    const base = { id, label: labelOf(id), expandable: expandableOf(id) };
+    if (shape.kind === 'chapter') {
+      const raw = await cache.get(shape.key(book, chapter));
+      rows.push({ ...base, instance: null, instanceRaw: null, ...telemetryOf(raw) });
+    } else {
+      const prefix = shape.prefix(book, chapter);
+      const { keys } = await cache.list({ prefix });
+      const found = await Promise.all(
+        keys.map(async (k): Promise<RunRow> => {
+          const tail = k.name.slice(prefix.length);
+          const raw = await cache.get(k.name);
+          return {
+            ...base,
+            instance: shape.label(tail),
+            instanceRaw: tail,
+            ...telemetryOf(raw),
+          };
+        }),
+      );
+      rows.push(...found);
+    }
   }
 
-  const runs = [...chapterRows, ...instanceRows];
   const totals = {
-    count: runs.length,
-    cached: runs.filter((r) => r.cached).length,
-    cost: runs.reduce((s, r) => s + (r.cost ?? 0), 0),
-    coldMs: runs.reduce((s, r) => s + (r.coldMs ?? 0), 0),
+    count: rows.length,
+    cached: rows.filter((r) => r.cached).length,
+    cost: rows.reduce((s, r) => s + (r.cost ?? 0), 0),
+    coldMs: rows.reduce((s, r) => s + (r.coldMs ?? 0), 0),
   };
-  return { book, chapter: Number(chapter), runs, totals };
+  return { book, chapter: Number(chapter), runs: rows, totals };
+}
+
+/** The source-input ids the registry references (dep ids that aren't producers).
+ *  Marked available ($0, cached) as run-tree leaves. Derived, not listed. */
+function sourceIdsOf(defs: ReturnType<typeof tanachProducerDefs>): Set<string> {
+  const producerIds = new Set(defs.map((d) => d.id));
+  const sources = new Set<string>();
+  for (const d of defs)
+    for (const dep of d.dependencies ?? []) {
+      if (typeof dep === 'string' && !producerIds.has(dep)) sources.add(dep);
+    }
+  return sources;
+}
+
+/** Build the build-provenance DAG for ONE piece: its forward dependency subgraph
+ *  (the core derivation over the registry) with the root's cached telemetry
+ *  attached. Returns null for a non-chapter-addressable id (unknown producer, or
+ *  the selection-keyed `translate` — nothing to read per chapter). */
+export async function chapterRunTree(
+  cache: RunsCache,
+  book: string,
+  chapter: string,
+  id: string,
+  instanceRaw: string | null,
+  lang: string,
+): Promise<RunTree | null> {
+  const shape = KEY_SHAPES[id];
+  if (!shape) return null;
+  const defs = tanachProducerDefs();
+
+  const telemetry: Record<string, RunTelemetry> = {};
+  const key =
+    shape.kind === 'chapter'
+      ? shape.key(book, chapter)
+      : shape.key(book, chapter, instanceRaw ?? '');
+  telemetry[id] = treeTelemetryOf(await cache.get(key));
+  // Source inputs are fetched/assembled on demand — show them as available.
+  for (const s of sourceIdsOf(defs)) telemetry[s] = { cached: true };
+
+  return buildRunTree(defs, telemetry, id, { tractate: book, page: chapter, lang });
 }

--- a/packages/tanach/src/worker/producers/defs.ts
+++ b/packages/tanach/src/worker/producers/defs.ts
@@ -26,6 +26,7 @@
 
 import type { Producer } from '@corpus/core/model/producer';
 import type { EnrichmentRunDef, MarkRunDef } from '@corpus/core/run/run-producer';
+import type { ProducerDef } from '@corpus/core/telemetry/runtree';
 import { EVENTS_SCHEMA, EVENTS_SYSTEM, EVENTS_USER_TEMPLATE } from './events.ts';
 import { GEOGRAPHY_SCHEMA, GEOGRAPHY_SYSTEM, GEOGRAPHY_USER_TEMPLATE } from './geography.ts';
 import {
@@ -304,6 +305,37 @@ export interface TanachEnrichmentDef extends EnrichmentRunDef {
 
 function sourceDeps(p: Producer): string[] {
   return p.inputs.flatMap((i) => ('source' in i ? [i.source] : []));
+}
+
+/** EVERY input that is a build dependency, as a dependency id: a source name, or
+ *  the producer it consumes. Unlike sourceDeps this keeps `{ producer }` inputs,
+ *  so a producer→producer dependency becomes a real DAG edge (and flips
+ *  isExpandable) instead of being silently dropped — the id resolves to a
+ *  producer node when it matches a registry id, else a source leaf. `{ spine }`
+ *  inputs are the addressing space, not a built input, so they are not edges. */
+export function inputDeps(p: Pick<Producer, 'inputs'>): string[] {
+  return p.inputs.flatMap((i) =>
+    'source' in i ? [i.source] : 'producer' in i ? [i.producer] : [],
+  );
+}
+
+/**
+ * Project the registry into the minimal `ProducerDef[]` the core run-tree
+ * derivation (`@corpus/core/telemetry/runtree` buildRunTree / isExpandable)
+ * consumes: id + label + producerKind + the dependency ids (ALL inputs, via
+ * inputDeps). Every tanach producer's inputs are SOURCES today (none consumes
+ * another producer), so `isExpandable` derives `false` for all of them — the
+ * inspector's lack of a DAG drill-down is a property of THIS registry, not a
+ * hard-coded flag. The day a tanach producer takes another producer as input,
+ * inputDeps surfaces that edge and it flips on its own.
+ */
+export function tanachProducerDefs(): ProducerDef[] {
+  return Object.values(TANACH_PRODUCERS).map((p) => ({
+    id: p.id,
+    label: p.label,
+    dependencies: inputDeps(p),
+    producerKind: p.kind.startsWith('mark') ? 'mark' : 'enrichment',
+  }));
 }
 
 export function markRunDefOf(id: 'events'): TanachMarkDef {

--- a/packages/tanach/tests/inspect.test.ts
+++ b/packages/tanach/tests/inspect.test.ts
@@ -1,5 +1,7 @@
+import { isExpandable } from '@corpus/core/telemetry/runtree';
 import { describe, expect, it } from 'vitest';
-import { chapterRuns, type RunsCache, telemetryOf } from '../src/worker/inspect';
+import { chapterRuns, chapterRunTree, type RunsCache, telemetryOf } from '../src/worker/inspect';
+import { inputDeps, tanachProducerDefs } from '../src/worker/producers/defs';
 
 /** A StoredArtifact-shaped envelope (the fields telemetryOf reads). */
 function envelope(over: Record<string, unknown> = {}): string {
@@ -77,7 +79,7 @@ describe('chapterRuns', () => {
     };
   }
 
-  it('shows the two chapter pieces always (cached or miss) and lists per-instance pieces', async () => {
+  it('shows every chapter piece always (cached or miss) and lists per-instance pieces', async () => {
     const store = {
       'overview:v1:Genesis:22': envelope({
         elapsed_ms: 5000,
@@ -86,7 +88,7 @@ describe('chapterRuns', () => {
       'note:v1:Genesis:22:1-19': envelope(),
       'note:v1:Genesis:22:20-24': envelope(),
       'synthesis:v1:Genesis:22:2': envelope(),
-      // events is intentionally absent -> a miss row
+      // events / geography / tidbit intentionally absent -> miss rows
       // an unrelated chapter must not leak in:
       'overview:v1:Genesis:23': envelope(),
       'note:v1:Genesis:23:1-5': envelope(),
@@ -94,8 +96,16 @@ describe('chapterRuns', () => {
     const res = await chapterRuns(fakeCache(store), 'Genesis', '22');
 
     const ids = res.runs.map((r) => `${r.id}${r.instance ? `:${r.instance}` : ''}`);
-    // two chapter rows first (events missing, overview present), then the instances
-    expect(ids).toEqual(['events', 'overview', 'note:1-19', 'note:20-24', 'synthesis:v2']);
+    // chapter rows first (events/geography/tidbit miss, overview present), then instances
+    expect(ids).toEqual([
+      'events',
+      'overview',
+      'geography',
+      'tidbit',
+      'note:1-19',
+      'note:20-24',
+      'synthesis:v2',
+    ]);
 
     const events = res.runs.find((r) => r.id === 'events');
     expect(events?.cached).toBe(false);
@@ -103,10 +113,27 @@ describe('chapterRuns', () => {
     expect(overview?.cached).toBe(true);
     expect(overview?.coldMs).toBe(5000);
 
-    expect(res.totals.count).toBe(5);
-    expect(res.totals.cached).toBe(4); // all but the missing events
+    expect(res.totals.count).toBe(7);
+    expect(res.totals.cached).toBe(4); // overview + two notes + one synthesis
     // overview 0.01 + three instance envelopes at 0.0004 each
     expect(res.totals.cost).toBeCloseTo(0.01 + 0.0004 * 3, 6);
+  });
+
+  it('every row carries a registry-DERIVED `expandable` (false: tanach pieces depend only on sources)', async () => {
+    const res = await chapterRuns(fakeCache({}), 'Genesis', '22');
+    expect(res.runs.length).toBeGreaterThan(0);
+    expect(res.runs.every((r) => r.expandable === false)).toBe(true);
+  });
+
+  it('an instance row keeps the raw key tail (for the run-tree fetch) distinct from its display label', async () => {
+    const res = await chapterRuns(
+      fakeCache({ 'synthesis:v1:Genesis:22:7': envelope() }),
+      'Genesis',
+      '22',
+    );
+    const syn = res.runs.find((r) => r.id === 'synthesis' && r.instanceRaw === '7');
+    expect(syn?.instance).toBe('v7'); // display
+    expect(syn?.instanceRaw).toBe('7'); // addresses synthesis:v1:Genesis:22:7
   });
 
   it('handles a multi-word book name (space in the key) in the prefix', async () => {
@@ -117,5 +144,110 @@ describe('chapterRuns', () => {
     const res = await chapterRuns(fakeCache(store), 'I Samuel', '3');
     expect(res.runs.find((r) => r.id === 'note')?.instance).toBe('1-10');
     expect(res.runs.find((r) => r.id === 'overview')?.cached).toBe(true);
+  });
+});
+
+describe('tanachProducerDefs — the run-tree IS derived from the registry', () => {
+  it('every producer depends only on SOURCES, so isExpandable is false for all', () => {
+    const defs = tanachProducerDefs();
+    const producerIds = new Set(defs.map((d) => d.id));
+    for (const d of defs) {
+      for (const dep of d.dependencies ?? []) {
+        // no dependency points at another producer — they are all source inputs
+        expect(producerIds.has(dep as string)).toBe(false);
+      }
+      expect(isExpandable(defs, d.id)).toBe(false);
+    }
+  });
+
+  it('the projection keeps PRODUCER inputs, not just sources (so producer edges survive)', () => {
+    // The latent bug guard: a source-only projection would drop {producer} inputs,
+    // pinning isExpandable false forever. inputDeps must surface both.
+    expect(inputDeps({ inputs: [{ source: 'verse-text' }, { producer: 'overview' }] })).toEqual([
+      'verse-text',
+      'overview',
+    ]);
+  });
+
+  it('isExpandable is COMPUTED, not hard-coded: a producer→producer dep flips it true', () => {
+    // Synthesize a registry where `note` consumes `overview` (an enrichment).
+    const defs = tanachProducerDefs().map((d) =>
+      d.id === 'note'
+        ? { ...d, dependencies: [...(d.dependencies ?? []), { enrichment: 'overview' }] }
+        : d,
+    );
+    expect(isExpandable(defs, 'note')).toBe(true); // reaches a producer now
+    expect(isExpandable(defs, 'overview')).toBe(false); // still only sources
+  });
+});
+
+describe('chapterRunTree — the per-piece DAG, derived by core buildRunTree', () => {
+  function fakeCache(store: Record<string, string>): RunsCache {
+    return {
+      get: async (key) => store[key] ?? null,
+      list: async ({ prefix }) => ({
+        keys: Object.keys(store)
+          .filter((k) => k.startsWith(prefix))
+          .map((name) => ({ name })),
+      }),
+    };
+  }
+
+  it('unknown producer id -> null', async () => {
+    expect(await chapterRunTree(fakeCache({}), 'Genesis', '22', 'nope', null, 'en')).toBeNull();
+  });
+
+  it('translate (selection-keyed, no chapter key) -> null, not a misleading cold graph', async () => {
+    expect(
+      await chapterRunTree(fakeCache({}), 'Genesis', '22', 'translate', null, 'en'),
+    ).toBeNull();
+  });
+
+  it("synthesis's tree is root + its registry source inputs (verse-text, commentaries)", async () => {
+    const tree = await chapterRunTree(
+      fakeCache({ 'synthesis:v1:Genesis:22:2': envelope() }),
+      'Genesis',
+      '22',
+      'synthesis',
+      '2',
+      'en',
+    );
+    expect(tree?.root).toBe('synthesis');
+    expect(tree?.tractate).toBe('Genesis');
+    expect(tree?.page).toBe('22');
+    // edges point root -> each source input declared on the producer
+    const children = (tree?.edges ?? [])
+      .filter(([from]) => from === 'synthesis')
+      .map(([, to]) => to);
+    expect(children.sort()).toEqual(['commentaries', 'verse-text']);
+    // the sources are leaf nodes typed as sources, the root as llm
+    expect(tree?.nodes['verse-text'].kind).toBe('source');
+    expect(tree?.nodes.commentaries.kind).toBe('source');
+    expect(tree?.nodes.synthesis.kind).toBe('llm');
+  });
+
+  it('the root node carries the cached envelope telemetry (cached, model, cost, authority)', async () => {
+    const tree = await chapterRunTree(
+      fakeCache({
+        'overview:v1:Genesis:22': envelope({ elapsed_ms: 4321, transport: 'openrouter-gateway' }),
+      }),
+      'Genesis',
+      '22',
+      'overview',
+      null,
+      'en',
+    );
+    const root = tree?.nodes.overview;
+    expect(root?.cached).toBe(true);
+    expect(root?.cold_ms).toBe(4321);
+    expect(root?.model).toBe('openrouter/deepseek/deepseek-v4-flash');
+    expect(root?.cost).toBe(0.0004);
+    expect(root?.authority).toBe('ai'); // openrouter-gateway transport -> ai
+  });
+
+  it('a cold piece reports the root not cached, sources still available', async () => {
+    const tree = await chapterRunTree(fakeCache({}), 'Genesis', '22', 'overview', null, 'en');
+    expect(tree?.nodes.overview.cached).toBe(false);
+    expect(tree?.nodes['chapter-verses'].cached).toBe(true); // sources are fetched/assembled
   });
 });

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -29,6 +29,7 @@
     "./LoadProgress": "./src/LoadProgress.tsx",
     "./InspectorRow": "./src/InspectorRow.tsx",
     "./RunTree": "./src/RunTree.tsx",
+    "./RunTreeDag": "./src/RunTreeDag.tsx",
     "./RunWaterfall": "./src/RunWaterfall.tsx",
     "./UsagePage": "./src/UsagePage.tsx"
   },

--- a/packages/ui/src/RunTreeDag.tsx
+++ b/packages/ui/src/RunTreeDag.tsx
@@ -1,0 +1,414 @@
+/**
+ * @corpus/ui — RunTreeDag.
+ *
+ * The build-provenance dependency DAG for ONE piece, embeddable anywhere (flow
+ * layout, no dock chrome). PRESENTATIONAL: it renders a `RunTree` (the derived
+ * @corpus/core/telemetry shape) — the DAG canvas + the selected node's header +
+ * its provenance — and leaves the per-node DETAIL BODY (prompt / generated text)
+ * to the host via `renderDetail`. Selection + expansion are controlled by the
+ * host, so each app owns its data fetching while the graph maths + visuals stay
+ * identical across talmud and tanach.
+ *
+ * Arrows point dependency → consumer. Source nodes carry a database icon
+ * (fetched, $0); LLM nodes a sparkle (model + $). Shared nodes appear once with
+ * fan-in edges.
+ */
+
+import { createMemo, For, type JSX, Show } from 'solid-js';
+import {
+  ACTIVE_STROKE,
+  AuthorityBadge,
+  BADGE_LLM,
+  BADGE_PRO,
+  BADGE_SRC,
+  CANVAS,
+  CANVAS_BORDER,
+  CARD_STROKE,
+  computeLayout,
+  displayLabel,
+  edgePath,
+  fmtCost,
+  fmtMs,
+  type LaidEdge,
+  type Layout,
+  LEFT_PAD,
+  NODE_H,
+  NODE_W,
+  NodeIcon,
+  ProvenanceSection,
+  ROW_H,
+  type RunTree,
+  StalenessDot,
+  TOP_PAD,
+  type TreeNode,
+  variantOf,
+} from './RunTree.tsx';
+
+export interface RunTreeDagProps {
+  /** The derived run-tree (from @corpus/core/telemetry buildRunTree). */
+  tree: RunTree | null;
+  loading?: boolean;
+  /** Selected node id (controlled by the host). */
+  selected: string | null;
+  onSelect: (id: string) => void;
+  /** Expanded node ids (controlled by the host). */
+  expanded: Set<string>;
+  onToggleExpand: (id: string) => void;
+  /** Render the BODY of a non-source node's detail pane (prompt / generation).
+   *  The node header + ProvenanceSection are rendered by this component; omit
+   *  the slot to show provenance only. */
+  renderDetail?: (node: TreeNode) => JSX.Element;
+  /** Shown when the tree is null and not loading. */
+  emptyLabel?: string;
+}
+
+export function RunTreeDag(props: RunTreeDagProps): JSX.Element {
+  const layout = createMemo<Layout | null>(() => {
+    const t = props.tree;
+    return t ? computeLayout(t, props.expanded) : null;
+  });
+  const nodeOf = (id: string): TreeNode | undefined => props.tree?.nodes[id];
+  const hasKids = (id: string): boolean => !!props.tree?.edges.some((e) => e[0] === id);
+  const badgeColor = (n: TreeNode) =>
+    n.kind !== 'llm' ? BADGE_SRC : n.model?.includes('pro') ? BADGE_PRO : BADGE_LLM;
+  const connected = createMemo<Set<string>>(() => {
+    const sel = props.selected;
+    const lay = layout();
+    if (!sel || !lay) return new Set();
+    const set = new Set<string>([sel]);
+    for (const e of lay.edges) {
+      if (e.fromId === sel) set.add(e.toId);
+      if (e.toId === sel) set.add(e.fromId);
+    }
+    return set;
+  });
+  const isIncident = (e: LaidEdge) => e.fromId === props.selected || e.toId === props.selected;
+  const nodeY = (id: string) => {
+    const r = layout()!.rowOf.get(id)!;
+    return TOP_PAD + r * ROW_H;
+  };
+  const activate = (id: string) => {
+    props.onSelect(id);
+    if (hasKids(id)) props.onToggleExpand(id);
+  };
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        'flex-direction': 'column',
+        gap: '0.5rem',
+        'font-family': 'system-ui, sans-serif',
+        'font-size': '13px',
+      }}
+    >
+      {/* DAG */}
+      <div
+        style={{
+          'max-height': '52vh',
+          overflow: 'auto',
+          background: CANVAS,
+          padding: '0.5rem',
+          border: `1px solid ${CANVAS_BORDER}`,
+          'border-radius': '8px',
+        }}
+      >
+        <Show when={props.loading}>
+          <div style={{ padding: '0.5rem', color: '#aaa' }}>loading…</div>
+        </Show>
+        <Show when={props.tree === null && !props.loading}>
+          <div style={{ padding: '0.5rem', color: '#c00' }}>
+            {props.emptyLabel ?? 'no graph (unknown piece, or nothing cached)'}
+          </div>
+        </Show>
+        <Show when={layout()}>
+          {(lay) => (
+            <div
+              style={{
+                position: 'relative',
+                width: `${lay().width}px`,
+                height: `${lay().height}px`,
+              }}
+            >
+              <svg
+                aria-hidden="true"
+                width={lay().width}
+                height={lay().height}
+                style={{
+                  position: 'absolute',
+                  inset: 0,
+                  'pointer-events': 'none',
+                  overflow: 'visible',
+                }}
+              >
+                <defs>
+                  <marker
+                    id="rtd-arrow"
+                    markerWidth="8"
+                    markerHeight="8"
+                    refX="6"
+                    refY="3"
+                    orient="auto"
+                  >
+                    <path d="M0 0 L6 3 L0 6 z" fill="#c9b8b0" />
+                  </marker>
+                  <marker
+                    id="rtd-arrow-hot"
+                    markerWidth="8"
+                    markerHeight="8"
+                    refX="6"
+                    refY="3"
+                    orient="auto"
+                  >
+                    <path d="M0 0 L6 3 L0 6 z" fill="#8a2a2b" />
+                  </marker>
+                </defs>
+                <For each={lay().edges}>
+                  {(e) => {
+                    const hot = () => isIncident(e);
+                    const faded = () => !!props.selected && !hot();
+                    return (
+                      <path
+                        d={edgePath(e.toRow, e.fromRow, e.lane)}
+                        fill="none"
+                        stroke={hot() ? '#8a2a2b' : '#d3c4ba'}
+                        stroke-width={hot() ? 2 : 1.5}
+                        stroke-opacity={faded() ? 0.22 : hot() ? 0.85 : 1}
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        marker-end={`url(#${hot() ? 'rtd-arrow-hot' : 'rtd-arrow'})`}
+                      />
+                    );
+                  }}
+                </For>
+              </svg>
+              <For each={lay().order}>
+                {(id) => {
+                  const n = () => nodeOf(id)!;
+                  const isLLM = () => n().kind === 'llm';
+                  const sel = () => props.selected === id;
+                  const exp = () => props.expanded.has(id);
+                  const slow = () => (n().cold_ms ?? 0) > 10_000;
+                  const dim = () => !!props.selected && !connected().has(id);
+                  return (
+                    // biome-ignore lint/a11y/useSemanticElements: node card contains a nested expand <button>; a native button cannot contain another button
+                    <div
+                      role="button"
+                      tabIndex={0}
+                      onClick={() => activate(id)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          activate(id);
+                        }
+                      }}
+                      style={{
+                        position: 'absolute',
+                        left: `${LEFT_PAD}px`,
+                        top: `${nodeY(id)}px`,
+                        width: `${NODE_W}px`,
+                        height: `${NODE_H}px`,
+                        display: 'flex',
+                        'align-items': 'center',
+                        gap: '0.5rem',
+                        padding: '0 0.6rem',
+                        cursor: 'pointer',
+                        'box-sizing': 'border-box',
+                        background: sel() ? '#fdf2f2' : '#fff',
+                        border: `${sel() ? 1.75 : 1}px solid ${sel() ? ACTIVE_STROKE : CARD_STROKE}`,
+                        'border-radius': '11px',
+                        'box-shadow': '0 1px 2px rgba(58,51,32,0.08)',
+                        opacity: dim() ? 0.42 : 1,
+                        transition: 'opacity 0.12s',
+                      }}
+                    >
+                      <NodeIcon variant={variantOf(n())} color={badgeColor(n())} />
+                      <div style={{ flex: 1, 'min-width': 0 }}>
+                        <div style={{ display: 'flex', 'align-items': 'baseline', gap: '0.4rem' }}>
+                          <span
+                            style={{
+                              'font-weight': 600,
+                              'font-size': '0.84rem',
+                              color: '#2a2723',
+                              'white-space': 'nowrap',
+                              overflow: 'hidden',
+                              'text-overflow': 'ellipsis',
+                            }}
+                          >
+                            {displayLabel(n().id, n().label)}
+                          </span>
+                          <span
+                            style={{
+                              'margin-left': 'auto',
+                              'font-size': '0.68rem',
+                              'font-variant-numeric': 'tabular-nums',
+                              color: slow() ? '#b45309' : '#9a857c',
+                              'flex-shrink': 0,
+                            }}
+                          >
+                            {fmtMs(n().cold_ms)}
+                          </span>
+                          <Show when={n().staleness}>
+                            {(s) => (
+                              <StalenessDot
+                                staleness={s()}
+                                inputsChanged={n().inputsChanged}
+                                isMark={n().producer === 'mark'}
+                              />
+                            )}
+                          </Show>
+                        </div>
+                        <div
+                          style={{
+                            display: 'flex',
+                            'align-items': 'center',
+                            gap: '0.3rem',
+                            'font-size': '0.66rem',
+                            'font-family': 'ui-monospace, Menlo, monospace',
+                            color: isLLM() ? '#9a8fb5' : '#9aa4ad',
+                            'white-space': 'nowrap',
+                            overflow: 'hidden',
+                            'text-overflow': 'ellipsis',
+                          }}
+                        >
+                          <Show when={n().authority}>
+                            {(a) => <AuthorityBadge authority={a()} />}
+                          </Show>
+                          {isLLM()
+                            ? `${(n().model ?? '').split('/').pop()} · ${fmtCost(n().cost)}`
+                            : 'source · $0'}
+                        </div>
+                      </div>
+                      <Show when={hasKids(id)}>
+                        <button
+                          type="button"
+                          onClick={(ev) => {
+                            ev.stopPropagation();
+                            props.onSelect(id);
+                            props.onToggleExpand(id);
+                          }}
+                          title={exp() ? 'collapse inputs' : 'expand inputs'}
+                          style={{
+                            'flex-shrink': 0,
+                            width: '18px',
+                            height: '18px',
+                            'border-radius': '50%',
+                            border: '1px solid #d8c9c0',
+                            background: '#fff',
+                            color: '#8a7d74',
+                            cursor: 'pointer',
+                            'font-size': '0.8rem',
+                            'line-height': 1,
+                            display: 'inline-flex',
+                            'align-items': 'center',
+                            'justify-content': 'center',
+                            padding: 0,
+                          }}
+                        >
+                          {exp() ? '–' : '+'}
+                        </button>
+                      </Show>
+                    </div>
+                  );
+                }}
+              </For>
+            </div>
+          )}
+        </Show>
+      </div>
+
+      {/* node detail */}
+      <Show when={props.selected ? nodeOf(props.selected) : null}>
+        {(n) => (
+          <div style={{ border: '1px solid #eee', 'border-radius': '8px', overflow: 'hidden' }}>
+            <div
+              style={{
+                padding: '0.45rem 0.7rem',
+                'border-bottom': '1px solid #f0f0f0',
+                display: 'flex',
+                'flex-wrap': 'wrap',
+                gap: '0.35rem',
+                'align-items': 'center',
+              }}
+            >
+              <span
+                style={{ 'font-weight': 600, 'font-size': '0.84rem', 'margin-right': '0.2rem' }}
+              >
+                {displayLabel(n().id, n().label)}
+              </span>
+              <span
+                style={{
+                  'font-size': '0.66rem',
+                  background: '#f1f1f3',
+                  'border-radius': '4px',
+                  padding: '0.05rem 0.4rem',
+                  color: '#555',
+                  'font-family': 'ui-monospace, Menlo, monospace',
+                }}
+              >
+                {n().kind === 'source' ? 'source' : (n().model ?? 'llm')}
+              </span>
+              <Show when={n().cold_ms != null}>
+                <span
+                  style={{
+                    'font-size': '0.66rem',
+                    background: '#f1f1f3',
+                    'border-radius': '4px',
+                    padding: '0.05rem 0.4rem',
+                    color: '#555',
+                    'font-family': 'ui-monospace, Menlo, monospace',
+                  }}
+                >
+                  gen {fmtMs(n().cold_ms)}
+                </span>
+              </Show>
+              <Show when={n().kind === 'llm'}>
+                <span
+                  style={{
+                    'font-size': '0.66rem',
+                    background: '#ecfdf5',
+                    'border-radius': '4px',
+                    padding: '0.05rem 0.4rem',
+                    color: '#047857',
+                    'font-family': 'ui-monospace, Menlo, monospace',
+                  }}
+                >
+                  {fmtCost(n().cost)}
+                </span>
+              </Show>
+              <span
+                style={{
+                  'font-size': '0.66rem',
+                  'border-radius': '4px',
+                  padding: '0.05rem 0.4rem',
+                  'font-family': 'ui-monospace, Menlo, monospace',
+                  ...(n().cached
+                    ? { background: '#dcfce7', color: '#15803d' }
+                    : { background: '#fef3c7', color: '#b45309' }),
+                }}
+              >
+                {n().cached ? 'cached' : 'not cached'}
+              </span>
+            </div>
+            <div style={{ 'max-height': '38vh', 'overflow-y': 'auto', padding: '0.6rem 0.7rem' }}>
+              <Show
+                when={n().kind === 'source'}
+                fallback={
+                  <>
+                    {props.renderDetail?.(n())}
+                    <ProvenanceSection node={n()} />
+                  </>
+                }
+              >
+                <div style={{ 'font-size': '0.82rem', color: '#555' }}>
+                  A <b>source</b> input — fetched/assembled, no model call (cost $0). The piece's
+                  prompt reads its text.
+                </div>
+              </Show>
+            </div>
+          </div>
+        )}
+      </Show>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Makes the build-provenance inspector a single **shared, registry-derived** surface across both apps — so tanach's inspector is the *same* waterfall + DAG as talmud's, and expandability comes from the producer registry instead of a hard-coded flag.

### Shared component
- **`@corpus/ui/RunTreeDag`** — talmud's embeddable dependency-DAG, extracted into a **presentational** shared component: data in via props (`tree`, controlled `selected`/`expanded`) + a `renderDetail` slot for the per-node body. The DAG canvas, edge highlighting, node header, and `ProvenanceSection` are the shared render.
- **Talmud's `RunTreeDag`** is now a thin wrapper over it (owns the `/api/run-tree` + `/api/run` fetches and supplies the prompt/generation detail body). No visual change — only `AlignPage` consumes it.

### Tanach
- The inspector gains the same **waterfall + DAG**: click a cached piece to open its dependency DAG (the shared component).
- **`GET /api/run-tree/:book/:chapter/:id`** derives the per-piece DAG via core `buildRunTree` over the tanach producer registry.
- `chapter-runs` rows now carry an **`expandable`** flag, derived from the registry via `isExpandable` — **false for every tanach producer** because none consumes another producer (only sources). That is the derived answer to "why are they expandable at all?".
- `inspect.ts`: the producer **set / labels / kind / expandability** are all derived from the registry (`producers/defs.ts` → `tanachProducerDefs` / `inputDeps`). Only the literal cache-key bytes stay an explicit per-id table (`KEY_SHAPES`), byte-exact to the writer (`run-ports.ts`) — the one thing not derivable. Incidentally fixes a gap (geography:v2 + tidbit:v2 were missing from the inspector) and a drift hazard (it re-derived keys independently).

## Derivation is tested, not assumed
- `inputDeps` keeps `{producer}` inputs (not just sources) — so a producer→producer edge survives the projection (guards a latent bug where it would pin `isExpandable` false forever).
- `isExpandable` **flips true** when a synthetic producer→producer dep is added — proving it's computed from the registry, not hard-coded.
- `chapterRunTree`'s edges are exactly the registry inputs (synthesis → {verse-text, commentaries}); the root carries the cached envelope telemetry (cached/model/cost/authority); `translate` (selection-keyed) yields no chapter graph.

## Gate
`pnpm typecheck` + `pnpm test` (113 core / 59 tanach / 2535 talmud) + `pnpm lint` + both builds green. Reviewed read-only with Codex (no talmud regression; key bytes confirmed byte-exact; both review findings fixed).