### PR TITLE
Cost page: show OpenRouter's real billed spend (was ~2.5x low)

### DIFF
--- a/packages/talmud/src/client/UsagePage.tsx
+++ b/packages/talmud/src/client/UsagePage.tsx
@@ -256,9 +256,30 @@ interface TelemetrySection {
   recentErrors: RecentError[];
   totalCount: number;
 }
+interface OrModelRow {
+  model: string;
+  requests: number;
+  costUsd: number;
+  tokensIn: number;
+  tokensOut: number;
+}
+interface OrCost {
+  configured: boolean;
+  ok: boolean;
+  error?: string;
+  windowStart?: string;
+  windowEnd?: string;
+  days?: number;
+  requests?: number;
+  costUsd?: number;
+  lifetimeUsd?: number;
+  byModel?: OrModelRow[];
+  byDay?: Array<{ date: string; costUsd: number }>;
+}
 interface CostSectionData {
   selfTracked: UsageSummary | null;
   aiGateway: AigwCost;
+  openRouter?: OrCost;
   costAvoided?: { recentUsd: number; recentCalls: number };
 }
 interface BacklogSectionData {
@@ -1349,10 +1370,68 @@ function ActivitySection(props: { activity: ZoneActivity }): JSX.Element {
   );
 }
 
+/** Per-model cost table shared by the OpenRouter (billed) and AI Gateway
+ *  (gateway-estimated) breakdowns — both carry the same row shape. */
+function ModelCostTable(props: {
+  rows: Array<{
+    model: string;
+    requests: number;
+    tokensIn: number;
+    tokensOut: number;
+    costUsd: number;
+  }>;
+}): JSX.Element {
+  const cellNum = {
+    padding: '0.4rem 0.5rem',
+    'text-align': 'right',
+    'font-variant-numeric': 'tabular-nums',
+  } as const;
+  return (
+    <table style={tableStyle}>
+      <thead>
+        <tr style={{ 'text-align': 'left', 'border-bottom': '1px solid #eee', color: '#666' }}>
+          <th style={thStyle}>{t('usage.col.model')}</th>
+          <th style={{ ...thStyle, 'text-align': 'right' }}>{t('usage.col.requests')}</th>
+          <th style={{ ...thStyle, 'text-align': 'right' }}>{t('usage.col.tokens')}</th>
+          <th style={{ ...thStyle, 'text-align': 'right' }}>{t('usage.col.cost')}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <For each={props.rows}>
+          {(m) => (
+            <tr style={{ 'border-bottom': '1px solid #f4f4f4' }}>
+              <td
+                style={{
+                  padding: '0.4rem 0.5rem',
+                  'font-family': 'monospace',
+                  'font-size': '0.8rem',
+                }}
+              >
+                {m.model}
+              </td>
+              <td style={cellNum}>{fmtInt(m.requests)}</td>
+              <td style={cellNum}>{fmtTokens(m.tokensIn + m.tokensOut)}</td>
+              <td style={cellNum}>{fmtUsd(m.costUsd)}</td>
+            </tr>
+          )}
+        </For>
+      </tbody>
+    </table>
+  );
+}
+
 function CostSection(props: { cost: CostSectionData; stats: CacheStats | undefined }): JSX.Element {
   const aigw = () => props.cost.aiGateway;
+  const or = () => props.cost.openRouter;
   const self = () => props.cost.selfTracked;
   const avoided = () => props.cost.costAvoided;
+  // The authoritative billed number: OpenRouter's own ledger when wired up, else
+  // the AI Gateway figure (which under-prices price-routed DeepSeek).
+  const billedUsd = (): number | null => {
+    if (or()?.ok) return or()?.costUsd ?? null;
+    if (aigw().ok) return aigw().costUsd ?? null;
+    return null;
+  };
 
   // Per-producer estimate of the cost to warm ALL of shas at full depth. Each
   // producer's unit cost ($/priced call) is projected across its own fire-rate
@@ -1390,40 +1469,103 @@ function CostSection(props: { cost: CostSectionData; stats: CacheStats | undefin
   const last30 = () => sumWindow(30);
   // How much of the provider's billed spend our 30-day tracking accounts for.
   const converge = () => {
-    const billed = aigw().ok ? (aigw().costUsd ?? 0) : 0;
+    const billed = billedUsd() ?? 0;
     if (billed <= 0) return null;
     return Math.round((last30().costUsd / billed) * 100);
   };
 
   return (
     <>
-      {/* Total spent — authoritative, billed by the provider. */}
+      {/* Total spent — authoritative, OpenRouter's own billed ledger. */}
       <h3 style={{ 'font-size': '0.8rem', color: '#777', margin: '0.2rem 0 0.4rem' }}>
         {t('usage.cost.billed.title')}{' '}
         <span style={{ color: '#999', 'font-weight': 'normal' }}>{t('usage.cost.billed.sub')}</span>
       </h3>
       <Show
-        when={aigw().ok}
+        when={or()?.ok}
         fallback={
-          <p
-            style={{
-              color: aigw().configured ? '#c33' : '#888',
-              'font-size': '0.82rem',
-              background: '#fafafa',
-              padding: '0.5rem 0.7rem',
-              'border-radius': '4px',
-              border: '1px solid #eee',
-            }}
-          >
+          <>
+            {/* No provisioning key (or query failed): fall back to the AI Gateway
+                figure, but flag that it under-prices routed models. */}
             <Show
-              when={!aigw().configured}
-              fallback={t('usage.aigw.queryFailed', { error: aigw().error ?? '' })}
+              when={or() && !or()?.configured}
+              fallback={
+                <Show when={or()?.error}>
+                  <p style={{ color: '#c33', 'font-size': '0.8rem', margin: '0 0 0.4rem' }}>
+                    {t('usage.or.queryFailed', { error: or()?.error ?? '' })}
+                  </p>
+                </Show>
+              }
             >
-              {t('usage.aigw.notConfigured.before')}
-              <code>wrangler secret put CF_ANALYTICS_TOKEN</code>
-              {t('usage.aigw.notConfigured.after', { error: aigw().error ?? '' })}
+              <p
+                style={{
+                  color: '#8a6d00',
+                  'font-size': '0.8rem',
+                  background: '#fffdf2',
+                  padding: '0.5rem 0.7rem',
+                  'border-radius': '4px',
+                  border: '1px solid #f0e6c0',
+                  margin: '0 0 0.5rem',
+                }}
+              >
+                {t('usage.or.notConfigured.before')}
+                <code>wrangler secret put OPENROUTER_PROVISIONING_KEY</code>
+                {t('usage.or.notConfigured.after')}
+              </p>
             </Show>
-          </p>
+            <Show
+              when={aigw().ok}
+              fallback={
+                <p
+                  style={{
+                    color: aigw().configured ? '#c33' : '#888',
+                    'font-size': '0.82rem',
+                    background: '#fafafa',
+                    padding: '0.5rem 0.7rem',
+                    'border-radius': '4px',
+                    border: '1px solid #eee',
+                  }}
+                >
+                  <Show
+                    when={!aigw().configured}
+                    fallback={t('usage.aigw.queryFailed', { error: aigw().error ?? '' })}
+                  >
+                    {t('usage.aigw.notConfigured.before')}
+                    <code>wrangler secret put CF_ANALYTICS_TOKEN</code>
+                    {t('usage.aigw.notConfigured.after', { error: aigw().error ?? '' })}
+                  </Show>
+                </p>
+              }
+            >
+              <div
+                style={{
+                  display: 'flex',
+                  gap: '0.6rem',
+                  'flex-wrap': 'wrap',
+                  'margin-bottom': '0.3rem',
+                }}
+              >
+                <StatCard
+                  label={t('usage.stat.totalCost')}
+                  value={fmtUsd(aigw().costUsd)}
+                  color="#2a8a42"
+                  sub={t('usage.cost.gatewayApprox')}
+                />
+                <StatCard label={t('usage.stat.requests')} value={fmtInt(aigw().requests ?? 0)} />
+                <StatCard label={t('usage.stat.tokensIn')} value={fmtTokens(aigw().tokensIn)} />
+                <StatCard label={t('usage.stat.tokensOut')} value={fmtTokens(aigw().tokensOut)} />
+              </div>
+              <Show when={(aigw().byModel?.length ?? 0) > 0}>
+                <Collapsible
+                  id="aigwByModel"
+                  title={t('usage.byModel')}
+                  sub={t('usage.byModel.sub', { count: fmtInt(aigw().byModel?.length ?? 0) })}
+                >
+                  <ModelCostTable rows={aigw().byModel ?? []} />
+                </Collapsible>
+              </Show>
+            </Show>
+          </>
         }
       >
         <div
@@ -1431,75 +1573,36 @@ function CostSection(props: { cost: CostSectionData; stats: CacheStats | undefin
         >
           <StatCard
             label={t('usage.stat.totalCost')}
-            value={fmtUsd(aigw().costUsd)}
+            value={fmtUsd(or()?.costUsd)}
             color="#2a8a42"
           />
-          <StatCard label={t('usage.stat.requests')} value={fmtInt(aigw().requests ?? 0)} />
-          <StatCard label={t('usage.stat.tokensIn')} value={fmtTokens(aigw().tokensIn)} />
-          <StatCard label={t('usage.stat.tokensOut')} value={fmtTokens(aigw().tokensOut)} />
+          <Show when={typeof or()?.lifetimeUsd === 'number'}>
+            <StatCard
+              label={t('usage.stat.lifetime')}
+              value={fmtUsd(or()?.lifetimeUsd)}
+              sub={t('usage.cost.lifetimeSub')}
+            />
+          </Show>
+          <StatCard label={t('usage.stat.requests')} value={fmtInt(or()?.requests ?? 0)} />
         </div>
-        <Show when={(aigw().byModel?.length ?? 0) > 0}>
+        <Show when={(or()?.byModel?.length ?? 0) > 0}>
+          <Collapsible
+            id="orByModel"
+            title={t('usage.byModel')}
+            sub={t('usage.byModel.sub', { count: fmtInt(or()?.byModel?.length ?? 0) })}
+          >
+            <ModelCostTable rows={or()?.byModel ?? []} />
+          </Collapsible>
+        </Show>
+        {/* Demoted: the gateway figure, for comparison only — it under-prices
+            price-routed DeepSeek, so it reads low against the billed total above. */}
+        <Show when={aigw().ok}>
           <Collapsible
             id="aigwByModel"
-            title={t('usage.byModel')}
-            sub={t('usage.byModel.sub', { count: fmtInt(aigw().byModel?.length ?? 0) })}
+            title={t('usage.cost.gatewayCompare.title', { cost: fmtUsd(aigw().costUsd) })}
+            sub={t('usage.cost.gatewayCompare.sub')}
           >
-            <table style={tableStyle}>
-              <thead>
-                <tr
-                  style={{ 'text-align': 'left', 'border-bottom': '1px solid #eee', color: '#666' }}
-                >
-                  <th style={thStyle}>{t('usage.col.model')}</th>
-                  <th style={{ ...thStyle, 'text-align': 'right' }}>{t('usage.col.requests')}</th>
-                  <th style={{ ...thStyle, 'text-align': 'right' }}>{t('usage.col.tokens')}</th>
-                  <th style={{ ...thStyle, 'text-align': 'right' }}>{t('usage.col.cost')}</th>
-                </tr>
-              </thead>
-              <tbody>
-                <For each={aigw().byModel}>
-                  {(m) => (
-                    <tr style={{ 'border-bottom': '1px solid #f4f4f4' }}>
-                      <td
-                        style={{
-                          padding: '0.4rem 0.5rem',
-                          'font-family': 'monospace',
-                          'font-size': '0.8rem',
-                        }}
-                      >
-                        {m.model}
-                      </td>
-                      <td
-                        style={{
-                          padding: '0.4rem 0.5rem',
-                          'text-align': 'right',
-                          'font-variant-numeric': 'tabular-nums',
-                        }}
-                      >
-                        {fmtInt(m.requests)}
-                      </td>
-                      <td
-                        style={{
-                          padding: '0.4rem 0.5rem',
-                          'text-align': 'right',
-                          'font-variant-numeric': 'tabular-nums',
-                        }}
-                      >
-                        {fmtTokens(m.tokensIn + m.tokensOut)}
-                      </td>
-                      <td
-                        style={{
-                          padding: '0.4rem 0.5rem',
-                          'text-align': 'right',
-                          'font-variant-numeric': 'tabular-nums',
-                        }}
-                      >
-                        {fmtUsd(m.costUsd)}
-                      </td>
-                    </tr>
-                  )}
-                </For>
-              </tbody>
-            </table>
+            <ModelCostTable rows={aigw().byModel ?? []} />
           </Collapsible>
         </Show>
       </Show>
@@ -1605,7 +1708,7 @@ function CostSection(props: { cost: CostSectionData; stats: CacheStats | undefin
               >
                 {t('usage.cost.converge', {
                   pct: String(converge()),
-                  billed: fmtUsd(aigw().costUsd),
+                  billed: fmtUsd(billedUsd() ?? undefined),
                 })}
               </p>
             </Show>

--- a/packages/talmud/src/client/i18n.ts
+++ b/packages/talmud/src/client/i18n.ts
@@ -806,9 +806,32 @@ const CATALOG = {
   // Reframed cost view: a billed total + our own windowed tracking.
   'usage.cost.billed.title': { en: 'Total spent', he: 'סך ההוצאה' },
   'usage.cost.billed.sub': {
-    en: 'billed by the provider · last 30 days',
-    he: 'מחויב על ידי הספק · 30 הימים האחרונים',
+    en: 'actually billed · last 30 days',
+    he: 'מה שחויב בפועל · 30 הימים האחרונים',
   },
+  'usage.stat.lifetime': { en: 'Lifetime', he: 'מאז ומתמיד' },
+  'usage.cost.lifetimeSub': { en: 'all-time on OpenRouter', he: 'מאז ומתמיד ב-OpenRouter' },
+  'usage.cost.gatewayApprox': {
+    en: 'approx · gateway-estimated',
+    he: 'משוער · לפי ה-Gateway',
+  },
+  'usage.cost.gatewayCompare.title': {
+    en: 'AI Gateway estimate: {cost}',
+    he: 'אומדן AI Gateway: {cost}',
+  },
+  'usage.cost.gatewayCompare.sub': {
+    en: 'gateway-computed · under-prices routed DeepSeek',
+    he: 'מחושב ב-Gateway · מתמחר בחסר את DeepSeek המנותב',
+  },
+  'usage.or.queryFailed': {
+    en: 'OpenRouter query failed: {error}',
+    he: 'שאילתת OpenRouter נכשלה: {error}',
+  },
+  'usage.or.notConfigured.before': {
+    en: 'Showing the AI Gateway estimate — it under-prices price-routed models. For the real billed total, set an OpenRouter management key via ',
+    he: 'מוצג אומדן ה-AI Gateway — הוא מתמחר בחסר מודלים מנותבים. לקבלת הסכום המחויב האמיתי, הגדירו מפתח ניהול של OpenRouter באמצעות ',
+  },
+  'usage.or.notConfigured.after': { en: '.', he: '.' },
   'usage.cost.tracked.title': { en: 'Our tracking', he: 'המעקב שלנו' },
   'usage.cost.tracked.sub': {
     en: 'priced models · per producer',
@@ -823,8 +846,8 @@ const CATALOG = {
   'usage.cost.winAll': { en: 'All time', he: 'מאז ומתמיד' },
   'usage.cost.winCalls': { en: '{count} calls', he: '{count} קריאות' },
   'usage.cost.converge': {
-    en: "Our 30-day tracking is {pct}% of the {billed} billed — the gap is Workers AI and other models the provider bills but we can't yet price per producer. The two should converge.",
-    he: 'המעקב שלנו ל-30 יום הוא {pct}% מתוך {billed} שחויבו — הפער הוא Workers AI ומודלים נוספים שהספק מחייב אך איננו מתמחרים לכל מפיק. השניים אמורים להתכנס.',
+    en: 'Our 30-day per-producer tracking is {pct}% of the {billed} billed. Both now use the real billed cost, so they should converge — the remaining gap is Workers AI (neuron-billed, unpriced here) plus older days still aging out of the window after the cost-source fix.',
+    he: 'המעקב שלנו לפי מפיק ל-30 יום הוא {pct}% מתוך {billed} שחויבו. שניהם משתמשים כעת בעלות המחויבת בפועל, ולכן הם אמורים להתכנס — הפער הנותר הוא Workers AI (מחויב בנוירונים, ללא תמחור כאן) וכן ימים ישנים שעדיין יוצאים מהחלון לאחר תיקון מקור העלות.',
   },
   'usage.aigw.queryFailed': {
     en: 'AI Gateway query failed: {error}',

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -205,6 +205,7 @@ import {
 } from './inspect-anchors';
 import { noteLintAttempt, readLintFailures } from './lint-failures';
 import { ALIGN_MARKS } from './mark-categories';
+import { fetchOpenRouterCost } from './openrouter-cost';
 import {
   ARGUMENT_BRIDGE_OUTPUT_SCHEMA,
   ARGUMENT_CROSS_FLOW_OUTPUT_SCHEMA,
@@ -6711,17 +6712,28 @@ function captureLlmUsage(
     result: { model?: string; usage?: LLMUsage | null; parse_error?: string | null };
   },
 ): void {
-  const { input, output } = normalizeUsage(
-    args.result.usage as Parameters<typeof normalizeUsage>[0],
-  );
-  const cost = priceCostUsd(
-    args.result.model,
-    args.result.usage as Parameters<typeof priceCostUsd>[1],
-  );
-  const { costInUsd, costOutUsd } = costSplitUsd(
-    args.result.model,
-    args.result.usage as Parameters<typeof costSplitUsd>[1],
-  );
+  const usage = args.result.usage;
+  const { input, output } = normalizeUsage(usage as Parameters<typeof normalizeUsage>[0]);
+  // The REAL billed amount OpenRouter returns (we send `usage:{include:true}`),
+  // net of prompt-cache and at the actual routed-provider price. This is the
+  // truth — the list-price estimate below under-counts price-routed DeepSeek by
+  // multiples (V4 Pro routes to a third party well above its listed rate). Only
+  // fall back to the list-price estimate when no billed figure came back (e.g.
+  // Workers AI, or a response that dropped usage accounting).
+  const billed = typeof usage?.cost === 'number' ? usage.cost : null;
+  const estimate = priceCostUsd(args.result.model, usage as Parameters<typeof priceCostUsd>[1]);
+  const cost = billed ?? estimate;
+  // The in/out split is a list-price ESTIMATE (OpenRouter bills one number, no
+  // per-side breakdown). Scale it to the billed total so the two sides sum to
+  // the real cost while preserving the input-vs-output ratio from list prices.
+  const split = costSplitUsd(args.result.model, usage as Parameters<typeof costSplitUsd>[1]);
+  let { costInUsd, costOutUsd } = split;
+  if (billed != null && costInUsd != null && costOutUsd != null) {
+    const estSum = costInUsd + costOutUsd;
+    const scale = estSum > 0 ? billed / estSum : 0;
+    costInUsd *= scale;
+    costOutUsd *= scale;
+  }
   recordUsage(rc.env, rc.ctx, {
     ok: !args.result.parse_error,
     cacheHit: false,
@@ -6884,6 +6896,26 @@ async function loadAigwCached(
   );
   return fresh;
 }
+// Authoritative billed spend from OpenRouter's own ledger (the invoice), sub-
+// cached 5 min like the gateway figure. This is the real "Total spent" — the
+// gateway number under-prices price-routed DeepSeek (see openrouter-cost.ts).
+async function loadOpenRouterCostCached(
+  c: UsageCtx,
+  cache?: KVNamespace,
+): Promise<Awaited<ReturnType<typeof fetchOpenRouterCost>>> {
+  if (!cache) return fetchOpenRouterCost(c.env);
+  const raw = await cache.get('or-cost:v1');
+  if (raw) {
+    try {
+      return JSON.parse(raw) as Awaited<ReturnType<typeof fetchOpenRouterCost>>;
+    } catch {
+      /* recompute */
+    }
+  }
+  const fresh = await fetchOpenRouterCost(c.env);
+  c.executionCtx.waitUntil(cache.put('or-cost:v1', JSON.stringify(fresh), { expirationTtl: 300 }));
+  return fresh;
+}
 async function loadActivityCached(
   c: UsageCtx,
   cache?: KVNamespace,
@@ -6975,9 +7007,10 @@ async function buildTelemetrySection(cache?: KVNamespace) {
 }
 
 async function buildCostSection(c: UsageCtx, cache?: KVNamespace) {
-  const [selfTracked, aiGateway, telRaw] = await Promise.all([
+  const [selfTracked, aiGateway, openRouter, telRaw] = await Promise.all([
     cache ? readUsageSummary(cache) : null,
     loadAigwCached(c, cache),
+    loadOpenRouterCostCached(c, cache),
     cache ? cache.get('telemetry:v1:recent') : null,
   ]);
   // Cost avoided by serving cache hits, over the recent telemetry window. Each
@@ -6995,6 +7028,7 @@ async function buildCostSection(c: UsageCtx, cache?: KVNamespace) {
   return {
     selfTracked,
     aiGateway,
+    openRouter,
     costAvoided: { recentUsd: Math.round(avoidedUsd * 1e6) / 1e6, recentCalls: avoidedCalls },
   };
 }

--- a/packages/talmud/src/worker/mcp-openapi.ts
+++ b/packages/talmud/src/worker/mcp-openapi.ts
@@ -456,8 +456,10 @@ export const TALMUD_OPENAPI: Record<string, unknown> = {
     '/api/usage/cost': {
       get: {
         summary:
-          'Cost section: self-tracked spend (per model/mark/enrichment, input-vs-output split), AI Gateway billed cost, and recent cost-avoided-by-cache.',
-        responses: { '200': { description: '{ selfTracked, aiGateway, costAvoided }' } },
+          'Cost section: OpenRouter billed spend (authoritative, from /activity + lifetime /credits), self-tracked spend (per model/mark/enrichment, input-vs-output split), AI Gateway estimate (under-prices routed models), and recent cost-avoided-by-cache.',
+        responses: {
+          '200': { description: '{ selfTracked, aiGateway, openRouter, costAvoided }' },
+        },
       },
     },
     '/api/usage/telemetry': {

--- a/packages/talmud/src/worker/openrouter-cost.ts
+++ b/packages/talmud/src/worker/openrouter-cost.ts
@@ -1,0 +1,178 @@
+/**
+ * Authoritative spend straight from OpenRouter — what we are ACTUALLY billed.
+ *
+ * Why this exists (and why it is the real "Total spent"): the Cloudflare AI
+ * Gateway `cost` figure (aigw-analytics.ts) is computed from CF's own per-model
+ * price table, which uses each model's canonical/listed price. But our DeepSeek
+ * calls route under `{ sort: 'price', require_parameters: true }`, so OpenRouter
+ * picks whatever qualifying provider is cheapest at call time — frequently a
+ * third party that bills well ABOVE the listed first-party rate. The gateway is
+ * blind to that, so it under-reports DeepSeek spend by multiples (V4 Pro was
+ * shown at ~$326 against ~$1,148 actually billed). OpenRouter's own activity
+ * ledger is the ground truth — it is the number on the invoice.
+ *
+ * `/api/v1/activity` returns one row per (day, model, endpoint) with the real
+ * `usage` (USD billed). It requires a MANAGEMENT/provisioning key, not the
+ * inference key — so this reads `OPENROUTER_PROVISIONING_KEY` (set via
+ * `wrangler secret put OPENROUTER_PROVISIONING_KEY`). `/api/v1/credits` gives
+ * the account lifetime total.
+ *
+ * Degrades gracefully: with no provisioning key, returns { configured:false }
+ * so the dashboard falls back to the gateway figure and says the real number
+ * isn't wired up, rather than fabricating one.
+ */
+
+export interface OrModelRow {
+  model: string;
+  requests: number;
+  costUsd: number;
+  tokensIn: number;
+  tokensOut: number;
+}
+
+export interface OrDayRow {
+  date: string;
+  costUsd: number;
+}
+
+export interface OrCost {
+  /** Do we have a provisioning key. */
+  configured: boolean;
+  /** Did the query succeed. */
+  ok: boolean;
+  error?: string;
+  windowStart?: string;
+  windowEnd?: string;
+  /** Distinct UTC days the activity ledger covered. */
+  days?: number;
+  requests?: number;
+  /** Billed USD over the activity window — authoritative. */
+  costUsd?: number;
+  /** Account lifetime billed USD (from /credits), independent of the window. */
+  lifetimeUsd?: number;
+  byModel?: OrModelRow[];
+  byDay?: OrDayRow[];
+}
+
+/** One `/api/v1/activity` row (the fields we use; the API sends more). */
+export interface OrActivityRow {
+  date?: string;
+  model?: string;
+  model_permaslug?: string;
+  usage?: number;
+  requests?: number;
+  prompt_tokens?: number;
+  completion_tokens?: number;
+}
+
+interface OrEnv {
+  OPENROUTER_PROVISIONING_KEY?: string;
+}
+
+const BASE = 'https://openrouter.ai/api/v1';
+
+/**
+ * Aggregate raw activity rows into window totals + per-model + per-day. Pure, so
+ * it is unit-tested directly against a captured response. `costUsd` is summed
+ * from each row's `usage` (the real billed amount). The model label prefers the
+ * dated `model_permaslug` (what actually served) and falls back to `model`.
+ */
+export function aggregateActivity(rows: OrActivityRow[]): {
+  requests: number;
+  costUsd: number;
+  byModel: OrModelRow[];
+  byDay: OrDayRow[];
+  windowStart?: string;
+  windowEnd?: string;
+  days: number;
+} {
+  let requests = 0;
+  let costUsd = 0;
+  const byModel = new Map<string, OrModelRow>();
+  const byDay = new Map<string, number>();
+  for (const r of rows) {
+    const usd = typeof r.usage === 'number' ? r.usage : 0;
+    const reqs = typeof r.requests === 'number' ? r.requests : 0;
+    const tin = typeof r.prompt_tokens === 'number' ? r.prompt_tokens : 0;
+    const tout = typeof r.completion_tokens === 'number' ? r.completion_tokens : 0;
+    requests += reqs;
+    costUsd += usd;
+    const day = (r.date ?? '').slice(0, 10);
+    if (day) byDay.set(day, (byDay.get(day) ?? 0) + usd);
+    const model = r.model_permaslug || r.model || '(unknown)';
+    const m = byModel.get(model) ?? { model, requests: 0, costUsd: 0, tokensIn: 0, tokensOut: 0 };
+    m.requests += reqs;
+    m.costUsd += usd;
+    m.tokensIn += tin;
+    m.tokensOut += tout;
+    byModel.set(model, m);
+  }
+  const days = [...byDay.keys()].sort();
+  return {
+    requests,
+    costUsd,
+    byModel: [...byModel.values()].sort((a, b) => b.costUsd - a.costUsd),
+    byDay: days.map((date) => ({ date, costUsd: byDay.get(date) ?? 0 })),
+    windowStart: days[0],
+    windowEnd: days[days.length - 1],
+    days: days.length,
+  };
+}
+
+async function fetchJson(
+  url: string,
+  token: string,
+): Promise<{ ok: boolean; status: number; json: unknown }> {
+  const res = await fetch(url, { headers: { authorization: `Bearer ${token}` } });
+  let json: unknown = null;
+  try {
+    json = await res.json();
+  } catch {
+    /* leave null */
+  }
+  return { ok: res.ok, status: res.status, json };
+}
+
+export async function fetchOpenRouterCost(env: OrEnv): Promise<OrCost> {
+  const token = env.OPENROUTER_PROVISIONING_KEY;
+  if (!token) {
+    return {
+      configured: false,
+      ok: false,
+      error: 'not configured (missing OPENROUTER_PROVISIONING_KEY)',
+    };
+  }
+  try {
+    const [activity, credits] = await Promise.all([
+      fetchJson(`${BASE}/activity`, token),
+      fetchJson(`${BASE}/credits`, token),
+    ]);
+    if (!activity.ok) {
+      const msg =
+        (activity.json as { error?: { message?: string } })?.error?.message ??
+        `HTTP ${activity.status}`;
+      return { configured: true, ok: false, error: String(msg).slice(0, 300) };
+    }
+    const rows = ((activity.json as { data?: OrActivityRow[] })?.data ?? []) as OrActivityRow[];
+    const agg = aggregateActivity(rows);
+    const lifetimeUsd = (credits.json as { data?: { total_usage?: number } })?.data?.total_usage;
+    return {
+      configured: true,
+      ok: true,
+      windowStart: agg.windowStart,
+      windowEnd: agg.windowEnd,
+      days: agg.days,
+      requests: agg.requests,
+      costUsd: agg.costUsd,
+      lifetimeUsd: typeof lifetimeUsd === 'number' ? lifetimeUsd : undefined,
+      byModel: agg.byModel,
+      byDay: agg.byDay,
+    };
+  } catch (err) {
+    return {
+      configured: true,
+      ok: false,
+      error: String((err as Error)?.message ?? err).slice(0, 300),
+    };
+  }
+}

--- a/packages/talmud/src/worker/types.ts
+++ b/packages/talmud/src/worker/types.ts
@@ -57,6 +57,10 @@ export interface Bindings {
   // Cloudflare API token (Account Analytics: Read) for the AI Gateway cost
   // query in aigw-analytics.ts. Set via `wrangler secret put CF_ANALYTICS_TOKEN`.
   CF_ANALYTICS_TOKEN?: string;
+  // OpenRouter MANAGEMENT/provisioning key (not the inference key) for the
+  // authoritative billed-spend query in openrouter-cost.ts (/api/v1/activity +
+  // /credits). Set via `wrangler secret put OPENROUTER_PROVISIONING_KEY`.
+  OPENROUTER_PROVISIONING_KEY?: string;
   OPENROUTER_GATEWAY_PROVIDER?: string;
   DEFAULT_LLM_MODEL?: string;
   // Enrichment job queue — see wrangler.toml + queue handler at the bottom

--- a/packages/talmud/tests/openrouter-cost.test.ts
+++ b/packages/talmud/tests/openrouter-cost.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { aggregateActivity, type OrActivityRow } from '../src/worker/openrouter-cost';
+
+// Rows shaped like the real GET /api/v1/activity response (one row per
+// day+model+endpoint), trimmed to the fields aggregateActivity reads.
+const ROWS: OrActivityRow[] = [
+  {
+    date: '2026-06-24 00:00:00',
+    model_permaslug: 'deepseek/deepseek-v4-pro-20260423',
+    usage: 20,
+    requests: 100,
+    prompt_tokens: 1_000_000,
+    completion_tokens: 50_000,
+  },
+  {
+    date: '2026-06-24 00:00:00',
+    model_permaslug: 'deepseek/deepseek-v4-flash-20260423',
+    usage: 5,
+    requests: 400,
+    prompt_tokens: 4_000_000,
+    completion_tokens: 100_000,
+  },
+  {
+    date: '2026-06-23 00:00:00',
+    model_permaslug: 'deepseek/deepseek-v4-pro-20260423',
+    usage: 10,
+    requests: 60,
+    prompt_tokens: 500_000,
+    completion_tokens: 30_000,
+  },
+];
+
+describe('aggregateActivity', () => {
+  it('sums billed usage and requests across all rows', () => {
+    const agg = aggregateActivity(ROWS);
+    expect(agg.costUsd).toBeCloseTo(35, 6);
+    expect(agg.requests).toBe(560);
+  });
+
+  it('groups by model (dated permaslug) and sorts by cost desc', () => {
+    const agg = aggregateActivity(ROWS);
+    expect(agg.byModel.map((m) => m.model)).toEqual([
+      'deepseek/deepseek-v4-pro-20260423',
+      'deepseek/deepseek-v4-flash-20260423',
+    ]);
+    const pro = agg.byModel[0];
+    expect(pro.costUsd).toBeCloseTo(30, 6); // 20 + 10 across two days
+    expect(pro.requests).toBe(160);
+    expect(pro.tokensIn).toBe(1_500_000);
+    expect(pro.tokensOut).toBe(80_000);
+  });
+
+  it('rolls per-day totals and reports the window', () => {
+    const agg = aggregateActivity(ROWS);
+    expect(agg.days).toBe(2);
+    expect(agg.windowStart).toBe('2026-06-23');
+    expect(agg.windowEnd).toBe('2026-06-24');
+    const day24 = agg.byDay.find((d) => d.date === '2026-06-24');
+    expect(day24?.costUsd).toBeCloseTo(25, 6); // 20 + 5
+  });
+
+  it('falls back to model when permaslug is absent and tolerates missing fields', () => {
+    const agg = aggregateActivity([
+      { date: '2026-06-24', model: 'openai/gpt-5.5', usage: 1.5, requests: 2 },
+      { date: '2026-06-24' }, // empty row contributes nothing
+    ]);
+    expect(agg.costUsd).toBeCloseTo(1.5, 6);
+    expect(agg.byModel[0].model).toBe('openai/gpt-5.5');
+  });
+
+  it('is empty-safe', () => {
+    const agg = aggregateActivity([]);
+    expect(agg.costUsd).toBe(0);
+    expect(agg.requests).toBe(0);
+    expect(agg.byModel).toEqual([]);
+    expect(agg.byDay).toEqual([]);
+    expect(agg.days).toBe(0);
+  });
+});


### PR DESCRIPTION
## The bug

The `/usage` cost page reported **~2.5x less than actual spend**. For the same 30-day window:

| Source | 30-day total | DeepSeek V4 **Pro** |
|---|---|---|
| Page "Total spent" (AI Gateway) | **$582** | $326 |
| **OpenRouter actually billed** (`/api/v1/activity`) | **$1,468** | **$1,148** |

OpenRouter account lifetime is **$1,860**. Token counts match exactly on both sides (~860M in / 49M out for Pro), so this is a **pricing** error, not a counting one.

## Root cause

The entire ~$885 gap is one model, **DeepSeek V4 Pro**, mispriced in two places that both feed the page:

1. **The daily rollup recorded a list-price estimate**, not the real billed cost. `captureLlmUsage` used `MODEL_PRESETS` ($0.435/$0.87 for Pro — a promo rate flagged in settings.ts as expiring 2026-05-31). But Pro routes under `{sort:'price', require_parameters:true}` to a third-party provider billing ~$1.30/$2.60. The app **already captures** OpenRouter's real `usage.cost` (`usage:{include:true}`, stamped per cache entry) — it just wasn't what the rollup summed.
2. **The "Total spent" headline was the Cloudflare AI Gateway figure**, which computes cost from CF's own per-model table and is blind to the routed provider — same under-count.

## The fix

- `captureLlmUsage` now records OpenRouter's **billed `usage.cost`** (falling back to the estimate only when no billed figure returns, e.g. Workers AI), scaling the in/out split to the billed total while preserving the list-price ratio. Per-producer / per-daf attribution becomes accurate; the shas projection auto-corrects.
- New **`openrouter-cost.ts`** pulls the authoritative billed total straight from OpenRouter's own ledger (`/api/v1/activity` per-model + `/credits` lifetime). It becomes the primary **Total spent** (+ a Lifetime stat); the AI Gateway number is demoted to a labelled "gateway estimate — under-prices routed DeepSeek" comparison.

## New secret required

`wrangler secret put OPENROUTER_PROVISIONING_KEY` — a **management/provisioning** key (the inference key returns 403 on `/activity`). Without it the page degrades gracefully to the AI Gateway figure and shows a "set this key for the real total" note.

## Verification
- `pnpm typecheck`, `pnpm lint` (biome) clean; `pnpm test` 2598 pass incl. new `openrouter-cost.test.ts` (5).
- Vite build succeeds.
- Numbers above are real prod data pulled live from OpenRouter `/activity` + `/credits` and the AI Gateway analytics.
- Codex read-only review: one finding (convergence banner showed gateway $ while dividing by the billed $) fixed.

Note: the 30-day self-tracked window self-heals as pre-fix estimate-era days age out; OpenRouter `/activity` headline is accurate immediately.