### PR TITLE
Daf-view render: gate enrichment cards on the view (stop warm-daf /api/run fan-out)

### DIFF
--- a/packages/talmud/src/client/MarkEnrichmentCards.tsx
+++ b/packages/talmud/src/client/MarkEnrichmentCards.tsx
@@ -563,10 +563,18 @@ export default function MarkEnrichmentCards(props: Props) {
           applyResult(d, s, cached);
           continue;
         }
+        // Wait for the materialized daf-view to settle before firing /api/run.
+        // It's ONE fetch that serves every cached piece; firing per-card before
+        // it lands just races it and wastes a request (the warm-daf fan-out the
+        // view was meant to eliminate). This effect re-runs when the view settles
+        // (viewReady is a tracked read above). Fail-safe: loadDafView ALWAYS
+        // settles (empty on failure), so a hit becomes possible OR we fall
+        // through and fetch as before — the gate never hangs.
+        if (!viewReady) continue;
         // Second tier: the materialized daf-view (one fetch on daf open). Serves
         // WHOLE-DAF pieces (keyed by producer id) so they render without their
-        // own /api/run. Best-effort + guaranteed-correct key — a miss (view not
-        // loaded, or a per-instance piece) just falls through to the fetch below.
+        // own /api/run. Best-effort + guaranteed-correct key — a miss (a
+        // per-instance piece) just falls through to the per-instance tier below.
         const fromView = dafViewWholeDafResult(d.id, props.tractate, props.page, curLang);
         if (fromView) {
           runResultCache.set(
@@ -577,24 +585,21 @@ export default function MarkEnrichmentCards(props: Props) {
           continue;
         }
         // Third tier: PER-INSTANCE daf-view pieces (keyed producerId::instanceId).
-        // Only when the view is loaded (a hit is possible) — and gate on the
-        // instanceId hash: if it hasn't settled, wait (this effect re-runs when it
-        // does) rather than fetch-then-miss. The hash settles in ~1ms, so the gate
-        // is imperceptible; if the view isn't loaded we skip the gate and fetch as
-        // today. Fail-safe: any miss falls through to the fetch below.
-        if (viewReady) {
-          if (iid === undefined) continue; // hash not settled yet — re-runs on settle
-          const fromInstance = iid
-            ? dafViewPieceResult(d.id, iid, props.tractate, props.page, curLang)
-            : undefined;
-          if (fromInstance) {
-            runResultCache.set(
-              runCacheKey(d.id, props.tractate, props.page, props.instanceKey, curLang),
-              fromInstance,
-            );
-            applyResult(d, s, fromInstance);
-            continue;
-          }
+        // The view is loaded here (gated above), so a hit is possible — gate on
+        // the instanceId hash: if it hasn't settled, wait (this effect re-runs
+        // when it does) rather than fetch-then-miss. The hash settles in ~1ms, so
+        // the gate is imperceptible. Fail-safe: any miss falls through to fetch.
+        if (iid === undefined) continue; // hash not settled yet — re-runs on settle
+        const fromInstance = iid
+          ? dafViewPieceResult(d.id, iid, props.tractate, props.page, curLang)
+          : undefined;
+        if (fromInstance) {
+          runResultCache.set(
+            runCacheKey(d.id, props.tractate, props.page, props.instanceKey, curLang),
+            fromInstance,
+          );
+          applyResult(d, s, fromInstance);
+          continue;
         }
         const cur = runs()[d.id];
         if (cur && cur.kind !== 'idle' && cur.stamp === s) continue;

--- a/packages/talmud/src/client/dafViewStore.ts
+++ b/packages/talmud/src/client/dafViewStore.ts
@@ -44,11 +44,20 @@ const [view, setView] = createSignal<{ key: string; pieces: Record<string, DafVi
   null,
 );
 
+// The most recently REQUESTED daf-view key. A load only writes the signal if its
+// key is still the latest — so a slow/failed load for a daf the user already
+// navigated away from can never clobber the view of the daf now on screen.
+let latestKey = '';
+
 /**
- * Fire-and-forget: load the materialized view for a daf and stash it. Called as
- * early as possible on daf open so it's usually ready by the time a whole-daf
- * card would otherwise fetch. Best-effort — any failure leaves the store empty
- * and cards fetch per-piece as before.
+ * Load the materialized view for a daf and stash it. Called as early as possible
+ * on daf open so it's ready by the time a card would otherwise fetch.
+ *
+ * The signal ALWAYS settles — on success with the pieces, on failure/timeout
+ * with an empty view. That matters because cards gate their `/api/run` on
+ * `dafViewLoaded`: settling-even-on-failure guarantees the gate resolves (cards
+ * fall through and fetch as before) instead of hanging forever. Fail-safe: an
+ * empty view just means every lookup misses and the card fetches per-piece.
  */
 export async function loadDafView(
   tractate: string,
@@ -56,13 +65,28 @@ export async function loadDafView(
   lang: 'en' | 'he',
 ): Promise<void> {
   const key = dafKey(tractate, page, lang);
+  latestKey = key;
+  // Only write the signal if THIS is still the daf the reader is on.
+  const settle = (pieces: Record<string, DafViewPiece>) => {
+    if (latestKey === key) setView({ key, pieces });
+  };
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), 15000);
   try {
-    const r = await fetch(`/api/daf-view/${encodeURIComponent(tractate)}/${page}?lang=${lang}`);
-    if (!r.ok) return;
+    const r = await fetch(`/api/daf-view/${encodeURIComponent(tractate)}/${page}?lang=${lang}`, {
+      signal: ctrl.signal,
+    });
+    if (!r.ok) {
+      settle({});
+      return;
+    }
     const j = (await r.json()) as DafViewPayload;
-    setView({ key, pieces: j.pieces ?? {} });
+    settle(j.pieces ?? {});
   } catch {
-    /* best-effort: leave the store as-is */
+    // Network error / abort / timeout: settle empty so the gate resolves.
+    settle({});
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/packages/talmud/tests/daf-view-store.test.ts
+++ b/packages/talmud/tests/daf-view-store.test.ts
@@ -80,6 +80,61 @@ describe('loadDafView + dafViewWholeDafResult', () => {
   });
 });
 
+// The card effect gates its /api/run on dafViewLoaded(). For that gate to be
+// fail-safe (never hang a card), loadDafView MUST settle the loaded flag even
+// when the fetch fails — the card then falls through and fetches as before.
+describe('loadDafView fail-safe settle', () => {
+  it('marks the view LOADED even on an HTTP error (so the card gate resolves)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('{}', { status: 500 })),
+    );
+    await loadDafView('Berakhot', '4a', 'en');
+    expect(dafViewLoaded('Berakhot', '4a', 'en')).toBe(true); // settled...
+    expect(dafViewWholeDafResult('tidbit', 'Berakhot', '4a', 'en')).toBeUndefined(); // ...but empty
+  });
+
+  it('marks the view LOADED even when fetch throws (network error)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('network down');
+      }),
+    );
+    await loadDafView('Berakhot', '4b', 'en');
+    expect(dafViewLoaded('Berakhot', '4b', 'en')).toBe(true);
+  });
+});
+
+// A slow load for a daf the reader already left must never overwrite the view of
+// the daf now on screen (the user navigates while a fetch is in flight).
+describe('loadDafView latest-key guard', () => {
+  it('a stale load resolving LAST does not clobber the current daf', async () => {
+    const resolvers: Record<string, (r: Response) => void> = {};
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        (url: string) =>
+          new Promise<Response>((res) => {
+            resolvers[url.includes('/52a') ? 'stale' : 'current'] = res;
+          }),
+      ),
+    );
+    const pStale = loadDafView('Chullin', '52a', 'en'); // reader was here
+    const pCurrent = loadDafView('Chullin', '53a', 'en'); // ...then navigated here
+    const body = (id: string) =>
+      new Response(JSON.stringify({ pieces: { tidbit: piece({ producerId: id }) } }), {
+        status: 200,
+      });
+    // current resolves first, the stale one resolves AFTER (the race we guard).
+    resolvers.current(body('current'));
+    resolvers.stale(body('stale'));
+    await Promise.all([pStale, pCurrent]);
+    expect(dafViewLoaded('Chullin', '53a', 'en')).toBe(true); // current view stands
+    expect(dafViewLoaded('Chullin', '52a', 'en')).toBe(false); // stale never took over
+  });
+});
+
 describe('dafViewLoaded', () => {
   function stubFetch(payload: unknown) {
     vi.stubGlobal(


### PR DESCRIPTION
## What

Browser-rendering verification (headless Chrome via Cloudflare Browser Rendering, driven against prod) revealed that a **fully warm** daf still fires **~78 `POST /api/run`** — ~65 of them *after* `/api/daf-view` had already resolved with every piece present. The materialized-view optimization (#461–#472) wasn't actually preventing the fan-out.

Root cause in the enrichment-card effect: the whole-daf tier was only consulted *after* the card had already raced ahead and fired `/api/run` (no `viewReady` gate), and a failed/slow view load never settled the gate.

## This slice (enrichment-card path)

- **Gate the card's `/api/run` on `dafViewLoaded()`** — wait for the ONE view fetch to settle before firing per-card. Then whole-daf + per-instance pieces render from it; a miss falls through and fetches as before. The effect re-runs when the view settles.
- **`loadDafView` now ALWAYS settles** the loaded flag (empty view on HTTP error, network error, or a 15s timeout) so the gate can never hang a card. A **latest-key guard** prevents a slow load for a daf the reader already left from clobbering the daf now on screen.
- Dropped the per-instance tier's now-redundant `viewReady` check.

## Safety

`MarkEnrichmentCards` only mounts under `DafViewer`, which always calls `loadDafView`. Worst case: a warm card waits for the single view fetch instead of firing a redundant cache-hit `/api/run`. Fail-safe throughout.

## Verification

- New tests: fail-safe settle (HTTP + network error → `loaded:true` but empty) + latest-key race guard. Full suite green (2558), typecheck + biome clean.
- Will verify live with the browser harness post-deploy (expect the enrichment `/api/run` count to drop sharply).

## Follow-up slices

Route the **base marks** (DafViewer) and the **argument / argument-move cards** (ArgumentSidebar/ArgumentNarrative) through the view too; fix the single-cold-piece completeness bug (`rabbi.identity.pin` flips a 99%-warm daf to `complete:false`).