### PR TITLE
Usage Content-In: list curated rabbi + Yerushalmi datasets

### DIFF
--- a/packages/talmud/src/client/i18n.ts
+++ b/packages/talmud/src/client/i18n.ts
@@ -629,6 +629,13 @@ const CATALOG = {
     en: 'Place coordinates (hand-curated)',
     he: 'נקודות ציון של מקומות (ידני)',
   },
+  'usage.src.rabbi-family': { en: 'Rabbi family relations', he: 'קשרי משפחה של חכמים' },
+  'usage.src.rabbi-hierarchy': { en: 'Rabbi teacher–student edges', he: 'קשרי רב–תלמיד' },
+  'usage.src.rabbi-orientation': { en: 'Rabbi orientation', he: 'נטיית החכמים' },
+  'usage.src.yerushalmi-curated': {
+    en: 'Yerushalmi parallels (curated)',
+    he: 'מקבילות ירושלמי (ידני)',
+  },
   'usage.src.dy': { en: 'DafYomi notes (all)', he: 'הערות דף יומי (הכול)' },
   'usage.src.dy.insights': { en: 'Insights', he: 'תובנות' },
   'usage.src.dy.background': { en: 'Background', he: 'רקע' },

--- a/packages/talmud/src/worker/cache-stats.ts
+++ b/packages/talmud/src/worker/cache-stats.ts
@@ -20,6 +20,7 @@
  */
 
 import { GEO_CITIES } from '../client/geoShapes';
+import curatedYerushalmiData from '../lib/data/curated-yerushalmi-parallels.json';
 import rabbiFamilyData from '../lib/data/rabbi-family.json';
 import rabbiHierarchyData from '../lib/data/rabbi-hierarchy.json';
 import rabbiOrientationData from '../lib/data/rabbi-orientation.json';
@@ -856,6 +857,16 @@ export async function computeCacheStats(cache: KVNamespace): Promise<CacheStats>
     if (edgeCount > 0) withHierarchyEdges++;
   }
   const hierarchyDenom = withBio || HIERARCHY.totalNodes || 0;
+
+  // Curated/internal datasets we ship and use (not external fetches): the rabbi
+  // relationship graphs + the hand-curated Bavli<->Yerushalmi parallels. Tagged
+  // 'Custom' (our own data), counts only.
+  const curatedYeruCount =
+    (curatedYerushalmiData as { parallels?: unknown[] }).parallels?.length ?? 0;
+  sources.push(entityRow('rabbi-family', 'Custom', withFamily, 'rabbis'));
+  sources.push(entityRow('rabbi-hierarchy', 'Custom', totalEdges, 'edges'));
+  sources.push(entityRow('rabbi-orientation', 'Custom', withOrientation, 'rabbis'));
+  sources.push(entityRow('yerushalmi-curated', 'Custom', curatedYeruCount, 'parallels'));
 
   return {
     generatedAt: new Date().toISOString(),


### PR DESCRIPTION
## What

Auditing the bundled data the app ships and uses turned up four curated datasets missing from `/usage` Content-In. Added as **Custom** source rows (counts only):

| Dataset | Count |
|---|---|
| Rabbi family relations (`rabbi-family.json`) | ~207 rabbis |
| Rabbi teacher–student edges (`rabbi-hierarchy.json`) | ~1,710 edges |
| Rabbi orientation (`rabbi-orientation.json`) | ~281 rabbis |
| Yerushalmi parallels (`curated-yerushalmi-parallels.json`) | curated |

Counts reuse the figures the rabbi pass already computes (`withFamily` / `totalEdges` / `withOrientation`); the Yerushalmi count comes from the bundled JSON. With these + the earlier additions, Content-In now lists **every external + bundled dataset the app uses**.

## Verification
- `pnpm typecheck`, `pnpm lint`, `pnpm test` (2602), build — clean.
- Additive to the `sources` array; no cache-stats version bump.