### PR TITLE
howitworks: spine step as #spine-style section cards; drop the lifecycle row

### DIFF
--- a/packages/talmud/src/client/HowItWorksPage.tsx
+++ b/packages/talmud/src/client/HowItWorksPage.tsx
@@ -350,27 +350,6 @@ export function DeepDive(props: {
 
 // ── content ────────────────────────────────────────────────────────────────
 
-const STEPS: { n: string; title: string; body: string }[] = [
-  { n: '1', title: 'Resolve inputs', body: 'Walk the dependency graph into prompt variables.' },
-  {
-    n: '2',
-    title: 'Render + call',
-    body: 'Fill the prompt, pick the model, call it (or run a computed branch).',
-  },
-  {
-    n: '3',
-    title: 'Parse + check',
-    body: 'Parse JSON; transforms repair, validators gate the write.',
-  },
-  { n: '4', title: 'Stamp provenance', body: 'Record authority, inputs (hashed), model, cost.' },
-  {
-    n: '5',
-    title: 'Store',
-    body: 'Write under a frozen key, no TTL. Human edits are never clobbered.',
-  },
-  { n: '6', title: 'Render', body: 'The view composes from the cached artifact.' },
-];
-
 const CACHE_FACTS: { title: string; body: JSX.Element }[] = [
   {
     title: 'Frozen keys',
@@ -405,7 +384,6 @@ const CACHE_FACTS: { title: string; body: JSX.Element }[] = [
 const CHAPTERS: { id: string; title: string }[] = [
   { id: 'thesis', title: 'The idea' },
   { id: 'model', title: 'The model, shown' },
-  { id: 'lifecycle', title: 'How a piece is built' },
   { id: 'graph', title: 'The build graph' },
   { id: 'enrichments', title: 'Every enrichment' },
   { id: 'freshness', title: 'Caching & freshness' },
@@ -571,81 +549,7 @@ export function HowItWorksPage(): JSX.Element {
             </Show>
           </section>
 
-          {/* 3 — lifecycle */}
-          <section id="lifecycle" ref={registerSection('lifecycle')} style={sectionStyle}>
-            <h2 style={h2}>How a piece is built</h2>
-            <p style={{ ...lead, color: 'var(--muted)', 'font-size': '0.85rem' }}>
-              One function — <Mono>runProducer</Mono> — runs every producer the same way.
-            </p>
-            <div
-              style={{
-                display: 'flex',
-                'flex-wrap': 'wrap',
-                gap: '0.5rem',
-                'align-items': 'stretch',
-              }}
-            >
-              <For each={STEPS}>
-                {(step, i) => (
-                  <>
-                    <div
-                      style={{
-                        flex: '1 1 150px',
-                        border: '1px solid var(--line)',
-                        'border-radius': '8px',
-                        background: '#fff',
-                        padding: '0.6rem 0.7rem',
-                      }}
-                    >
-                      <div
-                        style={{
-                          display: 'flex',
-                          'align-items': 'center',
-                          gap: '0.4rem',
-                          'margin-bottom': '0.25rem',
-                        }}
-                      >
-                        <span
-                          style={{
-                            width: '1.3rem',
-                            height: '1.3rem',
-                            'border-radius': '50%',
-                            background: 'var(--accent)',
-                            color: '#fff',
-                            display: 'inline-flex',
-                            'align-items': 'center',
-                            'justify-content': 'center',
-                            'font-size': '0.74rem',
-                            'font-weight': 700,
-                          }}
-                        >
-                          {step.n}
-                        </span>
-                        <strong style={{ 'font-size': '0.85rem' }}>{step.title}</strong>
-                      </div>
-                      <p
-                        style={{
-                          margin: 0,
-                          'font-size': '0.78rem',
-                          'line-height': 1.45,
-                          color: '#555',
-                        }}
-                      >
-                        {step.body}
-                      </p>
-                    </div>
-                    <Show when={i() < STEPS.length - 1}>
-                      <span style={{ 'align-self': 'center', color: '#cbb', 'font-size': '1rem' }}>
-                        →
-                      </span>
-                    </Show>
-                  </>
-                )}
-              </For>
-            </div>
-          </section>
-
-          {/* 4 — the build graph */}
+          {/* 3 — the build graph */}
           <section id="graph" ref={registerSection('graph')} style={sectionStyle}>
             <h2 style={h2}>The build graph</h2>
             <p style={{ ...lead, color: 'var(--muted)', 'font-size': '0.85rem' }}>

--- a/packages/talmud/src/client/WorkedExample.tsx
+++ b/packages/talmud/src/client/WorkedExample.tsx
@@ -1,12 +1,13 @@
 /**
  * "Show, don't tell": the four primitives demonstrated on a real daf. The
  * reader steps spine -> anchor -> artifact -> producer and each step layers
- * onto the SAME live spine (Berakhot 2a, fetched). The anchored piece is a real
- * cached `pesukim` instance — a biblical citation sitting on one segment.
+ * onto the SAME spine — rendered as the daf's sections (titled cards, a shorter
+ * cousin of the #spine statement view). Click a section to anchor it; the
+ * chosen section IS the artifact (a real `argument` mark instance).
  */
 import { createMemo, createSignal, For, type JSX, Show } from 'solid-js';
 import { familyColor } from './HowItWorksGraph';
-import type { WorkedExample as Example } from './howItWorks/example';
+import type { WorkedExample as Example, Section } from './howItWorks/example';
 import type { Graph } from './howItWorks/graphModel';
 
 type StepKey = 'spine' | 'anchor' | 'artifact' | 'producer';
@@ -15,8 +16,7 @@ const STEPS: { key: StepKey; label: string; caption: string }[] = [
   {
     key: 'spine',
     label: 'Spine',
-    caption:
-      'A spine is an addressable text. This daf is a path of segments — each one has an address.',
+    caption: 'A spine is an addressable text. Here it is, broken into its sections — pick one.',
   },
   {
     key: 'anchor',
@@ -26,14 +26,16 @@ const STEPS: { key: StepKey; label: string; caption: string }[] = [
   {
     key: 'artifact',
     label: 'Artifact',
-    caption: 'An artifact is one produced piece — a typed body, its anchor, and provenance.',
+    caption: 'That section is itself an artifact — a typed body, its anchor, and provenance.',
   },
   {
     key: 'producer',
     label: 'Producer',
-    caption: 'A producer is the recipe that makes artifacts. Every one is in the graph below.',
+    caption: 'A producer made it. Every one is in the graph below.',
   },
 ];
+
+const PRECISION = ['token', 'segment', 'division', 'unit', 'work'];
 
 function chipStyle(active: boolean, color: string): JSX.CSSProperties {
   return {
@@ -48,33 +50,30 @@ function chipStyle(active: boolean, color: string): JSX.CSSProperties {
   };
 }
 
-const PRECISION = ['token', 'segment', 'division', 'unit', 'work'];
-
 export function WorkedExample(props: {
   example: Example;
   graph: Graph;
   onOpenInGraph: (id: string) => void;
 }): JSX.Element {
   const [step, setStep] = createSignal<StepKey>('spine');
-  const art = () => props.example.artifact;
-  const lit = () => step() !== 'spine' && !!art();
+  const [activeIdx, setActiveIdx] = createSignal(0);
 
-  // Real producer facts, derived from the registry (no hardcoding).
-  const producerNode = createMemo(() => props.graph.byId.get(art()?.producerId ?? ''));
+  const sections = (): Section[] => props.example.sections;
+  const active = (): Section | undefined => sections().find((s) => s.idx === activeIdx());
+  const accent = (): string => familyColor(props.example.producerId);
+  const highlight = (): boolean => step() !== 'spine';
+
+  const producerNode = createMemo(() => props.graph.byId.get(props.example.producerId));
   const authority = (): string =>
     producerNode()?.mark?.extractor?.kind === 'computed' ? 'rule' : 'ai';
-  const feedsInto = createMemo(() => {
-    const id = art()?.producerId;
-    if (!id) return [] as string[];
-    return props.graph.edges.filter((e) => e.from === id).map((e) => e.to);
-  });
+  const feedsInto = createMemo(() =>
+    props.graph.edges.filter((e) => e.from === props.example.producerId).map((e) => e.to),
+  );
 
-  const segCount = () => Math.max(props.example.segsEn.length, props.example.segsHe.length);
-  const inRange = (i: number): boolean => {
-    const a = art();
-    return !!a && lit() && i >= a.startSeg && i <= a.endSeg;
+  const pickSection = (idx: number): void => {
+    setActiveIdx(idx);
+    if (step() === 'spine') setStep('anchor');
   };
-  const accent = (): string => familyColor(art()?.producerId ?? 'pesuk');
 
   return (
     <div>
@@ -122,15 +121,8 @@ export function WorkedExample(props: {
         {STEPS.find((s) => s.key === step())?.caption}
       </p>
 
-      <div
-        style={{
-          display: 'grid',
-          gap: '1rem',
-          'align-items': 'start',
-        }}
-        class="hiw-example"
-      >
-        {/* the spine */}
+      <div style={{ display: 'grid', gap: '1rem', 'align-items': 'start' }} class="hiw-example">
+        {/* the spine, as section cards */}
         <div
           style={{
             border: '1px solid var(--line)',
@@ -151,25 +143,77 @@ export function WorkedExample(props: {
           >
             spine: bavli · {props.example.tractate} {props.example.page}
           </div>
-          <div style={{ 'max-height': '380px', overflow: 'auto' }}>
+          <div style={{ padding: '0.5rem' }}>
             <Show
-              when={segCount() > 0}
+              when={sections().length}
               fallback={
-                <For each={[0, 1, 2, 3, 4, 5, 6]}>
-                  {(i) => <SegRow index={i} en="" he="" highlight={inRange(i)} accent={accent()} />}
-                </For>
+                <p style={{ color: 'var(--muted)', 'font-size': '0.82rem', margin: '0.3rem' }}>
+                  Loading sections…
+                </p>
               }
             >
-              <For each={Array.from({ length: segCount() }, (_, i) => i)}>
-                {(i) => (
-                  <SegRow
-                    index={i}
-                    en={props.example.segsEn[i] ?? ''}
-                    he={props.example.segsHe[i] ?? ''}
-                    highlight={inRange(i)}
-                    accent={accent()}
-                  />
-                )}
+              <For each={sections()}>
+                {(sec) => {
+                  const on = (): boolean => highlight() && sec.idx === activeIdx();
+                  return (
+                    <button
+                      type="button"
+                      onClick={() => pickSection(sec.idx)}
+                      style={{
+                        display: 'flex',
+                        'align-items': 'flex-start',
+                        gap: '0.55rem',
+                        width: '100%',
+                        'text-align': 'left',
+                        cursor: 'pointer',
+                        'margin-bottom': '0.4rem',
+                        padding: '0.5rem 0.6rem',
+                        'border-radius': '8px',
+                        border: `1px solid ${on() ? accent() : 'var(--line)'}`,
+                        'border-left': `3px solid ${on() ? accent() : 'transparent'}`,
+                        background: on() ? `${accent()}10` : '#fff',
+                      }}
+                    >
+                      <span
+                        style={{
+                          'flex-shrink': 0,
+                          width: '1.5rem',
+                          height: '1.5rem',
+                          'border-radius': '50%',
+                          border: `1px solid ${accent()}66`,
+                          color: accent(),
+                          display: 'inline-flex',
+                          'align-items': 'center',
+                          'justify-content': 'center',
+                          'font-size': '0.72rem',
+                          'font-weight': 700,
+                          'font-variant-numeric': 'tabular-nums',
+                        }}
+                      >
+                        {sec.idx + 1}
+                      </span>
+                      <span style={{ 'min-width': 0 }}>
+                        <span
+                          style={{ 'font-size': '0.85rem', 'line-height': 1.35, color: '#1f2937' }}
+                        >
+                          {sec.title}
+                        </span>
+                        <span
+                          style={{
+                            display: 'block',
+                            'font-family': 'ui-monospace, SFMono-Regular, Menlo, monospace',
+                            'font-size': '0.66rem',
+                            color: '#9a958a',
+                            'margin-top': '0.15rem',
+                          }}
+                        >
+                          seg {sec.startSeg}
+                          {sec.endSeg !== sec.startSeg ? `–${sec.endSeg}` : ''}
+                        </span>
+                      </span>
+                    </button>
+                  );
+                }}
               </For>
             </Show>
           </div>
@@ -182,8 +226,8 @@ export function WorkedExample(props: {
               <Row k="kind" v="text (ordered)" />
               <Row k="address" v={`[${props.example.tractate}, ${props.example.page}, n]`} mono />
               <p style={note}>
-                Each segment is independently addressable. A reference may stop early — the whole
-                daf is just the path with the segment left off.
+                The whole daf is the path with the segment left off. Each section is a span of it —
+                click one to anchor it.
               </p>
             </Panel>
           </Show>
@@ -193,7 +237,11 @@ export function WorkedExample(props: {
               <Row k="spine" v="bavli" mono />
               <Row
                 k="span"
-                v={art() ? `[${props.example.page}, seg ${art()?.startSeg}]` : '[2a, seg n]'}
+                v={
+                  active()
+                    ? `[${props.example.page}, seg ${active()?.startSeg}–${active()?.endSeg}]`
+                    : '[2a, seg n]'
+                }
                 mono
               />
               <Row k="precision" v="segment" mono />
@@ -213,113 +261,67 @@ export function WorkedExample(props: {
           </Show>
 
           <Show when={step() === 'artifact'}>
-            <Show
-              when={art()}
-              fallback={
-                <Panel title="Artifact" accent={accent()}>
-                  <p style={note}>
-                    An artifact is a typed body pinned to an anchor, with provenance. (No cached
-                    piece to show right now.)
-                  </p>
-                </Panel>
-              }
+            <div
+              style={{
+                border: `1px solid ${accent()}55`,
+                'border-left': `4px solid ${accent()}`,
+                'border-radius': '8px',
+                background: '#fff',
+                padding: '0.85rem 1rem',
+              }}
             >
-              {(a) => (
-                <div
-                  style={{
-                    border: `1px solid ${accent()}55`,
-                    'border-left': `4px solid ${accent()}`,
-                    'border-radius': '8px',
-                    background: '#fff',
-                    padding: '0.85rem 1rem',
-                  }}
-                >
-                  <div
-                    style={{
-                      display: 'flex',
-                      'align-items': 'baseline',
-                      gap: '0.5rem',
-                      'flex-wrap': 'wrap',
-                    }}
-                  >
-                    <strong style={{ color: accent() }}>{a().title}</strong>
-                    <span style={chipStyle(false, accent())}>{a().kind}</span>
-                  </div>
-                  <Show when={a().excerpt}>
-                    <p
-                      dir="rtl"
-                      lang="he"
-                      style={{
-                        margin: '0.4rem 0 0',
-                        'font-family': '"Mekorot Vilna", serif',
-                        color: '#555',
-                      }}
-                    >
-                      {a().excerpt}
-                    </p>
-                  </Show>
-                  <Show when={a().body}>
-                    <p
-                      style={{
-                        margin: '0.45rem 0 0',
-                        'font-size': '0.88rem',
-                        'line-height': 1.5,
-                        color: '#333',
-                      }}
-                    >
-                      {a().body}
-                    </p>
-                  </Show>
-                  <div
-                    style={{
-                      'margin-top': '0.6rem',
-                      'border-top': '1px dashed #e3e0d7',
-                      'padding-top': '0.5rem',
-                    }}
-                  >
-                    <div
-                      style={{
-                        'font-size': '0.64rem',
-                        'text-transform': 'uppercase',
-                        'letter-spacing': '0.06em',
-                        color: '#9a958a',
-                        'margin-bottom': '0.3rem',
-                      }}
-                    >
-                      provenance
-                    </div>
-                    <div style={{ display: 'flex', 'flex-wrap': 'wrap', gap: '0.3rem' }}>
-                      <span style={chipStyle(false, authority() === 'ai' ? '#7c3aed' : '#0f766e')}>
-                        authority: {authority()}
-                      </span>
-                      <span style={chipStyle(false, accent())}>producer: {a().producerId}</span>
-                      <span style={chipStyle(false, '#6b7280')}>
-                        anchor: [{props.example.page}, seg {a().startSeg}]
-                      </span>
-                    </div>
-                  </div>
+              <div
+                style={{
+                  display: 'flex',
+                  'align-items': 'baseline',
+                  gap: '0.5rem',
+                  'flex-wrap': 'wrap',
+                }}
+              >
+                <strong style={{ color: accent() }}>{active()?.title ?? 'a section'}</strong>
+                <span style={chipStyle(false, accent())}>mark-instance</span>
+              </div>
+              <p
+                style={{
+                  margin: '0.45rem 0 0',
+                  'font-size': '0.85rem',
+                  'line-height': 1.5,
+                  color: '#555',
+                }}
+              >
+                A section the <code style={mono}>{props.example.producerId}</code> mark discovered
+                on this daf — a typed body pinned to where it sits.
+              </p>
+              <div
+                style={{
+                  'margin-top': '0.6rem',
+                  'border-top': '1px dashed #e3e0d7',
+                  'padding-top': '0.5rem',
+                }}
+              >
+                <div style={provLabel}>provenance</div>
+                <div style={{ display: 'flex', 'flex-wrap': 'wrap', gap: '0.3rem' }}>
+                  <span style={chipStyle(false, authority() === 'ai' ? '#7c3aed' : '#0f766e')}>
+                    authority: {authority()}
+                  </span>
+                  <span style={chipStyle(false, accent())}>
+                    producer: {props.example.producerId}
+                  </span>
+                  <span style={chipStyle(false, '#6b7280')}>
+                    anchor: [{props.example.page}, seg {active()?.startSeg}–{active()?.endSeg}]
+                  </span>
                 </div>
-              )}
-            </Show>
+              </div>
+            </div>
           </Show>
 
           <Show when={step() === 'producer'}>
-            <Panel title={art()?.producerId ?? 'producer'} accent={accent()} mono>
-              <Row k="behavior" v="discovers (finds the anchors)" />
+            <Panel title={props.example.producerId} accent={accent()} mono>
+              <Row k="behavior" v="discovers (finds the sections)" />
               <Row k="built from" v="gemara" mono />
               <Show when={feedsInto().length}>
                 <div style={{ 'margin-top': '0.4rem' }}>
-                  <div
-                    style={{
-                      'font-size': '0.64rem',
-                      'text-transform': 'uppercase',
-                      'letter-spacing': '0.06em',
-                      color: '#9a958a',
-                      'margin-bottom': '0.3rem',
-                    }}
-                  >
-                    feeds into
-                  </div>
+                  <div style={provLabel}>feeds into</div>
                   <div style={{ display: 'flex', 'flex-wrap': 'wrap', gap: '0.3rem' }}>
                     <For each={feedsInto()}>
                       {(id) => <span style={chipStyle(false, accent())}>{id}</span>}
@@ -329,7 +331,7 @@ export function WorkedExample(props: {
               </Show>
               <button
                 type="button"
-                onClick={() => props.onOpenInGraph(art()?.producerId ?? '')}
+                onClick={() => props.onOpenInGraph(props.example.producerId)}
                 style={{
                   'margin-top': '0.7rem',
                   background: 'var(--accent)',
@@ -357,6 +359,17 @@ const note: JSX.CSSProperties = {
   'font-size': '0.8rem',
   'line-height': 1.5,
   color: '#666',
+};
+const provLabel: JSX.CSSProperties = {
+  'font-size': '0.64rem',
+  'text-transform': 'uppercase',
+  'letter-spacing': '0.06em',
+  color: '#9a958a',
+  'margin-bottom': '0.3rem',
+};
+const mono: JSX.CSSProperties = {
+  'font-family': 'ui-monospace, SFMono-Regular, Menlo, monospace',
+  'font-size': '0.82em',
 };
 
 function Panel(props: {
@@ -399,55 +412,6 @@ function Row(props: { k: string; v: string; mono?: boolean }): JSX.Element {
         }}
       >
         {props.v}
-      </span>
-    </div>
-  );
-}
-
-function SegRow(props: {
-  index: number;
-  en: string;
-  he: string;
-  highlight: boolean;
-  accent: string;
-}): JSX.Element {
-  const preview = (): string => {
-    const t = props.en || props.he;
-    return t.length > 88 ? `${t.slice(0, 87)}…` : t || '—';
-  };
-  return (
-    <div
-      style={{
-        display: 'flex',
-        gap: '0.5rem',
-        padding: '0.3rem 0.6rem',
-        'border-bottom': '1px solid #f1efe8',
-        background: props.highlight ? `${props.accent}14` : 'transparent',
-        'border-left': props.highlight ? `3px solid ${props.accent}` : '3px solid transparent',
-      }}
-    >
-      <span
-        style={{
-          'font-family': 'ui-monospace, SFMono-Regular, Menlo, monospace',
-          'font-size': '0.68rem',
-          color: props.highlight ? props.accent : '#aaa',
-          'min-width': '1.6rem',
-          'font-weight': props.highlight ? 700 : 400,
-        }}
-      >
-        {props.index}
-      </span>
-      <span
-        style={{
-          'font-size': '0.78rem',
-          color: '#444',
-          overflow: 'hidden',
-          'text-overflow': 'ellipsis',
-          'white-space': 'nowrap',
-        }}
-        dir={props.en ? 'ltr' : 'rtl'}
-      >
-        {preview()}
       </span>
     </div>
   );

--- a/packages/talmud/src/client/howItWorks/example.ts
+++ b/packages/talmud/src/client/howItWorks/example.ts
@@ -1,19 +1,19 @@
 /**
- * Real data for the "show, don't tell" worked example on #howitworks. Pulls an
- * actual daf (Berakhot 2a) and one real piece anchored to it, so the page
- * demonstrates spine -> anchor -> artifact -> producer on live content rather
- * than describing it.
+ * Real data for the "show, don't tell" worked example on #howitworks. Pulls the
+ * actual sections of a daf (Berakhot 2a) so the page demonstrates
+ * spine -> anchor -> artifact -> producer on live content — a shorter cousin of
+ * the #spine statement view.
  *
- *  - /api/daf       -> the spine: the daf's ordered segments (real text)
- *  - /api/daf-view  -> a real cached `pesukim` instance: a biblical citation
- *                      anchored to one segment (body + segment range)
+ * The sections are the real `argument` mark instances (each a titled span of
+ * the daf), read from /api/daf-view. They double as the artifact in the walk:
+ * a discovered section IS an artifact.
  */
 import { createResource, type Resource } from 'solid-js';
 
 const TRACTATE = 'berakhot';
 const PAGE = '2a';
 
-/** Strip Sefaria/HebrewBooks markup so a segment preview is plain text. */
+/** Strip Sefaria/HebrewBooks markup so a title is plain text. */
 export function stripHtml(s: string): string {
   return s
     .replace(/<[^>]*>/g, '')
@@ -24,12 +24,9 @@ export function stripHtml(s: string): string {
     .trim();
 }
 
-export interface WorkedArtifact {
-  producerId: string; // the producer that made it, e.g. 'pesukim'
-  kind: string; // 'mark-instance'
-  title: string; // e.g. 'Deuteronomy 6:7'
-  body: string; // the produced summary
-  excerpt?: string; // the Hebrew phrase it cites
+export interface Section {
+  idx: number;
+  title: string;
   startSeg: number;
   endSeg: number;
 }
@@ -37,10 +34,13 @@ export interface WorkedArtifact {
 export interface WorkedExample {
   tractate: string;
   page: string;
-  segsEn: string[];
-  segsHe: string[];
-  artifact: WorkedArtifact | null;
+  /** The producer that discovers these sections. */
+  producerId: string;
+  sections: Section[];
 }
+
+const str = (v: unknown): string => (typeof v === 'string' ? v : '');
+const num = (v: unknown): number => (typeof v === 'number' ? v : 0);
 
 interface RawInstance {
   startSegIdx?: number;
@@ -48,45 +48,29 @@ interface RawInstance {
   fields?: Record<string, unknown>;
 }
 
-const str = (v: unknown): string => (typeof v === 'string' ? v : '');
-
-function pickPesukim(view: unknown): WorkedArtifact | null {
+/** Pure: project a /api/daf-view response into the section cards. */
+export function sectionsFromView(view: unknown): Section[] {
   const pieces = (view as { pieces?: Record<string, { parsed?: unknown }> })?.pieces;
-  const parsed = pieces?.pesukim?.parsed as { instances?: RawInstance[] } | undefined;
-  const inst = parsed?.instances?.find((i) => typeof i.startSegIdx === 'number');
-  if (!inst) return null;
-  const f = inst.fields ?? {};
-  return {
-    producerId: 'pesukim',
-    kind: 'mark-instance',
-    title: str(f.verseRef) || 'a biblical citation',
-    body: str(f.summary),
-    excerpt: str(f.excerpt) || undefined,
-    startSeg: inst.startSegIdx ?? 0,
-    endSeg: inst.endSegIdx ?? inst.startSegIdx ?? 0,
-  };
+  const parsed = pieces?.argument?.parsed as { instances?: RawInstance[] } | undefined;
+  const insts = parsed?.instances;
+  if (!Array.isArray(insts)) return [];
+  return insts.map((i, idx) => ({
+    idx,
+    title: stripHtml(str(i.fields?.title)) || `Section ${idx + 1}`,
+    startSeg: num(i.startSegIdx),
+    endSeg: num(i.endSegIdx),
+  }));
 }
 
 async function fetchExample(): Promise<WorkedExample> {
-  const [dafR, viewR] = await Promise.allSettled([
-    fetch(`/api/daf/${TRACTATE}/${PAGE}?source=sefaria`),
-    fetch(`/api/daf-view/${TRACTATE}/${PAGE}`),
-  ]);
-
-  let segsEn: string[] = [];
-  let segsHe: string[] = [];
-  if (dafR.status === 'fulfilled' && dafR.value.ok) {
-    const j = (await dafR.value.json()) as { mainSegmentsEn?: string[]; mainSegmentsHe?: string[] };
-    segsEn = (j.mainSegmentsEn ?? []).map(stripHtml);
-    segsHe = (j.mainSegmentsHe ?? []).map(stripHtml);
+  let sections: Section[] = [];
+  try {
+    const res = await fetch(`/api/daf-view/${TRACTATE}/${PAGE}`);
+    if (res.ok) sections = sectionsFromView(await res.json());
+  } catch {
+    sections = [];
   }
-
-  let artifact: WorkedArtifact | null = null;
-  if (viewR.status === 'fulfilled' && viewR.value.ok) {
-    artifact = pickPesukim(await viewR.value.json());
-  }
-
-  return { tractate: TRACTATE, page: PAGE, segsEn, segsHe, artifact };
+  return { tractate: TRACTATE, page: PAGE, producerId: 'argument', sections };
 }
 
 export function useWorkedExample(): Resource<WorkedExample> {

--- a/packages/talmud/tests/how-it-works-example.test.ts
+++ b/packages/talmud/tests/how-it-works-example.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { stripHtml } from '../src/client/howItWorks/example';
+import { sectionsFromView, stripHtml } from '../src/client/howItWorks/example';
 
 describe('stripHtml', () => {
   it('removes tags and collapses whitespace', () => {
@@ -11,5 +11,37 @@ describe('stripHtml', () => {
   });
   it('is a no-op on plain text', () => {
     expect(stripHtml('plain text')).toBe('plain text');
+  });
+});
+
+describe('sectionsFromView', () => {
+  const view = {
+    pieces: {
+      argument: {
+        parsed: {
+          instances: [
+            { startSegIdx: 0, endSegIdx: 4, fields: { title: 'Opening Mishnah' } },
+            { startSegIdx: 5, endSegIdx: 7, fields: { title: 'Gemara’s first question' } },
+          ],
+        },
+      },
+    },
+  };
+  it('projects argument instances into numbered sections', () => {
+    const secs = sectionsFromView(view);
+    expect(secs).toHaveLength(2);
+    expect(secs[0]).toEqual({ idx: 0, title: 'Opening Mishnah', startSeg: 0, endSeg: 4 });
+    expect(secs[1].startSeg).toBe(5);
+  });
+  it('is empty (not a throw) when the argument piece is missing', () => {
+    expect(sectionsFromView({})).toEqual([]);
+    expect(sectionsFromView({ pieces: {} })).toEqual([]);
+    expect(sectionsFromView(null)).toEqual([]);
+  });
+  it('falls back to a generic title when none is present', () => {
+    const secs = sectionsFromView({
+      pieces: { argument: { parsed: { instances: [{ startSegIdx: 2, endSegIdx: 2 }] } } },
+    });
+    expect(secs[0].title).toBe('Section 1');
   });
 });

--- a/packages/talmud/tests/how-it-works-page.test.tsx
+++ b/packages/talmud/tests/how-it-works-page.test.tsx
@@ -34,9 +34,17 @@ describe('HowItWorksPage', () => {
         } else if (u.includes('/api/marks')) {
           body = { marks: [{ id: 'rabbi', label: 'Rabbi', dependencies: ['gemara'] }] };
         } else if (u.includes('/api/daf-view')) {
-          body = { pieces: {} };
-        } else if (u.includes('/api/daf')) {
-          body = { mainSegmentsEn: ['seg zero'], mainSegmentsHe: ['שלום'] };
+          body = {
+            pieces: {
+              argument: {
+                parsed: {
+                  instances: [
+                    { startSegIdx: 0, endSegIdx: 4, fields: { title: 'Opening Mishnah' } },
+                  ],
+                },
+              },
+            },
+          };
         }
         return { ok: true, json: async () => body } as Response;
       }),
@@ -58,9 +66,19 @@ describe('HowItWorksPage', () => {
     // chapter rail labels (render synchronously)
     expect(text).toContain('The model, shown');
     expect(text).toContain('The build graph');
-    // a lifecycle step (renders synchronously, independent of the fetch)
-    expect(text).toContain('Resolve inputs');
+    expect(text).toContain('Every enrichment');
+    expect(text).toContain('Caching & freshness');
     expect(root.querySelector('.hiw-rail')).toBeTruthy();
+    root.remove();
+  });
+
+  it('renders the worked-example section cards once the daf-view resolves', async () => {
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    dispose = render(() => <HowItWorksPage />, root);
+    // let the registry + daf-view resources resolve and Solid flush
+    await new Promise((r) => setTimeout(r, 30));
+    expect(root.textContent ?? '').toContain('Opening Mishnah');
     root.remove();
   });
 });


### PR DESCRIPTION
Follow-up to the `#howitworks` rework, on feedback:

## Spine step → a shorter `#spine`
The worked example's **Spine** step now renders the daf's real **sections as numbered title cards** (a condensed cousin of the `#spine` statement view) instead of the raw text-preview list. The sections are the real `argument` mark instances (title + segment span) read from `/api/daf-view`. Clicking a card anchors it, and the chosen section **is** the artifact (a discovered mark instance) — so Spine → Anchor → Artifact → Producer all operate on the same cards. `example.ts` gains a pure, unit-tested `sectionsFromView`.

## Dropped the lifecycle row
Removed the "How a piece is built" chapter (the 6-step `runProducer` flow + its rail entry), per feedback.

## Verification
- `pnpm typecheck`, `pnpm lint` (Biome, 643 files), full suite (**2548 tests**) green; clean production build.
- New `sectionsFromView` unit tests; the jsdom mount test now also asserts a real section card (`Opening Mishnah`) renders once the daf-view resolves.
- Note: the section cards need the warm `argument` mark, which **prod has** (Berakhot 2a → 4 sections, confirmed) but local dev's producer cache is empty — so the cards are verified via the async render test + prod data rather than a local screenshot (the shared chrome-devtools profile was also locked by another agent).