### PR TITLE
Reset stale per-instance UI state in QAPanel + ArgumentNarrative

### DIFF
--- a/packages/talmud/src/client/ArgumentNarrative.tsx
+++ b/packages/talmud/src/client/ArgumentNarrative.tsx
@@ -7,7 +7,7 @@
  * an LLM call only when a dev opens a narrative section.
  */
 
-import { createResource, createSignal, For, type JSX, Show } from 'solid-js';
+import { createEffect, createResource, createSignal, For, type JSX, Show } from 'solid-js';
 import { lang } from './i18n';
 
 interface Actor {
@@ -113,6 +113,16 @@ export default function ArgumentNarrative(props: {
     () => runNarrative(props.tractate, props.page, props.section),
   );
   const [activeBeat, setActiveBeat] = createSignal<number | null>(null);
+  // The argument card reuses this component across section switches (it's keyed on
+  // card kind, not the section), so reset the active beat + clear any daf
+  // highlight when the section changes — otherwise the previous section's beat
+  // selection bleeds into the next one.
+  createEffect(() => {
+    void props.section.startSegIdx;
+    void props.section.endSegIdx;
+    setActiveBeat(null);
+    props.onHighlight?.(null);
+  });
 
   return (
     <div style={{ 'margin-top': '0.6rem' }}>

--- a/packages/talmud/src/client/QAPanel.tsx
+++ b/packages/talmud/src/client/QAPanel.tsx
@@ -27,7 +27,7 @@
  * `user_question` in the body.
  */
 
-import { createResource, createSignal, For, type JSX, onMount, Show } from 'solid-js';
+import { createEffect, createResource, createSignal, For, type JSX, onMount, Show } from 'solid-js';
 import { trackAI } from './aiActivity';
 import {
   isPausedBody,
@@ -318,6 +318,22 @@ export default function QAPanel(props: QAPanelProps): JSX.Element {
       }
     >
   >({});
+
+  // This panel is reused across instances when the parent card is kept mounted
+  // and only its instance prop changes (e.g. switching between two aggadata
+  // stories / pesukim in the sidebar — the card is keyed on kind, not instance).
+  // The resources below re-key on instanceId(), but these fold/draft signals do
+  // not, so reset them on instance change — otherwise the previous instance's
+  // expanded state and opened answers bleed into the next one.
+  createEffect(() => {
+    void props.instanceId;
+    setExpanded(false);
+    setShowAll(false);
+    setAskingOpen(false);
+    setAskText('');
+    setAskError(null);
+    setOpenAnswers({});
+  });
 
   // Two parallel resources, both gated on `expanded` so we don't pay
   // anything until the user opens the panel for the first time.


### PR DESCRIPTION
Found while auditing for the same bug class as #497 (the rabbi-card stale-data fix).

Both components hold local `createSignal` interaction state tied to an instance/section, but the parent card is keyed on **kind** (not the specific instance), so the component is **reused** rather than remounted when you switch instances — and the previous instance's UI state bleeds into the next.

- **QAPanel** — reset `expanded` / `showAll` / `askingOpen` / `askText` / `askError` / `openAnswers` on `instanceId` change. The suggested/registry resources already re-key on `instanceId`, but the fold + opened-answers state did not, so switching between two same-kind cards (e.g. aggadata stories, pesukim) in the sidebar showed the previous one's expanded panel and opened answers.
- **ArgumentNarrative** — reset `activeBeat` and clear the daf highlight on section change, so a previous section's highlighted story beat doesn't carry over.

## Verification
- `pnpm typecheck` / `biome check` — clean
- `pnpm test` — 2596 passed