### PR TITLE
Add #voices: a per-daf voice graph (whole-daf rabbi network)

### DIFF
--- a/packages/talmud/src/client/App.tsx
+++ b/packages/talmud/src/client/App.tsx
@@ -12,6 +12,7 @@ import { SpineCoveragePage } from './SpineCoveragePage';
 import { TopBar } from './TopBar';
 import { TutorialPage } from './TutorialPage';
 import { UsagePage } from './UsagePage';
+import { VoicesPage } from './VoicesPage';
 
 function currentRoute() {
   // #sages/<slug> deep-links into SagesPage; treat the prefix as the route.
@@ -82,7 +83,17 @@ export default function App() {
                                             fallback={
                                               <Show
                                                 when={route() === 'howitworks'}
-                                                fallback={<DafViewer />}
+                                                fallback={
+                                                  <Show
+                                                    when={
+                                                      route() === 'voices' ||
+                                                      route().startsWith('voices/')
+                                                    }
+                                                    fallback={<DafViewer />}
+                                                  >
+                                                    <VoicesPage />
+                                                  </Show>
+                                                }
                                               >
                                                 <HowItWorksPage />
                                               </Show>

--- a/packages/talmud/src/client/DafViewer.tsx
+++ b/packages/talmud/src/client/DafViewer.tsx
@@ -3961,6 +3961,25 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
               </a>
               {' · '}
               <a
+                href={`?tractate=${encodeURIComponent(tractate())}&page=${encodeURIComponent(page())}#voices`}
+                onClick={(e) => {
+                  e.preventDefault();
+                  const u = new URL(window.location.href);
+                  u.searchParams.set('tractate', tractate());
+                  u.searchParams.set('page', page());
+                  u.hash = 'voices';
+                  window.location.href = u.toString();
+                }}
+                style={{
+                  color: 'inherit',
+                  'text-decoration': 'none',
+                  'border-bottom': '1px dotted #bbb',
+                }}
+              >
+                {t('voices.page.link')}
+              </a>
+              {' · '}
+              <a
                 href="#mcp"
                 style={{
                   color: 'inherit',

--- a/packages/talmud/src/client/DafVoiceGraph.tsx
+++ b/packages/talmud/src/client/DafVoiceGraph.tsx
@@ -1,0 +1,365 @@
+/**
+ * The daf-wide VOICE graph: every named rabbi (and collective voice) on the daf
+ * as a node, their argumentative relations (opposes / supports / responds-to /
+ * cites / resolves) as directed edges, stitched across all the daf's sections by
+ * `buildDafVoiceGraph`. Nodes sit in a vertical column (daf order, top to
+ * bottom); connectors route through a right-side lane so they never cross node
+ * boxes and only ever run horizontally or vertically (orthogonal — no
+ * diagonals), exactly like the argument FLOW graph, so the two read as one
+ * visual language at different zooms.
+ *
+ * Nodes are coloured by the speaker's generation (the same red→blue spectrum as
+ * the inline rabbi marks); a collective voice (Stam, Sages) gets a neutral
+ * stripe. Click a node to focus it — its relations stay lit, the rest fade.
+ */
+import { createMemo, createSignal, For, type JSX, Show } from 'solid-js';
+import type { DafVoiceEdge, DafVoiceNode, VoiceRelationKind } from '../lib/typing/dafVoices';
+import {
+  assignLanes,
+  type FlowConnection,
+  KIND_COLOR,
+  KIND_DASH,
+  stmtRelKind,
+  wrapTitle,
+} from './ArgumentFlowGraph';
+import { colorForGeneration, GENERATION_BY_ID } from './generations';
+import { lang, t } from './i18n';
+
+interface Props {
+  nodes: DafVoiceNode[];
+  edges: DafVoiceEdge[];
+}
+
+const NODE_W = 256;
+const NODE_H = 50;
+const ROW_GAP = 12;
+const TOP_PAD = 12;
+const LEFT_PAD = 12;
+const LANE_BASE = 12;
+const LANE_STEP = 12;
+const CORNER_R = 16;
+const STRIPE_W = 6;
+const COLLECTIVE_INK = '#b8b2a4';
+// `supports` (raya / proof) has no section-flow kin, so it keeps its own
+// evidential hue — matching ArgumentFlowGraph's STMT_SUPPORTS_COLOR.
+const SUPPORTS_COLOR = '#0891b2';
+
+const REL_ORDER: VoiceRelationKind[] = ['opposes', 'responds-to', 'resolves', 'cites', 'supports'];
+
+/** Relation colour: `supports` is special (own hue); the rest borrow the
+ *  section-flow palette through the same `stmtRelKind` mapping the per-section
+ *  statement spine uses. */
+function relColor(kind: VoiceRelationKind): string {
+  return kind === 'supports' ? SUPPORTS_COLOR : KIND_COLOR[stmtRelKind(kind)];
+}
+function relDash(kind: VoiceRelationKind): string | undefined {
+  return kind === 'supports' ? undefined : KIND_DASH[stmtRelKind(kind)];
+}
+
+export default function DafVoiceGraph(props: Props): JSX.Element {
+  const [focus, setFocus] = createSignal<string | null>(null);
+  const toggleFocus = (name: string) => setFocus((f) => (f === name ? null : name));
+
+  // name -> row index (column position), in daf order.
+  const rowOf = createMemo(() => new Map(props.nodes.map((n, i) => [n.name, i])));
+  const nodeY = (i: number) => TOP_PAD + i * (NODE_H + ROW_GAP);
+  const rowMidY = (i: number) => nodeY(i) + NODE_H / 2;
+
+  // Edges reduced to row endpoints (drop any whose endpoint isn't a node — the
+  // builder already guarantees this, but stay defensive).
+  const layoutEdges = createMemo(() => {
+    const rm = rowOf();
+    return props.edges
+      .map((e) => ({ e, from: rm.get(e.from), to: rm.get(e.to) }))
+      .filter(
+        (x): x is { e: DafVoiceEdge; from: number; to: number } =>
+          x.from !== undefined && x.to !== undefined && x.from !== x.to,
+      );
+  });
+
+  // Lane assignment reuses the flow graph's interval-graph colouring: edges with
+  // overlapping vertical extent never share a lane (no drawing on top of each other).
+  const lanes = createMemo(() =>
+    assignLanes(
+      layoutEdges().map((x) => ({ from: x.from, to: x.to, kind: 'continues' }) as FlowConnection),
+    ),
+  );
+  const laneCount = createMemo(() => {
+    const ls = lanes();
+    return ls.length ? Math.max(...ls) + 1 : 0;
+  });
+  const laneX = (lane: number) => LEFT_PAD + NODE_W + LANE_BASE + lane * LANE_STEP;
+  const gutter = () => LANE_BASE + Math.max(1, laneCount()) * LANE_STEP + 10;
+  const width = () => LEFT_PAD + NODE_W + gutter();
+  const height = () =>
+    props.nodes.length ? TOP_PAD + props.nodes.length * (NODE_H + ROW_GAP) - ROW_GAP + TOP_PAD : 0;
+
+  // Names lit when a node is focused: the node itself + every voice it relates to.
+  const litNames = createMemo(() => {
+    const f = focus();
+    if (!f) return null;
+    const lit = new Set<string>([f]);
+    for (const e of props.edges) {
+      if (e.from === f) lit.add(e.to);
+      if (e.to === f) lit.add(e.from);
+    }
+    return lit;
+  });
+  const nodeDim = (name: string) => {
+    const lit = litNames();
+    return lit ? (lit.has(name) ? 1 : 0.3) : 1;
+  };
+  const edgeOpacity = (e: DafVoiceEdge) => {
+    const f = focus();
+    if (!f) return 0.82;
+    return e.from === f || e.to === f ? 0.95 : 0.1;
+  };
+
+  const edgePath = (y1: number, y2: number, x: number): string => {
+    const rightX = LEFT_PAD + NODE_W;
+    const dir = y2 >= y1 ? 1 : -1;
+    const r = Math.min(CORNER_R, x - rightX, Math.abs(y2 - y1) / 2 || CORNER_R);
+    return [
+      `M ${rightX} ${y1}`,
+      `L ${x - r} ${y1}`,
+      `Q ${x} ${y1} ${x} ${y1 + dir * r}`,
+      `L ${x} ${y2 - dir * r}`,
+      `Q ${x} ${y2} ${x - r} ${y2}`,
+      `L ${rightX} ${y2}`,
+    ].join(' ');
+  };
+
+  const relsPresent = createMemo(() => {
+    const seen = new Set<VoiceRelationKind>();
+    for (const e of props.edges) seen.add(e.kind);
+    return REL_ORDER.filter((k) => seen.has(k));
+  });
+
+  const displayName = (n: DafVoiceNode) => (lang() === 'he' && n.nameHe ? n.nameHe : n.name);
+  const genLabel = (n: DafVoiceNode): string => {
+    if (n.collective) return t('dafvoices.collective');
+    if (!n.generation) return '';
+    return GENERATION_BY_ID[n.generation as keyof typeof GENERATION_BY_ID]?.label ?? '';
+  };
+
+  return (
+    <Show when={props.nodes.length > 0}>
+      <div
+        style={{
+          width: '100%',
+          'min-width': 0,
+          'max-height': '70vh',
+          'overflow-x': 'auto',
+          'overflow-y': 'auto',
+          direction: 'ltr',
+          border: '1px solid #ece9df',
+          'border-radius': '8px',
+          background: '#fdfcf9',
+          padding: '0.35rem 0.2rem',
+        }}
+      >
+        <svg
+          role="img"
+          aria-label="Daf voice graph"
+          width={width()}
+          height={height()}
+          viewBox={`0 0 ${width()} ${height()}`}
+          style={{ display: 'block' }}
+        >
+          <defs>
+            <For each={[...REL_ORDER]}>
+              {(kind) => (
+                <marker
+                  id={`voice-arrow-${kind}`}
+                  markerWidth="8"
+                  markerHeight="8"
+                  refX="6"
+                  refY="3"
+                  orient="auto"
+                >
+                  <path d="M 0 0 L 6 3 L 0 6 z" fill={relColor(kind)} />
+                </marker>
+              )}
+            </For>
+            <filter id="voice-card-shadow" x="-10%" y="-20%" width="120%" height="150%">
+              <feDropShadow
+                dx="0"
+                dy="1"
+                stdDeviation="1.4"
+                flood-color="#3a3320"
+                flood-opacity="0.12"
+              />
+            </filter>
+          </defs>
+
+          {/* Connectors (behind nodes). */}
+          <For each={layoutEdges()}>
+            {(x, i) => {
+              const c = x.e;
+              const y1 = rowMidY(x.from);
+              const y2 = rowMidY(x.to);
+              const lane = lanes()[i()];
+              return (
+                <path
+                  d={edgePath(y1, y2, laneX(lane))}
+                  fill="none"
+                  stroke={relColor(c.kind)}
+                  stroke-width={1.5}
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-opacity={edgeOpacity(c)}
+                  stroke-dasharray={relDash(c.kind)}
+                  marker-end={`url(#voice-arrow-${c.kind})`}
+                >
+                  <title>{`${c.from} — ${t(`dafvoices.rel.${c.kind}`)} → ${c.to}${c.note ? ` (${c.note})` : ''}${c.sections.length > 1 ? ` ·  ${c.sections.length}` : ''}`}</title>
+                </path>
+              );
+            }}
+          </For>
+
+          {/* Nodes: rounded card + generation stripe + name + generation/role line. */}
+          <For each={props.nodes}>
+            {(n, i) => {
+              const stripe = n.collective ? COLLECTIVE_INK : colorForGeneration(n.generation);
+              const lines = () => wrapTitle(displayName(n), 24, 2);
+              const focused = () => focus() === n.name;
+              const pick = () => toggleFocus(n.name);
+              const top = nodeY(i());
+              const cx = LEFT_PAD + STRIPE_W + 11;
+              const titleX = LEFT_PAD + STRIPE_W + 11;
+              const sub = () => {
+                const g = genLabel(n);
+                const secs = n.sections.length;
+                const secTxt = secs > 1 ? `·  ${secs} ${t('dafvoices.sections')}` : '';
+                return [g, secTxt].filter(Boolean).join('  ');
+              };
+              return (
+                // biome-ignore lint/a11y/useSemanticElements: native <button> cannot be used inside an SVG diagram
+                <g
+                  role="button"
+                  tabindex={0}
+                  style={{ cursor: 'pointer', opacity: nodeDim(n.name) }}
+                  onClick={pick}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      pick();
+                    }
+                  }}
+                >
+                  <title>{`${n.name}${n.generation && !n.collective ? ` — ${genLabel(n)}` : ''} · ${n.sections.length} section${n.sections.length > 1 ? 's' : ''}`}</title>
+                  {/* Stripe under a left-inset white body (the SVG analog of border-left). */}
+                  <rect
+                    x={LEFT_PAD}
+                    y={top}
+                    width={NODE_W}
+                    height={NODE_H}
+                    rx={9}
+                    ry={9}
+                    fill={stripe}
+                  />
+                  <rect
+                    x={LEFT_PAD + STRIPE_W}
+                    y={top}
+                    width={NODE_W - STRIPE_W}
+                    height={NODE_H}
+                    rx={9}
+                    ry={9}
+                    fill={focused() ? '#fdf2f2' : '#ffffff'}
+                  />
+                  <rect
+                    x={LEFT_PAD}
+                    y={top}
+                    width={NODE_W}
+                    height={NODE_H}
+                    rx={9}
+                    ry={9}
+                    fill="none"
+                    stroke={focused() ? '#8a2a2b' : '#e4e0d4'}
+                    stroke-width={focused() ? 1.75 : 1}
+                    filter="url(#voice-card-shadow)"
+                  />
+                  <For each={lines()}>
+                    {(line, li) => (
+                      <text
+                        x={titleX}
+                        y={top + 17 + li() * 15}
+                        text-anchor={lang() === 'he' ? 'end' : 'start'}
+                        dominant-baseline="central"
+                        font-size="13"
+                        font-weight="600"
+                        font-family="system-ui, -apple-system, sans-serif"
+                        fill="#2a2520"
+                        font-style={n.collective ? 'italic' : 'normal'}
+                        direction={lang() === 'he' ? 'rtl' : 'ltr'}
+                      >
+                        {line}
+                      </text>
+                    )}
+                  </For>
+                  <Show when={sub()}>
+                    <text
+                      x={cx}
+                      y={top + NODE_H - 11}
+                      text-anchor={lang() === 'he' ? 'end' : 'start'}
+                      dominant-baseline="central"
+                      font-size="9.5"
+                      font-weight="600"
+                      letter-spacing="0.03em"
+                      font-family="system-ui, sans-serif"
+                      fill={n.collective ? '#8a857c' : stripe}
+                      fill-opacity={0.85}
+                      direction={lang() === 'he' ? 'rtl' : 'ltr'}
+                    >
+                      {sub()}
+                    </text>
+                  </Show>
+                </g>
+              );
+            }}
+          </For>
+        </svg>
+      </div>
+
+      {/* Legend: relation kinds present. */}
+      <Show when={relsPresent().length > 0}>
+        <div
+          style={{
+            display: 'flex',
+            'flex-wrap': 'wrap',
+            gap: '0.35rem 0.45rem',
+            'margin-top': '0.55rem',
+          }}
+        >
+          <For each={relsPresent()}>
+            {(kind) => (
+              <span
+                style={{
+                  display: 'inline-flex',
+                  'align-items': 'center',
+                  gap: '0.35rem',
+                  padding: '0.12rem 0.5rem',
+                  background: '#faf8f3',
+                  border: '1px solid #ece7db',
+                  'border-radius': '999px',
+                  'font-size': '0.66rem',
+                  color: '#6b6661',
+                }}
+              >
+                <span
+                  style={{
+                    display: 'inline-block',
+                    width: '16px',
+                    height: 0,
+                    'border-top': `2px ${relDash(kind) ? 'dashed' : 'solid'} ${relColor(kind)}`,
+                  }}
+                />
+                {t(`dafvoices.rel.${kind}`)}
+              </span>
+            )}
+          </For>
+        </div>
+      </Show>
+    </Show>
+  );
+}

--- a/packages/talmud/src/client/VoicesPage.tsx
+++ b/packages/talmud/src/client/VoicesPage.tsx
@@ -1,0 +1,293 @@
+/**
+ * #voices — the per-daf VOICE graph page. Stitches every section's
+ * `argument.voices` into one daf-wide rabbi network (who disputes / responds to
+ * / cites whom across the whole daf), then lists the per-section detail beneath
+ * it as the audit view.
+ *
+ * Read-only and client-only: the data already rides along in the single
+ * `/api/daf-view` fetch — each `argument.synthesis` piece carries its section's
+ * `argument.voices` in `deps_resolved` (voices is a synthesis dependency), and
+ * the `rabbi` mark supplies generations for node colouring. Nothing is
+ * generated here; a cold section simply isn't shown (the banner says how many
+ * are still warming). This per-daf graph is the unit the eventual Talmud-wide
+ * rabbi network aggregates.
+ */
+import { createMemo, createResource, createSignal, For, type JSX, Show } from 'solid-js';
+import { dafRefHe } from '../lib/sefref';
+import {
+  buildDafVoiceGraph,
+  type DafVoiceGraph as DafVoiceGraphData,
+  type SectionVoicesInput,
+  type VoiceClass,
+} from '../lib/typing/dafVoices';
+import type { ArgumentVoicesData } from '../lib/typing/voices';
+import DafVoiceGraph from './DafVoiceGraph';
+import { type DafViewPiece, loadDafView } from './dafViewStore';
+import { colorForGeneration } from './generations';
+import { lang, t } from './i18n';
+import { resolveVoiceGroup } from './voiceGroups';
+
+interface DafRef {
+  tractate: string;
+  page: string;
+}
+
+function readRef(): DafRef {
+  const p = new URLSearchParams(window.location.search);
+  return { tractate: p.get('tractate') ?? 'Berakhot', page: p.get('page') ?? '2a' };
+}
+
+interface BuiltView {
+  graph: DafVoiceGraphData;
+  /** Total argument sections on the daf (warm or not). */
+  totalSections: number;
+  /** Sections that had voices data (made it into the graph). */
+  analyzedSections: number;
+  complete: boolean;
+}
+
+type RabbiMarkParsed = {
+  instances?: Array<{ fields?: { name?: string; nameHe?: string; generation?: string } }>;
+};
+type ArgumentMarkParsed = {
+  instances?: Array<{ startSegIdx?: number; fields?: { title?: string } }>;
+};
+
+function buildFromPieces(pieces: Record<string, DafViewPiece>, complete: boolean): BuiltView {
+  // Rabbi generations: name -> generation id, for node colouring.
+  const genByName = new Map<string, string>();
+  const rabbiParsed = pieces.rabbi?.parsed as RabbiMarkParsed | undefined;
+  for (const inst of rabbiParsed?.instances ?? []) {
+    const nm = inst.fields?.name?.trim();
+    if (nm && inst.fields?.generation && !genByName.has(nm)) {
+      genByName.set(nm, inst.fields.generation);
+    }
+  }
+
+  // Section daf-order: title -> first startSegIdx from the argument mark.
+  const orderByTitle = new Map<string, number>();
+  const argParsed = pieces.argument?.parsed as ArgumentMarkParsed | undefined;
+  (argParsed?.instances ?? []).forEach((inst, i) => {
+    const ti = inst.fields?.title?.trim();
+    if (ti && !orderByTitle.has(ti)) {
+      orderByTitle.set(ti, typeof inst.startSegIdx === 'number' ? inst.startSegIdx : i);
+    }
+  });
+  const totalSections = orderByTitle.size;
+
+  // One section per argument.synthesis piece; its voices ride in deps_resolved.
+  const sections: SectionVoicesInput[] = [];
+  for (const piece of Object.values(pieces)) {
+    if (piece.producerId !== 'argument.synthesis') continue;
+    const voices = piece.deps_resolved?.['argument.voices'] as ArgumentVoicesData | undefined;
+    sections.push({ title: piece.instanceLabel ?? piece.instanceId ?? '', voices: voices ?? null });
+  }
+  sections.sort(
+    (a, b) =>
+      (orderByTitle.get(a.title) ?? Number.MAX_SAFE_INTEGER) -
+      (orderByTitle.get(b.title) ?? Number.MAX_SAFE_INTEGER),
+  );
+
+  const classify = (name: string): VoiceClass => ({
+    collective: !!resolveVoiceGroup(name),
+    generation: genByName.get(name),
+  });
+
+  const graph = buildDafVoiceGraph(sections, classify);
+  return {
+    graph,
+    totalSections: Math.max(totalSections, graph.sections.length),
+    analyzedSections: graph.sections.length,
+    complete,
+  };
+}
+
+export function VoicesPage(): JSX.Element {
+  const [ref, setRef] = createSignal<DafRef>(readRef());
+  const sync = () => setRef(readRef());
+  window.addEventListener('popstate', sync);
+  window.addEventListener('hashchange', sync);
+
+  const [payload] = createResource(
+    () => `${ref().tractate}:${ref().page}:${lang()}`,
+    async () => {
+      const r = ref();
+      return loadDafView(r.tractate, r.page, lang());
+    },
+  );
+
+  const built = createMemo<BuiltView | null>(() => {
+    const p = payload();
+    if (!p) return null;
+    return buildFromPieces(p.pieces ?? {}, !!p.complete);
+  });
+
+  const title = () =>
+    lang() === 'he' ? dafRefHe(ref().tractate, ref().page) : `${ref().tractate} ${ref().page}`;
+  const backHref = () =>
+    `?tractate=${encodeURIComponent(ref().tractate)}&page=${encodeURIComponent(ref().page)}#daf`;
+
+  // Look up a node's generation colour / collective-ness for the breakdown chips.
+  const nodeByName = createMemo(() => {
+    const m = new Map<string, DafVoiceGraphData['nodes'][number]>();
+    for (const n of built()?.graph.nodes ?? []) m.set(n.name, n);
+    return m;
+  });
+
+  return (
+    <main class="page-shell" style={{ '--page-max': '880px', color: '#222' }}>
+      <header style={{ 'margin-bottom': '1.1rem' }}>
+        <a
+          href={backHref()}
+          style={{ color: '#666', 'font-size': '0.85rem', 'text-decoration': 'none' }}
+        >
+          ← {t('voices.page.back')}
+        </a>
+        <h1 style={{ margin: '0.4rem 0 0', 'font-size': '1.45rem' }}>
+          {t('voices.page.title')} · <span style={{ color: '#8a2a2b' }}>{title()}</span>
+        </h1>
+        <p
+          style={{ margin: '0.3rem 0 0', color: '#666', 'font-size': '0.9rem', 'line-height': 1.5 }}
+        >
+          {t('voices.page.subtitle')}
+        </p>
+      </header>
+
+      <Show
+        when={!payload.loading}
+        fallback={<p style={{ color: '#888' }}>{t('voices.page.loading')}</p>}
+      >
+        <Show
+          when={built() && built()!.graph.nodes.length > 0}
+          fallback={
+            <div
+              style={{
+                border: '1px solid #ece7db',
+                'border-radius': '8px',
+                background: '#faf8f3',
+                padding: '1rem 1.1rem',
+                color: '#6b6661',
+                'line-height': 1.55,
+              }}
+            >
+              <p style={{ margin: 0 }}>{t('voices.page.empty')}</p>
+              <a
+                href={backHref()}
+                style={{ color: '#8a2a2b', 'font-size': '0.85rem', 'text-decoration': 'none' }}
+              >
+                {t('voices.page.openDaf')} →
+              </a>
+            </div>
+          }
+        >
+          {/* Partial-warming banner: some sections aren't analyzed yet. */}
+          <Show when={built()!.analyzedSections < built()!.totalSections}>
+            <div
+              style={{
+                border: '1px solid #e7ddc6',
+                'border-radius': '8px',
+                background: '#fbf6e9',
+                padding: '0.55rem 0.85rem',
+                color: '#8a6d3b',
+                'font-size': '0.82rem',
+                'margin-bottom': '0.9rem',
+              }}
+            >
+              {t('voices.page.partial')
+                .replace('{done}', String(built()!.analyzedSections))
+                .replace('{total}', String(built()!.totalSections))}
+            </div>
+          </Show>
+
+          <DafVoiceGraph nodes={built()!.graph.nodes} edges={built()!.graph.edges} />
+
+          {/* Per-section breakdown — the audit view: each section's voices + relations. */}
+          <section style={{ 'margin-top': '1.6rem' }}>
+            <h2 style={{ 'font-size': '0.95rem', color: '#444', margin: '0 0 0.6rem' }}>
+              {t('voices.page.bySection')}
+            </h2>
+            <For each={built()!.graph.sections}>
+              {(sec, idx) => (
+                <article
+                  style={{
+                    border: '1px solid #ece7db',
+                    'border-radius': '8px',
+                    background: '#fff',
+                    padding: '0.7rem 0.9rem',
+                    'margin-bottom': '0.7rem',
+                  }}
+                >
+                  <h3 style={{ margin: '0 0 0.5rem', 'font-size': '0.9rem', color: '#2a2520' }}>
+                    <span style={{ color: '#b8b2a4' }}>{idx() + 1}.</span> {sec.title}
+                  </h3>
+                  <div style={{ display: 'flex', 'flex-wrap': 'wrap', gap: '0.3rem 0.4rem' }}>
+                    <For each={sec.voices.voices}>
+                      {(v) => {
+                        const node = () => nodeByName().get(v.name);
+                        const color = () =>
+                          node()?.collective ? '#b8b2a4' : colorForGeneration(node()?.generation);
+                        return (
+                          <span
+                            style={{
+                              display: 'inline-flex',
+                              'align-items': 'center',
+                              gap: '0.3rem',
+                              padding: '0.1rem 0.5rem',
+                              'border-radius': '999px',
+                              border: '1px solid #eee',
+                              background: '#fafafa',
+                              'font-size': '0.78rem',
+                              color: '#333',
+                            }}
+                          >
+                            <span
+                              style={{
+                                width: '8px',
+                                height: '8px',
+                                'border-radius': '999px',
+                                background: color(),
+                                display: 'inline-block',
+                              }}
+                            />
+                            {lang() === 'he' && v.nameHe ? v.nameHe : v.name}
+                          </span>
+                        );
+                      }}
+                    </For>
+                  </div>
+                  <Show when={sec.voices.edges.length > 0}>
+                    <ul
+                      style={{
+                        margin: '0.55rem 0 0',
+                        padding: '0 0 0 0',
+                        'list-style': 'none',
+                        'font-size': '0.8rem',
+                        color: '#555',
+                        'line-height': 1.7,
+                      }}
+                    >
+                      <For each={sec.voices.edges}>
+                        {(e) => (
+                          <li>
+                            <strong style={{ 'font-weight': 600, color: '#2a2520' }}>
+                              {e.from}
+                            </strong>{' '}
+                            <span style={{ color: '#8a6d3b' }}>{t(`dafvoices.rel.${e.kind}`)}</span>{' '}
+                            <strong style={{ 'font-weight': 600, color: '#2a2520' }}>{e.to}</strong>
+                            <Show when={e.note}>
+                              <span style={{ color: '#999' }}> — {e.note}</span>
+                            </Show>
+                          </li>
+                        )}
+                      </For>
+                    </ul>
+                  </Show>
+                </article>
+              )}
+            </For>
+          </section>
+        </Show>
+      </Show>
+    </main>
+  );
+}

--- a/packages/talmud/src/client/i18n.ts
+++ b/packages/talmud/src/client/i18n.ts
@@ -145,6 +145,33 @@ const CATALOG = {
   'voices.legend.supports': { en: 'supports / responds', he: 'תומך / מגיב' },
   'voices.legend.opposes': { en: 'opposes', he: 'חולק' },
   'voices.legend.cites': { en: 'cites', he: 'מצטט' },
+
+  // — #voices page (daf-wide voice graph) —
+  'voices.page.title': { en: 'Voices', he: 'קולות' },
+  'voices.page.back': { en: 'back to daf', he: 'חזרה לדף' },
+  'voices.page.subtitle': {
+    en: 'Who argues, answers, and cites whom across the whole daf — every section’s voices stitched into one graph.',
+    he: 'מי חולק, משיב ומצטט את מי לאורך כל הדף — קולות כל המקטעים מאוחדים לגרף אחד.',
+  },
+  'voices.page.loading': { en: 'Loading the daf’s voices…', he: 'טוען את קולות הדף…' },
+  'voices.page.empty': {
+    en: 'No voices have been analyzed for this daf yet. Open the daf and browse its sections to generate them.',
+    he: 'עדיין לא נותחו קולות עבור דף זה. פִּתחו את הדף ועיינו במקטעים כדי לחשב אותם.',
+  },
+  'voices.page.openDaf': { en: 'Open the daf', he: 'פתיחת הדף' },
+  'voices.page.partial': {
+    en: '{done} of {total} sections analyzed — open the daf to warm the rest.',
+    he: '{done} מתוך {total} מקטעים נותחו — פִּתחו את הדף כדי לחשב את השאר.',
+  },
+  'voices.page.bySection': { en: 'By section', he: 'לפי מקטע' },
+  'voices.page.link': { en: 'Voice graph', he: 'גרף הקולות' },
+  'dafvoices.collective': { en: 'collective voice', he: 'קול קיבוצי' },
+  'dafvoices.sections': { en: 'sections', he: 'מקטעים' },
+  'dafvoices.rel.opposes': { en: 'opposes', he: 'חולק על' },
+  'dafvoices.rel.supports': { en: 'supports', he: 'תומך ב' },
+  'dafvoices.rel.responds-to': { en: 'responds to', he: 'משיב ל' },
+  'dafvoices.rel.cites': { en: 'cites', he: 'מצטט את' },
+  'dafvoices.rel.resolves': { en: 'resolves', he: 'מיישב את' },
   // Voice roles (argument taxonomy)
   'voice.role.originator': { en: 'originator', he: 'פותח' },
   'voice.role.questioner': { en: 'questioner', he: 'מקשה' },

--- a/packages/talmud/src/lib/typing/dafVoices.ts
+++ b/packages/talmud/src/lib/typing/dafVoices.ts
@@ -1,0 +1,144 @@
+/**
+ * @fileoverview Merge a daf's per-section `argument.voices` graphs into ONE
+ * daf-wide voice network: rabbis (and collective voices) as nodes, their
+ * argumentative relations (opposes / supports / responds-to / cites / resolves)
+ * as edges, accumulated across every section of the daf.
+ *
+ * Each section's `argument.voices` is a section-LOCAL dispute graph (who argues
+ * with whom WITHIN that section). The #voices page stitches them: a voice that
+ * speaks in three sections is ONE node carrying all three; a relation seen in
+ * two sections carries both. The result reads the whole daf as a single
+ * conversation, and is the seed for the eventual Talmud-wide rabbi network
+ * (aggregate these per-daf graphs across Shas).
+ *
+ * Pure + DOM-free (so it's unit-testable). `deriveVoiceEdges` repairs each
+ * section's edge directions / drops malformed edges BEFORE the merge, so even
+ * pre-transform cached graphs stitch correctly.
+ */
+import { type ArgumentEdge, type ArgumentVoicesData, deriveVoiceEdges } from './voices';
+
+export type VoiceRelationKind = ArgumentEdge['kind'];
+
+/**
+ * How the caller classifies a voice name. Injected as a callback so this module
+ * stays free of the client generation / voice-group tables — the page supplies
+ * the real classifier (rabbi-mark generations + `resolveVoiceGroup`), a test
+ * supplies a fake.
+ */
+export interface VoiceClass {
+  /** Generation id (from the rabbi mark) for node coloring; undefined when the
+   *  voice isn't a registered rabbi — a collective voice, or a name the rabbi
+   *  mark didn't catch. */
+  generation?: string;
+  /** True for an anonymous / collective voice (Stam, Sages, Tanna Kamma, …) —
+   *  rendered without a generation stripe. */
+  collective: boolean;
+}
+
+export interface SectionVoicesInput {
+  /** Section title (the `argument.synthesis` instance label). */
+  title: string;
+  /** Raw `deps_resolved['argument.voices']` for the section (repaired here). */
+  voices: ArgumentVoicesData | null | undefined;
+}
+
+export interface DafVoiceNode {
+  /** Conventional English name — the dedup key across sections. */
+  name: string;
+  nameHe?: string;
+  generation?: string;
+  collective: boolean;
+  /** Section titles where this voice speaks, in first-appearance order. */
+  sections: string[];
+  /** Distinct roles this voice plays across the daf (originator, respondent, …). */
+  roles: string[];
+}
+
+export interface DafVoiceEdge {
+  from: string;
+  to: string;
+  kind: VoiceRelationKind;
+  /** Section titles where this relation occurs. */
+  sections: string[];
+  /** First note seen for the relation (e.g. "cites baraita"). */
+  note?: string;
+}
+
+export interface DafVoiceGraph {
+  nodes: DafVoiceNode[];
+  edges: DafVoiceEdge[];
+  /** Per-section breakdown (repaired), in daf order — the detail / audit view. */
+  sections: { title: string; voices: ArgumentVoicesData }[];
+}
+
+function pushUnique(arr: string[], v: string): void {
+  if (v && !arr.includes(v)) arr.push(v);
+}
+
+/**
+ * Stitch the per-section voice graphs into one daf-wide graph. Nodes are keyed
+ * by conventional English `name` (the prompt emits a stable form per voice), so
+ * the same rabbi across sections collapses to one node carrying every section,
+ * role, and relation. Insertion order is daf order (first appearance), which the
+ * renderer reads top-to-bottom.
+ */
+export function buildDafVoiceGraph(
+  sections: SectionVoicesInput[],
+  classify: (name: string) => VoiceClass,
+): DafVoiceGraph {
+  const nodes = new Map<string, DafVoiceNode>();
+  const edges = new Map<string, DafVoiceEdge>();
+  const outSections: { title: string; voices: ArgumentVoicesData }[] = [];
+
+  for (const sec of sections) {
+    const raw = sec.voices;
+    if (!raw || !Array.isArray(raw.voices)) continue;
+    const repaired = deriveVoiceEdges({
+      voices: raw.voices,
+      edges: Array.isArray(raw.edges) ? raw.edges : [],
+    }) as ArgumentVoicesData;
+    outSections.push({ title: sec.title, voices: repaired });
+
+    // Voices first (all registered), so the edge pass below can reject an edge
+    // whose endpoint never appeared as a node in any section.
+    for (const v of repaired.voices) {
+      const name = (v?.name ?? '').trim();
+      if (!name) continue;
+      let node = nodes.get(name);
+      if (!node) {
+        const cls = classify(name);
+        node = {
+          name,
+          nameHe: v.nameHe?.trim() || undefined,
+          generation: cls.generation,
+          collective: cls.collective,
+          sections: [],
+          roles: [],
+        };
+        nodes.set(name, node);
+      }
+      if (!node.nameHe && v.nameHe?.trim()) node.nameHe = v.nameHe.trim();
+      pushUnique(node.sections, sec.title);
+      if (typeof v.role === 'string' && v.role) pushUnique(node.roles, v.role);
+    }
+
+    for (const e of repaired.edges) {
+      const from = (e?.from ?? '').trim();
+      const to = (e?.to ?? '').trim();
+      if (!from || !to || from === to) continue;
+      if (!nodes.has(from) || !nodes.has(to)) continue;
+      // JSON-encode the triple so names carrying spaces can't collide
+      // ("A" + "B C" vs "A B" + "C").
+      const key = JSON.stringify([from, to, e.kind]);
+      let edge = edges.get(key);
+      if (!edge) {
+        edge = { from, to, kind: e.kind, sections: [], note: e.note?.trim() || undefined };
+        edges.set(key, edge);
+      }
+      pushUnique(edge.sections, sec.title);
+      if (!edge.note && e.note?.trim()) edge.note = e.note.trim();
+    }
+  }
+
+  return { nodes: [...nodes.values()], edges: [...edges.values()], sections: outSections };
+}

--- a/packages/talmud/tests/typing/dafVoices.test.ts
+++ b/packages/talmud/tests/typing/dafVoices.test.ts
@@ -1,0 +1,132 @@
+/**
+ * buildDafVoiceGraph (src/lib/typing/dafVoices.ts) — stitches the per-section
+ * argument.voices graphs of a daf into one daf-wide voice network: voices dedupe
+ * by name across sections (carrying every section + role), relations dedupe by
+ * (from, to, kind) (carrying every section), and edge directions are repaired
+ * per-section via deriveVoiceEdges before the merge.
+ */
+import { describe, expect, it } from 'vitest';
+import { buildDafVoiceGraph, type VoiceClass } from '../../src/lib/typing/dafVoices';
+import type { ArgumentVoicesData } from '../../src/lib/typing/voices';
+
+// Classifier fake: Stam is collective, named rabbis carry a generation.
+const GENS: Record<string, string> = {
+  'Rabbi Yochanan': 'amora-ey-2',
+  'Reish Lakish': 'amora-ey-2',
+  Rava: 'amora-bavel-4',
+};
+const classify = (name: string): VoiceClass =>
+  name === 'Stam' ? { collective: true } : { collective: false, generation: GENS[name] };
+
+const sectionA: ArgumentVoicesData = {
+  voices: [
+    { name: 'Rabbi Yochanan', nameHe: 'רבי יוחנן', role: 'originator', side: 'A', stance: '' },
+    { name: 'Reish Lakish', nameHe: 'ריש לקיש', role: 'objector', side: 'B', stance: '' },
+  ],
+  edges: [{ from: 'Reish Lakish', to: 'Rabbi Yochanan', kind: 'opposes' }],
+};
+const sectionB: ArgumentVoicesData = {
+  voices: [
+    { name: 'Rabbi Yochanan', nameHe: 'רבי יוחנן', role: 'respondent', side: 'A', stance: '' },
+    { name: 'Rava', nameHe: 'רבא', role: 'questioner', side: 'B', stance: '' },
+  ],
+  // Same opposition AND a fresh cites edge; the opposition recurs in section B too.
+  edges: [{ from: 'Rava', to: 'Rabbi Yochanan', kind: 'cites', note: 'cites the dispute' }],
+};
+
+describe('buildDafVoiceGraph', () => {
+  it('dedupes a voice across sections, accumulating its sections + roles', () => {
+    const g = buildDafVoiceGraph(
+      [
+        { title: 'First sugya', voices: sectionA },
+        { title: 'Second sugya', voices: sectionB },
+      ],
+      classify,
+    );
+    const yochanan = g.nodes.find((n) => n.name === 'Rabbi Yochanan');
+    expect(yochanan).toBeTruthy();
+    expect(yochanan?.sections).toEqual(['First sugya', 'Second sugya']);
+    expect(yochanan?.roles).toEqual(['originator', 'respondent']);
+    expect(yochanan?.generation).toBe('amora-ey-2');
+    expect(yochanan?.nameHe).toBe('רבי יוחנן');
+    // One node per distinct name (Yochanan, Reish Lakish, Rava).
+    expect(g.nodes.map((n) => n.name)).toEqual(['Rabbi Yochanan', 'Reish Lakish', 'Rava']);
+  });
+
+  it('marks collective voices and leaves them generation-less', () => {
+    const g = buildDafVoiceGraph(
+      [
+        {
+          title: 'S',
+          voices: {
+            voices: [{ name: 'Stam', role: 'questioner', side: 'stam', stance: '' }],
+            edges: [],
+          },
+        },
+      ],
+      classify,
+    );
+    expect(g.nodes[0]).toMatchObject({ name: 'Stam', collective: true });
+    expect(g.nodes[0].generation).toBeUndefined();
+  });
+
+  it('keeps distinct relation kinds between the same pair as separate edges', () => {
+    const g = buildDafVoiceGraph(
+      [
+        { title: 'First sugya', voices: sectionA },
+        { title: 'Second sugya', voices: sectionB },
+      ],
+      classify,
+    );
+    const opp = g.edges.find((e) => e.kind === 'opposes');
+    const cites = g.edges.find((e) => e.kind === 'cites');
+    expect(opp).toMatchObject({
+      from: 'Reish Lakish',
+      to: 'Rabbi Yochanan',
+      sections: ['First sugya'],
+    });
+    expect(cites).toMatchObject({ from: 'Rava', to: 'Rabbi Yochanan', note: 'cites the dispute' });
+  });
+
+  it('accumulates an edge seen in multiple sections', () => {
+    const g = buildDafVoiceGraph(
+      [
+        { title: 'First sugya', voices: sectionA },
+        // The same opposition recurs verbatim in a later section.
+        { title: 'Third sugya', voices: sectionA },
+      ],
+      classify,
+    );
+    const opp = g.edges.filter((e) => e.kind === 'opposes');
+    expect(opp).toHaveLength(1);
+    expect(opp[0].sections).toEqual(['First sugya', 'Third sugya']);
+  });
+
+  it('drops an edge whose endpoint never appears as a voice node', () => {
+    const g = buildDafVoiceGraph(
+      [
+        {
+          title: 'S',
+          voices: {
+            voices: [{ name: 'Rava', role: 'originator', side: 'A', stance: '' }],
+            edges: [{ from: 'Rava', to: 'Ghost', kind: 'opposes' }],
+          },
+        },
+      ],
+      classify,
+    );
+    expect(g.edges).toHaveLength(0);
+  });
+
+  it('ignores sections with no voices data', () => {
+    const g = buildDafVoiceGraph(
+      [
+        { title: 'cold', voices: null },
+        { title: 'warm', voices: sectionA },
+      ],
+      classify,
+    );
+    expect(g.sections.map((s) => s.title)).toEqual(['warm']);
+    expect(g.nodes).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## What

A new reader page at **`#voices?tractate=&page=`** that stitches every argument section's `argument.voices` into **one daf-wide graph**: rabbis (and collective voices) as nodes, their argumentative relations (`opposes` / `supports` / `responds-to` / `cites` / `resolves`) as directed edges, accumulated across the whole daf. Beneath the graph, a per-section breakdown serves as the audit view.

Today the only voice rendering is the per-*section* statement spine, buried inside each argument card. This is the first view that shows the daf as a single conversation — and it's deliberately the unit a future Talmud-wide rabbi network will aggregate (the disambiguation-graph direction).

## How

Read-only and **client-only** — no worker changes, nothing is generated:

- `argument.voices` is a dependency of `argument.synthesis`, and `/api/daf-view` already returns each warmed synthesis piece with its `deps_resolved`. So every warm section's voices ride along in the single daf-view fetch; the `rabbi` mark supplies generations for node colouring. A cold section simply isn't shown — a banner reports how many sections are still warming.

Pieces:
- `lib/typing/dafVoices.ts` — `buildDafVoiceGraph`: pure, DOM-free merge (dedupe voices by name across sections, relations by `(from, to, kind)`, repair edge directions via `deriveVoiceEdges`). Unit-tested (`tests/typing/dafVoices.test.ts`).
- `client/DafVoiceGraph.tsx` — SVG renderer that reuses the argument-flow idiom (vertical node column + right-gutter orthogonal connectors, `KIND_COLOR` / `assignLanes` / `stmtRelKind`), nodes coloured by generation, click-to-focus a voice (its relations stay lit, the rest fade).
- `client/VoicesPage.tsx` — builds the graph from the daf-view, renders graph + per-section breakdown + completeness banner.
- `App.tsx` route wiring, `i18n.ts` (EN/HE), and an entry link from the daf footer cluster (next to alignment debug).

## Verification

`pnpm typecheck`, `pnpm test` (2608 pass, incl. 6 new), `pnpm lint`, and `pnpm --filter talmud build` all green. The merge core is unit-tested; recommend a quick visual check on a warm daf (e.g. Berakhot 2a) after deploy.

## Notes / follow-ups

- The entry link currently lives in the daf's dev-footer cluster; easy to promote to a more prominent spot if we want it reader-facing.
- "X in the name of Y" is shown via the existing `transmitter` role + `cites` edges (implicit); an explicit directional attribution relation is a future producer change.
- Node order is daf order (first appearance); a chronological (by-generation) sort toggle is a natural future option.