### PR TITLE
Daily Daf-Yomi warm: route generation onto DafWarmWorkflow (off the queue)

### DIFF
--- a/packages/talmud/src/worker/yomi-cron.ts
+++ b/packages/talmud/src/worker/yomi-cron.ts
@@ -20,6 +20,7 @@
 
 import { instanceIdOf } from './cache-keys';
 import type { JobMessage } from './types';
+import type { DafWarmParams } from './workflow-warm';
 
 const SEFARIA_CALENDAR_URL = 'https://www.sefaria.org/api/calendars';
 const WARM_MARKS = ['rabbi', 'argument', 'halacha', 'aggadata', 'yerushalmi', 'pesukim'] as const;
@@ -102,6 +103,10 @@ async function warmRunId(
 interface YomiCronEnv {
   CACHE?: KVNamespace;
   ENRICHMENT_QUEUE?: Queue<JobMessage>;
+  /** The per-daf generation Workflow. When bound, the daily warm runs each daf's
+   *  marks + enrichments as bounded per-step Workflow invocations (memory-safe,
+   *  parallel) instead of a queue fan-out of mark + deep-warm jobs. */
+  DAF_WARM_WORKFLOW?: Workflow<DafWarmParams>;
 }
 
 export async function runYomiWarmCron(env: YomiCronEnv): Promise<void> {
@@ -121,7 +126,26 @@ export async function runYomiWarmCron(env: YomiCronEnv): Promise<void> {
   const pages = [`${daf}a`, `${daf}b`];
   const jobs: Promise<void>[] = [];
   const queue = env.ENRICHMENT_QUEUE;
-  const enqueue = async (markId: string, page: string, lang: 'en' | 'he'): Promise<void> => {
+  const wf = env.DAF_WARM_WORKFLOW;
+
+  // Trigger the per-daf generation Workflow for one language: it generates the
+  // daf's marks -> whole-daf -> per-instance enrichments as bounded per-step
+  // invocations (parallel, memory-safe) — the same surface the legacy per-mark +
+  // deep-warm jobs warmed, but without the queue fan-out that risked an isolate
+  // OOM on a dense daf.
+  const triggerWorkflow = async (page: string, lang: 'en' | 'he'): Promise<void> => {
+    if (!wf) return;
+    try {
+      const inst = await wf.create({ params: { tractate, page, lang } });
+      console.log(`[yomi-cron] DafWarmWorkflow lang=${lang} ${tractate}/${page} id=${inst.id}`);
+    } catch (e) {
+      console.error(`[yomi-cron] DafWarmWorkflow lang=${lang} ${tractate}/${page} failed:`, e);
+    }
+  };
+
+  // Legacy fallback (only when the Workflow binding is somehow unavailable):
+  // enqueue a mark / deep-warm job onto the queue, exactly as before.
+  const enqueueMark = async (markId: string, page: string, lang: 'en' | 'he'): Promise<void> => {
     const runId = await warmRunId(markId, tractate, page, lang);
     const job: JobMessage = {
       runId,
@@ -132,24 +156,32 @@ export async function runYomiWarmCron(env: YomiCronEnv): Promise<void> {
     };
     try {
       await queue.send(job);
-      console.log(
-        `[yomi-cron] enqueued mark=${markId} lang=${lang} ${tractate}/${page} runId=${runId}`,
-      );
     } catch (e) {
-      console.error(
-        `[yomi-cron] enqueue mark=${markId} lang=${lang} ${tractate}/${page} failed:`,
-        e,
-      );
+      console.error(`[yomi-cron] enqueue mark=${markId} ${tractate}/${page} failed:`, e);
     }
   };
-  for (const page of pages) {
-    for (const markId of WARM_MARKS) jobs.push(enqueue(markId, page, 'en'));
-    // Second pass: Hebrew structural marks so HE readers hit a warm :he cache.
-    for (const markId of WARM_MARKS_HE) jobs.push(enqueue(markId, page, 'he'));
-    // Reverse-index capture — enqueued last; it depends on the marks above and
-    // pulls any not-yet-warmed ones (incl. argument-move) via dependency
-    // resolution, so it runs only once they've landed. mark_input { id: 'daf' }
-    // keys the canonical daf-level cache the browse-path prefetch shares.
+  const enqueueDeepWarm = async (page: string, lang: 'en' | 'he'): Promise<void> => {
+    const deepRunId = (await warmRunId('warm-deep', tractate, page, lang))
+      .replace(/[^a-zA-Z0-9._:-]+/g, '_')
+      .slice(0, 200);
+    const deepJob: JobMessage = {
+      runId: deepRunId,
+      warm_deep: true,
+      tractate,
+      page,
+      ...(lang === 'he' ? { lang: 'he' } : {}),
+    };
+    try {
+      await queue.send(deepJob);
+    } catch (e) {
+      console.error(`[yomi-cron] enqueue deep-warm lang=${lang} ${tractate}/${page} failed:`, e);
+    }
+  };
+
+  // Reverse-index capture (rabbi.observations) — stays on the queue: it warms the
+  // DAF-LEVEL { id: 'daf' } aggregation key (the browse-path prefetch shares it),
+  // which the Workflow's per-rabbi enumeration does not produce.
+  const enqueueObservations = async (page: string): Promise<void> => {
     const obsRunId = await warmRunId('rabbi.observations', tractate, page);
     const obsJob: JobMessage = {
       runId: obsRunId,
@@ -158,54 +190,30 @@ export async function runYomiWarmCron(env: YomiCronEnv): Promise<void> {
       tractate,
       page,
     };
-    jobs.push(
-      env.ENRICHMENT_QUEUE.send(obsJob)
-        .then(() => {
-          console.log(
-            `[yomi-cron] enqueued rabbi.observations ${tractate}/${page} runId=${obsRunId}`,
-          );
-        })
-        .catch((e) => {
-          console.error(`[yomi-cron] enqueue rabbi.observations ${tractate}/${page} failed:`, e);
-        }),
-    );
-    // Deep-warm the daf so the section-typing views + reader-facing prose are
-    // ready for the daf-yomi crowd — notably argument.narrative on story
-    // sections, which the deep-warm path pre-warms only for narrative-primary
-    // sections (cache-respecting, so the marks above are reused, not re-paid).
-    // Warm BOTH languages: the prose enrichments (synthesis, narrative,
-    // suggested-questions, essays) and, transitively via dependency resolution,
-    // every rabbi-card leaf enrichment (rabbi.synthesis -> rabbi.bio/.geography/
-    // .relationships/...) are language-specific. Without the :he pass a Hebrew
-    // reader regenerates the entire prose surface on first open even though the
-    // structure is warm. One full deep-warm per language per daily daf.
-    for (const lang of ['en', 'he'] as const) {
-      const deepRunId = (await warmRunId('warm-deep', tractate, page, lang))
-        .replace(/[^a-zA-Z0-9._:-]+/g, '_')
-        .slice(0, 200);
-      const deepJob: JobMessage = {
-        runId: deepRunId,
-        warm_deep: true,
-        tractate,
-        page,
-        ...(lang === 'he' ? { lang: 'he' } : {}),
-      };
-      jobs.push(
-        env.ENRICHMENT_QUEUE.send(deepJob)
-          .then(() => {
-            console.log(
-              `[yomi-cron] enqueued deep-warm lang=${lang} ${tractate}/${page} runId=${deepRunId}`,
-            );
-          })
-          .catch((e) => {
-            console.error(
-              `[yomi-cron] enqueue deep-warm lang=${lang} ${tractate}/${page} failed:`,
-              e,
-            );
-          }),
-      );
+    try {
+      await queue.send(obsJob);
+    } catch (e) {
+      console.error(`[yomi-cron] enqueue rabbi.observations ${tractate}/${page} failed:`, e);
     }
+  };
+
+  for (const page of pages) {
+    if (wf) {
+      // Memory-safe parallel path: one Workflow per language warms the full
+      // mark + enrichment surface for that daf.
+      for (const lang of ['en', 'he'] as const) jobs.push(triggerWorkflow(page, lang));
+    } else {
+      // Fallback to the legacy queue fan-out (mark jobs + a per-language deep-warm)
+      // if the Workflow binding is missing.
+      console.warn('[yomi-cron] DAF_WARM_WORKFLOW unavailable; falling back to queue warm');
+      for (const markId of WARM_MARKS) jobs.push(enqueueMark(markId, page, 'en'));
+      for (const markId of WARM_MARKS_HE) jobs.push(enqueueMark(markId, page, 'he'));
+      for (const lang of ['en', 'he'] as const) jobs.push(enqueueDeepWarm(page, lang));
+    }
+    jobs.push(enqueueObservations(page));
   }
   await Promise.allSettled(jobs);
-  console.log(`[yomi-cron] enqueued ${jobs.length} warm job(s) for ${tractate} ${daf}`);
+  console.log(
+    `[yomi-cron] warmed ${tractate} ${daf} via ${wf ? 'DafWarmWorkflow' : 'queue fallback'} (${jobs.length} task(s))`,
+  );
 }

--- a/packages/talmud/tests/yomi-cron.test.ts
+++ b/packages/talmud/tests/yomi-cron.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { JobMessage } from '../src/worker/types';
+import type { DafWarmParams } from '../src/worker/workflow-warm';
 import { runYomiWarmCron } from '../src/worker/yomi-cron';
 
 // Sefaria's calendar shape for "tomorrow is Berakhot 12".
@@ -19,6 +20,18 @@ function collectJobs() {
   return { sent, queue };
 }
 
+function collectWorkflows() {
+  const created: DafWarmParams[] = [];
+  let n = 0;
+  const wf = {
+    create: async ({ params }: { params: DafWarmParams }) => {
+      created.push(params);
+      return { id: `wf-${n++}` };
+    },
+  } as unknown as Workflow<DafWarmParams>;
+  return { created, wf };
+}
+
 describe('runYomiWarmCron', () => {
   let fetchSpy: ReturnType<typeof vi.spyOn>;
 
@@ -34,6 +47,38 @@ describe('runYomiWarmCron', () => {
 
   afterEach(() => {
     fetchSpy.mockRestore();
+  });
+
+  // The primary path: a bound Workflow warms each daf via memory-safe per-step
+  // invocations instead of a queue fan-out of mark + deep-warm jobs.
+  describe('with the DafWarmWorkflow bound (primary path)', () => {
+    it('triggers ONE Workflow per (amud, language) and NO mark/deep-warm queue jobs', async () => {
+      const { sent, queue } = collectJobs();
+      const { created, wf } = collectWorkflows();
+      await runYomiWarmCron({ ENRICHMENT_QUEUE: queue, DAF_WARM_WORKFLOW: wf });
+
+      // 2 amudim x 2 languages = 4 Workflow instances.
+      expect(created.length).toBe(4);
+      expect(created.map((p) => `${p.page}:${p.lang}`).sort()).toEqual([
+        '12a:en',
+        '12a:he',
+        '12b:en',
+        '12b:he',
+      ]);
+      // The heavy generation no longer goes through the queue.
+      expect(sent.filter((j) => j.mark_id).length).toBe(0);
+      expect(sent.filter((j) => j.warm_deep).length).toBe(0);
+    });
+
+    it('STILL enqueues rabbi.observations (daf-level reverse-index the Workflow does not warm)', async () => {
+      const { sent, queue } = collectJobs();
+      const { wf } = collectWorkflows();
+      await runYomiWarmCron({ ENRICHMENT_QUEUE: queue, DAF_WARM_WORKFLOW: wf });
+
+      const obs = sent.filter((j) => j.enrichment_id === 'rabbi.observations');
+      expect(obs.map((j) => j.page).sort()).toEqual(['12a', '12b']);
+      expect(obs.every((j) => (j.mark_input as { id?: string })?.id === 'daf')).toBe(true);
+    });
   });
 
   it('deep-warms the prose surface in BOTH languages (en + he parity)', async () => {


### PR DESCRIPTION
## What

The daily pre-warm fanned out a queue job per mark (6 EN + 5 HE) plus a per-language `warm_deep` job (`deepWarmDaf`) per amud — heavy generation on the enrichment queue, the one path that can still pile multiple dense source loads into a single 128 MB isolate. With the parallel `DafWarmWorkflow` (#493) and the cold-path cutover (#494) in place, the daily warm moves onto the memory-safe Workflow.

- When `DAF_WARM_WORKFLOW` is bound (always, in prod), the cron triggers **one Workflow per (amud, language)**. It generates the same marks + whole-daf + per-instance enrichment surface the mark/deep-warm jobs warmed — but as **bounded per-step invocations, in parallel**, so a dense daf can't OOM an isolate. Cache keys identical (same `runMark`/`runEnrichment`) → pure path swap, no re-warm.
- **`rabbi.observations` stays on the queue**: it warms the daf-level `{ id: 'daf' }` reverse-index key, which the Workflow's per-rabbi enumeration doesn't produce.
- The legacy queue fan-out is kept as a **fallback** for the (shouldn't-happen) missing-binding case. And since the cold cutover now self-generates any cold daf a reader opens, a cron miss is no longer a cold reader — just a slightly slower first open.

## Verification

- Tests: with the Workflow bound — 4 instances (2 amudim × 2 langs), **zero** mark/deep-warm queue jobs, `rabbi.observations` still enqueued daf-level; the existing en/he-parity tests now cover the fallback path. Full suite green (2596), typecheck + biome clean.
- `DafWarmWorkflow` itself is already proven live (cold Temurah 8b / Keritot 11a). Next daily cron run exercises this path end-to-end.

## Follow-up (not in this PR)

The rotating `warm` cron phase (`runWarmCron`) and the admin `rewarm` path also call `deepWarmDaf` on the queue — candidates for the same swap.