### PR TITLE
Overview: highlight the whole focused section on the daf

### DIFF
--- a/packages/talmud/src/client/ArgumentSidebar.tsx
+++ b/packages/talmud/src/client/ArgumentSidebar.tsx
@@ -1099,11 +1099,29 @@ function ArgumentOverviewMaps(props: SpecialBlockProps): JSX.Element {
   // changes; the daf-side highlight is owned by the detail card's header.
   const [selectedStmt, setSelectedStmt] = createSignal<string | null>(null);
   const [highlightedMove, setHighlightedMove] = createSignal<string | null>(null);
+  // Focusing a section (a map-node click, or opening one from a gutter
+  // marker / reader chip) highlights that WHOLE section on the daf. The reader
+  // is in the Overview (kind 'argument-overview'), where DafViewer's section-
+  // wide paint never fires — that one is gated to the legacy 'argument' card —
+  // so without this the only highlight came from clicking a sub-statement.
+  // Clicking a statement node below narrows the highlight to that statement
+  // (selectStatement → onHighlightMove); selectedStmt is NOT a dependency of
+  // this effect, so the narrower highlight isn't clobbered. The section's seg
+  // range carries no token offsets, so the full span lights up.
   createEffect(() => {
-    void focused();
+    const fi = focused();
     setSelectedStmt(null);
     setHighlightedMove(null);
-    props.onHighlightRange?.(null);
+    const sec = sections()[fi];
+    if (sec && typeof sec.startSegIdx === 'number' && typeof sec.endSegIdx === 'number') {
+      props.onHighlightRange?.({
+        start: sec.startSegIdx,
+        end: sec.endSegIdx,
+        key: `section-${fi}`,
+      });
+    } else {
+      props.onHighlightRange?.(null);
+    }
   });
   const selectedMove = (): ArgumentMoveInstance | undefined =>
     focusedSpine()?.moves.find((m) => m.fields.id === selectedStmt());


### PR DESCRIPTION
## What

On the Overview, clicking a **section node on the map** — or opening a section from an **argument gutter marker / reader chip** — now highlights that **whole section** on the daf. Previously a daf highlight appeared only when you clicked an individual **statement** sub-node (a single move's segment range).

## Why

Both `openArgument` (gutter/chip) and the map node's `onSelect` route to `{kind: 'argument-overview', focus: index}` — the Overview focused on a section. In `ArgumentOverviewMaps`, the effect that runs on focus change *cleared* the daf highlight (`onHighlightRange(null)`) rather than setting it. DafViewer's section-wide paint is gated to the legacy `kind === 'argument'` card, so it never fires for the Overview. Net result: focusing a section did nothing on the daf; only a statement click highlighted (its one segment).

## The fix

When a section is focused, push its full seg range through the same `onHighlightRange` channel the statement clicks already use — with no token offsets, so the entire span lights up. Clicking a statement node still narrows the highlight to that statement: `selectedStmt` is not a dependency of the focus effect, so the narrower highlight isn't clobbered.

One small, intended behavior note: the section that's focused when the Overview opens (the active/expanded node — section 0 generically, or the specific section when opened from a gutter anchor/chip) is now highlighted on open, consistent with its visual focus state.

## Checks

- `pnpm typecheck` clean
- `biome check` clean
- `pnpm test` — 2598/2598 pass