### PR TITLE
Entity pieces PR1: register entity:rabbi / entity:place spines (rails, no behavior change)

### DIFF
--- a/packages/core/src/cache/keys.ts
+++ b/packages/core/src/cache/keys.ts
@@ -174,7 +174,13 @@ export async function instanceIdOf(markInput: unknown): Promise<string> {
   return await shortHash(JSON.stringify(markInput ?? null));
 }
 
-function slugId(s: string): string {
+/** The canonical identity slug for a mark instance / entity. This is the SAME
+ *  function {@link instanceIdOf} applies to a rabbi/place name to derive the
+ *  cache `instance_id` (e.g. "Rav Huna" → "rav_huna"), so it is also the path
+ *  component an `entity:*` spine address uses — keeping an entity anchor's id
+ *  byte-identical to the cache key's instance_id (see model/anchor.entityAnchor
+ *  and the talmud spine registry). Exported so there is ONE slug, not two. */
+export function slugId(s: string): string {
   return s
     .toLowerCase()
     .replace(/[^a-z0-9._-]+/g, '_')

--- a/packages/core/src/model/anchor.ts
+++ b/packages/core/src/model/anchor.ts
@@ -48,6 +48,21 @@ export function isRange(p: AnchorPoint | AnchorRange): p is AnchorRange {
   return 'start' in p;
 }
 
+/**
+ * The anchor for a piece that sits on an ENTITY spine (`entity:rabbi`,
+ * `entity:place`) rather than a text position — a one-level address whose single
+ * path component is the entity id. `precision:'unit'` (the whole entity is the
+ * addressable unit; entity spines are unordered, so there is no finer grain).
+ *
+ * `id` MUST be the canonical identity slug (cache/keys `slugId`) so the anchor's
+ * id is byte-identical to the global enrichment's cache `instance_id` — the
+ * invariant that lets these pieces be expressed on a spine WITHOUT changing any
+ * cache key. `via` records how the placement was earned (defaults to 'entity').
+ */
+export function entityAnchor(spineId: string, id: string, via = 'entity'): Anchor {
+  return { spine: spineId, span: [{ path: [id] }], precision: 'unit', via };
+}
+
 const PRECISION_RANK: Record<AnchorPrecision, number> = {
   token: 5,
   segment: 4,

--- a/packages/core/tests/entity-anchor.test.ts
+++ b/packages/core/tests/entity-anchor.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { slugId } from '../src/cache/keys.ts';
+import { anchorKey, entityAnchor } from '../src/model/anchor.ts';
+
+describe('entityAnchor — the anchor for an entity-spine piece', () => {
+  it('is a one-level address: spine + [id] path, precision unit', () => {
+    expect(entityAnchor('entity:rabbi', 'rav_huna')).toEqual({
+      spine: 'entity:rabbi',
+      span: [{ path: ['rav_huna'] }],
+      precision: 'unit',
+      via: 'entity',
+    });
+  });
+
+  it('via defaults to "entity" and can be overridden', () => {
+    expect(entityAnchor('entity:place', 'sura', 'human').via).toBe('human');
+  });
+
+  it('anchorKey is stable and reflects the spine + id (provenance/display excluded)', () => {
+    const a = entityAnchor('entity:rabbi', 'abaye');
+    const b = entityAnchor('entity:rabbi', 'abaye', 'human'); // different via, same LOCATION
+    expect(anchorKey(a)).toBe(anchorKey(b));
+    expect(anchorKey(a)).toContain('entity:rabbi');
+    expect(anchorKey(a)).not.toBe(anchorKey(entityAnchor('entity:rabbi', 'rava')));
+  });
+
+  it('the id is taken verbatim — callers pass the canonical slug', () => {
+    // entityAnchor does NOT slug; that is the caller's job (via slugId), so the
+    // id stays byte-identical to the cache instance_id it must match.
+    expect(entityAnchor('entity:rabbi', slugId('Rav Huna')).span).toEqual([{ path: ['rav_huna'] }]);
+  });
+});

--- a/packages/talmud/src/worker/spines.ts
+++ b/packages/talmud/src/worker/spines.ts
@@ -16,9 +16,18 @@
  *
  * Wiring the reserved 'external' anchor of the four-primitive model: until now no
  * spine consumed a non-Gemara target. These do.
+ *
+ * Entity spines ('entity:rabbi', 'entity:place') are the registries the "global"
+ * rabbi/place enrichments belong to — one position per entity, addressed by its
+ * identity slug. They are UNORDERED (kind:'entity'); their single level is the
+ * id, normalized through the SAME `slugId` the cache uses for an enrichment's
+ * `instance_id`, so an entity anchor's id is byte-identical to the cached key
+ * (e.g. entity:rabbi/'rav_huna' ⇄ enrich:rabbi.bio:5:rav_huna). No cache key
+ * changes — this only gives those pieces an honest place to sit.
  */
 
-import { createSpineRegistry, type SpineDef } from '@corpus/core/model/spine';
+import { slugId } from '@corpus/core/cache/keys';
+import { createSpineRegistry, type RefPart, type SpineDef } from '@corpus/core/model/spine';
 import { CODIFIERS } from '../lib/halacha/codifiers.ts';
 
 const codifierSpines: SpineDef[] = CODIFIERS.map((c) => ({
@@ -28,8 +37,24 @@ const codifierSpines: SpineDef[] = CODIFIERS.map((c) => ({
   levels: ['section', 'chapter', 'entry'],
 }));
 
+/** entity:* spines: one level (the id), slugged to the cache's instance_id.
+ *  NB: matches instanceIdOf byte-for-byte for the real inputs (English
+ *  `fields.name`); a degenerate/Hebrew-only name would slug to "_" here while
+ *  instanceIdOf falls back to a hash — not a corpus case (rabbi/place marks
+ *  always carry an English name), and the authoritative id downstream is
+ *  instanceIdOf's output, not a raw name run back through this. */
+const entitySpine = (id: string, label: string): SpineDef => ({
+  id,
+  kind: 'entity',
+  label,
+  levels: ['id'],
+  normalizePath: (path: RefPart[]) => [slugId(String(path[0]))],
+});
+
 export const talmudSpines = createSpineRegistry([
   { id: 'bavli', kind: 'text', label: 'Talmud Bavli', levels: ['tractate', 'page', 'seg'] },
   { id: 'tanach', kind: 'text', label: 'Tanach', levels: ['book', 'chapter', 'verse'] },
   ...codifierSpines,
+  entitySpine('entity:rabbi', 'Rabbi'),
+  entitySpine('entity:place', 'Place'),
 ]);

--- a/packages/talmud/tests/entity-spine.test.ts
+++ b/packages/talmud/tests/entity-spine.test.ts
@@ -1,0 +1,78 @@
+import { entityAnchor } from '@corpus/core/model/anchor';
+import { describe, expect, it } from 'vitest';
+import { instanceIdOf, keyForEnrichment } from '../src/worker/cache-keys';
+import { findCodeEnrichment } from '../src/worker/code-marks';
+import { talmudSpines } from '../src/worker/spines';
+
+// Entity spines lift the "global" rabbi/place enrichments onto an addressable
+// registry WITHOUT changing any cache key. The whole safety of that rests on one
+// invariant: an entity anchor's id is byte-identical to the enrichment's cache
+// `instance_id`. These tests pin that — and the key shape — so a future change
+// that drifts the entity slug away from instanceIdOf fails here, not in prod.
+
+describe('entity spines are registered + resolve', () => {
+  it('entity:rabbi and entity:place exist, are entity-kind, one level', () => {
+    for (const id of ['entity:rabbi', 'entity:place']) {
+      const def = talmudSpines.get(id);
+      expect(def, id).toBeDefined();
+      expect(def?.kind).toBe('entity');
+      expect(def?.levels).toEqual(['id']);
+    }
+  });
+
+  it('normalizePath slugs the id to the cache instance_id form', () => {
+    expect(talmudSpines.ref('entity:rabbi', ['Rav Huna'])).toEqual(['rav_huna']);
+    expect(talmudSpines.ref('entity:place', ['Eretz Yisrael'])).toEqual(['eretz_yisrael']);
+  });
+
+  it('rejects a path deeper than the single id level', () => {
+    expect(() => talmudSpines.ref('entity:rabbi', ['abaye', 'extra'])).toThrow();
+  });
+});
+
+describe('key-compat invariant — entity id === cache instance_id', () => {
+  // Representative rabbis: single-word, multi-word (underscore slug), title form.
+  for (const name of ['Abaye', 'Rav Huna', 'Rabbi Yochanan']) {
+    it(`${name}: instanceIdOf === entity:rabbi path === entityAnchor id`, async () => {
+      const fromMark = await instanceIdOf({ fields: { name } });
+      const fromSpine = talmudSpines.ref('entity:rabbi', [name])[0];
+      const fromAnchor = entityAnchor('entity:rabbi', fromSpine).span[0];
+      expect(fromSpine).toBe(fromMark);
+      expect((fromAnchor as { path: string[] }).path[0]).toBe(fromMark);
+    });
+  }
+
+  it('place names agree the same way', async () => {
+    const fromMark = await instanceIdOf({ fields: { name: 'Pumbedita' } });
+    expect(talmudSpines.ref('entity:place', ['Pumbedita'])[0]).toBe(fromMark);
+  });
+});
+
+describe('the global enrichment cache key is unchanged by the lift', () => {
+  it('rabbi.bio keys by instance alone (no daf), matching the entity id', async () => {
+    const def = findCodeEnrichment('rabbi.bio');
+    expect(def, 'rabbi.bio def').not.toBeNull();
+    expect((def as { scope: string }).scope).toBe('global');
+
+    const id = await instanceIdOf({ fields: { name: 'Rav Huna' } });
+    // global scope => no daf passed; the key is enrich:rabbi.bio:<v>:<id>.
+    const key = keyForEnrichment(def!, id);
+    expect(key).toBe(
+      `enrich:rabbi.bio:${(def as { cache_version: string }).cache_version}:rav_huna`,
+    );
+    // and the entity anchor addresses exactly that id.
+    expect((entityAnchor('entity:rabbi', id).span[0] as { path: string[] }).path[0]).toBe(
+      'rav_huna',
+    );
+  });
+
+  it('places.profile is global + keyed by instance alone too', async () => {
+    const def = findCodeEnrichment('places.profile');
+    expect(def, 'places.profile def').not.toBeNull();
+    expect((def as { scope: string }).scope).toBe('global');
+    const id = await instanceIdOf({ fields: { name: 'Sura' } });
+    expect(keyForEnrichment(def!, id)).toBe(
+      `enrich:places.profile:${(def as { cache_version: string }).cache_version}:sura`,
+    );
+  });
+});


### PR DESCRIPTION
## What

The foundation (PR1) for lifting the **"global"-scoped rabbi/place enrichments onto entity spines** (roadmap item 5).

**The realization:** a `scope:'global'` enrichment is already a per-entity piece — its cache key is `enrich:rabbi.bio:5:rav_huna` (no tractate/page), keyed by the rabbi slug. What's missing is that the piece can't *say* so: there's no `entity:rabbi` spine registered, and the anchor pretends to sit on a daf. This PR lays the rails; it changes **no cache key and no runtime behavior**.

- **core** — export `slugId` from `cache/keys.ts`: the *one* identity slug `instanceIdOf` already applies to a rabbi/place name to derive the cache `instance_id`, now also the entity spine's path component (so there aren't two slug implementations to drift apart). Add `entityAnchor(spineId, id)` to `model/anchor.ts` — a one-level `{spine, span:[{path:[id]}], precision:'unit', via}` address. Pure; touches no key derivation.
- **talmud** — register `entity:rabbi` + `entity:place` in `talmudSpines` (`kind:'entity'`, unordered, level `['id']`, `normalizePath = slugId`). `talmudSpines` has no runtime consumers yet, so this is purely declarative.

## Safety (the whole point)
Cache keys are byte-frozen (a change cold-misses all of Shas). The key is derived from `scope` + `instance_id`, **orthogonal to the spine**, so the lift is additive. Tests pin the invariant that makes future PRs safe: an entity anchor's id is **byte-identical** to the cache `instance_id` —
`instanceIdOf({fields:{name}}) === ref('entity:rabbi',[name])[0] === entityAnchor id` for Abaye / Rav Huna / Rabbi Yochanan + a place — and the global keys stay the frozen `enrich:rabbi.bio:<v>:rav_huna` / `enrich:places.profile:<v>:sura` shape.

One documented boundary: a Hebrew-only/degenerate name would slug to `_` here while `instanceIdOf` hashes — not a corpus case (rabbi/place marks always carry an English `fields.name`), and the authoritative id downstream is `instanceIdOf`'s output.

## Gate
117 core + 64 tanach + 2564 talmud tests green; `pnpm typecheck` + `pnpm lint` + both builds clean. Codex review: **no findings** (confirmed zero behavior/key change, byte-identity invariant holds).

## Next (separate PRs)
- **PR2** — stamp the entity anchor into the global pieces' build manifest (honest provenance; the inspector shows `entity:rabbi/abaye`). Additive.
- **PR3** — a `/rabbi/:slug` entity view aggregating the already-warmed enrichments + `rabbi.observations` + the dapim a rabbi appears on. Read-only, no spend.