### PR TITLE
Daf-view: only argument.synthesis from argument enrichments (fix completeness regression)

### DIFF
--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -2734,13 +2734,19 @@ app.get('/api/daf-view/:tractate/:page', async (c) => {
 
   const iid = await instanceIdOf({ fields: {} });
   const markAnchorById = new Map(CODE_MARKS.map((m) => [m.id, (m as { anchor?: string }).anchor]));
-  // Argument section enrichments (argument.synthesis) ARE enumerated: the per-
-  // instance path keys them by instanceIdOf(instance), which for an argument
-  // section resolves to slug(fields.title) — the same key the client computes
-  // from argumentSynthInstance(section) (title is preserved through the section
-  // adapter). This is the slug(title) join already proven by /api/daf-runs. So a
-  // warm daf's argument cards render from the view instead of fanning out.
-  const localEnrichments = CODE_ENRICHMENTS.filter((e) => e.scope === 'local');
+  // Argument SECTION enrichments are excluded EXCEPT argument.synthesis. It's the
+  // only one warmed at load (the prefetch + DEEP_WARM_PLAN) and keyed by
+  // slug(fields.title) — the same key the client computes from
+  // argumentSynthInstance(section) (title is preserved through the section
+  // adapter), the slug(title) join already proven by /api/daf-runs. Including it
+  // lets a warm daf's argument cards render from the view instead of fanning out.
+  // The others (argument.voices / argument.narrative / argument.background) are
+  // demand-driven / dev-only — not fired at load and not in any warm surface — so
+  // counting them would wrongly mark a daf incomplete (e.g. argument.narrative is
+  // dev-only on-demand) and deny it the hard edge cache.
+  const localEnrichments = CODE_ENRICHMENTS.filter(
+    (e) => e.scope === 'local' && (e.target_mark !== 'argument' || e.id === 'argument.synthesis'),
+  );
   const perInstanceTargets = new Set(
     localEnrichments
       .map((e) => e.target_mark)


### PR DESCRIPTION
## What

Follow-up fix to #491. That PR removed the argument exclusion wholesale, which also pulled in `argument.voices` / `argument.narrative` / `argument.background`. **`argument.narrative` is dev-only on-demand** (never warmed), so it enumerated as cold and flipped a warm daf to `complete:false` — losing the hard edge cache.

Verified live regression: Berakhot 2a → `Cache-Control: max-age=20`, `cold:['argument.narrative']`.

## Fix

Narrow the inclusion to **`argument.synthesis` only** — the one argument enrichment that's warmed at load (prefetch + `DEEP_WARM_PLAN`) *and* fired at load, so it's the only one whose presence in the view removes a real `/api/run`. The others are demand-driven/dev-only (fired on section-open, not load) and not in any warm surface, so they must not gate completeness.

## Verification

- Typecheck + instance-id key-agreement tests green.
- Will verify live: Berakhot 2a back to `complete:true` + hard edge cache; `argument.synthesis` stays 0 at load (cards render from the view).