### PR TITLE
Usage Content-In: mark the Natural Earth map basemap

### DIFF
--- a/packages/talmud/src/client/i18n.ts
+++ b/packages/talmud/src/client/i18n.ts
@@ -629,6 +629,7 @@ const CATALOG = {
     en: 'Place coordinates (hand-curated)',
     he: 'נקודות ציון של מקומות (ידני)',
   },
+  'usage.src.basemap': { en: 'Map basemap (Natural Earth)', he: 'מפת בסיס (Natural Earth)' },
   'usage.src.rabbi-family': { en: 'Rabbi family relations', he: 'קשרי משפחה של חכמים' },
   'usage.src.rabbi-hierarchy': { en: 'Rabbi teacher–student edges', he: 'קשרי רב–תלמיד' },
   'usage.src.rabbi-orientation': { en: 'Rabbi orientation', he: 'נטיית החכמים' },

--- a/packages/talmud/src/worker/cache-stats.ts
+++ b/packages/talmud/src/worker/cache-stats.ts
@@ -19,7 +19,7 @@
  * short-circuits on `generatedAt < 60s ago`.
  */
 
-import { GEO_CITIES } from '../client/geoShapes';
+import { BAVEL_SHAPE, GEO_CITIES, ISRAEL_SHAPE } from '../client/geoShapes';
 import curatedYerushalmiData from '../lib/data/curated-yerushalmi-parallels.json';
 import rabbiFamilyData from '../lib/data/rabbi-family.json';
 import rabbiHierarchyData from '../lib/data/rabbi-hierarchy.json';
@@ -838,6 +838,15 @@ export async function computeCacheStats(cache: KVNamespace): Promise<CacheStats>
   // grounds the geography map. Babylonian academy towns (Sura, Pumbedita, …) +
   // Roman-era Galilee that no external Bible gazetteer covers.
   sources.push(entityRow('geo-coords', 'Custom', GEO_CITIES.length, 'places'));
+  // Cartographic basemap geometry (coastlines + rivers) clipped from public-
+  // domain Natural Earth and bundled in geoShapes.ts. Not "content" but a real
+  // external dataset we ship to draw the geography map — counted as vector paths.
+  const basemapPaths =
+    ISRAEL_SHAPE.landPaths.length +
+    ISRAEL_SHAPE.riverPaths.length +
+    BAVEL_SHAPE.landPaths.length +
+    BAVEL_SHAPE.riverPaths.length;
+  sources.push(entityRow('basemap', 'Custom', basemapPaths, 'map paths'));
 
   let withFamily = 0;
   for (const n of Object.values(FAMILY.nodes ?? {})) {


### PR DESCRIPTION
## What

The geography map is drawn from **public-domain Natural Earth** coastline/river geometry, clipped + Douglas-Peucker-simplified into `geoShapes.ts` (the Israel + Bavel window shapes). It's a real external dataset we ship — so it should be visible in the source inventory, not invisible.

Adds a **Custom** Content-In row — *"Map basemap (Natural Earth)"* — counted as the bundled vector paths (`landPaths + riverPaths` across both region shapes).

This was the one source I'd flagged as "rendering geometry, not content" — now marked so the inventory is honest about it.

## Verification
- `pnpm typecheck`, `pnpm lint`, `pnpm test` (2602), build — clean.
- Additive to the `sources` array; no version bump.