### PR TITLE
PR-10 cleanup: remove dead four-primitive-consolidation indirection

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,6 @@
     "./registry/*": "./src/registry/*.ts",
     "./sidebar/*": "./src/sidebar/*.ts",
     "./llm/*": "./src/llm/*.ts",
-    "./studio/*": "./src/studio/*.ts",
     "./cache/*": "./src/cache/*.ts",
     "./sefaria/*": "./src/sefaria/*.ts",
     "./model/*": "./src/model/*.ts",

--- a/packages/talmud/src/worker/producer-registry.ts
+++ b/packages/talmud/src/worker/producer-registry.ts
@@ -104,21 +104,14 @@ export function richMarkFromKvDef(kv: KvMarkDefinition): SchemaMarkDefinition {
 }
 
 // ---------------------------------------------------------------------------
-// Flat KV enrichment def ↔ rich (studio-schema) def. The old loadEnrichmentDef
-// returned the flat KV def VERBATIM (the runner consumes the flat shape), so
-// unlike marks there was no synthesis to copy — this pair exists so the KV def
-// can ride through the Producer projection and come back byte-identical:
-//   flat ─richEnrichmentFromKvDef→ rich ─producerFromEnrichment→ Producer
-//        ─enrichmentFromProducer→ rich ─kvEnrichmentFromRichDef→ flat (verbatim)
-// Synthesis constants mirror the mark synthesis (status 'draft', def_hash
-// 'kv') plus mode 'augment-content' (KV enrichments are per-instance prompt
-// experiments; the old code never assigned them a mode at all — the constant
-// only shapes Producer metadata and is stripped again by the inverse, so no
-// behavior changes). Unknown KV-authored extra fields ride along verbatim
-// (→ Producer.legacy.rest), preserving the old "return kv verbatim" contract;
-// the one unrepresentable case is an extra whose name collides with a rich
-// field (mode/target_mark/extractor/…) — impossible via the CRUD, which
-// validates + strips extras on write.
+// Flat KV enrichment def → rich (studio-schema) def, so a KV-authored def can
+// ride through the Producer projection (flat ─richEnrichmentFromKvDef→ rich
+// ─producerFromEnrichment→ Producer). Synthesis constants mirror the mark
+// synthesis (status 'draft', def_hash 'kv') plus mode 'augment-content' (KV
+// enrichments are per-instance prompt experiments; the old code never assigned
+// them a mode — the constant only shapes Producer metadata). Unknown
+// KV-authored extra fields ride along verbatim (→ Producer.legacy.rest),
+// preserving the old "return kv verbatim" contract.
 // ---------------------------------------------------------------------------
 
 const KV_ENRICHMENT_FLAT_FIELDS = new Set([
@@ -137,24 +130,6 @@ const KV_ENRICHMENT_FLAT_FIELDS = new Set([
   'output_schema',
   'thinking_off',
   'reasoning_effort',
-  'cache_version',
-  'source',
-  'updated_at',
-]);
-
-const RICH_ENRICHMENT_FIELDS = new Set([
-  'id',
-  'label',
-  'description',
-  'category',
-  'target_mark',
-  'mode',
-  'scope',
-  'dependencies',
-  'passes',
-  'extractor',
-  'status',
-  'def_hash',
   'cache_version',
   'source',
   'updated_at',
@@ -189,35 +164,6 @@ export function richEnrichmentFromKvDef(kv: KvEnrichmentDefinition): SchemaEnric
     source: kv.source,
     updated_at: kv.updated_at,
   } as SchemaEnrichmentDefinition;
-}
-
-/** Exact inverse of {@link richEnrichmentFromKvDef}: strips the synthesis
- *  constants (mode/status/def_hash) and unnests the LLM extractor back into
- *  the flat prompt fields. Only ever applied to KV-resolved defs, whose
- *  extractor is always the 'llm' shape the synthesis built. */
-export function kvEnrichmentFromRichDef(def: SchemaEnrichmentDefinition): KvEnrichmentDefinition {
-  const llm = def.extractor as LLMExtractor;
-  return {
-    ...restExcept(def, RICH_ENRICHMENT_FIELDS),
-    id: def.id,
-    label: def.label,
-    ...ownKey(def, 'description'),
-    mark: def.target_mark,
-    scope: def.scope,
-    ...ownKey(def, 'dependencies'),
-    ...ownKey(def, 'passes'),
-    system_prompt: llm.system_prompt,
-    user_prompt_template: llm.user_prompt_template,
-    ...ownKey(llm, 'system_prompt_he'),
-    ...ownKey(llm, 'user_prompt_template_he'),
-    ...ownKey(llm, 'model'),
-    ...ownKey(llm, 'output_schema'),
-    ...ownKey(llm, 'thinking_off'),
-    ...ownKey(llm, 'reasoning_effort'),
-    cache_version: def.cache_version,
-    source: def.source,
-    updated_at: def.updated_at,
-  } as KvEnrichmentDefinition;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/talmud/src/worker/studio-schema.ts
+++ b/packages/talmud/src/worker/studio-schema.ts
@@ -59,9 +59,7 @@ import type { SidebarRecipe } from '@corpus/core/sidebar/recipe';
 //
 // The SHAPES are owned by @corpus/core/model/compat (the Legacy* structural
 // types the four-primitive bridges project from) and re-exported here under
-// their original studio names, so consumer imports are unchanged. The
-// anchor→render COMPATIBLE matrix stays in this file — render kinds are
-// app-side.
+// their original studio names, so consumer imports are unchanged.
 // ===========================================================================
 
 /** The seven anchor kinds:
@@ -198,19 +196,6 @@ export type RenderConfig =
   | VisualizationRenderConfig
   | ConnectionRenderConfig
   | ChipRenderConfig;
-
-/** Anchor × Render compatibility — enforced by validateMark. Adding a row to
- *  this matrix opens a new combination; the corresponding renderer must
- *  handle it. */
-export const COMPATIBLE: Readonly<Record<AnchorKind, RenderKind[]>> = {
-  segment: ['row-tag', 'inline'],
-  'segment-range': ['gutter+sidebar', 'inline'],
-  phrase: ['inline', 'meta-component'],
-  'multi-anchor': ['connection', 'gutter+sidebar'],
-  'cross-daf': ['inline', 'meta-component'],
-  external: ['inline', 'meta-component'],
-  'whole-daf': ['chip', 'visualization'],
-};
 
 // ===========================================================================
 // Extractor — how a mark's instances are computed.
@@ -535,20 +520,6 @@ export interface MarkRunOutput {
 }
 
 // ===========================================================================
-// Validation — runtime + compile-time guards.
-// ===========================================================================
-
-export const ID_RE = /^[a-z][a-z0-9._-]{0,63}$/i;
-
-export function isValidId(s: unknown): s is string {
-  return typeof s === 'string' && ID_RE.test(s);
-}
-
-export function isCompatible(anchor: AnchorKind, render: RenderKind): boolean {
-  return COMPATIBLE[anchor]?.includes(render) ?? false;
-}
-
-// ===========================================================================
 // AUTHORING CHECKLIST — what to ask the user when they propose a new mark.
 // ===========================================================================
 /*
@@ -577,7 +548,7 @@ correct the ones I got wrong.
 
   6. render       — pick from { inline, gutter+sidebar, row-tag,
                     meta-component, overlay, visualization, connection, chip }.
-                    Confirm against COMPATIBLE matrix. Defaults by anchor:
+                    Defaults by anchor:
                       phrase        → inline
                       segment-range → gutter+sidebar
                       segment       → row-tag


### PR DESCRIPTION
## What

The closing **PR-10** of the four-primitive consolidation (#356–#364): retire the legacy indirection that's now pure dead code.

The honest finding: the consolidation was done cleanly — `knip` reports **zero** unused exports anywhere in `@corpus/core` (the compat bridges are all load-bearing). So this is a small, surgical removal of the few verified-dead leftovers:

- **`studio-schema.ts`** — drop the legacy studio validators nothing calls anymore: the `COMPATIBLE` anchor×render matrix + `isCompatible` (`validateMark` no longer checks compatibility), and `ID_RE` + `isValidId` (`studio-registry` carries its own local copies). Stale authoring-checklist + header comments updated.
- **`producer-registry.ts`** — drop `kvEnrichmentFromRichDef`, the never-called inverse of `richEnrichmentFromKvDef` (the KV loader returns the flat def verbatim, so the rich→flat inverse was never needed), plus `RICH_ENRICHMENT_FIELDS` (used only by it). The forward KV→rich→Producer projection is untouched.
- **`core/package.json`** — drop the `./studio/*` exports glob (`src/studio/` doesn't exist; nothing imports `@corpus/core/studio/*`).

## Safety
Each removal verified to have **zero static importers**, including no test usage. Codex review (read-only) confirmed no dynamic / re-export / string-keyed reachability a grep would miss, and that `validateMark` + the registry round-trip are unaffected.

`pnpm typecheck` + `pnpm lint` + 113 core / 64 tanach / 2551 talmud tests + both builds all green.