### PR TITLE
Warm Workflow: skip demand-driven .qa enrichments (no wasted cold-gen; cold dapim can complete)

### DIFF
--- a/packages/talmud/src/worker/code-marks.ts
+++ b/packages/talmud/src/worker/code-marks.ts
@@ -1817,6 +1817,9 @@ function makeEnrichment(
      *  default). When set, thinking is left ON and reasoning_effort is passed
      *  through. Use for heavy cross-section reasoning (argument-overview.flow). */
     reasoningEffort?: 'low' | 'medium' | 'high';
+    /** Computed only ON DEMAND (e.g. a user-question-parameterized `.qa`), never
+     *  proactively warmed. Excluded from warm generation + view completeness. */
+    demandDriven?: boolean;
   },
 ): EnrichmentDefinition {
   return {
@@ -1828,6 +1831,7 @@ function makeEnrichment(
     scope: opts.scope,
     dependencies: opts.dependencies,
     ...(opts.passes ? { passes: opts.passes } : {}),
+    ...(opts.demandDriven ? { demand_driven: true } : {}),
     extractor: {
       kind: 'llm',
       ...(opts.model ? { model: opts.model } : {}),
@@ -4188,6 +4192,7 @@ CODE_ENRICHMENTS.push(
         { enrichment: 'argument-move.commentaries' },
         { mark: 'argument-move' },
       ],
+      demandDriven: true, // user-question parameterized — generated on demand, never warmed
       defHash: 'argument-move.qa-v5',
       cacheVersion: '5',
       model: ARGUMENT_PRO_MODEL,
@@ -5973,6 +5978,7 @@ CODE_ENRICHMENTS.push(
         { enrichment: 'pesukim.synthesis' },
         { mark: 'pesukim' },
       ],
+      demandDriven: true, // user-question parameterized — generated on demand, never warmed
       defHash: 'pesukim.qa-v3',
       cacheVersion: '3',
       model: ARGUMENT_PRO_MODEL,
@@ -6589,6 +6595,7 @@ CODE_ENRICHMENTS.push(
         { enrichment: 'aggadata.synthesis' },
         { mark: 'aggadata' },
       ],
+      demandDriven: true, // user-question parameterized — generated on demand, never warmed
       defHash: 'aggadata.qa-v1',
       cacheVersion: '1',
       model: ARGUMENT_PRO_MODEL,

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -11383,6 +11383,7 @@ export class DafWarmWorkflow extends WorkflowEntrypoint<Bindings, DafWarmParams>
       id: e.id,
       scope: e.scope,
       target_mark: e.target_mark,
+      demand_driven: (e as { demand_driven?: boolean }).demand_driven,
     }));
 
     // Each producer runs in its OWN step.do() — its own invocation, its own

--- a/packages/talmud/src/worker/workflow-warm.ts
+++ b/packages/talmud/src/worker/workflow-warm.ts
@@ -23,6 +23,9 @@ export interface EnrichmentLike {
   id: string;
   scope?: string;
   target_mark?: string;
+  /** Computed only on demand (e.g. a user-question `.qa`, or the lazy homonym
+   *  pin) — never proactively warmed, so the warm Workflow skips it. */
+  demand_driven?: boolean;
 }
 
 /**
@@ -30,12 +33,13 @@ export interface EnrichmentLike {
  * whole-daf (or which declare no target mark). Same bucketing rule the daf-view
  * uses to separate whole-daf from per-instance pieces, so the two stay in sync.
  * Per-instance enrichments are intentionally excluded here (step 1 warms the
- * whole-daf surface; per-instance fan-out is a later step).
+ * whole-daf surface; per-instance fan-out is a later step). Demand-driven
+ * enrichments are skipped — they're generated only when a reader asks.
  */
 export function wholeDafEnrichmentIds(marks: MarkLike[], enrichments: EnrichmentLike[]): string[] {
   const anchorById = new Map(marks.map((m) => [m.id, m.anchor]));
   return enrichments
-    .filter((e) => e.scope === 'local')
+    .filter((e) => e.scope === 'local' && !e.demand_driven)
     .filter((e) => !e.target_mark || anchorById.get(e.target_mark) === 'whole-daf')
     .map((e) => e.id);
 }
@@ -44,9 +48,11 @@ export function wholeDafEnrichmentIds(marks: MarkLike[], enrichments: Enrichment
  * Per-instance local enrichments (one cached entry per target-mark instance):
  * scope local, target mark is NOT whole-daf, and NOT `argument` (its dual
  * display/synth instance shape needs separate handling — the same exclusion the
- * daf-view and /api/daf-runs carry). The warm Workflow generates one step per
- * (enrichment, instance) for these. Returns {id, targetMark} so the caller can
- * read the target mark's instances.
+ * daf-view and /api/daf-runs carry). DEMAND-DRIVEN enrichments are skipped: a
+ * user-question `.qa` or the lazy homonym pin is generated only when the reader
+ * asks, so warming it Shas-wide is pure waste (and it can't be keyed without the
+ * question). The warm Workflow generates one step per (enrichment, instance) for
+ * what remains. Returns {id, targetMark} so the caller can read the instances.
  */
 export function perInstanceEnrichments(
   marks: MarkLike[],
@@ -54,7 +60,7 @@ export function perInstanceEnrichments(
 ): { id: string; targetMark: string }[] {
   const anchorById = new Map(marks.map((m) => [m.id, m.anchor]));
   return enrichments
-    .filter((e) => e.scope === 'local')
+    .filter((e) => e.scope === 'local' && !e.demand_driven)
     .filter(
       (e) =>
         !!e.target_mark &&

--- a/packages/talmud/tests/workflow-warm.test.ts
+++ b/packages/talmud/tests/workflow-warm.test.ts
@@ -41,6 +41,15 @@ describe('perInstanceEnrichments', () => {
     expect(out).toEqual([]);
   });
 
+  it('EXCLUDES demand-driven enrichments (.qa, the lazy pin) — never warmed', () => {
+    const out = perInstanceEnrichments(MARKS, [
+      { id: 'pesukim.synthesis', scope: 'local', target_mark: 'pesukim' }, // warmed
+      { id: 'pesukim.qa', scope: 'local', target_mark: 'pesukim', demand_driven: true }, // on-demand
+      { id: 'rabbi.identity.pin', scope: 'local', target_mark: 'rabbi', demand_driven: true }, // lazy
+    ]);
+    expect(out).toEqual([{ id: 'pesukim.synthesis', targetMark: 'pesukim' }]);
+  });
+
   it('partitions cleanly vs wholeDafEnrichmentIds (no overlap, argument in neither)', () => {
     const enrichments = [
       { id: 'argument-overview.synthesis', scope: 'local', target_mark: 'argument-overview' },


### PR DESCRIPTION
## What

Verifying the cold-path cutover (#494) on a cold daf surfaced that the parallel `DafWarmWorkflow` generates the `.qa` enrichments (`argument-move.qa` / `pesukim.qa` / `aggadata.qa`) for **every instance**. Those are user-question-parameterized — generated **on demand** when a reader asks, keyed per `(instance, normalized question)`. Warming them Shas-wide is:
1. **Pure waste** — dozens of extra LLM calls per cold daf, keyed without a question.
2. **A completeness blocker** — they never have a no-question cache entry, so the daf-view counted them cold → a freshly cold-generated daf could never reach `complete:True` (so never earn the hard edge cache).

## Fix

Flag the three `.qa` defs `demand_driven` (the flag slice 2 / #490 added for the lazy homonym pin; **not** part of `def_hash` / the cache key → no re-warm). The warm Workflow's `perInstanceEnrichments` + `wholeDafEnrichmentIds` now skip demand-driven producers, and the daf-view completeness already excludes them (#490). So a cold daf generates only what's actually warmed and reaches `complete:True`. Also stops warming `rabbi.identity.pin` (already `demand_driven`) for free.

## Verification

- Tests: `perInstanceEnrichments` excludes demand-driven (`.qa` + the pin). Full suite green (2594), typecheck + biome clean.
- Will verify live: a cold daf generated via `/api/daf-generate` reaches `complete:True` with no `.qa` in its cold list.