### PR TITLE
Usage Content-In: add per-entity fetched sources (Tanach verses, rabbi topics)

### DIFF
--- a/packages/talmud/src/client/UsagePage.tsx
+++ b/packages/talmud/src/client/UsagePage.tsx
@@ -207,6 +207,9 @@ interface SourceRow {
   denom: number;
   percent: number;
   aligned?: AlignedSample | null;
+  /** 'entity' rows are keyed per rabbi/verse: count-only, no daf percentage. */
+  scope?: 'daf' | 'entity';
+  unit?: string;
 }
 
 interface CacheStats {
@@ -635,7 +638,8 @@ function OriginBadge(props: { origin: SourceOrigin }): JSX.Element {
 
 function SourceRowView(props: { row: SourceRow }): JSX.Element {
   const r = () => props.row;
-  const complete = () => r().percent >= 100;
+  const entity = () => r().scope === 'entity';
+  const complete = () => !entity() && r().percent >= 100;
   const aligned = () => r().aligned ?? null;
   const num = {
     padding: '0.45rem 0.5rem',
@@ -649,15 +653,30 @@ function SourceRowView(props: { row: SourceRow }): JSX.Element {
         <OriginBadge origin={r().origin} />
       </td>
       <td style={num}>
-        {fmtInt(r().count)} / {fmtInt(r().denom)}
+        <Show
+          when={entity()}
+          fallback={
+            <>
+              {fmtInt(r().count)} / {fmtInt(r().denom)}
+            </>
+          }
+        >
+          {fmtInt(r().count)}
+          <span style={{ color: '#999' }}> {r().unit}</span>
+        </Show>
       </td>
       <td style={{ padding: '0.45rem 0.5rem', width: '26%' }}>
-        <ProgressBar percent={r().percent} />
+        {/* Per-entity sources have no per-daf denominator, so no coverage bar. */}
+        <Show when={!entity()}>
+          <ProgressBar percent={r().percent} />
+        </Show>
       </td>
       <td style={{ ...num, color: complete() ? '#2a8a42' : '#333', 'white-space': 'nowrap' }}>
-        {r().percent.toFixed(1)}%
-        <Show when={complete()}>
-          <span style={{ 'margin-left': '0.3rem' }}>✓</span>
+        <Show when={!entity()} fallback={<span style={{ color: '#bbb' }}>—</span>}>
+          {r().percent.toFixed(1)}%
+          <Show when={complete()}>
+            <span style={{ 'margin-left': '0.3rem' }}>✓</span>
+          </Show>
         </Show>
       </td>
       <td style={{ ...num, color: '#555', 'white-space': 'nowrap' }}>

--- a/packages/talmud/src/client/i18n.ts
+++ b/packages/talmud/src/client/i18n.ts
@@ -620,6 +620,8 @@ const CATALOG = {
     he: 'סוגיות מקבילות (מסורת הש״ס)',
   },
   'usage.src.commentary-works': { en: 'Commentaries (all works)', he: 'מפרשים (כל החיבורים)' },
+  'usage.src.pasuk': { en: 'Tanach verses', he: 'פסוקי תנ״ך' },
+  'usage.src.rabbi-enriched': { en: 'Rabbi topics', he: 'נושאי חכמים' },
   'usage.src.dy': { en: 'DafYomi notes (all)', he: 'הערות דף יומי (הכול)' },
   'usage.src.dy.insights': { en: 'Insights', he: 'תובנות' },
   'usage.src.dy.background': { en: 'Background', he: 'רקע' },

--- a/packages/talmud/src/worker/cache-stats.ts
+++ b/packages/talmud/src/worker/cache-stats.ts
@@ -53,6 +53,12 @@ export interface SourceRow {
   denom: number;
   percent: number;
   aligned: AlignedSample | null;
+  /** 'daf' (default): keyed per amud, so count/denom is a coverage fraction of
+   *  all dapim. 'entity': keyed per rabbi / per verse, so there is no daf
+   *  denominator — the UI shows the cached count + `unit` and no percentage. */
+  scope?: 'daf' | 'entity';
+  /** For scope 'entity': what each cached row is (e.g. 'rabbis', 'verses'). */
+  unit?: string;
 }
 
 export interface CacheStats {
@@ -600,6 +606,8 @@ export async function computeCacheStats(cache: KVNamespace): Promise<CacheStats>
     commWorksCount,
     parallelsAligned,
     commWorksAligned,
+    pasukCount,
+    rabbiEnrichedCount,
     dyTypes,
   ] = await Promise.all([
     countPrefix(cache, 'hb:v2:'),
@@ -631,6 +639,12 @@ export async function computeCacheStats(cache: KVNamespace): Promise<CacheStats>
     countPrefix(cache, 'commentaries:v1:'),
     sampleAligned(cache, 'talmud-parallels:v1:', nonEmptyValue),
     sampleAligned(cache, 'commentaries:v1:', alignedCommentaryWorks),
+    // Per-ENTITY source fetches (keyed per verse / per rabbi, not per daf) — no
+    // /dapim denominator, so the dashboard shows their cached counts. (Rabbi
+    // Wikipedia/Wikidata bios live in the bundled rabbi dataset — see the rabbi
+    // coverage block — not a per-rabbi KV cache, so they aren't sources here.)
+    countPrefix(cache, 'pasuk:v4:'), // Tanach verse text (Sefaria)
+    countPrefix(cache, 'rabbi-enriched:v1:'), // rabbi topic links (Sefaria)
     sampleDafyomiTypes(cache),
   ]);
   const dafyomiAligned: AlignedSample | null =
@@ -650,6 +664,18 @@ export async function computeCacheStats(cache: KVNamespace): Promise<CacheStats>
     denom: total,
     percent: pct(count, total),
     aligned,
+  });
+  // A per-entity source (per rabbi / per verse): no /dapim denominator, so it
+  // carries only its cached count + the unit it is counted in.
+  const entityRow = (id: string, origin: SourceOrigin, count: number, unit: string): SourceRow => ({
+    id,
+    origin,
+    count,
+    denom: 0,
+    percent: 0,
+    aligned: null,
+    scope: 'entity',
+    unit,
   });
   const sources: SourceRow[] = [
     {
@@ -693,6 +719,10 @@ export async function computeCacheStats(cache: KVNamespace): Promise<CacheStats>
         aligned: null,
       };
     }),
+    // Per-ENTITY source fetches: keyed per verse / per rabbi, so there is no
+    // per-daf denominator — surfaced as cached counts (scope 'entity').
+    entityRow('pasuk', 'Sefaria', pasukCount, 'verses'),
+    entityRow('rabbi-enriched', 'Sefaria', rabbiEnrichedCount, 'rabbis'),
   ];
 
   const markDefs = await mergedMarks(cache);


### PR DESCRIPTION
## What

The `/usage` **Content-In** table only listed **daf-keyed** fetches, so two real source fetches were missing — they're keyed **per-entity** (per verse / per rabbi), so they don't fit the "/5,375 dapim" denominator:

| Source | Origin | Cached (prod) |
|---|---|---|
| **Tanach verses** (`pasuk:v4:`) | Sefaria | ~2,317 verses |
| **Rabbi topics** (`rabbi-enriched:v1:`) | Sefaria | ~392 rabbis |

`SourceRow` gains an optional `scope: 'entity'` + `unit`; entity rows render as a cached **count** ("N verses" / "N rabbis") with no coverage bar or daf-percentage (those columns show "—").

## What I deliberately left out (and why)

The other candidates the question raised turn out **not** to be per-daf fetches:
- **Rabbi bios (Wikipedia) / Wikidata** — the per-rabbi KV caches (`rabbi-wiki-bio:v1:`, `rabbi-wikidata:v1:`) are **empty** in prod (0 each); the actual bios are **bundled** into the rabbi dataset (`rabbi-places.json`) and are already surfaced in the dashboard's **rabbi coverage** block (`withBio` / `withWiki`).
- **Geography / region** (`region:v1:`) — **0 cached**: it's a deterministic on-demand join of places the marks already found ("places have no global gazetteer"), not an external fetch, and nothing warms it.

Adding those would render misleading 0% rows, so they're out; the rabbi/geography data stays where it actually lives (the rabbi coverage block).

## Verification
- `pnpm typecheck`, `pnpm lint` (biome), `pnpm test` (2602) clean; vite build OK.
- Prod KV prefix counts checked directly to confirm which sources are actually populated (pasuk 2,317 / rabbi-enriched 392; the dropped three = 0).
- No `cache-stats` version bump needed — rows are additive to the existing `sources` array; a stale payload just lacks them until the 60s refresh.