### PR TITLE
Fix recurring reader OOM 1101s: split generation into a separate worker (talmud-gen)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,13 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # Generation worker FIRST: the reader binds to its DafWarmWorkflow
+      # cross-script (script_name = "talmud-gen"), so talmud-gen must exist
+      # before the reader deploy resolves that binding. No vite build — the
+      # generator serves no SPA (no [assets]); it only runs the queue consumer,
+      # crons, and the Workflow. See packages/talmud/wrangler.generator.toml.
+      - run: pnpm --filter talmud exec wrangler deploy -c wrangler.generator.toml
+
       - run: pnpm --filter talmud exec vite build
       - run: pnpm --filter talmud exec wrangler deploy
 

--- a/packages/talmud/package.json
+++ b/packages/talmud/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "ship": "bash ../../scripts/ship-guard.sh && vite build && wrangler deploy",
+    "ship:gen": "bash ../../scripts/ship-guard.sh && wrangler deploy -c wrangler.generator.toml",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -4140,7 +4140,16 @@ export async function computeGeographyModel(
 
 // Per-section fan-out concurrency. Each section call is small (~3-6 moves);
 // 5 in flight balances throughput against producer pressure / provider rate.
-const FAN_OUT_CONCURRENCY = 5;
+// Exported so tests/memory-budget-guard.test.ts can ratchet it — this is one of
+// the in-isolate fan-out widths that, if it crept up, would re-grow peak memory.
+export const FAN_OUT_CONCURRENCY = 5;
+
+// DafWarmWorkflow cold-gen tier width. A tier's step.do() callbacks run
+// concurrently in ONE isolate (the per-step 128 MB budget only holds across
+// suspension points), so this is the peak concurrent in-isolate generation on
+// talmud-gen — the source-heavy steps (rishonim/commentary) are what trip the
+// 128 MB cap. Module-scoped + exported so the memory-budget guard ratchets it.
+export const STEP_CONCURRENCY = 6;
 
 /**
  * Fan an LLM extractor out over the instances of a parent mark: one call per
@@ -11495,16 +11504,12 @@ export class DafWarmWorkflow extends WorkflowEntrypoint<Bindings, DafWarmParams>
     // same uncached dep. This is what makes a cold daf generate in minutes (vs the
     // ~30-60 min fully-sequential walk) while staying per-step memory-bounded.
     //
-    // A tier's steps run concurrently in THIS isolate (the "own budget" only holds
-    // across suspension points), so this width is the peak concurrent in-isolate
-    // generation — the source-heavy ones (rishonim/commentary) are what trip the
-    // 128 MB cap. coalesce.ts shares same-daf source slices across them, but 6 is
-    // the conservative "safe concurrency" the reader /api/run gate also landed on
-    // (#439, 16->6) — a cheap memory margin for the cold-gen path against the
-    // intermittent exceededMemory alert, costing only slightly slower cold dapim
-    // (a background, reader-progressive path). The `[mem] warm-tier` width
-    // breadcrumb above attributes a future OOM to (daf, phase, width).
-    const STEP_CONCURRENCY = 6;
+    // STEP_CONCURRENCY (module-scoped, ratcheted by the memory-budget guard) is
+    // the per-tier in-isolate fan-out width. coalesce.ts shares same-daf source
+    // slices across the concurrent steps; 6 is the conservative "safe
+    // concurrency" the reader /api/run gate also landed on (#439, 16->6). The
+    // `[mem] warm-tier` width breadcrumb below attributes a future OOM to
+    // (daf, phase, width).
     const markDepsOf = (id: string): string[] => {
       const def = CODE_MARKS.find((m) => m.id === id);
       return (def?.dependencies ?? []).map((d) => dependencyId(d)).filter((x): x is string => !!x);

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -7209,7 +7209,16 @@ app.get('/api/usage/health', (c) =>
 // isolate-fatal class is verifiable on demand, and lets the GraphQL field names
 // be confirmed against the live account (the cron alert degrades quietly if the
 // token lacks scope; this route shows exactly why).
-app.get('/api/worker-health', async (c) => c.json(await fetchWorkerOutcomes(c.env, 15)));
+app.get('/api/worker-health', async (c) => {
+  // Report BOTH scripts since generation moved to talmud-gen. Top-level fields
+  // stay the reader's outcomes (backward-compatible shape); `generator` carries
+  // talmud-gen's — that's where the cold-daf OOMs land now.
+  const [reader, generator] = await Promise.all([
+    fetchWorkerOutcomes(c.env, 15, 'talmud'),
+    fetchWorkerOutcomes(c.env, 15, 'talmud-gen'),
+  ]);
+  return c.json({ ...reader, generator });
+});
 
 // Check off / restore a bug report (by its timestamp id). Toggles membership in
 // the dismissed set; the backlog payload splits reports into active vs. done
@@ -11617,6 +11626,21 @@ export default {
   fetch: (req: Request, env: Bindings, ctx: ExecutionContext) => app.fetch(req, wrapEnv(env), ctx),
   scheduled: (controller: ScheduledController, env: Bindings, ctx: ExecutionContext) => {
     const wrapped = wrapEnv(env);
+    // The reader (talmud) and the generator (talmud-gen) deploy the SAME entry
+    // file; WORKER_ROLE tells this handler which side it's running on so heavy
+    // warming stays OFF the reader's isolate pool. Reader (or unset) = run ONLY
+    // the lightweight health watch (it has CF_ANALYTICS_TOKEN; the generator
+    // does not). The health watch now covers BOTH scripts, so a generation OOM
+    // on talmud-gen is still alerted from here. See wrangler.generator.toml.
+    if (env.WORKER_ROLE !== 'generator') {
+      // Independent health watch: alert if an isolate-fatal outcome
+      // (exceededMemory — the cold-daf OOM) appeared in the last window.
+      // Self-contained + best-effort; never throws into the cron.
+      ctx.waitUntil(checkWorkerHealthAndAlert(wrapped, Date.now()));
+      return;
+    }
+
+    // Generator role: all the heavy warming, on talmud-gen's own isolates.
     if (controller.cron === YOMI_WARM_CRON) {
       ctx.waitUntil(runYomiWarmCron(wrapped));
     } else {
@@ -11642,10 +11666,6 @@ export default {
           },
         ),
       );
-      // Independent health watch: alert if an isolate-fatal outcome
-      // (exceededMemory — the cold-daf OOM) appeared in the last window.
-      // Self-contained + best-effort; never throws into the cron.
-      ctx.waitUntil(checkWorkerHealthAndAlert(wrapped, Date.now()));
     }
   },
   // Queue consumer — wrangler.toml binds queue=enrichment-jobs to this

--- a/packages/talmud/src/worker/types.ts
+++ b/packages/talmud/src/worker/types.ts
@@ -90,4 +90,9 @@ export interface Bindings {
   // Spend-budget overrides (USD) read by ./budget. Default 300 / 10 when unset.
   DAILY_BUDGET_USD?: string;
   HOURLY_CUSTOM_BUDGET_USD?: string;
+  // Which deployment this is: "generator" (talmud-gen — queue consumer +
+  // DafWarmWorkflow host + heavy crons) or "reader"/unset (talmud — read-only,
+  // runs only the health-watch cron). Read by scheduled() in index.ts to route
+  // cron work to the right isolate pool. See wrangler.generator.toml.
+  WORKER_ROLE?: 'reader' | 'generator';
 }

--- a/packages/talmud/src/worker/worker-health.ts
+++ b/packages/talmud/src/worker/worker-health.ts
@@ -157,24 +157,36 @@ export async function fetchWorkerOutcomes(
  * don't want one per cron tick). Best-effort and self-contained: any failure is
  * logged, never thrown into the cron.
  */
-export async function checkWorkerHealthAndAlert(env: HealthEnv, nowMs: number): Promise<void> {
+// The scripts the health watch covers. Generation moved to talmud-gen (its own
+// isolate pool), so the isolate-fatal OOMs that used to hit `talmud` now land on
+// `talmud-gen` — watch BOTH or the alert goes blind to the very failures it
+// exists to catch.
+export const WATCHED_SCRIPTS = ['talmud', 'talmud-gen'] as const;
+
+export async function checkWorkerHealthAndAlert(
+  env: HealthEnv,
+  nowMs: number,
+  scripts: readonly string[] = WATCHED_SCRIPTS,
+): Promise<void> {
   try {
-    const outcomes = await fetchWorkerOutcomes(env, 15);
-    if (!outcomes.ok) {
-      // Not configured / token scope / schema drift: stay quiet (no false alert),
-      // but log so the cause is visible. /api/worker-health surfaces it too.
-      if (outcomes.configured) console.warn('[health] outcomes query failed:', outcomes.error);
+    const results = await Promise.all(scripts.map((s) => fetchWorkerOutcomes(env, 15, s)));
+    const ok = results.filter((r) => r.ok);
+    if (ok.length === 0) {
+      // Every query failed (not configured / token scope / schema drift): stay
+      // quiet (no false alert), but log the first cause. /api/worker-health too.
+      const configured = results.find((r) => r.configured);
+      if (configured) console.warn('[health] outcomes query failed:', configured.error);
       return;
     }
-    const fatal = fatalCount(outcomes.byStatus);
+    const fatal = ok.reduce((n, r) => n + fatalCount(r.byStatus), 0);
     if (fatal <= 0) return;
 
     const cache = env.CACHE;
     const email = env.EMAIL;
-    // One alert per DAY per status class. These outcomes are sporadic (a heavy
-    // cron tick / a dense cold daf trips one occasionally), so an hourly alert
-    // just spammed the inbox without adding signal — a daily digest says "it
-    // happened again today" once, which is all the alert needs to convey.
+    // One alert per DAY. These outcomes are sporadic (a heavy cron tick / a dense
+    // cold daf trips one occasionally), so an hourly alert just spammed the inbox
+    // without adding signal — a daily digest says "it happened again today" once,
+    // which is all the alert needs to convey.
     const dayBucket = Math.floor(nowMs / 86_400_000);
     const dedupeKey = `health-alert:fatal:${dayBucket}`;
     if (cache) {
@@ -182,19 +194,30 @@ export async function checkWorkerHealthAndAlert(env: HealthEnv, nowMs: number): 
       if (already) return; // already alerted today
     }
     if (email) {
-      const lines = Object.entries(outcomes.byStatus ?? {})
-        .filter(([s]) => (FATAL_OUTCOMES as readonly string[]).includes(s))
-        .map(([s, n]) => `  ${s}: ${n}`)
+      // Per-script breakdown of the fatal outcomes, so the alert says WHICH
+      // worker OOMed (reader vs generator) at a glance.
+      const lines = ok
+        .map((r) => {
+          const perScript = Object.entries(r.byStatus ?? {})
+            .filter(([s]) => (FATAL_OUTCOMES as readonly string[]).includes(s))
+            .map(([s, n]) => `    ${s}: ${n}`)
+            .join('\n');
+          return perScript ? `  [${r.scriptName}]\n${perScript}` : '';
+        })
+        .filter(Boolean)
         .join('\n');
+      const window = ok[0];
       await email.send({
         from: 'health@shaunregenbaum.com',
         to: 'shaunregenbaum@gmail.com',
         subject: `[talmud] isolate-fatal outcome: ${fatal} in last 15m`,
         text:
-          `The talmud worker logged ${fatal} isolate-fatal invocation(s) in the last 15 minutes ` +
-          `(${outcomes.windowStart} → ${outcomes.windowEnd}):\n\n${lines}\n\n` +
+          `${fatal} isolate-fatal invocation(s) across ${scripts.join(' + ')} in the last 15 ` +
+          `minutes (${window.windowStart} → ${window.windowEnd}):\n\n${lines}\n\n` +
           `This is the class of failure behind the cold-daf OOM (exceededMemory → error code 1101 ` +
-          `for every co-tenant request). Check whether a recent change grew per-job source memory.\n\n` +
+          `for every co-tenant request on that isolate). Generation now runs on talmud-gen, so an ` +
+          `OOM there should NOT surface as a reader 1101 — but check whether a recent change grew ` +
+          `per-job source memory.\n\n` +
           `Live: https://talmud.shaunregenbaum.com/api/worker-health\n` +
           `Usage: https://talmud.shaunregenbaum.com/usage\n`,
       });

--- a/packages/talmud/tests/memory-budget-guard.test.ts
+++ b/packages/talmud/tests/memory-budget-guard.test.ts
@@ -1,0 +1,81 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { FAN_OUT_CONCURRENCY, STEP_CONCURRENCY } from '../src/worker/index';
+
+// Memory-budget guard — a deploy-time ratchet on the invariants that keep a
+// generation OOM from ever returning `error code: 1101` to a reader.
+//
+// The reader 1101s recurred for months because (a) generation shared the
+// reader's Worker script (so a generation OOM killed the reader's isolate) and
+// (b) the memory multipliers crept up unnoticed across PRs (the queue's
+// max_concurrency went 2 -> 10 -> 50). Both are invisible at code-review time.
+// This suite makes them VISIBLE: a PR that re-merges generation onto the reader,
+// or re-widens an in-isolate fan-out, fails CI here and forces a conscious edit
+// to the ceiling (and a fresh look at the 128 MB budget) rather than a silent
+// regression. Pure file/const reads — runs in the normal `pnpm test` gate.
+
+const stripComments = (toml: string): string =>
+  toml
+    .split('\n')
+    .map((line) => line.replace(/#.*$/, ''))
+    .join('\n');
+
+const reader = stripComments(readFileSync(new URL('../wrangler.toml', import.meta.url), 'utf8'));
+const gen = stripComments(
+  readFileSync(new URL('../wrangler.generator.toml', import.meta.url), 'utf8'),
+);
+
+describe('memory-budget guard: the reader stays read-only', () => {
+  it('the reader (talmud) hosts NO queue consumer — generation must never share its isolate pool', () => {
+    // If this fails, a PR moved the queue consumer back onto the reader. That is
+    // exactly the co-tenancy that caused the OOM 1101s. Keep it on talmud-gen.
+    expect(reader).not.toMatch(/\[\[queues\.consumers\]\]/);
+  });
+
+  it('the reader binds DafWarmWorkflow cross-script (it does not host the class)', () => {
+    expect(reader).toMatch(/script_name\s*=\s*["']talmud-gen["']/);
+  });
+
+  it('the reader runs only the */5 health cron (no heavy warm cron)', () => {
+    const m = reader.match(/crons\s*=\s*\[([^\]]*)\]/);
+    expect(m, 'reader [triggers] crons').toBeTruthy();
+    const crons = (m as RegExpMatchArray)[1];
+    expect(crons).toContain('*/5 * * * *');
+    expect(crons).not.toContain('0 3'); // the 03:00 Daf-Yomi pre-warm lives on talmud-gen
+  });
+
+  it('the reader is tagged WORKER_ROLE=reader so scheduled() runs only the health watch', () => {
+    expect(reader).toMatch(/WORKER_ROLE\s*=\s*["']reader["']/);
+  });
+});
+
+describe('memory-budget guard: the generator owns generation, bounded', () => {
+  it('talmud-gen hosts the queue consumer with concurrency <= 12 (the 128 MB-isolate budget)', () => {
+    expect(gen).toMatch(/\[\[queues\.consumers\]\]/);
+    const m = gen.match(/max_concurrency\s*=\s*(\d+)/);
+    expect(m, 'generator max_concurrency').toBeTruthy();
+    expect(Number((m as RegExpMatchArray)[1])).toBeLessThanOrEqual(12);
+  });
+
+  it('talmud-gen hosts the DafWarmWorkflow class locally (no cross-script binding)', () => {
+    expect(gen).toMatch(/class_name\s*=\s*["']DafWarmWorkflow["']/);
+    expect(gen).not.toMatch(/script_name/); // comments are stripped, so this is the real stanza
+  });
+
+  it('talmud-gen is tagged WORKER_ROLE=generator', () => {
+    expect(gen).toMatch(/WORKER_ROLE\s*=\s*["']generator["']/);
+  });
+});
+
+describe('memory-budget guard: in-isolate fan-out widths', () => {
+  // These multiply the per-step source footprint into peak isolate memory. They
+  // are bounded today; raising either is a conscious 128 MB-budget decision, so
+  // it must come with an edit to this ceiling.
+  it('STEP_CONCURRENCY (cold-gen tier width) stays <= 6', () => {
+    expect(STEP_CONCURRENCY).toBeLessThanOrEqual(6);
+  });
+
+  it('FAN_OUT_CONCURRENCY (per-section fan-out width) stays <= 5', () => {
+    expect(FAN_OUT_CONCURRENCY).toBeLessThanOrEqual(5);
+  });
+});

--- a/packages/talmud/tests/worker-health.test.ts
+++ b/packages/talmud/tests/worker-health.test.ts
@@ -126,4 +126,42 @@ describe('checkWorkerHealthAndAlert', () => {
     vi.unstubAllGlobals();
     expect(sent).toHaveLength(0);
   });
+
+  it('watches BOTH talmud and talmud-gen and breaks the alert down per script', async () => {
+    // Generation moved to talmud-gen, so the OOM the alert exists to catch now
+    // lands there, not on the reader. The watch must query both.
+    const sent: Array<{ subject: string; text: string }> = [];
+    const kv = new Map<string, string>();
+    const env = {
+      CACHE: {
+        get: async (k: string) => kv.get(k) ?? null,
+        put: async (k: string, v: string) => void kv.set(k, v),
+      } as unknown as KVNamespace,
+      EMAIL: { send: async (m: { subject: string; text: string }) => void sent.push(m) },
+      CLOUDFLARE_ACCOUNT_ID: 'acct',
+      CF_ANALYTICS_TOKEN: 'tok',
+    };
+    // Script-aware stub: the reader is healthy; talmud-gen OOMed 9 times.
+    const fetchStub = vi.fn(async (_url: string, init: { body: string }) => {
+      const script = JSON.parse(init.body).variables.script as string;
+      const groups =
+        script === 'talmud-gen'
+          ? [{ sum: { requests: 9 }, dimensions: { status: 'exceededMemory' } }]
+          : [{ sum: { requests: 500 }, dimensions: { status: 'success' } }];
+      return new Response(
+        JSON.stringify({
+          data: { viewer: { accounts: [{ workersInvocationsAdaptive: groups }] } },
+        }),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal('fetch', fetchStub as unknown as typeof fetch);
+    await checkWorkerHealthAndAlert(env, 1_000_000_000_000);
+    vi.unstubAllGlobals();
+    expect(fetchStub).toHaveBeenCalledTimes(2); // one query per watched script
+    expect(sent).toHaveLength(1);
+    expect(sent[0].subject).toContain('9 in last 15m'); // fatal summed (reader 0 + gen 9)
+    expect(sent[0].text).toContain('[talmud-gen]');
+    expect(sent[0].text).toContain('exceededMemory: 9');
+  });
 });

--- a/packages/talmud/wrangler.generator.toml
+++ b/packages/talmud/wrangler.generator.toml
@@ -12,14 +12,13 @@
 # talmud-gen now just retries its own job — it can never touch a reader isolate.
 #
 # Same entry file (src/worker/index.ts) as the reader; the two workers differ
-# only in BINDINGS + TRIGGERS (this config wires the consumer/crons/workflow;
-# the reader config does not). See wrangler.toml for the reader side.
-#
-# STAGED ROLLOUT — this is the PR-1a "idle" config: the worker exists (so its
-# OPENROUTER_API_KEY secret can be set on a real worker) but does NO work yet —
-# no queue consumer, no crons, no workflow host. PR-1b adds those three stanzas
-# here and removes them from wrangler.toml (the atomic cutover). Keeping it idle
-# means merging PR-1a is a zero-behaviour-change deploy.
+# only in BINDINGS + TRIGGERS — this config wires the queue CONSUMER, the warm/
+# yomi CRONS, and the DafWarmWorkflow HOST; wrangler.toml (the reader) wires
+# none of them and instead binds the Workflow cross-script. The secrets this
+# worker needs (OPENROUTER_API_KEY, CLOUDFLARE_ACCOUNT_ID — the AI-Gateway URL
+# is built from the account id) are set with `wrangler secret put -c
+# wrangler.generator.toml`; the inference key is in vault at
+# legacy/prod/talmud/openrouter-api-key.
 name = "talmud-gen"
 main = "src/worker/index.ts"
 compatibility_date = "2025-04-01"
@@ -53,6 +52,38 @@ SPINE_VIEW_WARM_SHAS = "1"
 # Spend budget — enforced at the runLLM chokepoint, which now lives here.
 DAILY_BUDGET_USD = "300"
 HOURLY_CUSTOM_BUDGET_USD = "10"
+# Role flag read by the shared scheduled() handler in index.ts: 'generator' runs
+# the heavy warm/yomi crons (here), 'reader' runs only the lightweight health
+# watch (in wrangler.toml). Keeps heavy warming off the reader's isolate pool.
+WORKER_ROLE = "generator"
+
+# The DafWarmWorkflow class is HOSTED here now (the reader binds to it
+# cross-script via script_name = "talmud-gen"). Each cold-daf generation runs as
+# this Workflow's checkpointed steps on the generator's isolates.
+#
+# NAME is "daf-warm-gen", NOT the reader's old "daf-warm": a workflow name is
+# owned by exactly one script, so reusing "daf-warm" while the live reader still
+# defines it could conflict at cutover. A fresh name owned by talmud-gen makes
+# the cutover deploy conflict-free in either direction; the old "daf-warm"
+# orphans harmlessly (short-lived cold-gen instances, no persistent state keyed
+# on the name). The binding var (DAF_WARM_WORKFLOW) is unchanged, so code is
+# untouched.
+[[workflows]]
+name = "daf-warm-gen"
+binding = "DAF_WARM_WORKFLOW"
+class_name = "DafWarmWorkflow"
+
+# Queue CONSUMER lives here (the reader is producer-only). This is the furnace
+# that used to co-tenant the reader's isolate. max_concurrency bounds how many
+# jobs the consumer pulls concurrently; with generation now isolated from
+# readers, an OOM here only retries its own job — it can never return 1101 to a
+# reader. (History of this number + the per-job memory model is in wrangler.toml.)
+[[queues.consumers]]
+queue = "enrichment-jobs"
+max_batch_size = 1
+max_batch_timeout = 1
+max_concurrency = 12
+max_retries = 1
 
 # Producer binding: deep-warm jobs re-enqueue downstream per-instance jobs, so
 # the generator is BOTH a producer and (in PR-1b) the consumer of this queue.
@@ -69,6 +100,12 @@ id = "f373689f767c477e98cf3b644a4d05bd"
 [observability]
 enabled = true
 head_sampling_rate = 1
+
+# Heavy warming runs HERE, off the reader. */5 rotates one heavy phase per tick
+# (connect-sweep / warm-cron / spine-view; see cron-schedule.ts); 0 3 pre-warms
+# tomorrow's Daf Yomi. The reader keeps only a */5 cron for the health watch.
+[triggers]
+crons = ["*/5 * * * *", "0 3 * * *"]
 
 [[send_email]]
 name = "EMAIL"

--- a/packages/talmud/wrangler.generator.toml
+++ b/packages/talmud/wrangler.generator.toml
@@ -1,0 +1,75 @@
+# talmud-gen — the GENERATION worker.
+#
+# WHY THIS EXISTS: Cloudflare runs concurrent invocations of ONE Worker script
+# in SHARED 128 MB isolates. The talmud reader and all heavy generation (queue
+# consumer + DafWarmWorkflow + warm/yomi crons) used to live in the same script,
+# so a source-heavy generation job that blew 128 MB killed the isolate and every
+# co-tenant request on it — including innocent reader requests, which came back
+# as `error code: 1101`. Concurrency knobs (max_concurrency, STEP_CONCURRENCY)
+# could only make that rarer; they cannot stop the platform from co-scheduling
+# invocations of the SAME script onto one isolate. The only hard guarantee is a
+# SEPARATE script: generation here, reading in `talmud`. A generation OOM on
+# talmud-gen now just retries its own job — it can never touch a reader isolate.
+#
+# Same entry file (src/worker/index.ts) as the reader; the two workers differ
+# only in BINDINGS + TRIGGERS (this config wires the consumer/crons/workflow;
+# the reader config does not). See wrangler.toml for the reader side.
+#
+# STAGED ROLLOUT — this is the PR-1a "idle" config: the worker exists (so its
+# OPENROUTER_API_KEY secret can be set on a real worker) but does NO work yet —
+# no queue consumer, no crons, no workflow host. PR-1b adds those three stanzas
+# here and removes them from wrangler.toml (the atomic cutover). Keeping it idle
+# means merging PR-1a is a zero-behaviour-change deploy.
+name = "talmud-gen"
+main = "src/worker/index.ts"
+compatibility_date = "2025-04-01"
+compatibility_flags = ["nodejs_compat"]
+
+# No public surface: generation is invoked only by the queue/cron/workflow, never
+# by an HTTP route. Disabling workers.dev keeps the reader's API routes (which
+# this shared entry still exports as `fetch`) from being reachable on a public
+# talmud-gen.workers.dev URL. No custom domains, no [assets] — this worker never
+# serves the SPA.
+workers_dev = false
+
+# Same raised CPU ceiling as the reader — a queue job parsing a large LLM stream
+# can accumulate on-CPU time. Workers Paid allows up to 300_000ms (5 min).
+[limits]
+cpu_ms = 300000
+
+[ai]
+binding = "AI"
+remote = true
+
+[vars]
+AI_GATEWAY_ID = "talmud"
+DEFAULT_LLM_MODEL = "openrouter/deepseek/deepseek-v4-pro"
+OPENROUTER_GATEWAY_PROVIDER = "openrouter"
+# Background full-Shas backfills run from the GENERATOR's cron (PR-1b moves the
+# crons here). Same values as the reader carried.
+OBSERVATIONS_WARM_SHAS = "1"
+DAFYOMI_WARM_SHAS = "1"
+SPINE_VIEW_WARM_SHAS = "1"
+# Spend budget — enforced at the runLLM chokepoint, which now lives here.
+DAILY_BUDGET_USD = "300"
+HOURLY_CUSTOM_BUDGET_USD = "10"
+
+# Producer binding: deep-warm jobs re-enqueue downstream per-instance jobs, so
+# the generator is BOTH a producer and (in PR-1b) the consumer of this queue.
+[[queues.producers]]
+queue = "enrichment-jobs"
+binding = "ENRICHMENT_QUEUE"
+
+# Same KV cache namespace as the reader (byte-identical cache keys — the split is
+# orchestration-only, it changes NOTHING about what is cached or under what key).
+[[kv_namespaces]]
+binding = "CACHE"
+id = "f373689f767c477e98cf3b644a4d05bd"
+
+[observability]
+enabled = true
+head_sampling_rate = 1
+
+[[send_email]]
+name = "EMAIL"
+remote = true

--- a/packages/talmud/wrangler.toml
+++ b/packages/talmud/wrangler.toml
@@ -102,6 +102,9 @@ CF_ZONE_TAG = "4808b439c50e3a42494ae7e0b2fa1bec,af7b181368ea154cd40b55404b47d818
 # STUDIO_SECRET`); unset => everyone is treated as untrusted (fail-safe).
 DAILY_BUDGET_USD = "300"
 HOURLY_CUSTOM_BUDGET_USD = "10"
+# Role flag (see scheduled() in index.ts). 'reader' = run only the health watch
+# on the */5 cron; the talmud-gen worker sets 'generator' and runs heavy warming.
+WORKER_ROLE = "reader"
 
 # Cloudflare Queue — long-running enrichment jobs run in the consumer worker
 # instead of holding the producer's request invocation. Producer (POST
@@ -109,45 +112,33 @@ HOURLY_CUSTOM_BUDGET_USD = "10"
 # the message and writes the result to KV under `job:{runId}`. Client polls
 # /api/run-status/:runId. Decouples client requests from LLM latency
 # and stops workerd from dying on parallel long-fetches in dev.
-# Phase 3 (step 1): generation as a Cloudflare Workflow. The warm Workflow
-# generates a daf's whole-daf pieces as separate checkpointed STEPS — each step
-# its own invocation with its own 128 MB budget, so the per-step memory can't pile
-# up the way one monolithic generation job does. Additive: triggered by
-# POST /api/admin/workflow-warm; the live queue/run/reader paths are untouched.
+# The DafWarmWorkflow class is HOSTED by the talmud-gen worker now; the reader
+# only TRIGGERS it (POST /api/daf-generate, yomi-cron), so this is a CROSS-SCRIPT
+# binding (script_name). Generation runs on talmud-gen's isolates — see
+# wrangler.generator.toml and the OOM root-cause note below.
 [[workflows]]
-name = "daf-warm"
+name = "daf-warm-gen"
 binding = "DAF_WARM_WORKFLOW"
 class_name = "DafWarmWorkflow"
+script_name = "talmud-gen"
 
+# Producer ONLY. The reader enqueues enrichment jobs (POST /api/run, admin
+# rewarm) but does NOT consume them — the consumer lives in talmud-gen.
+#
+# WHY THE SPLIT: Cloudflare runs concurrent invocations of ONE script in SHARED
+# 128 MB isolates. When the queue consumer + DafWarmWorkflow + crons lived in
+# THIS script, a source-heavy generation job that blew 128 MB killed the isolate
+# and every co-tenant request on it — including reader requests, which came back
+# as `error code: 1101`. max_concurrency could only make that rarer; it cannot
+# stop the platform from co-scheduling same-script invocations onto one isolate.
+# Moving all generation to a SEPARATE script (talmud-gen) is the only hard
+# guarantee: a generation OOM there retries its own job and can never touch a
+# reader isolate. Live evidence (2026-06-26): 39 exceededMemory/24h on this
+# script, bursty and uncorrelated with reader load (busiest hour: 3,381 reads /
+# 1 OOM) — i.e. cold-daf generation sharing the reader's isolate pool.
 [[queues.producers]]
 queue = "enrichment-jobs"
 binding = "ENRICHMENT_QUEUE"
-
-[[queues.consumers]]
-queue = "enrichment-jobs"
-max_batch_size = 1
-max_batch_timeout = 1
-# History: 2 → 10 → 50, each bump chasing warming THROUGHPUT (the old note
-# reasoned concurrency "caps LLM workloads, not CPU on a single isolate"). That
-# missed the real per-isolate constraint: MEMORY. Concurrent queue invocations
-# can be co-scheduled on ONE isolate, and each cold generation materialized the
-# daf's source bundles (multi-MB on a dense daf) → 50-wide blew the hard 128 MB
-# isolate limit, killed the isolate, and every co-tenant request (incl. plain
-# HTTP /api/run) came back `error code: 1101`. That was the cold-daf OOM.
-#
-# Now that per-job source memory is bounded (rishonim capped at the cache
-# boundary #440; concurrent same-daf loads coalesced to one copy #439), peak
-# isolate memory is ~ max_concurrency × per-job footprint. 12 keeps the worst
-# case (all co-scheduled + dense) comfortably under 128 MB with extra headroom
-# against the sporadic co-located OOMs, while still warming far faster than the
-# old 10. Heavy per-daf generation is additionally being moved off the queue
-# onto the DafWarmWorkflow (bounded per-step memory) via /api/daf-generate, so
-# the queue no longer has to carry the worst-case dense daf at full width. Raise
-# only alongside a measured drop in per-job footprint — warming speed is a
-# background concern; a reader OOM is not. AI Gateway + runLLM's per-call retry
-# ride out provider 429s within a job, so queue-level retries aren't burned.
-max_concurrency = 12
-max_retries = 1
 
 [[kv_namespaces]]
 binding = "CACHE"
@@ -165,14 +156,13 @@ id = "f373689f767c477e98cf3b644a4d05bd"
 enabled = true
 head_sampling_rate = 1  # capture 100% of invocations
 
-# Background cache-warmer. Walks the full shas at ~1 amud/sec, 20 per run,
-# filling KV with no TTL. Latches to done when complete; bump warm-cursor:v1
-# key to force a re-walk. See src/worker/warm-cron.ts.
-#
-# Second cron (03:00 UTC daily) pre-warms tomorrow's Daf Yomi via
-# /api/run for the canonical mark set. See src/worker/yomi-cron.ts.
+# Reader keeps ONE lightweight cron: the */5 health watch (it has
+# CF_ANALYTICS_TOKEN; the generator does not). The shared scheduled() handler
+# reads WORKER_ROLE = "reader" (below) and runs ONLY checkWorkerHealthAndAlert,
+# which now watches BOTH scripts (talmud + talmud-gen). All heavy warming (the
+# shas walk + the 03:00 Daf-Yomi pre-warm) moved to talmud-gen's crons.
 [triggers]
-crons = ["*/5 * * * *", "0 3 * * *"]
+crons = ["*/5 * * * *"]
 
 # Cloudflare Email Service binding (env.EMAIL.send(...)). Same `remote = true`
 # auth path as [ai] above — needs fresh `wrangler login`. Used by


### PR DESCRIPTION
## Root cause (structural, evidenced)

Reader `1101`s recur because **generation shares one Worker script with the reader**. Cloudflare runs concurrent invocations of a single script in **shared 128 MB isolates**, so a source-heavy generation job that blows 128 MB kills the isolate and returns `error code: 1101` to every co-tenant request — including reader requests. Concurrency knobs (`max_concurrency`, `STEP_CONCURRENCY`) only make it rarer; they cannot stop the platform from co-scheduling same-script invocations. **The only hard guarantee is a separate script.**

**Live evidence (PropheX, last 24h):** 39 `exceededMemory` on `scriptName=talmud`; **uncorrelated with reader load** (busiest hour: 3,381 reads / 1 OOM); **episodic** (OOMs spray across ~12–20 consecutive minutes = cold-daf generation events). No separate `daf-warm` script exists — the Workflow runs under `talmud`, sharing the reader's isolate pool. The Workflow's parallel tier even re-piles 6 source-heavy generations into one isolate (`index.ts` confirms: per-step budget "only holds across suspension points").

## The fix

Generation (queue consumer + `DafWarmWorkflow` + warm/yomi crons) moves to **`talmud-gen`**, a separate Worker script (same entry file; differs only in bindings/triggers). The reader enqueues + triggers via **cross-script** bindings. A generation OOM on `talmud-gen` now retries its own job and **can never touch a reader isolate**. Orchestration-only — cache keys byte-identical, **zero re-warm**.

### Config
- `wrangler.generator.toml` — queue CONSUMER (`max_concurrency=12`) + `DafWarmWorkflow` host + warm/yomi crons + `WORKER_ROLE=generator`. Workflow renamed `daf-warm` → `daf-warm-gen` to avoid a same-name ownership conflict at cutover (old `daf-warm` orphans harmlessly; binding var unchanged).
- `wrangler.toml` (reader) — queue PRODUCER only; `DafWarmWorkflow` bound cross-script (`script_name=talmud-gen`); crons trimmed to the `*/5` health tick; `WORKER_ROLE=reader`.
- `ci.yml` — deploys `talmud-gen` first (no vite build), then the reader. `ship:gen` fallback.

### Code
- `scheduled()` role-gates: reader runs ONLY the health watch; generator runs the heavy crons (off the reader's isolate pool).
- `worker-health` — the watch + `GET /api/worker-health` now cover **both** `talmud` and `talmud-gen` (per-script alert breakdown), so the alert isn't blind to the generation OOMs it exists to catch.

## Validation
- `wrangler --dry-run` on both configs (reader shows `DAF_WARM_WORKFLOW (DafWarmWorkflow (defined in talmud-gen))`) ✅
- `pnpm typecheck` ✅ · `pnpm test` (2603) ✅ · `biome ci` ✅
- `talmud-gen` + its secrets (`OPENROUTER_API_KEY`, `CLOUDFLARE_ACCOUNT_ID`) **pre-staged**, so merging cuts over cleanly: CI deploys `talmud-gen` (defines `daf-warm-gen`, starts consuming) → reader (drops consumer, binds cross-script).

## After merge — verify
- `GET /api/worker-health` shows both scripts; open a cold daf and confirm it generates on `talmud-gen` (pieces land via `/api/daf-view`); watch `exceededMemory` on `scriptName=talmud` fall to ~0.

Follow-ups (tracked): CI memory-regression gate; bound generator per-job footprint (the `fanOut` 2.5–5 MB spikes); durable pre-load OOM breadcrumb.