### PR TITLE
Generation coordinator trigger: /api/daf-generate single-flight + lower queue concurrency

### DIFF
--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -303,7 +303,12 @@ import {
 } from './warm-cron';
 import { lookupGloss } from './word-glosses';
 import { checkWorkerHealthAndAlert, fetchWorkerOutcomes } from './worker-health';
-import { type DafWarmParams, perInstanceEnrichments, wholeDafEnrichmentIds } from './workflow-warm';
+import {
+  type DafWarmParams,
+  dafGenSentinelKey,
+  perInstanceEnrichments,
+  wholeDafEnrichmentIds,
+} from './workflow-warm';
 import { runYomiWarmCron } from './yomi-cron';
 
 // `Bindings` and `JobMessage` now live in ./types (a neutral module so route
@@ -3217,6 +3222,38 @@ app.post('/api/admin/workflow-warm/:tractate/:page', async (c) => {
   const lang: 'en' | 'he' = c.req.query('lang') === 'he' ? 'he' : 'en';
   const instance = await wf.create({ params: { tractate, page, lang } });
   return c.json({ ok: true, id: instance.id, tractate, page, lang });
+});
+
+// The generation coordinator's trigger (Phase 2 foundation): kick off ONE
+// per-daf warm Workflow, single-flighted via a short KV sentinel so N concurrent
+// readers trigger ONE generation, not N. Open (readers call it) but budget-gated
+// and rate-limited by the sentinel (one Workflow per daf+lang per 15 min). The
+// Workflow generates the daf's pieces as bounded per-step invocations; the reader
+// sees them fill in via /api/daf-view. (The client cutover + streaming render are
+// the next step; this is the verifiable backend the coordinator is built on.)
+app.post('/api/daf-generate/:tractate/:page', async (c) => {
+  const wf = c.env.DAF_WARM_WORKFLOW;
+  if (!wf) return c.json({ error: 'DAF_WARM_WORKFLOW binding not available' }, 503);
+  const tractate = c.req.param('tractate');
+  const page = c.req.param('page');
+  const lang: 'en' | 'he' = c.req.query('lang') === 'he' ? 'he' : 'en';
+  const gate = await checkBudget(c.env, { custom: false });
+  if (!gate.ok) {
+    return c.json({ generating: false, paused: true, error: pauseErrorMessage(gate.scope) });
+  }
+  const cache = c.env.CACHE;
+  const sentinel = dafGenSentinelKey(tractate, page, lang);
+  // Single-flight: if a generation is already in flight for this daf, return it
+  // rather than starting a duplicate. (A rare simultaneous-first-hit race may
+  // start two; the 2nd's steps mostly cache-hit the 1st's output — a no-op. A
+  // Durable Object would make this atomic; the sentinel is good enough here.)
+  if (cache) {
+    const inflight = await cache.get(sentinel);
+    if (inflight) return c.json({ generating: true, already: true, instanceId: inflight });
+  }
+  const instance = await wf.create({ params: { tractate, page, lang } });
+  if (cache) await cache.put(sentinel, instance.id, { expirationTtl: 900 });
+  return c.json({ generating: true, instanceId: instance.id });
 });
 
 app.post('/api/admin/rewarm/:id/:tractate/:page', async (c) => {

--- a/packages/talmud/src/worker/workflow-warm.ts
+++ b/packages/talmud/src/worker/workflow-warm.ts
@@ -70,3 +70,15 @@ export interface DafWarmParams {
   page: string;
   lang: 'en' | 'he';
 }
+
+/**
+ * The single-flight sentinel key for /api/daf-generate. N concurrent readers of
+ * the same daf+lang must compute the SAME key so they coalesce onto one in-flight
+ * Workflow instead of starting N. Versioned (`v1`) so the format can evolve
+ * without colliding with stale entries. Per (tractate, page, lang) — language is
+ * part of the key because EN and HE generate distinct pieces. Kept byte-stable by
+ * the test suite: a silent prefix/format change would break single-flight.
+ */
+export function dafGenSentinelKey(tractate: string, page: string, lang: 'en' | 'he'): string {
+  return `dafgen:v1:${tractate}:${page}:${lang}`;
+}

--- a/packages/talmud/tests/workflow-warm.test.ts
+++ b/packages/talmud/tests/workflow-warm.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { perInstanceEnrichments, wholeDafEnrichmentIds } from '../src/worker/workflow-warm';
+import {
+  dafGenSentinelKey,
+  perInstanceEnrichments,
+  wholeDafEnrichmentIds,
+} from '../src/worker/workflow-warm';
 
 const MARKS = [
   { id: 'argument-overview', anchor: 'whole-daf' },
@@ -111,5 +115,35 @@ describe('wholeDafEnrichmentIds', () => {
 
   it('is empty for an empty registry', () => {
     expect(wholeDafEnrichmentIds([], [])).toEqual([]);
+  });
+});
+
+// The /api/daf-generate single-flight sentinel. N concurrent readers of the
+// same daf+lang MUST land on the same key (so they coalesce onto one Workflow),
+// and EN/HE must differ (they generate distinct pieces). A silent prefix/format
+// change here would break single-flight (every reader starts its own Workflow),
+// so the format is pinned byte-for-byte.
+describe('dafGenSentinelKey', () => {
+  it('is byte-stable per (tractate, page, lang)', () => {
+    expect(dafGenSentinelKey('Berakhot', '2a', 'en')).toBe('dafgen:v1:Berakhot:2a:en');
+    expect(dafGenSentinelKey('Chullin', '52a', 'he')).toBe('dafgen:v1:Chullin:52a:he');
+  });
+
+  it('is identical for the same daf+lang (so concurrent readers coalesce)', () => {
+    expect(dafGenSentinelKey('Shabbat', '21b', 'en')).toBe(
+      dafGenSentinelKey('Shabbat', '21b', 'en'),
+    );
+  });
+
+  it('differs by language (EN and HE generate distinct pieces)', () => {
+    expect(dafGenSentinelKey('Shabbat', '21b', 'en')).not.toBe(
+      dafGenSentinelKey('Shabbat', '21b', 'he'),
+    );
+  });
+
+  it('differs by daf (no cross-daf coalescing)', () => {
+    expect(dafGenSentinelKey('Shabbat', '21a', 'en')).not.toBe(
+      dafGenSentinelKey('Shabbat', '21b', 'en'),
+    );
   });
 });

--- a/packages/talmud/wrangler.toml
+++ b/packages/talmud/wrangler.toml
@@ -137,13 +137,16 @@ max_batch_timeout = 1
 #
 # Now that per-job source memory is bounded (rishonim capped at the cache
 # boundary #440; concurrent same-daf loads coalesced to one copy #439), peak
-# isolate memory is ~ max_concurrency × per-job footprint. 16 keeps the worst
-# case (all co-scheduled + dense) comfortably under 128 MB while still warming
-# far faster than the old 10 (~12h full-Shas). Raise only alongside a measured
-# drop in per-job footprint — warming speed is a background concern; a reader
-# OOM is not. AI Gateway + runLLM's per-call retry ride out provider 429s within
-# a job, so queue-level retries aren't burned.
-max_concurrency = 16
+# isolate memory is ~ max_concurrency × per-job footprint. 12 keeps the worst
+# case (all co-scheduled + dense) comfortably under 128 MB with extra headroom
+# against the sporadic co-located OOMs, while still warming far faster than the
+# old 10. Heavy per-daf generation is additionally being moved off the queue
+# onto the DafWarmWorkflow (bounded per-step memory) via /api/daf-generate, so
+# the queue no longer has to carry the worst-case dense daf at full width. Raise
+# only alongside a measured drop in per-job footprint — warming speed is a
+# background concern; a reader OOM is not. AI Gateway + runLLM's per-call retry
+# ride out provider 429s within a job, so queue-level retries aren't burned.
+max_concurrency = 12
 max_retries = 1
 
 [[kv_namespaces]]


### PR DESCRIPTION
## What

Adds the per-daf **generation coordinator's trigger** on top of the `DafWarmWorkflow` (already on master, #476/#479), plus an immediate OOM-headroom tweak.

- **`POST /api/daf-generate/:tractate/:page`** (open, budget-gated) kicks off **one** warm Workflow for a daf, **single-flighted** via a short KV sentinel so N concurrent readers of the same daf coalesce onto one generation instead of starting N. Heavy per-daf generation then runs as **bounded per-step Workflow invocations** (per-step memory budget) rather than a wide queue fan-out — the structural cure for the sporadic co-located isolate OOMs.
- **`dafGenSentinelKey()`** extracted as a pure helper (`dafgen:v1:t:p:lang`) so the single-flight contract is byte-locked by tests; a silent prefix/format change would break coalescing.
- **Lower queue `max_concurrency` 16 -> 12** for immediate OOM headroom while heavy generation migrates off the queue onto the Workflow.

## Scope

Backend-only and **additive** — does not touch the reader render path. Safe to ship independently.

## Next (separate PR)

The client cutover (read `/api/daf-view`, trigger this endpoint on a miss, render pieces progressively) and parallel/streaming generation in the Workflow.

## Verification

- `dafGenSentinelKey` byte-stability + per-`(daf, lang)` coalescing/divergence tests
- Full suite green (2555 tests); `tsc` clean; `biome` clean
- `wrangler deploy --dry-run` validates the `DAF_WARM_WORKFLOW` binding