### PR TITLE
Remove dead code + leftover debug logging

### DIFF
--- a/packages/talmud/src/lib/sefref/alignment/index.ts
+++ b/packages/talmud/src/lib/sefref/alignment/index.ts
@@ -219,8 +219,6 @@ export function findOptimalAlignment(
     if (score > 0.7) break;
   }
 
-  console.log('Best alignment offset:', bestOffset, 'with score:', bestScore.toFixed(3));
-
   // Create aligned pairs using dynamic programming approach
   const pairs: WordPair[] = [];
   let sefariaIdx = 0;
@@ -428,13 +426,6 @@ export function alignTexts(sefariaText: string, hebrewBooksText: string, maxLeng
   const sefariaWords = sefariaText.split(/\s+/).filter((w) => w.length > 0);
   const hebrewBooksWords = hebrewBooksText.split(/\s+/).filter((w) => w.length > 0);
 
-  console.log('Aligning texts:', {
-    sefariaWords: sefariaWords.length,
-    hebrewBooksWords: hebrewBooksWords.length,
-    sefariaPreview: sefariaText.substring(0, 100),
-    hebrewBooksPreview: hebrewBooksText.substring(0, 100),
-  });
-
   // Find optimal alignment
   const alignment = findOptimalAlignment(sefariaWords, hebrewBooksWords, maxLength);
 
@@ -447,13 +438,6 @@ export function alignTexts(sefariaText: string, hebrewBooksText: string, maxLeng
 
   // Calculate statistics
   const statistics = calculateMatchStatistics(wordComparison, alignment.score);
-
-  console.log('Alignment complete:', {
-    offset: alignment.offset,
-    alignedLength: alignment.pairs.length,
-    score: `${(alignment.score * 100).toFixed(1)}%`,
-    statistics,
-  });
 
   return {
     alignment,

--- a/packages/talmud/src/lib/sefref/amudim.ts
+++ b/packages/talmud/src/lib/sefref/amudim.ts
@@ -107,12 +107,3 @@ export function* iterAmudim(tractate: string): Generator<string> {
     if (a) yield a;
   }
 }
-
-export function amudCount(tractate: string): number {
-  const end = TRACTATE_END_AMUD[tractate.toLowerCase()];
-  if (!end) return 0;
-  const endNum = amudToNumber(end);
-  const startNum = amudToNumber(START_AMUD);
-  if (endNum == null || startNum == null) return 0;
-  return endNum - startNum + 1;
-}

--- a/packages/talmud/src/lib/sefref/sefaria/links.ts
+++ b/packages/talmud/src/lib/sefref/sefaria/links.ts
@@ -103,8 +103,6 @@ export async function getSefariaLinks(tractate: string, daf: string): Promise<Se
     const ref = `${tractate} ${daf}`; // e.g., "Berakhot 3a"
     const url = `https://www.sefaria.org/api/related/${ref.replace(' ', '_')}`;
 
-    console.log('Fetching Sefaria links for:', ref);
-
     const response = await fetch(url);
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -122,7 +120,6 @@ export async function getSefariaLinks(tractate: string, daf: string): Promise<Se
       .filter((link: SefariaLink | null): link is SefariaLink => link !== null)
       .filter(includeLink);
 
-    console.log(`Found ${links.length} relevant links for ${ref}`);
     return links;
   } catch (error) {
     console.error('Failed to fetch Sefaria links:', error);
@@ -190,16 +187,6 @@ export function linksToLinkingData(links: SefariaLink[], baseRef: string): Linki
     }
   });
 
-  console.log('Converted links to linking data:', {
-    baseRef,
-    rashiSegments: Object.keys(linking.rashi[baseRef]).length,
-    tosafotSegments: Object.keys(linking.tosafot[baseRef]).length,
-    traditionalSegments: Object.keys(linking.traditional[baseRef]).length,
-    crossRefSegments: Object.keys(linking.crossReferences[baseRef]).length,
-    rashiLinksCount: rashiLinks.length,
-    tosafotLinksCount: tosafotLinks.length,
-  });
-
   return linking;
 }
 
@@ -214,12 +201,6 @@ export async function getCommentaryLinks(
   const links = await getSefariaLinks(tractate, daf);
   const baseRef = `${tractate} ${daf}`;
   const linkingData = linksToLinkingData(links, baseRef);
-
-  console.log('getCommentaryLinks returning:', {
-    rashiKeys: Object.keys(linkingData.rashi[baseRef] || {}),
-    tosafotKeys: Object.keys(linkingData.tosafot[baseRef] || {}),
-    totalLinks: links.length,
-  });
 
   return {
     rashi: linkingData.rashi[baseRef] || {},


### PR DESCRIPTION
Cruft found in the audit.

- **`amudCount`** (sefref/amudim.ts) — exported but has zero importers across all packages (verified incl. the `export *` barrel). Its sibling helpers stay.
- **Debug `console.log`s** — leftover unstructured logging in the Sefaria links walk (`sefref/sefaria/links.ts`, 4) and the alignment workbench (`sefref/alignment/index.ts`, 3), e.g. `console.log('Fetching Sefaria links for:', ref)`. The `console.warn`/`console.error` error paths are kept, and the intentional `[prefix]`-tagged structured logs (`[mem]`, `[health]`, `[queue]`, …) are untouched.

44 lines deleted, no behaviour change.

## Verification
- `pnpm typecheck` / `biome check` — clean
- `pnpm test` — 2596 passed

> Note: the audit also flagged `RabbiPlacesTimeline.tsx` as dead, but it does not exist on master (only a comment in RabbiTrajectoryMap references it), and `RabbiGeographyCard`'s component is unrendered but its exported types are still used — left alone to avoid an unrelated type-extraction churn.