### PR TITLE
Inspector: share the DAG canvas — RunTreeDock onto @corpus/ui/RunTreeCanvas

### DIFF
--- a/packages/talmud/src/client/RunTreeDock.tsx
+++ b/packages/talmud/src/client/RunTreeDock.tsx
@@ -18,35 +18,24 @@
 
 import {
   ACTIVE_STROKE,
-  AuthorityBadge,
   BADGE_LLM,
   BADGE_PRO,
   BADGE_SRC,
   CANVAS,
-  CANVAS_BORDER,
-  CARD_STROKE,
-  computeLayout,
   displayLabel,
-  edgePath,
   fmtCost,
   fmtMs,
   type IconVariant,
-  type LaidEdge,
-  type Layout,
-  LEFT_PAD,
-  NODE_H,
-  NODE_W,
   NodeIcon,
   ProvenanceSection,
-  ROW_H,
   type RunResult,
   type RunTree,
   STALENESS_COLOR,
   StalenessDot,
-  TOP_PAD,
   type TreeNode,
   variantOf,
 } from '@corpus/ui/RunTree';
+import { RunTreeCanvas } from '@corpus/ui/RunTreeCanvas';
 import {
   createEffect,
   createMemo,
@@ -783,35 +772,17 @@ export default function RunTreeDock(props: {
     },
   );
 
-  const layout = createMemo<Layout | null>(() => {
-    const t = tree();
-    return t ? computeLayout(t, expanded()) : null;
-  });
+  // The DAG canvas (layout, edges, node cards, the incident-edge focus
+  // highlight) is the shared @corpus/ui/RunTreeCanvas; the dock keeps only the
+  // waterfall + its richer node-detail/freshness panes around it. nodeOf +
+  // toggleExpand remain — the detail pane and the canvas props use them.
   const nodeOf = (id: string): TreeNode | undefined => tree()?.nodes[id];
-  const hasKids = (id: string): boolean => !!tree()?.edges.some((e) => e[0] === id);
   const toggleExpand = (id: string) =>
     setExpanded((prev) => {
       const n = new Set(prev);
       n.has(id) ? n.delete(id) : n.add(id);
       return n;
     });
-  const badgeColor = (n: TreeNode) =>
-    n.kind !== 'llm' ? BADGE_SRC : n.model?.includes('pro') ? BADGE_PRO : BADGE_LLM;
-
-  // The selected node + everything one edge away — for the focus highlight
-  // (incident edges drawn bold, the rest faded).
-  const connected = createMemo<Set<string>>(() => {
-    const sel = selected();
-    const lay = layout();
-    if (!sel || !lay) return new Set();
-    const set = new Set<string>([sel]);
-    for (const e of lay.edges) {
-      if (e.fromId === sel) set.add(e.toId);
-      if (e.toId === sel) set.add(e.fromId);
-    }
-    return set;
-  });
-  const isIncident = (e: LaidEdge) => e.fromId === selected() || e.toId === selected();
 
   const [detail] = createResource(
     () => {
@@ -873,11 +844,6 @@ export default function RunTreeDock(props: {
     };
     document.addEventListener('mousemove', move);
     document.addEventListener('mouseup', up);
-  };
-
-  const nodeY = (id: string) => {
-    const r = layout()!.rowOf.get(id)!;
-    return TOP_PAD + r * ROW_H;
   };
 
   // Push the daf left by the panel width when open (mirrors the old left shelf).
@@ -1169,220 +1135,14 @@ export default function RunTreeDock(props: {
               padding: '0.5rem',
             }}
           >
-            <Show when={tree.loading}>
-              <div style={{ padding: '0.5rem', color: '#aaa' }}>loading…</div>
-            </Show>
-            <Show when={tree() === null && !tree.loading}>
-              <div style={{ padding: '0.5rem', color: '#c00' }}>
-                no graph (unknown piece, or nothing cached)
-              </div>
-            </Show>
-            <Show when={layout()}>
-              {(lay) => (
-                <div
-                  style={{
-                    position: 'relative',
-                    width: `${lay().width}px`,
-                    height: `${lay().height}px`,
-                    border: `1px solid ${CANVAS_BORDER}`,
-                    'border-radius': '8px',
-                    background: CANVAS,
-                  }}
-                >
-                  {/* edge layer */}
-                  <svg
-                    aria-hidden="true"
-                    width={lay().width}
-                    height={lay().height}
-                    style={{
-                      position: 'absolute',
-                      inset: 0,
-                      'pointer-events': 'none',
-                      overflow: 'visible',
-                    }}
-                  >
-                    <defs>
-                      <marker
-                        id="rt-arrow"
-                        markerWidth="8"
-                        markerHeight="8"
-                        refX="6"
-                        refY="3"
-                        orient="auto"
-                      >
-                        <path d="M0 0 L6 3 L0 6 z" fill="#c9b8b0" />
-                      </marker>
-                      <marker
-                        id="rt-arrow-hot"
-                        markerWidth="8"
-                        markerHeight="8"
-                        refX="6"
-                        refY="3"
-                        orient="auto"
-                      >
-                        <path d="M0 0 L6 3 L0 6 z" fill="#8a2a2b" />
-                      </marker>
-                    </defs>
-                    <For each={lay().edges}>
-                      {(e) => {
-                        const hot = () => isIncident(e);
-                        const faded = () => !!selected() && !hot();
-                        return (
-                          // arrow points dependency -> consumer ("what feeds into what")
-                          <path
-                            d={edgePath(e.toRow, e.fromRow, e.lane)}
-                            fill="none"
-                            stroke={hot() ? '#8a2a2b' : '#d3c4ba'}
-                            stroke-width={hot() ? 2 : 1.5}
-                            stroke-opacity={faded() ? 0.22 : hot() ? 0.85 : 1}
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            marker-end={`url(#${hot() ? 'rt-arrow-hot' : 'rt-arrow'})`}
-                          />
-                        );
-                      }}
-                    </For>
-                  </svg>
-                  {/* node cards */}
-                  <For each={lay().order}>
-                    {(id) => {
-                      const n = () => nodeOf(id)!;
-                      const isLLM = () => n().kind === 'llm';
-                      const sel = () => selected() === id;
-                      const exp = () => expanded().has(id);
-                      const slow = () => (n().cold_ms ?? 0) > 10_000;
-                      const dim = () => !!selected() && !connected().has(id);
-                      const activate = () => {
-                        setSelected(id);
-                        if (hasKids(id)) toggleExpand(id);
-                      };
-                      return (
-                        // biome-ignore lint/a11y/useSemanticElements: node card contains a nested expand <button>; a native button cannot contain another button
-                        <div
-                          role="button"
-                          tabIndex={0}
-                          onClick={activate}
-                          onKeyDown={(e) => {
-                            if (e.key === 'Enter' || e.key === ' ') {
-                              e.preventDefault();
-                              activate();
-                            }
-                          }}
-                          style={{
-                            position: 'absolute',
-                            left: `${LEFT_PAD}px`,
-                            top: `${nodeY(id)}px`,
-                            width: `${NODE_W}px`,
-                            height: `${NODE_H}px`,
-                            display: 'flex',
-                            'align-items': 'center',
-                            gap: '0.5rem',
-                            padding: '0 0.6rem',
-                            cursor: 'pointer',
-                            'box-sizing': 'border-box',
-                            background: sel() ? '#fdf2f2' : '#fff',
-                            border: `${sel() ? 1.75 : 1}px solid ${sel() ? ACTIVE_STROKE : CARD_STROKE}`,
-                            'border-radius': '11px',
-                            'box-shadow': '0 1px 2px rgba(58,51,32,0.08)',
-                            opacity: dim() ? 0.42 : 1,
-                            transition: 'opacity 0.12s',
-                          }}
-                        >
-                          <NodeIcon variant={variantOf(n())} color={badgeColor(n())} />
-                          <div style={{ flex: 1, 'min-width': 0 }}>
-                            <div
-                              style={{ display: 'flex', 'align-items': 'baseline', gap: '0.4rem' }}
-                            >
-                              <span
-                                style={{
-                                  'font-weight': 600,
-                                  'font-size': '0.84rem',
-                                  color: '#2a2723',
-                                  'white-space': 'nowrap',
-                                  overflow: 'hidden',
-                                  'text-overflow': 'ellipsis',
-                                }}
-                              >
-                                {displayLabel(n().id, n().label)}
-                              </span>
-                              <span
-                                style={{
-                                  'margin-left': 'auto',
-                                  'font-size': '0.68rem',
-                                  'font-variant-numeric': 'tabular-nums',
-                                  color: slow() ? '#b45309' : '#9a857c',
-                                  'flex-shrink': 0,
-                                }}
-                              >
-                                {fmtMs(n().cold_ms)}
-                              </span>
-                              <Show when={n().staleness}>
-                                {(s) => (
-                                  <StalenessDot
-                                    staleness={s()}
-                                    inputsChanged={n().inputsChanged}
-                                    isMark={n().producer === 'mark'}
-                                  />
-                                )}
-                              </Show>
-                            </div>
-                            <div
-                              style={{
-                                display: 'flex',
-                                'align-items': 'center',
-                                gap: '0.3rem',
-                                'font-size': '0.66rem',
-                                'font-family': 'ui-monospace, Menlo, monospace',
-                                color: isLLM() ? '#9a8fb5' : '#9aa4ad',
-                                'white-space': 'nowrap',
-                                overflow: 'hidden',
-                                'text-overflow': 'ellipsis',
-                              }}
-                            >
-                              <Show when={n().authority}>
-                                {(a) => <AuthorityBadge authority={a()} />}
-                              </Show>
-                              {isLLM()
-                                ? `${(n().model ?? '').split('/').pop()} · ${fmtCost(n().cost)}`
-                                : 'source · $0'}
-                            </div>
-                          </div>
-                          <Show when={hasKids(id)}>
-                            <button
-                              type="button"
-                              onClick={(ev) => {
-                                ev.stopPropagation();
-                                setSelected(id);
-                                toggleExpand(id);
-                              }}
-                              title={exp() ? 'collapse inputs' : 'expand inputs'}
-                              style={{
-                                'flex-shrink': 0,
-                                width: '18px',
-                                height: '18px',
-                                'border-radius': '50%',
-                                border: '1px solid #d8c9c0',
-                                background: '#fff',
-                                color: '#8a7d74',
-                                cursor: 'pointer',
-                                'font-size': '0.8rem',
-                                'line-height': 1,
-                                display: 'inline-flex',
-                                'align-items': 'center',
-                                'justify-content': 'center',
-                                padding: 0,
-                              }}
-                            >
-                              {exp() ? '–' : '+'}
-                            </button>
-                          </Show>
-                        </div>
-                      );
-                    }}
-                  </For>
-                </div>
-              )}
-            </Show>
+            <RunTreeCanvas
+              tree={tree() ?? null}
+              loading={tree.loading}
+              selected={selected()}
+              onSelect={setSelected}
+              expanded={expanded()}
+              onToggleExpand={toggleExpand}
+            />
           </div>
         </Show>
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -29,6 +29,7 @@
     "./LoadProgress": "./src/LoadProgress.tsx",
     "./InspectorRow": "./src/InspectorRow.tsx",
     "./RunTree": "./src/RunTree.tsx",
+    "./RunTreeCanvas": "./src/RunTreeCanvas.tsx",
     "./RunTreeDag": "./src/RunTreeDag.tsx",
     "./RunWaterfall": "./src/RunWaterfall.tsx",
     "./UsagePage": "./src/UsagePage.tsx"

--- a/packages/ui/src/RunTreeCanvas.tsx
+++ b/packages/ui/src/RunTreeCanvas.tsx
@@ -1,0 +1,297 @@
+/**
+ * @corpus/ui — RunTreeCanvas.
+ *
+ * The build-provenance DAG CANVAS: the SVG edge layer + the HTML node cards over
+ * the vertical lane layout, with the click-to-select / ⊕-to-expand interaction
+ * and the incident-edge focus highlight. PRESENTATIONAL and controlled (tree +
+ * selected/expanded in via props). This is the one piece every inspector surface
+ * shares — the embeddable @corpus/ui/RunTreeDag and talmud's RunTreeDock both
+ * render their DAG through here, so the graph maths + node visuals can't drift.
+ *
+ * It renders ONLY the canvas (loading / empty / the positioned layout); the host
+ * supplies the surrounding scroll box and whatever node-detail pane it wants.
+ * Arrows point dependency → consumer.
+ */
+
+import { createMemo, createUniqueId, For, type JSX, Show } from 'solid-js';
+import {
+  ACTIVE_STROKE,
+  AuthorityBadge,
+  BADGE_LLM,
+  BADGE_PRO,
+  BADGE_SRC,
+  CARD_STROKE,
+  computeLayout,
+  displayLabel,
+  edgePath,
+  fmtCost,
+  fmtMs,
+  type LaidEdge,
+  type Layout,
+  LEFT_PAD,
+  NODE_H,
+  NODE_W,
+  NodeIcon,
+  ROW_H,
+  type RunTree,
+  StalenessDot,
+  TOP_PAD,
+  type TreeNode,
+  variantOf,
+} from './RunTree.tsx';
+
+export interface RunTreeCanvasProps {
+  tree: RunTree | null;
+  loading?: boolean;
+  /** Selected node id (controlled by the host). */
+  selected: string | null;
+  onSelect: (id: string) => void;
+  /** Expanded node ids (controlled by the host). */
+  expanded: Set<string>;
+  onToggleExpand: (id: string) => void;
+  /** Shown when the tree is null and not loading. */
+  emptyLabel?: string;
+}
+
+export function RunTreeCanvas(props: RunTreeCanvasProps): JSX.Element {
+  // Per-instance SVG marker ids: two DAGs can mount in one document (e.g. the
+  // dock + an embedded RunTreeDag), and a shared id would let `marker-end`
+  // resolve to the wrong (possibly hidden) instance's marker.
+  const arrowId = createUniqueId();
+  const arrowHotId = createUniqueId();
+  const layout = createMemo<Layout | null>(() => {
+    const t = props.tree;
+    return t ? computeLayout(t, props.expanded) : null;
+  });
+  const nodeOf = (id: string): TreeNode | undefined => props.tree?.nodes[id];
+  const hasKids = (id: string): boolean => !!props.tree?.edges.some((e) => e[0] === id);
+  const badgeColor = (n: TreeNode) =>
+    n.kind !== 'llm' ? BADGE_SRC : n.model?.includes('pro') ? BADGE_PRO : BADGE_LLM;
+  const connected = createMemo<Set<string>>(() => {
+    const sel = props.selected;
+    const lay = layout();
+    if (!sel || !lay) return new Set();
+    const set = new Set<string>([sel]);
+    for (const e of lay.edges) {
+      if (e.fromId === sel) set.add(e.toId);
+      if (e.toId === sel) set.add(e.fromId);
+    }
+    return set;
+  });
+  const isIncident = (e: LaidEdge) => e.fromId === props.selected || e.toId === props.selected;
+  const nodeY = (id: string) => {
+    const r = layout()!.rowOf.get(id)!;
+    return TOP_PAD + r * ROW_H;
+  };
+  const activate = (id: string) => {
+    props.onSelect(id);
+    if (hasKids(id)) props.onToggleExpand(id);
+  };
+
+  return (
+    <>
+      <Show when={props.loading}>
+        <div style={{ padding: '0.5rem', color: '#aaa' }}>loading…</div>
+      </Show>
+      <Show when={props.tree === null && !props.loading}>
+        <div style={{ padding: '0.5rem', color: '#c00' }}>
+          {props.emptyLabel ?? 'no graph (unknown piece, or nothing cached)'}
+        </div>
+      </Show>
+      <Show when={layout()}>
+        {(lay) => (
+          <div
+            style={{
+              position: 'relative',
+              width: `${lay().width}px`,
+              height: `${lay().height}px`,
+            }}
+          >
+            <svg
+              aria-hidden="true"
+              width={lay().width}
+              height={lay().height}
+              style={{
+                position: 'absolute',
+                inset: 0,
+                'pointer-events': 'none',
+                overflow: 'visible',
+              }}
+            >
+              <defs>
+                <marker
+                  id={arrowId}
+                  markerWidth="8"
+                  markerHeight="8"
+                  refX="6"
+                  refY="3"
+                  orient="auto"
+                >
+                  <path d="M0 0 L6 3 L0 6 z" fill="#c9b8b0" />
+                </marker>
+                <marker
+                  id={arrowHotId}
+                  markerWidth="8"
+                  markerHeight="8"
+                  refX="6"
+                  refY="3"
+                  orient="auto"
+                >
+                  <path d="M0 0 L6 3 L0 6 z" fill="#8a2a2b" />
+                </marker>
+              </defs>
+              <For each={lay().edges}>
+                {(e) => {
+                  const hot = () => isIncident(e);
+                  const faded = () => !!props.selected && !hot();
+                  return (
+                    <path
+                      d={edgePath(e.toRow, e.fromRow, e.lane)}
+                      fill="none"
+                      stroke={hot() ? '#8a2a2b' : '#d3c4ba'}
+                      stroke-width={hot() ? 2 : 1.5}
+                      stroke-opacity={faded() ? 0.22 : hot() ? 0.85 : 1}
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      marker-end={`url(#${hot() ? arrowHotId : arrowId})`}
+                    />
+                  );
+                }}
+              </For>
+            </svg>
+            <For each={lay().order}>
+              {(id) => {
+                const n = () => nodeOf(id)!;
+                const isLLM = () => n().kind === 'llm';
+                const sel = () => props.selected === id;
+                const exp = () => props.expanded.has(id);
+                const slow = () => (n().cold_ms ?? 0) > 10_000;
+                const dim = () => !!props.selected && !connected().has(id);
+                return (
+                  // biome-ignore lint/a11y/useSemanticElements: node card contains a nested expand <button>; a native button cannot contain another button
+                  <div
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => activate(id)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        activate(id);
+                      }
+                    }}
+                    style={{
+                      position: 'absolute',
+                      left: `${LEFT_PAD}px`,
+                      top: `${nodeY(id)}px`,
+                      width: `${NODE_W}px`,
+                      height: `${NODE_H}px`,
+                      display: 'flex',
+                      'align-items': 'center',
+                      gap: '0.5rem',
+                      padding: '0 0.6rem',
+                      cursor: 'pointer',
+                      'box-sizing': 'border-box',
+                      background: sel() ? '#fdf2f2' : '#fff',
+                      border: `${sel() ? 1.75 : 1}px solid ${sel() ? ACTIVE_STROKE : CARD_STROKE}`,
+                      'border-radius': '11px',
+                      'box-shadow': '0 1px 2px rgba(58,51,32,0.08)',
+                      opacity: dim() ? 0.42 : 1,
+                      transition: 'opacity 0.12s',
+                    }}
+                  >
+                    <NodeIcon variant={variantOf(n())} color={badgeColor(n())} />
+                    <div style={{ flex: 1, 'min-width': 0 }}>
+                      <div style={{ display: 'flex', 'align-items': 'baseline', gap: '0.4rem' }}>
+                        <span
+                          style={{
+                            'font-weight': 600,
+                            'font-size': '0.84rem',
+                            color: '#2a2723',
+                            'white-space': 'nowrap',
+                            overflow: 'hidden',
+                            'text-overflow': 'ellipsis',
+                          }}
+                        >
+                          {displayLabel(n().id, n().label)}
+                        </span>
+                        <span
+                          style={{
+                            'margin-left': 'auto',
+                            'font-size': '0.68rem',
+                            'font-variant-numeric': 'tabular-nums',
+                            color: slow() ? '#b45309' : '#9a857c',
+                            'flex-shrink': 0,
+                          }}
+                        >
+                          {fmtMs(n().cold_ms)}
+                        </span>
+                        <Show when={n().staleness}>
+                          {(s) => (
+                            <StalenessDot
+                              staleness={s()}
+                              inputsChanged={n().inputsChanged}
+                              isMark={n().producer === 'mark'}
+                            />
+                          )}
+                        </Show>
+                      </div>
+                      <div
+                        style={{
+                          display: 'flex',
+                          'align-items': 'center',
+                          gap: '0.3rem',
+                          'font-size': '0.66rem',
+                          'font-family': 'ui-monospace, Menlo, monospace',
+                          color: isLLM() ? '#9a8fb5' : '#9aa4ad',
+                          'white-space': 'nowrap',
+                          overflow: 'hidden',
+                          'text-overflow': 'ellipsis',
+                        }}
+                      >
+                        <Show when={n().authority}>
+                          {(a) => <AuthorityBadge authority={a()} />}
+                        </Show>
+                        {isLLM()
+                          ? `${(n().model ?? '').split('/').pop()} · ${fmtCost(n().cost)}`
+                          : 'source · $0'}
+                      </div>
+                    </div>
+                    <Show when={hasKids(id)}>
+                      <button
+                        type="button"
+                        onClick={(ev) => {
+                          ev.stopPropagation();
+                          props.onSelect(id);
+                          props.onToggleExpand(id);
+                        }}
+                        title={exp() ? 'collapse inputs' : 'expand inputs'}
+                        style={{
+                          'flex-shrink': 0,
+                          width: '18px',
+                          height: '18px',
+                          'border-radius': '50%',
+                          border: '1px solid #d8c9c0',
+                          background: '#fff',
+                          color: '#8a7d74',
+                          cursor: 'pointer',
+                          'font-size': '0.8rem',
+                          'line-height': 1,
+                          display: 'inline-flex',
+                          'align-items': 'center',
+                          'justify-content': 'center',
+                          padding: 0,
+                        }}
+                      >
+                        {exp() ? '–' : '+'}
+                      </button>
+                    </Show>
+                  </div>
+                );
+              }}
+            </For>
+          </div>
+        )}
+      </Show>
+    </>
+  );
+}

--- a/packages/ui/src/RunTreeDag.tsx
+++ b/packages/ui/src/RunTreeDag.tsx
@@ -14,35 +14,18 @@
  * fan-in edges.
  */
 
-import { createMemo, For, type JSX, Show } from 'solid-js';
+import { type JSX, Show } from 'solid-js';
 import {
-  ACTIVE_STROKE,
-  AuthorityBadge,
-  BADGE_LLM,
-  BADGE_PRO,
-  BADGE_SRC,
   CANVAS,
   CANVAS_BORDER,
-  CARD_STROKE,
-  computeLayout,
   displayLabel,
-  edgePath,
   fmtCost,
   fmtMs,
-  type LaidEdge,
-  type Layout,
-  LEFT_PAD,
-  NODE_H,
-  NODE_W,
-  NodeIcon,
   ProvenanceSection,
-  ROW_H,
   type RunTree,
-  StalenessDot,
-  TOP_PAD,
   type TreeNode,
-  variantOf,
 } from './RunTree.tsx';
+import { RunTreeCanvas } from './RunTreeCanvas.tsx';
 
 export interface RunTreeDagProps {
   /** The derived run-tree (from @corpus/core/telemetry buildRunTree). */
@@ -63,34 +46,9 @@ export interface RunTreeDagProps {
 }
 
 export function RunTreeDag(props: RunTreeDagProps): JSX.Element {
-  const layout = createMemo<Layout | null>(() => {
-    const t = props.tree;
-    return t ? computeLayout(t, props.expanded) : null;
-  });
+  // The DAG canvas (edges + node cards + selection) is the shared RunTreeCanvas;
+  // this component adds only the surrounding scroll box + the node-detail pane.
   const nodeOf = (id: string): TreeNode | undefined => props.tree?.nodes[id];
-  const hasKids = (id: string): boolean => !!props.tree?.edges.some((e) => e[0] === id);
-  const badgeColor = (n: TreeNode) =>
-    n.kind !== 'llm' ? BADGE_SRC : n.model?.includes('pro') ? BADGE_PRO : BADGE_LLM;
-  const connected = createMemo<Set<string>>(() => {
-    const sel = props.selected;
-    const lay = layout();
-    if (!sel || !lay) return new Set();
-    const set = new Set<string>([sel]);
-    for (const e of lay.edges) {
-      if (e.fromId === sel) set.add(e.toId);
-      if (e.toId === sel) set.add(e.fromId);
-    }
-    return set;
-  });
-  const isIncident = (e: LaidEdge) => e.fromId === props.selected || e.toId === props.selected;
-  const nodeY = (id: string) => {
-    const r = layout()!.rowOf.get(id)!;
-    return TOP_PAD + r * ROW_H;
-  };
-  const activate = (id: string) => {
-    props.onSelect(id);
-    if (hasKids(id)) props.onToggleExpand(id);
-  };
 
   return (
     <div
@@ -102,7 +60,7 @@ export function RunTreeDag(props: RunTreeDagProps): JSX.Element {
         'font-size': '13px',
       }}
     >
-      {/* DAG */}
+      {/* DAG canvas — the shared @corpus/ui/RunTreeCanvas */}
       <div
         style={{
           'max-height': '52vh',
@@ -113,208 +71,15 @@ export function RunTreeDag(props: RunTreeDagProps): JSX.Element {
           'border-radius': '8px',
         }}
       >
-        <Show when={props.loading}>
-          <div style={{ padding: '0.5rem', color: '#aaa' }}>loading…</div>
-        </Show>
-        <Show when={props.tree === null && !props.loading}>
-          <div style={{ padding: '0.5rem', color: '#c00' }}>
-            {props.emptyLabel ?? 'no graph (unknown piece, or nothing cached)'}
-          </div>
-        </Show>
-        <Show when={layout()}>
-          {(lay) => (
-            <div
-              style={{
-                position: 'relative',
-                width: `${lay().width}px`,
-                height: `${lay().height}px`,
-              }}
-            >
-              <svg
-                aria-hidden="true"
-                width={lay().width}
-                height={lay().height}
-                style={{
-                  position: 'absolute',
-                  inset: 0,
-                  'pointer-events': 'none',
-                  overflow: 'visible',
-                }}
-              >
-                <defs>
-                  <marker
-                    id="rtd-arrow"
-                    markerWidth="8"
-                    markerHeight="8"
-                    refX="6"
-                    refY="3"
-                    orient="auto"
-                  >
-                    <path d="M0 0 L6 3 L0 6 z" fill="#c9b8b0" />
-                  </marker>
-                  <marker
-                    id="rtd-arrow-hot"
-                    markerWidth="8"
-                    markerHeight="8"
-                    refX="6"
-                    refY="3"
-                    orient="auto"
-                  >
-                    <path d="M0 0 L6 3 L0 6 z" fill="#8a2a2b" />
-                  </marker>
-                </defs>
-                <For each={lay().edges}>
-                  {(e) => {
-                    const hot = () => isIncident(e);
-                    const faded = () => !!props.selected && !hot();
-                    return (
-                      <path
-                        d={edgePath(e.toRow, e.fromRow, e.lane)}
-                        fill="none"
-                        stroke={hot() ? '#8a2a2b' : '#d3c4ba'}
-                        stroke-width={hot() ? 2 : 1.5}
-                        stroke-opacity={faded() ? 0.22 : hot() ? 0.85 : 1}
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        marker-end={`url(#${hot() ? 'rtd-arrow-hot' : 'rtd-arrow'})`}
-                      />
-                    );
-                  }}
-                </For>
-              </svg>
-              <For each={lay().order}>
-                {(id) => {
-                  const n = () => nodeOf(id)!;
-                  const isLLM = () => n().kind === 'llm';
-                  const sel = () => props.selected === id;
-                  const exp = () => props.expanded.has(id);
-                  const slow = () => (n().cold_ms ?? 0) > 10_000;
-                  const dim = () => !!props.selected && !connected().has(id);
-                  return (
-                    // biome-ignore lint/a11y/useSemanticElements: node card contains a nested expand <button>; a native button cannot contain another button
-                    <div
-                      role="button"
-                      tabIndex={0}
-                      onClick={() => activate(id)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' || e.key === ' ') {
-                          e.preventDefault();
-                          activate(id);
-                        }
-                      }}
-                      style={{
-                        position: 'absolute',
-                        left: `${LEFT_PAD}px`,
-                        top: `${nodeY(id)}px`,
-                        width: `${NODE_W}px`,
-                        height: `${NODE_H}px`,
-                        display: 'flex',
-                        'align-items': 'center',
-                        gap: '0.5rem',
-                        padding: '0 0.6rem',
-                        cursor: 'pointer',
-                        'box-sizing': 'border-box',
-                        background: sel() ? '#fdf2f2' : '#fff',
-                        border: `${sel() ? 1.75 : 1}px solid ${sel() ? ACTIVE_STROKE : CARD_STROKE}`,
-                        'border-radius': '11px',
-                        'box-shadow': '0 1px 2px rgba(58,51,32,0.08)',
-                        opacity: dim() ? 0.42 : 1,
-                        transition: 'opacity 0.12s',
-                      }}
-                    >
-                      <NodeIcon variant={variantOf(n())} color={badgeColor(n())} />
-                      <div style={{ flex: 1, 'min-width': 0 }}>
-                        <div style={{ display: 'flex', 'align-items': 'baseline', gap: '0.4rem' }}>
-                          <span
-                            style={{
-                              'font-weight': 600,
-                              'font-size': '0.84rem',
-                              color: '#2a2723',
-                              'white-space': 'nowrap',
-                              overflow: 'hidden',
-                              'text-overflow': 'ellipsis',
-                            }}
-                          >
-                            {displayLabel(n().id, n().label)}
-                          </span>
-                          <span
-                            style={{
-                              'margin-left': 'auto',
-                              'font-size': '0.68rem',
-                              'font-variant-numeric': 'tabular-nums',
-                              color: slow() ? '#b45309' : '#9a857c',
-                              'flex-shrink': 0,
-                            }}
-                          >
-                            {fmtMs(n().cold_ms)}
-                          </span>
-                          <Show when={n().staleness}>
-                            {(s) => (
-                              <StalenessDot
-                                staleness={s()}
-                                inputsChanged={n().inputsChanged}
-                                isMark={n().producer === 'mark'}
-                              />
-                            )}
-                          </Show>
-                        </div>
-                        <div
-                          style={{
-                            display: 'flex',
-                            'align-items': 'center',
-                            gap: '0.3rem',
-                            'font-size': '0.66rem',
-                            'font-family': 'ui-monospace, Menlo, monospace',
-                            color: isLLM() ? '#9a8fb5' : '#9aa4ad',
-                            'white-space': 'nowrap',
-                            overflow: 'hidden',
-                            'text-overflow': 'ellipsis',
-                          }}
-                        >
-                          <Show when={n().authority}>
-                            {(a) => <AuthorityBadge authority={a()} />}
-                          </Show>
-                          {isLLM()
-                            ? `${(n().model ?? '').split('/').pop()} · ${fmtCost(n().cost)}`
-                            : 'source · $0'}
-                        </div>
-                      </div>
-                      <Show when={hasKids(id)}>
-                        <button
-                          type="button"
-                          onClick={(ev) => {
-                            ev.stopPropagation();
-                            props.onSelect(id);
-                            props.onToggleExpand(id);
-                          }}
-                          title={exp() ? 'collapse inputs' : 'expand inputs'}
-                          style={{
-                            'flex-shrink': 0,
-                            width: '18px',
-                            height: '18px',
-                            'border-radius': '50%',
-                            border: '1px solid #d8c9c0',
-                            background: '#fff',
-                            color: '#8a7d74',
-                            cursor: 'pointer',
-                            'font-size': '0.8rem',
-                            'line-height': 1,
-                            display: 'inline-flex',
-                            'align-items': 'center',
-                            'justify-content': 'center',
-                            padding: 0,
-                          }}
-                        >
-                          {exp() ? '–' : '+'}
-                        </button>
-                      </Show>
-                    </div>
-                  );
-                }}
-              </For>
-            </div>
-          )}
-        </Show>
+        <RunTreeCanvas
+          tree={props.tree}
+          loading={props.loading}
+          selected={props.selected}
+          onSelect={props.onSelect}
+          expanded={props.expanded}
+          onToggleExpand={props.onToggleExpand}
+          emptyLabel={props.emptyLabel}
+        />
       </div>
 
       {/* node detail */}


### PR DESCRIPTION
## What

Finishes deduplicating the inspector DAG. `RunTreeDock` embedded its own ~220-line copy of the build-provenance DAG canvas (SVG edges + node cards + lane layout + the incident-edge focus highlight) — byte-identical to the shared `@corpus/ui/RunTreeDag`'s canvas, the duplication the dock's own code comment flagged (*"fold both onto a shared component once that settles"*).

- **New `@corpus/ui/RunTreeCanvas`** — presentational, controlled (tree + `selected`/`expanded` via props). Renders only the canvas (loading / empty / the positioned layout with edges + node cards + click-to-select + the per-node expand button); the host supplies the surrounding scroll box and its own node-detail pane. SVG marker ids are **per-instance (`createUniqueId`)** so two DAGs mounted in one document can't cross-resolve their arrowheads (improves on the prior shared-id behavior too).
- **`RunTreeDag`** is now canvas + detail-slot around `RunTreeCanvas` — no visual change.
- **`RunTreeDock`** keeps its richer node-detail pane, `FreshnessPanel`, resize, the `rootInstances` picker, the waterfall, and the by-anchor groups — only its inline DAG canvas is replaced by `<RunTreeCanvas>`; the dead helpers (`layout`/`connected`/`isIncident`/`nodeY`/`hasKids`/`badgeColor`) and their imports are removed.

Net: **one** DAG renderer behind talmud's dock, talmud's AlignPage, and the tanach inspector + alignment page.

## Gate
113 core + 64 tanach + 2551 talmud tests green; `pnpm typecheck` + `pnpm lint` + both builds clean. Reviewed read-only with Codex — dock selection / expand / focus-highlight / detail / freshness / resize / `rootInstances` all preserved, no dangling refs; the one finding (marker-id collision) is fixed.