### PR TITLE
Phase 3 (step 2): expand the warm Workflow to the full daf (marks + per-instance)

### DIFF
--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -303,7 +303,7 @@ import {
 } from './warm-cron';
 import { lookupGloss } from './word-glosses';
 import { checkWorkerHealthAndAlert, fetchWorkerOutcomes } from './worker-health';
-import { type DafWarmParams, wholeDafEnrichmentIds } from './workflow-warm';
+import { type DafWarmParams, perInstanceEnrichments, wholeDafEnrichmentIds } from './workflow-warm';
 import { runYomiWarmCron } from './yomi-cron';
 
 // `Bindings` and `JobMessage` now live in ./types (a neutral module so route
@@ -11321,17 +11321,24 @@ export class DafWarmWorkflow extends WorkflowEntrypoint<Bindings, DafWarmParams>
     const { tractate, page } = event.payload;
     const lang: 'en' | 'he' = event.payload.lang === 'he' ? 'he' : 'en';
     const wrapped = wrapEnv(this.env);
-    const ids = wholeDafEnrichmentIds(
-      CODE_MARKS.map((m) => ({ id: m.id, anchor: (m as { anchor?: string }).anchor })),
-      CODE_ENRICHMENTS.map((e) => ({ id: e.id, scope: e.scope, target_mark: e.target_mark })),
-    );
-    for (const id of ids) {
-      await step.do(`warm:${id}`, async () => {
-        const def = await loadEnrichmentDef(wrapped, id);
-        if (!def) return { id, skipped: 'no-def' };
-        // No ExecutionContext in a Workflow step — collect the generation's
-        // fire-and-forget waitUntil work (usage/cost telemetry) and await it
-        // within the step so it isn't dropped when the step returns.
+    const marksLite = CODE_MARKS.map((m) => ({
+      id: m.id,
+      anchor: (m as { anchor?: string }).anchor,
+    }));
+    const enrichLite = CODE_ENRICHMENTS.map((e) => ({
+      id: e.id,
+      scope: e.scope,
+      target_mark: e.target_mark,
+    }));
+
+    // Each producer runs in its OWN step.do() — its own invocation, its own
+    // 128 MB budget — so the daf's full dependency tree generates with bounded
+    // per-step memory instead of one monolithic job. No ExecutionContext exists
+    // in a Workflow step, so collect the generation's fire-and-forget telemetry
+    // (waitUntil) and await it within the step rather than dropping it.
+    type StepResult = { id: string; cached?: boolean; skipped?: string; iid?: string };
+    const runStep = (name: string, fn: (rc: RunCtx) => Promise<StepResult>): Promise<StepResult> =>
+      step.do(name, async () => {
         const pending: Promise<unknown>[] = [];
         const ctx = {
           waitUntil: (p: Promise<unknown>) => {
@@ -11340,10 +11347,48 @@ export class DafWarmWorkflow extends WorkflowEntrypoint<Bindings, DafWarmParams>
           passThroughOnException: () => {},
         } as unknown as ExecutionContext;
         const rc: RunCtx = { env: wrapped, url: 'https://localhost/internal', ctx, lang };
-        const res = await runEnrichmentOnce(rc, def, tractate, page, { fields: {} }, false);
+        const out = await fn(rc);
         await Promise.allSettled(pending);
-        return { id, cached: res.cache_hit ?? false, model: res.model };
+        return out;
       });
+
+    // 1) Marks first — enrichments depend on them, so doing them as steps means
+    //    each enrichment step finds its mark already cached instead of
+    //    regenerating it inline (the per-step decomposition of the DAG).
+    for (const m of CODE_MARKS) {
+      await runStep(`mark:${m.id}`, async (rc) => {
+        const def = await loadMarkDef(wrapped, m.id);
+        if (!def) return { id: m.id, skipped: 'no-def' };
+        const res = await runMarkOnce(rc, def, tractate, page, false);
+        return { id: m.id, cached: res.cache_hit ?? false };
+      });
+    }
+
+    // 2) Whole-daf enrichments ({fields:{}}).
+    for (const id of wholeDafEnrichmentIds(marksLite, enrichLite)) {
+      await runStep(`enrich:${id}`, async (rc) => {
+        const def = await loadEnrichmentDef(wrapped, id);
+        if (!def) return { id, skipped: 'no-def' };
+        const res = await runEnrichmentOnce(rc, def, tractate, page, { fields: {} }, false);
+        return { id, cached: res.cache_hit ?? false };
+      });
+    }
+
+    // 3) Per-instance enrichments — one step per (enrichment, target instance).
+    //    Instances come from the now-cached target mark (step 1). This read + the
+    //    instanceId hash run in the orchestration (cheap + deterministic) so they
+    //    replay identically — Workflow step NAMES must be stable across replays.
+    for (const { id, targetMark } of perInstanceEnrichments(marksLite, enrichLite)) {
+      const def = await loadEnrichmentDef(wrapped, id);
+      if (!def) continue;
+      const insts = await readMarkInstances(wrapped, targetMark, tractate, page);
+      for (const inst of insts) {
+        const iid = await instanceIdOf(inst);
+        await runStep(`enrich:${id}:${iid}`, async (rc) => {
+          const res = await runEnrichmentOnce(rc, def, tractate, page, inst, false);
+          return { id, iid, cached: res.cache_hit ?? false };
+        });
+      }
     }
   }
 }

--- a/packages/talmud/src/worker/workflow-warm.ts
+++ b/packages/talmud/src/worker/workflow-warm.ts
@@ -40,6 +40,30 @@ export function wholeDafEnrichmentIds(marks: MarkLike[], enrichments: Enrichment
     .map((e) => e.id);
 }
 
+/**
+ * Per-instance local enrichments (one cached entry per target-mark instance):
+ * scope local, target mark is NOT whole-daf, and NOT `argument` (its dual
+ * display/synth instance shape needs separate handling — the same exclusion the
+ * daf-view and /api/daf-runs carry). The warm Workflow generates one step per
+ * (enrichment, instance) for these. Returns {id, targetMark} so the caller can
+ * read the target mark's instances.
+ */
+export function perInstanceEnrichments(
+  marks: MarkLike[],
+  enrichments: EnrichmentLike[],
+): { id: string; targetMark: string }[] {
+  const anchorById = new Map(marks.map((m) => [m.id, m.anchor]));
+  return enrichments
+    .filter((e) => e.scope === 'local')
+    .filter(
+      (e) =>
+        !!e.target_mark &&
+        e.target_mark !== 'argument' &&
+        anchorById.get(e.target_mark) !== 'whole-daf',
+    )
+    .map((e) => ({ id: e.id, targetMark: e.target_mark as string }));
+}
+
 /** Params passed to the warm Workflow. */
 export interface DafWarmParams {
   tractate: string;

--- a/packages/talmud/tests/workflow-warm.test.ts
+++ b/packages/talmud/tests/workflow-warm.test.ts
@@ -1,5 +1,58 @@
 import { describe, expect, it } from 'vitest';
-import { wholeDafEnrichmentIds } from '../src/worker/workflow-warm';
+import { perInstanceEnrichments, wholeDafEnrichmentIds } from '../src/worker/workflow-warm';
+
+const MARKS = [
+  { id: 'argument-overview', anchor: 'whole-daf' },
+  { id: 'daf-background', anchor: 'whole-daf' },
+  { id: 'tidbit', anchor: 'whole-daf' },
+  { id: 'argument', anchor: 'segment' },
+  { id: 'pesukim', anchor: 'segment' },
+  { id: 'rabbi', anchor: 'name' },
+];
+
+// The two selectors must PARTITION the local enrichments: whole-daf vs
+// per-instance, with `argument` excluded from both. If a producer leaked into
+// both (or neither), the Workflow would double-run or skip it.
+describe('perInstanceEnrichments', () => {
+  it('returns {id,targetMark} for non-whole-daf, non-argument local enrichments', () => {
+    const out = perInstanceEnrichments(MARKS, [
+      { id: 'pesukim.synthesis', scope: 'local', target_mark: 'pesukim' },
+      { id: 'rabbi.synthesis', scope: 'local', target_mark: 'rabbi' },
+    ]);
+    expect(out).toEqual([
+      { id: 'pesukim.synthesis', targetMark: 'pesukim' },
+      { id: 'rabbi.synthesis', targetMark: 'rabbi' },
+    ]);
+  });
+
+  it('EXCLUDES whole-daf, argument, global, and no-target enrichments', () => {
+    const out = perInstanceEnrichments(MARKS, [
+      { id: 'tidbit.essay', scope: 'local', target_mark: 'tidbit' }, // whole-daf
+      { id: 'argument.synthesis', scope: 'local', target_mark: 'argument' }, // argument
+      { id: 'rabbi.identity', scope: 'global', target_mark: 'rabbi' }, // global
+      { id: 'standalone', scope: 'local' }, // no target
+    ]);
+    expect(out).toEqual([]);
+  });
+
+  it('partitions cleanly vs wholeDafEnrichmentIds (no overlap, argument in neither)', () => {
+    const enrichments = [
+      { id: 'argument-overview.synthesis', scope: 'local', target_mark: 'argument-overview' },
+      { id: 'pesukim.synthesis', scope: 'local', target_mark: 'pesukim' },
+      { id: 'argument.synthesis', scope: 'local', target_mark: 'argument' },
+    ];
+    const whole = new Set(wholeDafEnrichmentIds(MARKS, enrichments));
+    const perInst = new Set(perInstanceEnrichments(MARKS, enrichments).map((e) => e.id));
+    // disjoint
+    for (const id of whole) expect(perInst.has(id)).toBe(false);
+    // argument excluded from both
+    expect(whole.has('argument.synthesis')).toBe(false);
+    expect(perInst.has('argument.synthesis')).toBe(false);
+    // each non-argument piece is in exactly one bucket
+    expect(whole.has('argument-overview.synthesis')).toBe(true);
+    expect(perInst.has('pesukim.synthesis')).toBe(true);
+  });
+});
 
 // The warm Workflow's step list. It must include exactly the WHOLE-DAF
 // enrichments (target mark is whole-daf, or none) and exclude per-instance ones —


### PR DESCRIPTION
Step 1 (#476) ran only the whole-daf enrichments as steps. This makes `DafWarmWorkflow` a **complete per-daf generator** — every producer in its own `step.do()` (own invocation, own 128 MB budget), so the daf's **full dependency tree** generates with bounded per-step memory instead of one monolithic job:

1. **marks** (each a step) — first, so enrichment steps find their mark cached instead of regenerating it inline (the per-step DAG decomposition);
2. **whole-daf enrichments** (`{fields:{}}`);
3. **per-instance enrichments** — one step per (enrichment, target instance), read from the now-cached target mark. The instance read + `instanceIdOf` hash run in the orchestration (cheap, deterministic) so step **names replay identically** (Workflow determinism).

## Safety
- Reuses `runMarkOnce` / `runEnrichmentOnce` (the exact queue fns) → **byte-identical cache keys** → still **cannot re-warm**; cached pieces are no-ops.
- `argument` per-section facets stay excluded both here and in the daf-view (dual display/synth instance shape) — a later step.
- **Still additive**: only the admin trigger / `wrangler workflows trigger` reaches it; queue / run / reader untouched.

## Tests
`perInstanceEnrichments` (pure) — pins that it **partitions cleanly** vs `wholeDafEnrichmentIds` (disjoint sets, `argument` in neither, each non-argument piece in exactly one bucket). 9 workflow-warm cases; **2547** tests green; typecheck / biome / build / dry-run pass.

After deploy I'll trigger it on a cold daf and confirm marks + per-instance + whole-daf all generate as steps with no OOM, and the full daf lands in cache.