### PR TITLE
Cold-path cutover: render cold dapim from the parallel Workflow (no per-card /api/run fan-out)

### DIFF
--- a/packages/talmud/src/client/DafViewer.tsx
+++ b/packages/talmud/src/client/DafViewer.tsx
@@ -37,7 +37,7 @@ import DafLoadProgress from './DafLoadProgress';
 import { readDevMode, setDevModeActive } from './DevModeShelf';
 import { cancelPrefetch, prefetchDaf } from './dafPrefetch';
 import { setDafRunsTarget } from './dafRunsStore';
-import { loadDafView } from './dafViewStore';
+import { openDafView } from './dafViewStore';
 import { ensureMasechetIncipit } from './ensureMasechetIncipit';
 import { GutterIcons, type GutterKind } from './GutterIcons';
 import { GutterOverlay } from './GutterOverlay';
@@ -471,12 +471,13 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
   const ref = createMemo<Ref>(() => ({ tractate: tractate(), page: page() }));
   const [daf] = createResource(ref, fetchDaf);
 
-  // Phase 1: load the materialized daf-view (ONE fetch = all of a daf's cached
-  // pieces) as early as the daf itself, so whole-daf cards (Overview, …) render
-  // from it instead of each firing its own /api/run. Best-effort — a miss just
-  // means the card fetches as before (see dafViewStore).
+  // Open the materialized daf-view as early as the daf itself: load the cached
+  // pieces in ONE fetch so warm cards render from it, and if the daf is COLD,
+  // drive generation from the parallel Workflow (POST /api/daf-generate) +
+  // re-poll the view so cards fill in progressively — instead of each card
+  // fanning out its own /api/run. Best-effort + fail-safe (see openDafView).
   createEffect(() => {
-    void loadDafView(tractate(), page(), lang());
+    void openDafView(tractate(), page(), lang());
   });
 
   // Per-daf rabbi list — derived from the `rabbi` mark run (see dafRabbis()

--- a/packages/talmud/src/client/MarkEnrichmentCards.tsx
+++ b/packages/talmud/src/client/MarkEnrichmentCards.tsx
@@ -30,7 +30,13 @@ import {
 } from 'solid-js';
 import { trackAI } from './aiActivity';
 import { devModeActive } from './DevModeShelf';
-import { dafViewLoaded, dafViewPieceResult, dafViewWholeDafResult } from './dafViewStore';
+import {
+  dafViewLoaded,
+  dafViewPieceResult,
+  dafViewVersion,
+  dafViewWholeDafResult,
+  isViewDriven,
+} from './dafViewStore';
 import {
   isAbort,
   isPausedBody,
@@ -552,6 +558,12 @@ export default function MarkEnrichmentCards(props: Props) {
     // cards render from the view instead of fetching.
     const iid = instIid();
     const viewReady = dafViewLoaded(props.tractate, props.page, curLang);
+    // Tracked reads: re-run as the cold-generation poll fills the view in
+    // (dafViewVersion bumps per poll), and when view-driven mode flips off (the
+    // daf finished / stalled / timed out) so we then fall through and fetch any
+    // straggler. On a cold daf we render entirely from the Workflow + poll.
+    dafViewVersion();
+    const viewDriven = isViewDriven(props.tractate, props.page, curLang);
     const controller = new AbortController();
     onCleanup(() => controller.abort());
     untrack(() => {
@@ -599,6 +611,17 @@ export default function MarkEnrichmentCards(props: Props) {
             fromInstance,
           );
           applyResult(d, s, fromInstance);
+          continue;
+        }
+        // Cold daf, view-driven: the parallel Workflow is generating every piece
+        // (POST /api/daf-generate) and the poll fills the view in. WAIT for it
+        // rather than firing our own /api/run — that's the no-fan-out cutover.
+        // Show a loading state meanwhile. When generation settles (complete /
+        // stalled / timed out) viewDriven flips off and this effect re-runs and
+        // falls through to fetch any straggler. (viewDriven is a tracked read.)
+        if (viewDriven) {
+          const prev = runs()[d.id];
+          if (!prev || prev.kind === 'idle') setRun(d.id, { kind: 'loading', stamp: s });
           continue;
         }
         const cur = runs()[d.id];

--- a/packages/talmud/src/client/dafPrefetch.ts
+++ b/packages/talmud/src/client/dafPrefetch.ts
@@ -21,7 +21,7 @@
  */
 
 import { createSignal } from 'solid-js';
-import { dafViewHas, ensureDafView } from './dafViewStore';
+import { dafViewHas, ensureDafView, isViewDriven } from './dafViewStore';
 import { isAbort, isPausedError } from './enrichmentQueue';
 import { enqueueEnrichmentRun } from './MarkEnrichmentCards';
 
@@ -254,6 +254,15 @@ export function prefetchDaf(
   void (async () => {
     await ensureDafView(tractate, page, lang);
     if (myGen !== gen || controller.signal.aborted) return;
+    // Cold daf in view-driven mode: the parallel Workflow (POST /api/daf-generate,
+    // kicked by openDafView) is generating every piece. Do NOT fan out our own
+    // /api/run — mark the cohort done and let the view-poll fill the cards in. If
+    // generation later stalls/fails, openDafView drops view-driven and the cards
+    // fetch any straggler themselves.
+    if (isViewDriven(tractate, page, lang)) {
+      for (const t of tasks) markDone(t.enrichmentId, false, false);
+      return;
+    }
     for (const t of tasks) {
       if (myGen !== gen || controller.signal.aborted) return;
       if (await dafViewHas(t.enrichmentId, t.instance, tractate, page, lang)) {

--- a/packages/talmud/src/client/dafViewStore.ts
+++ b/packages/talmud/src/client/dafViewStore.ts
@@ -32,6 +32,8 @@ export interface DafViewPiece {
 
 interface DafViewPayload {
   complete?: boolean;
+  cached?: number;
+  total?: number;
   pieces?: Record<string, DafViewPiece>;
 }
 
@@ -41,9 +43,37 @@ function dafKey(tractate: string, page: string, lang: 'en' | 'he'): string {
 
 // Keyed by daf so a view loaded for a previous daf is never served for the
 // current one (the user navigates while a fetch is in flight).
-const [view, setView] = createSignal<{ key: string; pieces: Record<string, DafViewPiece> } | null>(
-  null,
-);
+const [view, setViewRaw] = createSignal<{
+  key: string;
+  pieces: Record<string, DafViewPiece>;
+} | null>(null);
+
+// Bumped on every view write. Card effects read this (tracked) so they re-run as
+// the cold-generation poll fills the view in — the progressive-render signal.
+// (The view's KEY stays constant while pieces grow, so dafViewLoaded alone
+// wouldn't re-fire the effect; the version does.)
+const [viewVersion, setViewVersion] = createSignal(0);
+function setView(v: { key: string; pieces: Record<string, DafViewPiece> } | null): void {
+  setViewRaw(v);
+  setViewVersion((n) => n + 1);
+}
+
+/** Reactive view-write counter — read it in a card effect to re-render as the
+ *  cold-generation poll delivers more pieces. */
+export function dafViewVersion(): number {
+  return viewVersion();
+}
+
+// Which daf key is currently VIEW-DRIVEN: a cold-generation Workflow is in flight
+// and the reader renders from the polling view (cards must NOT fire their own
+// /api/run). null when no generation is active (warm, settled, or fell back).
+const [genKey, setGenKey] = createSignal<string | null>(null);
+
+/** True while a cold daf is rendering from the Workflow + view-poll. Cards and
+ *  the prefetcher read this (reactive) to suppress their own /api/run fan-out. */
+export function isViewDriven(tractate: string, page: string, lang: 'en' | 'he'): boolean {
+  return genKey() === dafKey(tractate, page, lang);
+}
 
 // The most recently REQUESTED daf-view key. A load only writes the signal if its
 // key is still the latest — so a slow/failed load for a daf the user already
@@ -53,7 +83,7 @@ let latestKey = '';
 // In-flight load promise per daf key, so concurrent callers (DafViewer's open
 // effect + the prefetcher) share ONE fetch instead of racing two. Cleared once
 // the load settles.
-const inflight = new Map<string, Promise<void>>();
+const inflight = new Map<string, Promise<DafViewPayload | null>>();
 
 /**
  * Load the materialized view for a daf and stash it. Called as early as possible
@@ -66,11 +96,16 @@ const inflight = new Map<string, Promise<void>>();
  * fall through and fetch as before) instead of hanging forever. Fail-safe: an
  * empty view just means every lookup misses and the card fetches per-piece.
  */
-export function loadDafView(tractate: string, page: string, lang: 'en' | 'he'): Promise<void> {
+export function loadDafView(
+  tractate: string,
+  page: string,
+  lang: 'en' | 'he',
+): Promise<DafViewPayload | null> {
   const key = dafKey(tractate, page, lang);
   const existing = inflight.get(key);
   if (existing) return existing;
-  const run = doLoadDafView(key, tractate, page, lang);
+  latestKey = key;
+  const run = fetchViewOnce(key, tractate, page, lang);
   inflight.set(key, run);
   void run.finally(() => {
     if (inflight.get(key) === run) inflight.delete(key);
@@ -78,14 +113,19 @@ export function loadDafView(tractate: string, page: string, lang: 'en' | 'he'): 
   return run;
 }
 
-async function doLoadDafView(
+/**
+ * Fetch the view once, settle the signal (latest-key guarded so a stale daf can't
+ * clobber the current one), and RETURN the payload (so callers can read
+ * `complete`/`cached`). The signal ALWAYS settles — empty on any failure — so the
+ * card gate (`dafViewLoaded`) can't hang. Does NOT touch `latestKey` (entry
+ * points own that); the cold-generation poll reuses this each tick.
+ */
+async function fetchViewOnce(
   key: string,
   tractate: string,
   page: string,
   lang: 'en' | 'he',
-): Promise<void> {
-  latestKey = key;
-  // Only write the signal if THIS is still the daf the reader is on.
+): Promise<DafViewPayload | null> {
   const settle = (pieces: Record<string, DafViewPiece>) => {
     if (latestKey === key) setView({ key, pieces });
   };
@@ -97,13 +137,14 @@ async function doLoadDafView(
     });
     if (!r.ok) {
       settle({});
-      return;
+      return null;
     }
     const j = (await r.json()) as DafViewPayload;
     settle(j.pieces ?? {});
+    return j;
   } catch {
-    // Network error / abort / timeout: settle empty so the gate resolves.
     settle({});
+    return null;
   } finally {
     clearTimeout(timer);
   }
@@ -115,11 +156,92 @@ async function doLoadDafView(
  * The prefetcher awaits this so it can consult the view before deciding what to
  * warm. Fail-safe: on failure the view is empty, so callers just proceed.
  */
-export function ensureDafView(tractate: string, page: string, lang: 'en' | 'he'): Promise<void> {
+export function ensureDafView(
+  tractate: string,
+  page: string,
+  lang: 'en' | 'he',
+): Promise<DafViewPayload | null> {
   const key = dafKey(tractate, page, lang);
   const v = view();
-  if (v && v.key === key) return Promise.resolve();
+  if (v && v.key === key) return Promise.resolve(null);
   return loadDafView(tractate, page, lang);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Open a daf for rendering: load its view once, and if it's INCOMPLETE (cold),
+ * drive it from the parallel Workflow instead of letting the cards/prefetcher fan
+ * out their own /api/run. Fires the single-flight POST /api/daf-generate, then
+ * re-polls the view so cards fill in progressively (they read dafViewVersion).
+ *
+ * Fail-safe by construction — view-driven mode is dropped (cards fall back to
+ * their own fetch) whenever generation can't be trusted to finish:
+ *   - the generate trigger fails / is budget-paused (never enters view-driven);
+ *   - the cached-piece count stalls for ~32s (a stuck producer);
+ *   - a 12-minute hard cap elapses;
+ *   - the reader navigates away.
+ */
+export async function openDafView(
+  tractate: string,
+  page: string,
+  lang: 'en' | 'he',
+): Promise<void> {
+  const key = dafKey(tractate, page, lang);
+  const first = await loadDafView(tractate, page, lang);
+  if (latestKey !== key) return; // navigated away mid-load
+  if (!first || first.complete) return; // warm (or load failed → cards fetch as today)
+
+  // Optimistically enter view-driven BEFORE the async trigger resolves, so the
+  // prefetcher (firing around now) sees it and suppresses its fan-out.
+  setGenKey(key);
+  let triggered = false;
+  try {
+    const r = await fetch(
+      `/api/daf-generate/${encodeURIComponent(tractate)}/${page}?lang=${lang}`,
+      {
+        method: 'POST',
+      },
+    );
+    const resp = r.ok ? ((await r.json()) as { generating?: boolean }) : null;
+    triggered = !!resp?.generating;
+  } catch {
+    triggered = false;
+  }
+  if (!triggered) {
+    // Couldn't kick generation (paused/error/network) — leave view-driven so the
+    // cards fall back to their own /api/run exactly as before.
+    if (genKey() === key) setGenKey(null);
+    return;
+  }
+
+  try {
+    const POLL_MS = 8000;
+    const HARD_CAP_MS = 12 * 60 * 1000;
+    const STALL_LIMIT = 4; // ~32s with no new pieces → assume stuck, fall back
+    const deadline = Date.now() + HARD_CAP_MS;
+    let lastCached = -1;
+    let stalls = 0;
+    while (Date.now() < deadline) {
+      await sleep(POLL_MS);
+      if (latestKey !== key) return; // navigated away
+      const payload = await fetchViewOnce(key, tractate, page, lang);
+      if (latestKey !== key) return;
+      if (payload?.complete) return; // fully generated
+      const cached = payload?.cached ?? lastCached;
+      if (cached > lastCached) {
+        lastCached = cached;
+        stalls = 0;
+      } else {
+        stalls += 1;
+      }
+      if (stalls >= STALL_LIMIT) return; // stuck → drop view-driven, cards fetch
+    }
+  } finally {
+    if (genKey() === key) setGenKey(null);
+  }
 }
 
 /**

--- a/packages/talmud/tests/daf-view-store.test.ts
+++ b/packages/talmud/tests/daf-view-store.test.ts
@@ -7,7 +7,9 @@ import {
   dafViewPieceResult,
   dafViewWholeDafResult,
   ensureDafView,
+  isViewDriven,
   loadDafView,
+  openDafView,
   synthRunResult,
 } from '../src/client/dafViewStore';
 // The SERVER's key function — the client lookups must agree with it byte-for-byte
@@ -316,5 +318,91 @@ describe('client lookups agree with the server pieceKey format', () => {
     expect(
       dafViewPieceResult('pesukim.synthesis', 'abc123', 'Chullin', '52a', 'en')?.cache_hit,
     ).toBe(true);
+  });
+});
+
+// Phase B: the cold-path cutover. openDafView loads the view; if the daf is cold
+// it fires POST /api/daf-generate and re-polls the view (view-driven), so cards
+// render from the Workflow instead of fanning out. The crucial property is that
+// view-driven mode ALWAYS releases — on completion, generate-failure, a stall,
+// or navigation — so cards can never be stuck waiting forever.
+describe('openDafView (cold-path, view-driven)', () => {
+  // Route fetches by URL so one stub serves daf-view + daf-generate.
+  function routeFetch(opts: {
+    generate: { generating: boolean };
+    view: (callIdx: number) => { complete?: boolean; cached?: number; pieces?: unknown };
+  }) {
+    let viewCalls = 0;
+    const spy = vi.fn(async (url: string, _init?: RequestInit) => {
+      const u = String(url);
+      if (u.includes('/api/daf-generate')) {
+        return new Response(JSON.stringify(opts.generate), { status: 200 });
+      }
+      const body = opts.view(viewCalls++);
+      return new Response(JSON.stringify(body), { status: 200 });
+    });
+    vi.stubGlobal('fetch', spy);
+    return spy;
+  }
+
+  it('WARM daf: never triggers generation, never goes view-driven', async () => {
+    const spy = routeFetch({
+      generate: { generating: true },
+      view: () => ({ complete: true, pieces: {} }),
+    });
+    await openDafView('Warm', '2a', 'en');
+    expect(isViewDriven('Warm', '2a', 'en')).toBe(false);
+    expect(spy.mock.calls.some(([u]) => String(u).includes('/api/daf-generate'))).toBe(false);
+  });
+
+  it('COLD daf: triggers generation, goes view-driven, releases on complete', async () => {
+    vi.useFakeTimers();
+    try {
+      // first view call cold; the poll's view call reports complete.
+      routeFetch({
+        generate: { generating: true },
+        view: (i) =>
+          i === 0
+            ? { complete: false, cached: 1, pieces: {} }
+            : { complete: true, cached: 9, pieces: {} },
+      });
+      const p = openDafView('Cold', '3a', 'en');
+      await vi.advanceTimersByTimeAsync(50); // flush initial load + generate trigger
+      expect(isViewDriven('Cold', '3a', 'en')).toBe(true);
+      await vi.advanceTimersByTimeAsync(9000); // drive one poll → complete
+      await p;
+      expect(isViewDriven('Cold', '3a', 'en')).toBe(false); // released
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('COLD daf but generation PAUSED (generating:false): never goes view-driven (cards fetch)', async () => {
+    routeFetch({
+      generate: { generating: false },
+      view: () => ({ complete: false, cached: 0, pieces: {} }),
+    });
+    await openDafView('Paused', '4a', 'en');
+    expect(isViewDriven('Paused', '4a', 'en')).toBe(false);
+  });
+
+  it('releases view-driven when the cached count STALLS (a stuck producer)', async () => {
+    vi.useFakeTimers();
+    try {
+      // always incomplete, cached count never grows → stall detection fires.
+      routeFetch({
+        generate: { generating: true },
+        view: () => ({ complete: false, cached: 2, pieces: {} }),
+      });
+      const p = openDafView('Stuck', '5a', 'en');
+      await vi.advanceTimersByTimeAsync(50);
+      expect(isViewDriven('Stuck', '5a', 'en')).toBe(true);
+      // 4 stall polls (STALL_LIMIT) at 8s each → released.
+      await vi.advanceTimersByTimeAsync(8000 * 5);
+      await p;
+      expect(isViewDriven('Stuck', '5a', 'en')).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
## What

Phase B of the cold-path cutover (Phase A = #493 parallel Workflow). On a cold daf the reader used to fan out ~66 enrichment `/api/run` (each card + the prefetcher generating independently). Now the daf renders **view-driven** from the parallel `DafWarmWorkflow`:

- **`openDafView`** (DafViewer calls it on daf open): loads the view once; if **incomplete**, fires the single-flight `POST /api/daf-generate` and **re-polls the view every 8s** so cards fill in progressively. `dafViewVersion` bumps per poll; the card effect reads it (tracked) and re-renders as pieces land.
- While **view-driven** (`isViewDriven`), enrichment cards **wait** for their piece from the poll instead of firing `/api/run`, and the prefetcher **suppresses its fan-out** — the Workflow generates everything with bounded per-step memory.
- Marks still auto-run client-side (they drive the gutter + enumerate the cards), so the gutter stays responsive; only the heavy enrichment fan-out moves to the Workflow.

## Fail-safe by construction

View-driven mode **always releases**, after which cards fall back to their own `/api/run` exactly as before:
- generate trigger fails / budget-paused → never enters view-driven;
- cached-piece count stalls ~32s (a stuck producer) → released;
- 12-min hard cap; or the reader navigates away.

Warm dapim unaffected (complete view → not view-driven → renders from the one fetch as today). Cache keys unchanged.

## Verification

- Tests: `openDafView` state machine (warm = no trigger; cold = trigger + view-driven + release on complete; paused = never view-driven; stall = released) with fake timers; existing 23 store tests green; full suite **2593**; typecheck + biome clean.
- Will verify live with the browser harness on a cold daf: one `/api/daf-generate`, **zero enrichment `/api/run`**, pieces fill progressively, and the daf reaches complete.