### PR TITLE
Daf-view render: prefetcher skips pieces already in the view (kill warm-daf /api/run fan-out)

### DIFF
--- a/packages/talmud/src/client/DafViewer.tsx
+++ b/packages/talmud/src/client/DafViewer.tsx
@@ -806,15 +806,17 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
   createEffect(() => {
     const t = tractate();
     const p = page();
+    const l = lang();
     const statuses = markStatuses();
     const relevant = statuses.filter((s) => s.kind !== 'idle');
     if (relevant.length === 0) return; // no marks enabled / loaded yet
     if (relevant.some((s) => s.kind === 'loading')) return; // anchors not done
     const runs = markRunsByMarkId();
     // The Overview is promoted to readers, so warm its flow on every daf load
-    // (cache-respecting — a hit on already-warmed dapim costs nothing).
+    // (cache-respecting — a hit on already-warmed dapim costs nothing). Keyed on
+    // lang too, so an EN↔HE switch re-evaluates against the view for that lang.
     const sig =
-      `${t}:${p}:ov|` +
+      `${t}:${p}:${l}:ov|` +
       Object.entries(runs)
         .map(
           ([m, r]) =>
@@ -824,7 +826,7 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
         .join(',');
     if (sig === lastPrefetchSig) return;
     lastPrefetchSig = sig;
-    prefetchDaf(t, p, runs, { overview: true });
+    prefetchDaf(t, p, runs, { overview: true, lang: l });
   });
 
   // Comprehensively pre-warm the adjacent dapim on idle so navigating either

--- a/packages/talmud/src/client/dafPrefetch.ts
+++ b/packages/talmud/src/client/dafPrefetch.ts
@@ -21,6 +21,7 @@
  */
 
 import { createSignal } from 'solid-js';
+import { dafViewHas, ensureDafView } from './dafViewStore';
 import { isAbort, isPausedError } from './enrichmentQueue';
 import { enqueueEnrichmentRun } from './MarkEnrichmentCards';
 
@@ -146,9 +147,10 @@ export function prefetchDaf(
   tractate: string,
   page: string,
   marks: Record<string, MarkRun | undefined>,
-  opts?: { overview?: boolean },
+  opts?: { overview?: boolean; lang?: 'en' | 'he' },
 ): void {
   const dafKey = `${tractate}:${page}`;
+  const lang = opts?.lang ?? 'en';
   const myGen = ++gen;
   // Supersede any previous cohort: abort it so its tasks vacate the shared
   // queue, then arm a fresh controller for this daf's tasks.
@@ -226,59 +228,78 @@ export function prefetchDaf(
   });
   if (tasks.length === 0) return;
 
-  for (const t of tasks) {
-    // Resolve with the error (or null) so we can classify the outcome — a card
-    // still generates on open, but a budget pause or a wave of failures should
-    // surface in the bar instead of filling silently.
-    void enqueueEnrichmentRun(
-      t.enrichmentId,
-      tractate,
-      page,
-      t.instance,
-      t.instanceKey,
-      controller.signal,
-    )
-      .then(
-        () => null,
-        (err: unknown) => err,
-      )
-      .then((err: unknown) => {
-        if (myGen !== gen || controller.signal.aborted || isAbort(err)) return; // superseded / navigated away
-        const paused = isPausedError(err);
-        const failed = err != null && !paused;
-        setProgress((p) => {
-          if (p.dafKey !== dafKey) return p;
-          const done = p.done + 1;
-          return {
-            ...p,
-            dafKey,
-            total: p.total,
-            done,
-            paused: p.paused || paused,
-            failed: p.failed + (failed ? 1 : 0),
-            currentLabel: done < p.total ? (FRIENDLY[t.enrichmentId] ?? 'dafLoad.sections') : null,
-          };
-        });
-      });
-  }
+  // Bump the bar for one finished (or skipped-because-already-warm) task.
+  const markDone = (enrichmentId: string, paused: boolean, failed: boolean) => {
+    setProgress((p) => {
+      if (p.dafKey !== dafKey) return p;
+      const done = p.done + 1;
+      return {
+        ...p,
+        dafKey,
+        total: p.total,
+        done,
+        paused: p.paused || paused,
+        failed: p.failed + (failed ? 1 : 0),
+        currentLabel: done < p.total ? (FRIENDLY[enrichmentId] ?? 'dafLoad.sections') : null,
+      };
+    });
+  };
 
-  // Reverse-index capture (rabbi.observations) — one daf-level run, fired LAST
-  // and deliberately NOT counted in the visible progress bar: it's an internal
-  // deterministic collect step, not a card the reader opens. Enqueued after the
-  // synthesis tasks so it sits at the back of the LOW queue and runs once they
-  // (incl. rabbi.location, which it reads from cache for the high-confidence
-  // place tier) have landed. Correctness doesn't depend on ordering — it pulls
-  // its mark deps in regardless. mark_input { id: 'daf' } shares the canonical
-  // daf-level cache key with the cron path. Only when the daf has rabbis.
-  const rabbiParsed = marks.rabbi?.parsed as { instances?: MarkInstance[] } | undefined;
-  if (Array.isArray(rabbiParsed?.instances) && rabbiParsed.instances.length > 0) {
-    void enqueueEnrichmentRun(
-      'rabbi.observations',
-      tractate,
-      page,
-      { id: 'daf' },
-      'rabbi.observations:daf',
-      controller.signal,
-    ).catch(() => undefined);
-  }
+  // Warm only what the materialized view doesn't already serve. We wait for the
+  // view to settle first (one fetch, shared with DafViewer's open), then for each
+  // task: if the view already has the piece, count it done and skip the /api/run
+  // (the card renders it from the view) — on a warm daf that's ALL of them, so
+  // the old N-wide fan-out collapses to ~zero. A miss (cold daf, or view failed
+  // to load) enqueues as before. Generation/abort guards drop a superseded daf.
+  void (async () => {
+    await ensureDafView(tractate, page, lang);
+    if (myGen !== gen || controller.signal.aborted) return;
+    for (const t of tasks) {
+      if (myGen !== gen || controller.signal.aborted) return;
+      if (await dafViewHas(t.enrichmentId, t.instance, tractate, page, lang)) {
+        markDone(t.enrichmentId, false, false); // already warm — no request
+        continue;
+      }
+      // Resolve with the error (or null) so we can classify the outcome — a card
+      // still generates on open, but a budget pause or a wave of failures should
+      // surface in the bar instead of filling silently.
+      void enqueueEnrichmentRun(
+        t.enrichmentId,
+        tractate,
+        page,
+        t.instance,
+        t.instanceKey,
+        controller.signal,
+      )
+        .then(
+          () => null,
+          (err: unknown) => err,
+        )
+        .then((err: unknown) => {
+          if (myGen !== gen || controller.signal.aborted || isAbort(err)) return; // superseded / navigated away
+          const paused = isPausedError(err);
+          const failed = err != null && !paused;
+          markDone(t.enrichmentId, paused, failed);
+        });
+    }
+
+    // Reverse-index capture (rabbi.observations) — one daf-level run, deliberately
+    // NOT counted in the visible progress bar: it's an internal deterministic
+    // collect step, not a card the reader opens. Skipped when the view already has
+    // it. mark_input { id: 'daf' } shares the canonical daf-level cache key with
+    // the cron path. Only when the daf has rabbis.
+    const rabbiParsed = marks.rabbi?.parsed as { instances?: MarkInstance[] } | undefined;
+    if (Array.isArray(rabbiParsed?.instances) && rabbiParsed.instances.length > 0) {
+      if (!(await dafViewHas('rabbi.observations', { id: 'daf' }, tractate, page, lang))) {
+        void enqueueEnrichmentRun(
+          'rabbi.observations',
+          tractate,
+          page,
+          { id: 'daf' },
+          'rabbi.observations:daf',
+          controller.signal,
+        ).catch(() => undefined);
+      }
+    }
+  })();
 }

--- a/packages/talmud/src/client/dafViewStore.ts
+++ b/packages/talmud/src/client/dafViewStore.ts
@@ -15,6 +15,7 @@
  * or lacks a piece, the caller just fetches as before — no behaviour change.
  */
 
+import { instanceIdOf } from '@corpus/core/cache/keys';
 import { createSignal } from 'solid-js';
 import type { RunResult } from './enrichmentQueue';
 
@@ -49,9 +50,15 @@ const [view, setView] = createSignal<{ key: string; pieces: Record<string, DafVi
 // navigated away from can never clobber the view of the daf now on screen.
 let latestKey = '';
 
+// In-flight load promise per daf key, so concurrent callers (DafViewer's open
+// effect + the prefetcher) share ONE fetch instead of racing two. Cleared once
+// the load settles.
+const inflight = new Map<string, Promise<void>>();
+
 /**
  * Load the materialized view for a daf and stash it. Called as early as possible
- * on daf open so it's ready by the time a card would otherwise fetch.
+ * on daf open so it's ready by the time a card would otherwise fetch. Concurrent
+ * calls for the same daf share one in-flight fetch.
  *
  * The signal ALWAYS settles — on success with the pieces, on failure/timeout
  * with an empty view. That matters because cards gate their `/api/run` on
@@ -59,12 +66,24 @@ let latestKey = '';
  * fall through and fetch as before) instead of hanging forever. Fail-safe: an
  * empty view just means every lookup misses and the card fetches per-piece.
  */
-export async function loadDafView(
+export function loadDafView(tractate: string, page: string, lang: 'en' | 'he'): Promise<void> {
+  const key = dafKey(tractate, page, lang);
+  const existing = inflight.get(key);
+  if (existing) return existing;
+  const run = doLoadDafView(key, tractate, page, lang);
+  inflight.set(key, run);
+  void run.finally(() => {
+    if (inflight.get(key) === run) inflight.delete(key);
+  });
+  return run;
+}
+
+async function doLoadDafView(
+  key: string,
   tractate: string,
   page: string,
   lang: 'en' | 'he',
 ): Promise<void> {
-  const key = dafKey(tractate, page, lang);
   latestKey = key;
   // Only write the signal if THIS is still the daf the reader is on.
   const settle = (pieces: Record<string, DafViewPiece>) => {
@@ -88,6 +107,41 @@ export async function loadDafView(
   } finally {
     clearTimeout(timer);
   }
+}
+
+/**
+ * Resolve once the view for this daf+lang has SETTLED (loaded, or failed-empty).
+ * Short-circuits if it's already settled; otherwise shares the in-flight load.
+ * The prefetcher awaits this so it can consult the view before deciding what to
+ * warm. Fail-safe: on failure the view is empty, so callers just proceed.
+ */
+export function ensureDafView(tractate: string, page: string, lang: 'en' | 'he'): Promise<void> {
+  const key = dafKey(tractate, page, lang);
+  const v = view();
+  if (v && v.key === key) return Promise.resolve();
+  return loadDafView(tractate, page, lang);
+}
+
+/**
+ * Is a piece already present in the loaded view for this daf? Checks the whole-daf
+ * key (bare producer id) first, then the per-instance key (`producerId::iid`,
+ * where iid is `instanceIdOf(instance)` — the same hash the server keyed by).
+ * Used by the prefetcher to SKIP warming pieces the view already serves (so a
+ * warm daf no longer fans out N redundant /api/run). Returns false when the view
+ * isn't loaded for this daf — caller proceeds as before (fail-safe).
+ */
+export async function dafViewHas(
+  producerId: string,
+  instance: unknown,
+  tractate: string,
+  page: string,
+  lang: 'en' | 'he',
+): Promise<boolean> {
+  const v = view();
+  if (!v || v.key !== dafKey(tractate, page, lang)) return false;
+  if (v.pieces[producerId]) return true; // whole-daf piece
+  const iid = await instanceIdOf(instance);
+  return !!v.pieces[`${producerId}::${iid}`];
 }
 
 /** Build a faithful RunResult from a stored view piece (cache_hit, so the card

--- a/packages/talmud/tests/daf-view-store.test.ts
+++ b/packages/talmud/tests/daf-view-store.test.ts
@@ -1,9 +1,12 @@
+import { instanceIdOf } from '@corpus/core/cache/keys';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   type DafViewPiece,
+  dafViewHas,
   dafViewLoaded,
   dafViewPieceResult,
   dafViewWholeDafResult,
+  ensureDafView,
   loadDafView,
   synthRunResult,
 } from '../src/client/dafViewStore';
@@ -103,6 +106,77 @@ describe('loadDafView fail-safe settle', () => {
     );
     await loadDafView('Berakhot', '4b', 'en');
     expect(dafViewLoaded('Berakhot', '4b', 'en')).toBe(true);
+  });
+});
+
+// The prefetcher consults dafViewHas to SKIP warming pieces the view already
+// serves — the fix that collapses the warm-daf /api/run fan-out. It must match
+// both the whole-daf key (bare id) and the per-instance key (id::instanceIdOf).
+describe('dafViewHas (prefetch skip predicate)', () => {
+  function stubFetch(payload: unknown) {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify(payload), { status: 200 })),
+    );
+  }
+
+  it('true for a whole-daf piece already in the view', async () => {
+    stubFetch({ pieces: { 'tidbit.essay': piece({ producerId: 'tidbit.essay' }) } });
+    await loadDafView('Chullin', '52a', 'en');
+    expect(await dafViewHas('tidbit.essay', { fields: {} }, 'Chullin', '52a', 'en')).toBe(true);
+  });
+
+  it('true for a per-instance piece keyed by the real instanceIdOf hash', async () => {
+    const inst = { fields: { name: 'Rabbi Akiva' } };
+    const iid = await instanceIdOf(inst); // the same hash the server keys by
+    stubFetch({
+      pieces: { [`rabbi.synthesis::${iid}`]: piece({ producerId: 'rabbi.synthesis' }) },
+    });
+    await loadDafView('Chullin', '52a', 'en');
+    expect(await dafViewHas('rabbi.synthesis', inst, 'Chullin', '52a', 'en')).toBe(true);
+  });
+
+  it('false when the piece is absent (cold) — prefetcher warms it', async () => {
+    stubFetch({ pieces: { 'tidbit.essay': piece({ producerId: 'tidbit.essay' }) } });
+    await loadDafView('Chullin', '52a', 'en');
+    expect(
+      await dafViewHas('halacha.synthesis', { fields: { topic: 'x' } }, 'Chullin', '52a', 'en'),
+    ).toBe(false);
+  });
+
+  it('false when no view is loaded for this daf (fail-safe: prefetcher proceeds)', async () => {
+    expect(await dafViewHas('tidbit.essay', { fields: {} }, 'Sanhedrin', '90a', 'en')).toBe(false);
+  });
+});
+
+describe('ensureDafView', () => {
+  it('shares ONE fetch across concurrent callers (DafViewer + prefetcher)', async () => {
+    const spy = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ pieces: { tidbit: piece({ producerId: 'tidbit' }) } }), {
+          status: 200,
+        }),
+    );
+    vi.stubGlobal('fetch', spy);
+    await Promise.all([
+      ensureDafView('Nazir', '2a', 'en'),
+      ensureDafView('Nazir', '2a', 'en'),
+      loadDafView('Nazir', '2a', 'en'),
+    ]);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-fetch once the view is already loaded', async () => {
+    const spy = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ pieces: { tidbit: piece({ producerId: 'tidbit' }) } }), {
+          status: 200,
+        }),
+    );
+    vi.stubGlobal('fetch', spy);
+    await loadDafView('Nazir', '3a', 'en');
+    await ensureDafView('Nazir', '3a', 'en'); // already settled → no fetch
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
## What

Follow-up to #487. The browser harness showed #487 alone made **no difference** — a fully warm daf still fired ~78 `POST /api/run`. The real fan-out source is the daf-load **prefetcher** (`dafPrefetch.ts`), which eagerly fires `/api/run` for every section + whole-daf enrichment on open **without consulting the view**. The cards were just hitting the prefetched cache.

## Fix

The prefetcher now waits for the materialized view to settle (one fetch, shared with DafViewer's open via `ensureDafView`) and **skips any piece the view already serves** (`dafViewHas`: whole-daf key, else `producerId::instanceIdOf` — the same hash the server keyed by). On a warm daf that's every piece, so the old N-wide fan-out collapses to ~zero; the card renders each piece from the view. A miss (cold daf, or view failed to load) enqueues exactly as before — fail-safe.

Store additions:
- `ensureDafView` — awaitable, deduped load (concurrent callers share one fetch).
- `dafViewHas` — is this `(producer, instance)` already in the loaded view?
- `loadDafView` — in-flight dedup so DafViewer + prefetcher don't double-fetch.

Prefetch is now **lang-aware** (checks the view for the right language; the DafViewer prefetch signature keys on lang so EN↔HE re-evaluates). The progress bar counts skipped-because-warm pieces as instantly done, so a warm daf fills fast.

## Verification

- Tests: `dafViewHas` (whole-daf + per-instance via the real `instanceIdOf` + cold miss + no-view fail-safe), `ensureDafView` (one shared fetch, no re-fetch when loaded). Full suite green (2564), typecheck + biome clean.
- Will verify live with the browser harness (expect the warm-daf `/api/run` count to drop sharply from ~78).

## Follow-up

Route the **base marks** (DafViewer mark runner, ~12 calls) through the view; fix the single-cold-piece completeness bug (`rabbi.identity.pin` flips a 99%-warm daf to `complete:false`).