### PR TITLE
Daf-view: demand-driven pieces don't block completeness (restore hard edge cache)

### DIFF
--- a/packages/talmud/src/worker/code-marks.ts
+++ b/packages/talmud/src/worker/code-marks.ts
@@ -2072,6 +2072,10 @@ export const CODE_ENRICHMENTS: EnrichmentDefinition[] = [
     target_mark: 'rabbi',
     mode: 'augment-content',
     scope: 'local',
+    // Lazy: fetched on-demand the first time a reader opens an ambiguous-homonym
+    // card (never in a warm surface), so an uncached pin must not mark the daf's
+    // view incomplete and block its hard edge cache.
+    demand_driven: true,
     extractor: {
       kind: 'llm',
       // Placeholders — the real call is made in computeRabbiPin (worker/index.ts);

--- a/packages/talmud/src/worker/daf-view.ts
+++ b/packages/talmud/src/worker/daf-view.ts
@@ -78,14 +78,22 @@ export interface EnumeratedPiece {
   /** Expected to have content but none cached (for per-instance: not all
    *  instances cached). */
   cold: boolean;
+  /** Computed only on demand (never proactively warmed) — excluded from the
+   *  completeness verdict + the cold list, so one uncached lazy piece (e.g. the
+   *  homonym pin) can't keep a fully-warmed daf out of the hard edge cache. */
+  demandDriven?: boolean;
 }
 
 /** Roll enumerated producers up into the view's completeness verdict + cold list
- *  (deduped, since a per-instance producer contributes one entry per instance). */
+ *  (deduped, since a per-instance producer contributes one entry per instance).
+ *  Demand-driven producers are ignored: they're fetched lazily when the reader
+ *  opens that card, so an uncached one is expected, not "cold". */
 export function dafViewCompleteness(items: EnumeratedPiece[]): {
   complete: boolean;
   cold: string[];
 } {
-  const cold = [...new Set(items.filter((i) => i.cold).map((i) => i.producerId))];
+  const cold = [
+    ...new Set(items.filter((i) => i.cold && !i.demandDriven).map((i) => i.producerId)),
+  ];
   return { complete: cold.length === 0, cold };
 }

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -2778,6 +2778,10 @@ app.get('/api/daf-view/:tractate/:page', async (c) => {
     localEnrichments.map(async (def) => {
       const targetMark = def.target_mark;
       const perInstance = !!targetMark && markAnchorById.get(targetMark) !== 'whole-daf';
+      // Demand-driven (lazy) enrichments are fetched only when a reader opens the
+      // card — an uncached one is expected, so it must not count against the daf's
+      // view completeness (which gates the hard edge cache).
+      const demandDriven = (def as { demand_driven?: boolean }).demand_driven === true;
       if (perInstance) {
         const insts = instancesByMark.get(targetMark as string) ?? [];
         // Zero instances is "cold" ONLY if the parent mark itself isn't cached
@@ -2808,13 +2812,13 @@ app.get('/api/daf-view/:tractate/:page', async (c) => {
             }
           }),
         );
-        enumerated.push({ producerId: def.id, cold: anyCold });
+        enumerated.push({ producerId: def.id, cold: anyCold, demandDriven });
       } else {
         const res = await readCachedResult(
           c.env,
           keyForEnrichment(def, iid, { tractate, page }, undefined, lang),
         );
-        enumerated.push({ producerId: def.id, cold: !res });
+        enumerated.push({ producerId: def.id, cold: !res, demandDriven });
         if (res) {
           pieces[pieceKey(def.id)] = {
             producerId: def.id,

--- a/packages/talmud/src/worker/studio-schema.ts
+++ b/packages/talmud/src/worker/studio-schema.ts
@@ -461,6 +461,14 @@ export interface EnrichmentDefinition {
    *  MAX_LINT_ATTEMPTS). NOT part of def_hash / the cache key. */
   passes?: string[];
 
+  /** This enrichment is computed only ON DEMAND (when a reader opens the specific
+   *  card), never proactively warmed — e.g. the lazy homonym pin, or a
+   *  user-question-parameterized `.qa`. Such pieces must NOT count toward a daf's
+   *  materialized-view completeness (an uncached one is expected, not "cold"), so
+   *  a fully-warmed daf can still earn the hard edge cache. NOT part of def_hash /
+   *  the cache key. */
+  demand_driven?: boolean;
+
   extractor: Extractor;
 
   status: MarkStatus;

--- a/packages/talmud/tests/daf-view.test.ts
+++ b/packages/talmud/tests/daf-view.test.ts
@@ -64,4 +64,26 @@ describe('dafViewCompleteness', () => {
   it('an empty registry is trivially complete', () => {
     expect(dafViewCompleteness([])).toEqual({ complete: true, cold: [] });
   });
+
+  it('IGNORES a cold demand-driven producer (lazy pin must not block completeness)', () => {
+    // The real bug: rabbi.identity.pin is fetched on-demand, so it's uncached on
+    // an otherwise fully-warm daf — it must not flip complete to false (which
+    // would deny the daf its hard edge cache).
+    const r = dafViewCompleteness([
+      { producerId: 'rabbi', cold: false },
+      { producerId: 'tidbit', cold: false },
+      { producerId: 'rabbi.identity.pin', cold: true, demandDriven: true },
+    ]);
+    expect(r.complete).toBe(true);
+    expect(r.cold).toEqual([]);
+  });
+
+  it('still flags a cold NON-demand-driven producer alongside a demand-driven one', () => {
+    const r = dafViewCompleteness([
+      { producerId: 'rabbi.identity.pin', cold: true, demandDriven: true },
+      { producerId: 'tidbit', cold: true },
+    ]);
+    expect(r.complete).toBe(false);
+    expect(r.cold).toEqual(['tidbit']);
+  });
 });


### PR DESCRIPTION
## What

The browser harness showed a **fully warm** daf reporting `complete:false` in `/api/daf-view` — because of a single cold piece, `rabbi.identity.pin`, which is a **lazy on-demand** enrichment (fetched only when a reader opens an ambiguous-homonym card, never warmed). One straggler like that denied the whole daf its **hard edge cache** (`max-age=3600` + SWR vs the partial `max-age=20`), undercutting the "millions served by the edge, not the worker" goal.

## Fix

An optional **`demand_driven`** flag on `EnrichmentDefinition` (NOT part of `def_hash` / the cache key → no re-warm). Set on `rabbi.identity.pin`. The daf-view completeness verdict + cold list now **exclude demand-driven producers** — an uncached lazy piece is expected, not "cold". A genuinely cold proactively-warmed piece still flips `complete` to false as before.

## Verification

- Tests: `dafViewCompleteness` ignores a cold demand-driven producer but still flags a cold normal one beside it. Full suite green (2575), typecheck + biome clean.
- Will verify live: `/api/daf-view/Berakhot/2a` should now report `complete:true` with the hard `Cache-Control`.