### PR TITLE
Reset transient UI state on context switch (mobile Layers sheet + rabbi geography)

### DIFF
--- a/packages/talmud/src/client/DafViewer.tsx
+++ b/packages/talmud/src/client/DafViewer.tsx
@@ -1555,6 +1555,10 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
     setArgumentMoveHighlight(null);
     setCommAnchorActive(null);
     setCommentaryAnchorIndex(null);
+    // The mobile "Layers" sheet is a transient overlay for THIS daf's marks; it
+    // shouldn't linger open over the next daf after navigation (the sidebar
+    // above already closes on daf change — keep the two consistent).
+    setLayersOpen(false);
   });
 
   // Close any open sidebar when the language flips. Its contents are being

--- a/packages/talmud/src/client/RabbiGeographyCard.tsx
+++ b/packages/talmud/src/client/RabbiGeographyCard.tsx
@@ -10,7 +10,7 @@
  * the daf via onHighlightRange.
  */
 
-import { createSignal, For, type JSX, Show } from 'solid-js';
+import { createEffect, createSignal, For, type JSX, Show } from 'solid-js';
 import { t } from './i18n';
 
 // `seq` is the chronological life-order index from rabbi.geography (v4+),
@@ -97,6 +97,16 @@ function regionLabel(r: BirthPlace['region']): string {
 
 export default function RabbiGeographyCard(props: Props): JSX.Element {
   const [activeEvidenceKey, setActiveEvidenceKey] = createSignal<string | null>(null);
+
+  // When the card is reused for a different rabbi (props.data swaps), drop the
+  // previous rabbi's picked-evidence state and clear its daf highlight — the old
+  // key won't match any new row, so without this a stale highlight could linger.
+  // Mirrors RabbiTrajectoryMap's reset-on-data-change.
+  createEffect(() => {
+    void props.data;
+    setActiveEvidenceKey(null);
+    props.onHighlightRange?.(null);
+  });
 
   // Index evidence by kind + place so a chip can light up when this daf
   // references it. First-match wins (multiple evidence rows for the same


### PR DESCRIPTION
## What

A focused audit for the same bug class as the recent Overview-highlight fixes (#506/#507): UI state that **bleeds across a context switch**. Two confirmed, low-risk fixes:

1. **Mobile 'Layers' sheet stayed open across daf navigation.** Verified in-browser (mobile emulation): open the Layers sheet on Berakhot 2a, navigate to 2b → the sheet is still open. The sidebar already closes on daf change (`setSidebar(null)` in the daf-change effect); the Layers sheet didn't. Fix: `setLayersOpen(false)` there too. This only toggles the panel's *visibility* — `MarksRegistryPanel` stays mounted, so gutter extraction is unaffected.

2. **`RabbiGeographyCard` kept the previous rabbi's picked-evidence state** (and its daf highlight) when the card is reused for a different rabbi — it lacked the reset its sibling `RabbiTrajectoryMap` already has. Fix: reset `activeEvidenceKey` + clear the highlight on `props.data` change.

## Audit scope (3 parallel passes)

- **Clobber / mount-race class** (the #507 shape): **clean** — no other instances. The reset effects across the cards (QAPanel, RabbiLineageTree, RabbiTrajectoryMap, RunTreeDag, ArgumentNarrative) already key off the right prop.
- **Stale-on-switch**: one real gap (RabbiGeographyCard, fixed here).
- **Mobile**: the Layers-sheet persistence (fixed). A suspected **HIGH** "auto-scroll fights the user on resize/font-load" was a **false positive** — the `lastScrolledSelKey` guard already prevents re-scroll when the selection is unchanged. `mobileMode` ('translate') persisting across nav was left as-is (defensible — a reader staying in translate mode is intended); `headerOpen` persistence is marginal and left.

## Checks

- `pnpm typecheck`, `biome check`, `pnpm test` (2598/2598) all pass.
- Will verify the Layers fix in-browser on prod after deploy.