### PR TITLE
Reader: failed cards show a compact badge, error detail on hover

### DIFF
--- a/packages/talmud/src/client/ErrorBadge.tsx
+++ b/packages/talmud/src/client/ErrorBadge.tsx
@@ -1,0 +1,97 @@
+/**
+ * A compact failure indicator for a card/stage that errored while the page was
+ * being built. Instead of dumping the (often long, technical) error into the
+ * content flow, the card shows a small badge; the full message appears as a
+ * hover/focus overlay. Keeps a failed enrichment from shoving the reading layout
+ * around while keeping the detail one hover away.
+ *
+ * `tone` 'error' = a genuine bug (red); 'calm' = an expected, benign state like
+ * paused / provider temporarily unavailable (amber). Keyboard-accessible: the
+ * trigger is a real <button> so it focuses + the overlay shows on focus as well
+ * as hover, with the detail also exposed via the native `title` as a
+ * no-JS/screen-reader fallback.
+ */
+import { createSignal, type JSX, Show } from 'solid-js';
+
+export function ErrorBadge(props: {
+  tone: 'error' | 'calm';
+  label: string;
+  detail: string;
+}): JSX.Element {
+  const [open, setOpen] = createSignal(false);
+  const isError = () => props.tone === 'error';
+  const fg = () => (isError() ? '#c00' : '#a16207');
+  const bg = () => (isError() ? '#fff5f5' : '#fffbeb');
+  const border = () => (isError() ? '#f0caca' : '#f0e0b0');
+  return (
+    <span style={{ position: 'relative', display: 'inline-flex' }}>
+      <button
+        type="button"
+        aria-label={props.detail || props.label}
+        title={props.detail || props.label}
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        onFocus={() => setOpen(true)}
+        onBlur={() => setOpen(false)}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') setOpen(false);
+        }}
+        style={{
+          display: 'inline-flex',
+          'align-items': 'center',
+          gap: '0.35rem',
+          margin: 0,
+          padding: '0.15rem 0.45rem',
+          'border-radius': '999px',
+          'font-size': '0.72rem',
+          'font-weight': 600,
+          color: fg(),
+          background: bg(),
+          border: `1px solid ${border()}`,
+          cursor: 'default',
+        }}
+      >
+        {/* warning triangle (inline SVG, not an emoji) */}
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <path
+            d="M12 3L1.5 21h21L12 3z"
+            stroke={fg()}
+            stroke-width="2"
+            stroke-linejoin="round"
+            fill="none"
+          />
+          <path d="M12 10v4" stroke={fg()} stroke-width="2" stroke-linecap="round" />
+          <circle cx="12" cy="17" r="1.1" fill={fg()} />
+        </svg>
+        {props.label}
+      </button>
+      <Show when={open() && !!props.detail && props.detail !== props.label}>
+        <span
+          role="tooltip"
+          style={{
+            position: 'absolute',
+            top: 'calc(100% + 0.3rem)',
+            left: 0,
+            'z-index': 50,
+            'max-width': '300px',
+            'min-width': '160px',
+            width: 'max-content',
+            padding: '0.4rem 0.55rem',
+            background: '#fff',
+            color: '#333',
+            border: '1px solid #e2e0dd',
+            'border-radius': '6px',
+            'box-shadow': '0 4px 14px rgba(0,0,0,0.12)',
+            'font-family': isError() ? 'monospace' : 'inherit',
+            'font-size': '0.72rem',
+            'line-height': 1.45,
+            'white-space': 'normal',
+            'overflow-wrap': 'anywhere',
+          }}
+        >
+          {props.detail}
+        </span>
+      </Show>
+    </span>
+  );
+}

--- a/packages/talmud/src/client/MarkEnrichmentCards.tsx
+++ b/packages/talmud/src/client/MarkEnrichmentCards.tsx
@@ -37,6 +37,7 @@ import {
   dafViewWholeDafResult,
   isViewDriven,
 } from './dafViewStore';
+import { ErrorBadge } from './ErrorBadge';
 import {
   isAbort,
   isPausedBody,
@@ -887,19 +888,26 @@ export default function MarkEnrichmentCards(props: Props) {
     if (r.kind === 'error') {
       const paused = r.error === PAUSED_ERROR;
       const unavailable = !paused && isServiceUnavailableError(r.error);
-      // Both paused and provider-outage are calm, expected states — amber, plain
-      // text, localized. A genuine bug (parse/schema/unknown) stays loud (red mono).
+      // Both paused and provider-outage are calm, expected states (amber); a
+      // genuine bug (parse/schema/unknown) is loud (red). Either way the failure
+      // shows as a compact badge — not a block of text shoved into the reading
+      // flow — with the full message revealed on hover/focus (ErrorBadge).
       const calm = paused || unavailable;
       return (
-        <div
-          style={{
-            color: calm ? '#a16207' : '#c00',
-            'font-family': calm ? 'inherit' : 'monospace',
-            'font-size': '0.78rem',
-            padding: '0.4rem 0',
-          }}
-        >
-          {paused ? t('qa.error.paused') : unavailable ? t('enrich.error.unavailable') : r.error}
+        <div style={{ padding: '0.3rem 0' }}>
+          <ErrorBadge
+            tone={calm ? 'calm' : 'error'}
+            label={
+              paused
+                ? t('enrich.badge.paused')
+                : unavailable
+                  ? t('enrich.badge.unavailable')
+                  : t('enrich.badge.failed')
+            }
+            detail={
+              paused ? t('qa.error.paused') : unavailable ? t('enrich.error.unavailable') : r.error
+            }
+          />
         </div>
       );
     }

--- a/packages/talmud/src/client/i18n.ts
+++ b/packages/talmud/src/client/i18n.ts
@@ -1306,6 +1306,10 @@ const CATALOG = {
     en: 'AI generation is temporarily unavailable. Please try again later or tomorrow.',
     he: 'יצירת התוכן בבינה מלאכותית אינה זמינה כרגע. נא לנסות שוב מאוחר יותר או מחר.',
   },
+  // Short labels for the compact failure badge (full message shows on hover).
+  'enrich.badge.failed': { en: "Couldn't load", he: 'טעינה נכשלה' },
+  'enrich.badge.paused': { en: 'Paused', he: 'מושהה' },
+  'enrich.badge.unavailable': { en: 'Unavailable', he: 'לא זמין' },
 
   // — First-time-user tutorial —
   'tutorial.help': { en: 'Help', he: 'עזרה' },

--- a/packages/talmud/tests/client/error-badge.test.tsx
+++ b/packages/talmud/tests/client/error-badge.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { fireEvent, render } from '@solidjs/testing-library';
+import { describe, expect, it } from 'vitest';
+import { ErrorBadge } from '../../src/client/ErrorBadge';
+
+// The whole point: a failed card shows a compact badge (the short label) and
+// keeps the full error OUT of the content flow until hover/focus.
+
+describe('ErrorBadge', () => {
+  it('shows only the short label by default; detail is not in the flow', () => {
+    const { container, getByRole } = render(() => (
+      <ErrorBadge tone="error" label="Couldn't load" detail="TypeError: boom at line 1" />
+    ));
+    expect(container.textContent).toContain("Couldn't load");
+    expect(container.textContent).not.toContain('TypeError: boom');
+    // No tooltip rendered yet; the detail lives on the button's title/aria.
+    expect(container.querySelector('[role="tooltip"]')).toBeNull();
+    const btn = getByRole('button');
+    expect(btn.getAttribute('title')).toBe('TypeError: boom at line 1');
+  });
+
+  it('reveals the full detail in an overlay on hover and hides it on leave', () => {
+    const { container, getByRole } = render(() => (
+      <ErrorBadge tone="error" label="Couldn't load" detail="TypeError: boom at line 1" />
+    ));
+    const btn = getByRole('button');
+    fireEvent.mouseEnter(btn);
+    const tip = container.querySelector('[role="tooltip"]');
+    expect(tip?.textContent).toBe('TypeError: boom at line 1');
+    fireEvent.mouseLeave(btn);
+    expect(container.querySelector('[role="tooltip"]')).toBeNull();
+  });
+
+  it('reveals on keyboard focus too (accessible)', () => {
+    const { container, getByRole } = render(() => (
+      <ErrorBadge tone="error" label="Couldn't load" detail="schema mismatch" />
+    ));
+    fireEvent.focus(getByRole('button'));
+    expect(container.querySelector('[role="tooltip"]')?.textContent).toBe('schema mismatch');
+  });
+
+  it('does not render a redundant overlay when detail equals the label', () => {
+    const { container, getByRole } = render(() => (
+      <ErrorBadge tone="calm" label="Paused" detail="Paused" />
+    ));
+    fireEvent.mouseEnter(getByRole('button'));
+    expect(container.querySelector('[role="tooltip"]')).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

When a mark/enrichment card fails while the page is being built, the reader used to get the raw error dumped **inline in the card body** (red monospace, multi-line) — shoving the reading layout around right when the page is still settling.

Now a failed card shows a compact **`ErrorBadge`** with a short localized label, and the full message appears only on **hover/focus** as an overlay that doesn't occupy flow space.

| before | after |
|---|---|
| `TypeError: ... at line 1` printed inline in the card | small `⚠ Couldn't load` badge → full text on hover |

## Details
- New `ErrorBadge.tsx` — a real `<button>` (focusable, keyboard-accessible; the overlay shows on focus as well as hover). Tone preserved: **red** for genuine bugs (parse/schema/unknown), **amber** for the calm expected states (paused / provider temporarily unavailable). The detail is also set on the native `title`, so if a styled overlay is ever clipped by an `overflow:hidden` ancestor it still degrades to a browser tooltip.
- `MarkEnrichmentCards.tsx` `renderRunBody` error branch swaps the inline `<div>` for `<ErrorBadge>`. This is the shared body renderer for mark + enrichment cards, so it covers the build-time failures across stages.
- i18n: short badge labels `enrich.badge.failed/paused/unavailable` (the full sentence stays as the hover detail).

## Verification
- `pnpm typecheck`, `pnpm lint` (biome, incl. a11y rules) clean.
- `pnpm test`: 2598 pass + new `error-badge.test.tsx` (4): badge-only by default (detail not in flow), detail revealed on hover and on focus, hidden on leave, no redundant overlay when detail == label.
- Vite build OK.