### PR TITLE
Instrument daf-view/warm-tier memory for OOM attribution; clamp load bar to 100%

### DIFF
--- a/packages/talmud/src/client/DafLoadProgress.tsx
+++ b/packages/talmud/src/client/DafLoadProgress.tsx
@@ -64,7 +64,11 @@ export default function DafLoadProgress(props: DafLoadProgressProps = {}): JSX.E
   // warm revisit with a full cache reads ~100% at once). max() so the snapshot
   // only ever ADVANCES the bar; it never drags the live climb backward on a cold
   // load, where the snapshot lags the warm.
-  const percent = createMemo(() => Math.max(enginePercent(), dafCacheProgress().pct));
+  // Final clamp to [0,100]: the shared bar renders this verbatim as both the
+  // "N%" label and the fill width, so neither cohort's math may push it over 100.
+  const percent = createMemo(() =>
+    Math.min(100, Math.max(enginePercent(), dafCacheProgress().pct)),
+  );
 
   const label = createMemo(() => {
     const c = combined();

--- a/packages/talmud/src/client/dafRunsProgress.ts
+++ b/packages/talmud/src/client/dafRunsProgress.ts
@@ -92,5 +92,12 @@ export function cacheProgressOf(rows: DafRun[]): { total: number; cached: number
     total += r.instances?.total ?? 1;
     cached += r.instances?.cached ?? (r.cached ? 1 : 0);
   }
-  return { total, cached, pct: total > 0 ? Math.round((cached / total) * 100) : 0 };
+  // Clamp: per-instance `cached` can briefly overshoot `total` when the instance
+  // count and the cached-instance count come from snapshots taken a beat apart, so
+  // a raw ratio can read >100%. A progress fraction is never meaningfully over 100.
+  return {
+    total,
+    cached,
+    pct: total > 0 ? Math.min(100, Math.round((cached / total) * 100)) : 0,
+  };
 }

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -2849,16 +2849,38 @@ app.get('/api/daf-view/:tractate/:page', async (c) => {
   const { complete, cold } = dafViewCompleteness(enumerated);
   c.header('Cache-Control', dafViewCacheControl(complete));
   c.header('x-daf-view', complete ? 'complete' : 'partial');
-  return c.json({
+  // [mem] instrumentation — daf-view is the prime OOM suspect: it materializes
+  // every cached piece (incl. each per-instance enrichment's `deps_resolved`) for
+  // one daf in memory, and a reader repolls it every ~8s through the cold-gen
+  // window, so dense dapim can co-tenant several MB-scale materializations on one
+  // 128 MB isolate. Serialize once (same cost as c.json), expose the size on
+  // headers (so any daf is measurable on demand), and emit a breadcrumb —
+  // Workers Observability (head_sampling_rate=1) captures it, so after an
+  // exceededMemory alert the largest payloads in the window are queryable, and a
+  // suspiciously large one is logged at WARN (`[mem] daf-view-large`) for a
+  // trivial filter. Pure observability — no behaviour change.
+  const pieceCount = Object.keys(pieces).length;
+  const payload = JSON.stringify({
     tractate,
     page,
     lang,
     complete,
     total: enumerated.length,
-    cached: Object.keys(pieces).length,
+    cached: pieceCount,
     cold,
     pieces,
   });
+  const bytes = payload.length;
+  const DAF_VIEW_LARGE_BYTES = 1_500_000;
+  const large = bytes >= DAF_VIEW_LARGE_BYTES;
+  c.header('x-daf-view-pieces', String(pieceCount));
+  c.header('x-daf-view-bytes', String(bytes));
+  c.header('content-type', 'application/json; charset=UTF-8');
+  console[large ? 'warn' : 'log'](
+    `[mem] daf-view${large ? '-large' : ''}`,
+    JSON.stringify({ t: tractate, p: page, lang, pieces: pieceCount, bytes, complete }),
+  );
+  return c.body(payload);
 });
 
 app.get('/api/daf-runs/:tractate/:page', async (c) => {
@@ -11429,6 +11451,21 @@ export class DafWarmWorkflow extends WorkflowEntrypoint<Bindings, DafWarmParams>
       CODE_MARKS.map((m) => m.id),
       markDepsOf,
     )) {
+      // [mem] breadcrumb — a tier's steps run concurrently in THIS isolate (the
+      // "own budget" only holds across suspension points), so `width` is the peak
+      // concurrent in-isolate generation that coalesce.ts must dedupe source
+      // slices across. Attributes a cold-gen OOM to (daf, phase, width).
+      console.log(
+        '[mem] warm-tier',
+        JSON.stringify({
+          phase: 'marks',
+          t: tractate,
+          p: page,
+          lang,
+          width: tier.length,
+          conc: STEP_CONCURRENCY,
+        }),
+      );
       await parallelMap(tier, STEP_CONCURRENCY, (mid) =>
         runStep(`mark:${mid}`, async (rc) => {
           const def = await loadMarkDef(wrapped, mid);
@@ -11442,6 +11479,17 @@ export class DafWarmWorkflow extends WorkflowEntrypoint<Bindings, DafWarmParams>
     // 2) Whole-daf enrichments ({fields:{}}), in dependency tiers (e.g.
     //    argument-overview.flow before the synthesis that consumes it).
     for (const tier of topoTiers(wholeDafEnrichmentIds(marksLite, enrichLite), enrichDepsOf)) {
+      console.log(
+        '[mem] warm-tier',
+        JSON.stringify({
+          phase: 'whole-daf',
+          t: tractate,
+          p: page,
+          lang,
+          width: tier.length,
+          conc: STEP_CONCURRENCY,
+        }),
+      );
       await parallelMap(tier, STEP_CONCURRENCY, (id) =>
         runStep(`enrich:${id}`, async (rc) => {
           const def = await loadEnrichmentDef(wrapped, id);
@@ -11483,6 +11531,17 @@ export class DafWarmWorkflow extends WorkflowEntrypoint<Bindings, DafWarmParams>
           units.push({ id, def, inst, iid: await instanceIdOf(inst) });
         }
       }
+      console.log(
+        '[mem] warm-tier',
+        JSON.stringify({
+          phase: 'per-instance',
+          t: tractate,
+          p: page,
+          lang,
+          width: units.length,
+          conc: STEP_CONCURRENCY,
+        }),
+      );
       await parallelMap(units, STEP_CONCURRENCY, (u) =>
         runStep(`enrich:${u.id}:${u.iid}`, async (rc) => {
           const res = await runEnrichmentOnce(rc, u.def, tractate, page, u.inst, false);


### PR DESCRIPTION
Two items from the OOM-investigation session.

## 1. OOM attribution (instrument-first)

The `exceededMemory` alert only reports an outcome **count** for `scriptName: "talmud"` — not which route, and the dying isolate can't log after the fact. The `daf-warm` Workflow is a separate entity, so the count most likely reflects the **main worker's fetch/cron** path. The recently-grown main-worker memory path is `/api/daf-view` (#491/#492 added ~40-50 `argument.synthesis` per-instance pieces, each with `deps_resolved`), repolled every ~8s during cold generation. This adds attribution before touching the delicate warm-render path:

- **`/api/daf-view`** — serialize once (same cost as `c.json`), expose `x-daf-view-pieces` / `x-daf-view-bytes` response headers (any daf measurable on demand), and emit a `[mem] daf-view` breadcrumb — `console.warn` with a `-large` suffix past ~1.5 MB for a trivial log filter. Workers Observability (`head_sampling_rate=1`) captures it, so after an alert the largest payloads in the window are queryable.
- **`DafWarmWorkflow`** — a `[mem] warm-tier` breadcrumb per phase (marks / whole-daf / per-instance) recording the concurrent fan-out **width**, the memory-relevant metric for a cold-gen OOM (a tier's `step.do` callbacks run concurrently in one isolate; the "own budget" only holds across suspension points).

Pure observability — no behaviour change, no cache-key change. Next step: read `x-daf-view-bytes` on the densest dapim to confirm or refute the daf-view hypothesis, then fix the confirmed source.

## 2. Load bar can read >100%

The shared `LoadProgress` renders `percent()` verbatim as both the `N%` label and the fill `width` with no clamp. `cacheProgressOf` can return `pct > 100` when a per-instance producer's `cached` count momentarily overshoots `total` (instance-count and cached-count snapshots taken a beat apart). Clamp `pct` at the source and the final bar `percent` to `[0,100]`.

## Verification
- `pnpm typecheck` — clean
- `biome check` — clean
- `pnpm test` — 2596 passed