### PR TITLE
Daf-view: include argument section enrichments (finish warm-path render fix)

### DIFF
--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -2734,9 +2734,13 @@ app.get('/api/daf-view/:tractate/:page', async (c) => {
 
   const iid = await instanceIdOf({ fields: {} });
   const markAnchorById = new Map(CODE_MARKS.map((m) => [m.id, (m as { anchor?: string }).anchor]));
-  const localEnrichments = CODE_ENRICHMENTS.filter(
-    (e) => e.scope === 'local' && e.target_mark !== 'argument',
-  );
+  // Argument section enrichments (argument.synthesis) ARE enumerated: the per-
+  // instance path keys them by instanceIdOf(instance), which for an argument
+  // section resolves to slug(fields.title) — the same key the client computes
+  // from argumentSynthInstance(section) (title is preserved through the section
+  // adapter). This is the slug(title) join already proven by /api/daf-runs. So a
+  // warm daf's argument cards render from the view instead of fanning out.
+  const localEnrichments = CODE_ENRICHMENTS.filter((e) => e.scope === 'local');
   const perInstanceTargets = new Set(
     localEnrichments
       .map((e) => e.target_mark)

--- a/packages/talmud/tests/instance-id.test.ts
+++ b/packages/talmud/tests/instance-id.test.ts
@@ -65,6 +65,54 @@ describe('instanceIdOf — Hebrew title collision', () => {
   });
 });
 
+// The argument-shape join: /api/daf-view enumerates argument.synthesis by
+// instanceIdOf(rawMarkInstance); the client keys it via argumentSynthInstance(
+// section); deepWarmDaf warms it from the same raw instances. ALL THREE must
+// resolve to slug(fields.title) or the view can't serve argument cards (the
+// reason argument was once excluded from the view). Lock the agreement so the
+// exclusion can't silently creep back / a shape drift can't break the join.
+describe('instanceIdOf — argument section key agreement (view <-> client <-> warm)', () => {
+  // What readMarkInstances('argument') returns + what deepWarmDaf / the daf-view
+  // enumeration use.
+  const rawMarkInstance = {
+    startSegIdx: 0,
+    endSegIdx: 4,
+    fields: { title: 'The opening Mishnah', summary: 's', excerpt: 'e', rabbiNames: ['Abaye'] },
+  };
+  // The exact shape ArgumentSidebar.argumentSynthInstance(section) sends as the
+  // card's mark_input (kept structurally identical so a future drift fails here).
+  const clientSynthInstance = {
+    startSegIdx: 0,
+    endSegIdx: 4,
+    fields: { title: 'The opening Mishnah', summary: 's', excerpt: 'e', rabbiNames: ['Abaye'] },
+  };
+
+  it('keys an argument section by slug(title)', async () => {
+    expect(await instanceIdOf(rawMarkInstance)).toBe('the_opening_mishnah');
+  });
+
+  it('client synth-instance and server raw instance share ONE key (so the view serves the card)', async () => {
+    expect(await instanceIdOf(clientSynthInstance)).toBe(await instanceIdOf(rawMarkInstance));
+  });
+
+  it('title drives the key — extra/differing non-title fields do not shift it', async () => {
+    // The raw mark instance may carry fields the client projection omits; the id
+    // must stay title-stable so the two keys still meet.
+    const withExtra = {
+      startSegIdx: 0,
+      endSegIdx: 4,
+      fields: {
+        title: 'The opening Mishnah',
+        summary: 'a longer summary',
+        excerpt: 'different excerpt',
+        rabbiNames: ['Abaye', 'Rava'],
+        extra: 'x',
+      },
+    };
+    expect(await instanceIdOf(withExtra)).toBe(await instanceIdOf(rawMarkInstance));
+  });
+});
+
 // Regression: a rishonim instance carries no id/title/excerpt, so its id used to
 // hash to just {segIdx} — the synthesis cache key was blind to the comments. One
 // bad generation then stuck permanently (saw Berakhot 2a:1 render a Pesachim


### PR DESCRIPTION
## What

`argument.synthesis` was excluded from `/api/daf-view` out of caution over its "dual display/synth instance shape" — so on a warm daf the prefetcher couldn't skip it and the argument cards fanned out the last ~4 redundant `/api/run` (the remainder of the 78→18 warm-daf reduction from #489).

## Why it's safe (the caution was unfounded)

`instanceIdOf` keys an argument section by **`slug(fields.title)`** — a label, not a structural hash — and the title is preserved across the section adapter. So all three paths resolve to the **same key**:
- client: `argumentSynthInstance(section)` → `slug(title)`
- view: `readMarkInstances('argument')` raw instance → `slug(title)`
- warm: `deepWarmDaf` (argument.synthesis **is** in `DEEP_WARM_PLAN`) → `slug(title)`

This is the same `slug(title)` join `/api/daf-runs` already uses. The per-instance enumeration already handles argument correctly once it's no longer filtered out.

## Change

Drop the `target_mark !== 'argument'` filter in the daf-view handler. The view now contains `argument.synthesis::slug(title)`; the prefetcher's `dafViewHas` skips it and the card renders from the view. Safe for cron-warmed dapim (argument.synthesis is in the deep-warm surface, so it isn't cold → completeness unaffected).

## Verification

- Tests: instance-id key agreement (view ↔ client ↔ warm all key by `slug(title)`; title-stable against extra/differing non-title fields). Full suite green (2578).
- Will verify live with the harness: warm Berakhot 2a `argument.synthesis` should drop 4→0; `complete` stays true; clicking an argument section renders from the view (0 new `/api/run`).