### PR TITLE
Rabbi cards: reset map/lineage interaction state on rabbi switch (stale-data fix)

### DIFF
--- a/packages/talmud/src/client/RabbiLineageTree.tsx
+++ b/packages/talmud/src/client/RabbiLineageTree.tsx
@@ -15,7 +15,7 @@
  * Hebrew/Aramaic span on the daf via onHighlightRange.
  */
 
-import { createSignal, For, type JSX, Show } from 'solid-js';
+import { createEffect, createSignal, For, type JSX, Show } from 'solid-js';
 import { type EdgeRect, orthogonalEdgePath } from './flow/orthogonalEdge';
 import {
   GENERATION_BY_ID,
@@ -383,6 +383,18 @@ function partnerPath(from: LaidNode, to: LaidNode): string {
 export default function RabbiLineageTree(props: Props): JSX.Element {
   const [expanded, setExpanded] = createSignal(false);
   const [activeEvidenceKey, setActiveEvidenceKey] = createSignal<string | null>(null);
+
+  // Same reuse hazard as RabbiTrajectoryMap: this tree is kept mounted across
+  // rabbi switches (warm-daf deps refill synchronously, so the wrapping <Show>
+  // never remounts us), which would otherwise bleed the previous rabbi's
+  // expand + active-evidence selection into the next rabbi's lineage. Reset
+  // when the subject changes. (The highlight itself is cleared by the
+  // RabbiLineage special block's instanceKey effect.)
+  createEffect(() => {
+    void props.subjectName;
+    setExpanded(false);
+    setActiveEvidenceKey(null);
+  });
 
   const evidenceByPerson = (): Map<string, RelationshipsEvidence> => {
     const m = new Map<string, RelationshipsEvidence>();

--- a/packages/talmud/src/client/RabbiTrajectoryMap.tsx
+++ b/packages/talmud/src/client/RabbiTrajectoryMap.tsx
@@ -12,7 +12,7 @@
  */
 
 import { fitBbox, GEO_BBOX, GeoMap, type GeoTrajectoryStop } from '@corpus/ui/GeoMap';
-import { createMemo, createSignal, For, type JSX, Show } from 'solid-js';
+import { createEffect, createMemo, createSignal, For, type JSX, Show } from 'solid-js';
 import { buildTrajectory, type TrajectoryStop } from '../lib/geographyModel';
 import { collapsePlaced, type PlacedStop, regionTint, stopLatLng, TRAJ_COLOR } from './geoMapBase';
 import { lang, t } from './i18n';
@@ -48,6 +48,18 @@ const EVIDENCE_BORDER = '#eab308';
 export default function RabbiTrajectoryMap(props: Props): JSX.Element {
   const [activeEvidenceKey, setActiveEvidenceKey] = createSignal<string | null>(null);
   const [picked, setPicked] = createSignal<number | null>(null);
+
+  // The geography special block REUSES this component across rabbi switches: on a
+  // warm daf the next rabbi's deps refill synchronously, so the wrapping <Show>
+  // never toggles to remount us, and these interaction signals (plus any daf
+  // highlight we painted) would otherwise carry the PREVIOUS rabbi's selection
+  // into the new card. Reset them whenever the rabbi (its geography data) changes.
+  createEffect(() => {
+    void props.data;
+    setPicked(null);
+    setActiveEvidenceKey(null);
+    props.onHighlightRange?.(null);
+  });
 
   const placed = (): PlacedStop[] => collapsePlaced(buildTrajectory(props.data));
   // Stops we can actually plot — the detail card + default selection key off


### PR DESCRIPTION
## Problem

Clicking a **different rabbi** on an already-loaded (warm) daf left parts of the rabbi card showing the **previous** rabbi's state:
- the geography map's **picked node** (its detail card),
- the **"on daf" evidence highlight** (still painted on the daf text), and
- the lineage tree's **expanded** state.

This is the "sidebar/drawer not refreshing — shows old data belonging to a different rabbi" report.

## Root cause

The rabbi card (`SidebarCardFromHint`) is keyed only on `c().kind` (`<Show when={CARD_DEFS[c().kind]}>`), so it is **reused** across rabbi switches — only `instanceKey` changes. On a **warm** daf the next rabbi's synthesis is a `runResultCache` hit, so `MarkEnrichmentCards` refills `deps` **synchronously** in the same reactive batch as `SidebarCardFromHint`'s deps-reset effect. Solid coalesces `deps()` from `{} → newDeps` with no intermediate committed render, so the wrapping `<Show when={geo()}>` in `RabbiGeography`/`RabbiLineage` never toggles. `RabbiTrajectoryMap` / `RabbiLineageTree` therefore are **not** remounted, and their internal interaction signals (`picked`, `activeEvidenceKey`, `expanded`) carry over from the previous rabbi.

(`RabbiLineage` already cleared the daf highlight on `instanceKey` change; `RabbiGeography` did not, so the map's highlight also leaked.)

On a **cold** daf the refill is async, so there's a real empty-render gap → the `<Show>` toggles → the components remount fresh, which is why the bug only showed on already-loaded dapim.

## Fix

Both leaf components reset their interaction state when the subject changes:
- `RabbiTrajectoryMap` — resets `picked` + `activeEvidenceKey` and clears the daf highlight, keyed on `props.data`.
- `RabbiLineageTree` — resets `expanded` + `activeEvidenceKey`, keyed on `props.subjectName`.

Robust regardless of whether the `<Show>` happens to remount.

## Verification
- `pnpm typecheck` — clean
- `biome check` on both files — clean
- `pnpm test` — 2596 passed