### PR TITLE
Shared AI-paused banner: clear out-of-credits / cost-cap notice (both apps)

### DIFF
--- a/packages/core/src/llm/ai-status.ts
+++ b/packages/core/src/llm/ai-status.ts
@@ -1,0 +1,89 @@
+/**
+ * Classify a failed LLM call into a user-facing "AI features unavailable" reason.
+ *
+ * Both apps (talmud, tanach) funnel every paid call through the same `runLLM`
+ * chokepoint, which throws typed errors: a `BudgetPausedError` when our own
+ * cost-cap guard trips (daily / hourly), or a plain `LLMError` carrying the
+ * provider's HTTP status — notably 402 when the prepaid OpenRouter balance runs
+ * dry. A route can call `classifyAiUnavailable(err)` to decide whether a failure
+ * is a "we paused AI to control spend" state (worth a clear banner + a stable
+ * `{ aiUnavailable, reason }` envelope) versus an ordinary bug (which should keep
+ * surfacing as a 500/502). The reader-facing banner copy lives in @corpus/ui,
+ * keyed by the same `reason`; this module only owns the classification + a
+ * neutral one-liner for the JSON envelope.
+ */
+
+import { BudgetPausedError } from './budget';
+import { LLMError } from './llm-error';
+
+export type AiUnavailableReason =
+  | 'credits' // OpenRouter prepaid balance exhausted (HTTP 402)
+  | 'daily-cap' // our daily spend cap reached (BudgetPausedError scope 'all')
+  | 'hourly-cap' // our hourly custom-question cap reached (scope 'custom')
+  | 'rate-limit' // provider 429 (not our cap) — transient overload
+  | 'provider'; // provider 5xx / upstream outage — transient
+
+export interface AiUnavailable {
+  reason: AiUnavailableReason;
+  /** Epoch ms when the pause is expected to lift. Set for our budget caps
+   *  (we know the bucket rollover); unknown for credits/provider failures. */
+  retryAfter?: number;
+}
+
+// The provider returns 402 with an "Insufficient credits" body when out of
+// credits. We key off the typed status first; this regex is the fallback for
+// foreign throwables whose status we never captured (raw fetch / re-wrapped
+// messages) — the one signal we must not miss.
+const CREDITS_RE =
+  /insufficient credits|out of credits|requires more credits|add more (credits|using)/i;
+
+/**
+ * Map an error to an AI-unavailable reason, or `null` when it is an ordinary
+ * failure (a real bug, a 4xx that isn't payment, a malformed request) that
+ * should NOT be dressed up as a friendly "AI paused" banner.
+ */
+export function classifyAiUnavailable(err: unknown): AiUnavailable | null {
+  // Our own cost-cap guard — typed, and it knows when the pause lifts.
+  if (err instanceof BudgetPausedError) {
+    return {
+      reason: err.scope === 'custom' ? 'hourly-cap' : 'daily-cap',
+      retryAfter: err.until,
+    };
+  }
+  if (err instanceof LLMError) {
+    if (err.status === 402 || CREDITS_RE.test(err.message)) return { reason: 'credits' };
+    if (err.status === 429) return { reason: 'rate-limit' };
+    if (err.status >= 500) return { reason: 'provider' };
+    return null; // other 4xx: client/config error, not a spend pause
+  }
+  // Foreign throwable (raw fetch / provider body re-thrown without a status):
+  // last-resort sniff for the out-of-credits signal only.
+  const msg = err instanceof Error ? err.message : typeof err === 'string' ? err : '';
+  if (CREDITS_RE.test(msg)) return { reason: 'credits' };
+  return null;
+}
+
+export function isAiUnavailable(err: unknown): boolean {
+  return classifyAiUnavailable(err) !== null;
+}
+
+/**
+ * Neutral, corpus-agnostic one-liner for the JSON error envelope's `error`
+ * field. The banner in @corpus/ui renders richer, sponsor-aware copy from the
+ * same `reason`; this is the plain-text fallback (logs, non-UI clients, the
+ * inline message a card shows before the banner mounts).
+ */
+export function aiUnavailableMessage(reason: AiUnavailableReason): string {
+  switch (reason) {
+    case 'credits':
+      return 'AI features are paused — the project is out of AI credits right now.';
+    case 'daily-cap':
+      return "AI features are paused — today's AI budget has been reached. They'll be back tomorrow.";
+    case 'hourly-cap':
+      return "AI features are paused — this hour's AI budget has been reached. Try again shortly.";
+    case 'rate-limit':
+      return 'AI features are busy right now. Please try again in a moment.';
+    case 'provider':
+      return 'AI features are temporarily unavailable. Please try again shortly.';
+  }
+}

--- a/packages/core/tests/ai-status.test.ts
+++ b/packages/core/tests/ai-status.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type AiUnavailableReason,
+  aiUnavailableMessage,
+  classifyAiUnavailable,
+  isAiUnavailable,
+} from '../src/llm/ai-status.ts';
+import { BudgetPausedError } from '../src/llm/budget.ts';
+import { LLMError } from '../src/llm/llm-error.ts';
+
+describe('classifyAiUnavailable', () => {
+  it('maps OpenRouter 402 to credits', () => {
+    const err = new LLMError(
+      402,
+      'OpenRouter HTTP 402: {"error":{"message":"Insufficient credits..."}}',
+    );
+    expect(classifyAiUnavailable(err)).toEqual({ reason: 'credits' });
+  });
+
+  it('maps an out-of-credits message without a 402 status to credits', () => {
+    // Foreign throwable re-wrapped so the status is lost.
+    const err = new Error('Translate failed: Insufficient credits. Add more using ...');
+    expect(classifyAiUnavailable(err)).toEqual({ reason: 'credits' });
+  });
+
+  it('maps the daily budget pause to daily-cap and carries the lift time', () => {
+    const err = new BudgetPausedError('all', 1_700_000_000_000, 'daily spend over trip');
+    expect(classifyAiUnavailable(err)).toEqual({
+      reason: 'daily-cap',
+      retryAfter: 1_700_000_000_000,
+    });
+  });
+
+  it('maps the hourly custom-question pause to hourly-cap', () => {
+    const err = new BudgetPausedError('custom', 1_700_000_000_000);
+    expect(classifyAiUnavailable(err)).toEqual({
+      reason: 'hourly-cap',
+      retryAfter: 1_700_000_000_000,
+    });
+  });
+
+  it('maps provider 429 to rate-limit and 5xx to provider', () => {
+    expect(classifyAiUnavailable(new LLMError(429, 'OpenRouter HTTP 429: rate limited'))).toEqual({
+      reason: 'rate-limit',
+    });
+    expect(classifyAiUnavailable(new LLMError(503, 'OpenRouter HTTP 503: upstream'))).toEqual({
+      reason: 'provider',
+    });
+  });
+
+  it('returns null for ordinary failures (a real bug is not a spend pause)', () => {
+    expect(classifyAiUnavailable(new LLMError(400, 'bad request'))).toBeNull();
+    expect(classifyAiUnavailable(new Error('cannot read property foo of undefined'))).toBeNull();
+    expect(classifyAiUnavailable(null)).toBeNull();
+    expect(isAiUnavailable(new Error('TypeError'))).toBe(false);
+  });
+
+  it('has a message for every reason', () => {
+    const reasons: AiUnavailableReason[] = [
+      'credits',
+      'daily-cap',
+      'hourly-cap',
+      'rate-limit',
+      'provider',
+    ];
+    for (const r of reasons) expect(aiUnavailableMessage(r).length).toBeGreaterThan(10);
+  });
+});

--- a/packages/talmud/src/client/AiPausedBanner.tsx
+++ b/packages/talmud/src/client/AiPausedBanner.tsx
@@ -1,0 +1,51 @@
+/**
+ * Talmud's AI-paused banner: the shared <AiStatusBanner/> wired with a
+ * self-funding / sponsorship ask grounded in the LIVE "cost to finish Shas"
+ * figure (GET /api/shas-cost — the same estimateShasCost the usage page shows),
+ * so the number is the real one, never a hand-typed guess. The estimate is
+ * fetched lazily the first time the banner is about to appear, so an ordinary
+ * reader load never pays for it.
+ */
+
+import { AiStatusBanner } from '@corpus/ui/AiStatusBanner';
+import { aiStatus } from '@corpus/ui/aiStatus';
+import { createEffect, createSignal, type JSX } from 'solid-js';
+
+const CONTACT_HREF = 'mailto:shaunregenbaum@gmail.com?subject=Sponsoring%20the%20Talmud%20project';
+
+export function AiPausedBanner(): JSX.Element {
+  const [remainingUsd, setRemainingUsd] = createSignal<number | null>(null);
+  let fetched = false;
+  createEffect(() => {
+    if (!aiStatus() || fetched) return;
+    fetched = true;
+    fetch('/api/shas-cost')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((raw) => {
+        const d = raw as { available?: boolean; remainingUsd?: number } | null;
+        if (d?.available && typeof d.remainingUsd === 'number' && d.remainingUsd > 0) {
+          setRemainingUsd(d.remainingUsd);
+        }
+      })
+      .catch(() => {});
+  });
+
+  return (
+    <AiStatusBanner
+      sponsor={() => {
+        const rem = remainingUsd();
+        const figure =
+          rem != null
+            ? ` Bringing the whole Talmud online at full depth takes an estimated ~$${(
+                Math.round(rem / 100) * 100
+              ).toLocaleString('en-US')} more in AI.`
+            : '';
+        return {
+          message: `This is a self-funded project (about $300/week of AI).${figure} If you'd like to help finish Shas, get in touch.`,
+          ctaLabel: 'Sponsor / get in touch',
+          ctaHref: CONTACT_HREF,
+        };
+      }}
+    />
+  );
+}

--- a/packages/talmud/src/client/App.tsx
+++ b/packages/talmud/src/client/App.tsx
@@ -1,4 +1,5 @@
 import { createSignal, Show } from 'solid-js';
+import { AiPausedBanner } from './AiPausedBanner';
 import { AlignPage } from './AlignPage';
 import { AttributionsPage } from './AttributionsPage';
 import Compare from './Compare';
@@ -43,6 +44,9 @@ export default function App() {
 
   return (
     <>
+      {/* AI-paused notice (out of credits / cost cap) — shared across both apps;
+        shows above every route, including the daf reader. */}
+      <AiPausedBanner />
       {/* The daf page folds the EN/HE toggle into its own header; the floating
         bar covers the other routes. #tutorial is fully self-contained (and its
         Help button would be a no-op there), so it owns the whole viewport. */}

--- a/packages/talmud/src/client/MarkEnrichmentCards.tsx
+++ b/packages/talmud/src/client/MarkEnrichmentCards.tsx
@@ -18,6 +18,7 @@
  */
 
 import { instanceIdOf } from '@corpus/core/cache/keys';
+import { noteAiResponse, noteAiSuccess } from '@corpus/ui/aiStatus';
 import {
   createEffect,
   createResource,
@@ -221,12 +222,18 @@ async function runEnrichmentImpl(
       await sleep(RUN_POST_BACKOFF_MS[attempt], signal);
     }
   }
+  // Raise the shared AI-paused banner if the body is the { aiUnavailable, reason }
+  // envelope (budget pre-check pause, or a queued job that failed out-of-credits).
+  noteAiResponse(j);
   if (isPausedBody(j)) throw new Error(PAUSED_ERROR);
   if (!r.ok && r.status !== 202) {
     throw new Error((j as { error?: string }).error ?? `HTTP ${r.status}`);
   }
   if ('status' in j) {
-    if (j.status === 'ok') return j.result;
+    if (j.status === 'ok') {
+      noteAiSuccess();
+      return j.result;
+    }
     if (j.status === 'error') throw new Error(j.error);
     if (j.status === 'pending') return pollJob(j.runId, j.cacheKey, signal);
   }
@@ -302,9 +309,13 @@ async function pollJob(runId: string, cacheKey?: string, signal?: AbortSignal): 
       // still be running server-side, so keep polling instead of failing the card.
       continue;
     }
+    noteAiResponse(j);
     if (isPausedBody(j)) throw new Error(PAUSED_ERROR);
     if ('status' in j) {
-      if (j.status === 'ok') return (j as { result: RunResult }).result;
+      if (j.status === 'ok') {
+        noteAiSuccess();
+        return (j as { result: RunResult }).result;
+      }
       if (j.status === 'error') throw new Error((j as { error: string }).error);
       // pending — continue polling
     }

--- a/packages/talmud/src/client/QAPanel.tsx
+++ b/packages/talmud/src/client/QAPanel.tsx
@@ -27,6 +27,7 @@
  * `user_question` in the body.
  */
 
+import { noteAiResponse, noteAiSuccess } from '@corpus/ui/aiStatus';
 import { createEffect, createResource, createSignal, For, type JSX, onMount, Show } from 'solid-js';
 import { trackAI } from './aiActivity';
 import {
@@ -110,12 +111,16 @@ async function runEnrichmentDirect(
     body: JSON.stringify(body),
   });
   const j = (await r.json()) as RunResponse | { error?: string };
+  noteAiResponse(j);
   if (isPausedBody(j)) throw new Error(PAUSED_ERROR);
   if (!r.ok && r.status !== 202) {
     throw new Error((j as { error?: string }).error ?? `HTTP ${r.status}`);
   }
   if ('status' in j) {
-    if (j.status === 'ok') return j.result;
+    if (j.status === 'ok') {
+      noteAiSuccess();
+      return j.result;
+    }
     if (j.status === 'error') throw new Error(j.error);
     if (j.status === 'pending') return pollJob(j.runId, j.cacheKey);
   }
@@ -129,9 +134,13 @@ async function pollJob(runId: string, cacheKey?: string): Promise<RunResultLike>
     await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
     const r = await fetch(`/api/run-status/${encodeURIComponent(runId)}${qs}`);
     const j = (await r.json()) as RunResponse | { status: 'pending' };
+    noteAiResponse(j);
     if (isPausedBody(j)) throw new Error(PAUSED_ERROR);
     if ('status' in j) {
-      if (j.status === 'ok') return (j as { result: RunResultLike }).result;
+      if (j.status === 'ok') {
+        noteAiSuccess();
+        return (j as { result: RunResultLike }).result;
+      }
       if (j.status === 'error') throw new Error((j as { error: string }).error);
     }
   }

--- a/packages/talmud/src/client/main.tsx
+++ b/packages/talmud/src/client/main.tsx
@@ -6,6 +6,9 @@ import '@corpus/ui/tokens.css';
 import '@corpus/ui/themes/talmud.css';
 import '@corpus/ui/geomap.css';
 import '@corpus/ui/loadprogress.css';
+// Shared component-kit styles — for now just the AI-paused banner's `.ui-banner`
+// (talmud's first @corpus/ui component); the rest are unused `.ui-*` classes.
+import '@corpus/ui/components.css';
 import App from './App';
 import { installGlobalErrorLogger } from './missLog';
 

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -3,6 +3,7 @@ import { slugTractate } from '@corpus/core/cache/keys';
 import { continuationLink, type FlowEdge } from '@corpus/core/context/link';
 import { coordLabel } from '@corpus/core/context/types';
 import { gatewayActive, gatewayStatus, wrapEnv } from '@corpus/core/llm/ai-gateway';
+import { classifyAiUnavailable } from '@corpus/core/llm/ai-status';
 import {
   type BudgetScope,
   budgetStatus,
@@ -80,6 +81,7 @@ import { adjacentAmud, sefariaAPI, type TalmudPageData, TRACTATE_OPTIONS } from 
 import { iterAmudim, TRACTATE_END_AMUD } from '../lib/sefref/amudim';
 import { getDafyomiMasechet } from '../lib/sefref/dafyomi/masechtos';
 import { fetchHebrewBooksDaf } from '../lib/sefref/hebrewbooks/client';
+import { estimateShasCost } from '../lib/shasCost';
 import {
   type BridgeSection,
   buildBridgePrompt,
@@ -365,6 +367,16 @@ function pauseErrorMessage(scope?: BudgetScope): string {
   return scope === 'custom'
     ? 'Custom-question generation is paused for now (hourly budget reached). Please try again later.'
     : 'AI generation is paused for now (daily budget reached). Please try again tomorrow.';
+}
+
+/** Cross-app AI-unavailable fields for a budget pause, derived from scope. Spread
+ *  alongside the existing `paused`/`scope`/`retryAfter` so the shared client
+ *  banner (@corpus/ui, keyed off `aiUnavailable` + `reason`) lights up too. */
+function pausedAiFields(scope?: BudgetScope) {
+  return {
+    aiUnavailable: true as const,
+    reason: scope === 'custom' ? ('hourly-cap' as const) : ('daily-cap' as const),
+  };
 }
 
 function stripHtmlServer(html: string): string {
@@ -3283,7 +3295,12 @@ app.post('/api/daf-generate/:tractate/:page', async (c) => {
   const lang: 'en' | 'he' = c.req.query('lang') === 'he' ? 'he' : 'en';
   const gate = await checkBudget(c.env, { custom: false });
   if (!gate.ok) {
-    return c.json({ generating: false, paused: true, error: pauseErrorMessage(gate.scope) });
+    return c.json({
+      generating: false,
+      paused: true,
+      error: pauseErrorMessage(gate.scope),
+      ...pausedAiFields(gate.scope),
+    });
   }
   const cache = c.env.CACHE;
   const sentinel = dafGenSentinelKey(tractate, page, lang);
@@ -5525,6 +5542,7 @@ app.post('/api/run', async (c) => {
         paused: true,
         scope: gate.scope,
         retryAfter: pauseRetryAfterSec(gate.until),
+        ...pausedAiFields(gate.scope),
       },
       429,
     );
@@ -6602,6 +6620,7 @@ app.post('/api/qa/ask', async (c) => {
         paused: true,
         scope: gate.scope,
         retryAfter: pauseRetryAfterSec(gate.until),
+        ...pausedAiFields(gate.scope),
       },
       429,
     );
@@ -7192,6 +7211,42 @@ app.get('/api/usage/cost', (c) =>
     buildCostSection(c, c.env.CACHE),
   ),
 );
+
+// GET /api/shas-cost — the headline "what would it cost to bring the whole shas
+// online at full depth" estimate, the SAME computation the /usage page shows
+// (estimateShasCost over the cost rollup + cache coverage). Surfaced as a tiny
+// public summary so the AI-paused banner can ground its sponsorship ask in the
+// real remaining figure rather than a hand-typed number. SWR-cached 6h: the
+// estimate drifts slowly and computeCacheStats scans dozens of KV prefixes.
+app.get('/api/shas-cost', (c) => {
+  const cache = c.env.CACHE;
+  if (!cache) return c.json({ error: 'no cache binding' }, 503);
+  return serveUsageSection(c, cache, 'shas-cost:v1', 6 * 60 * 60 * 1000, async () => {
+    const [cost, stats] = await Promise.all([
+      buildCostSection(c, cache),
+      readCachedCacheStats(cache).then((s) => s ?? computeCacheStats(cache)),
+    ]);
+    const self = cost.selfTracked;
+    if (!self || self.totals.costUsd <= 0) return { available: false as const };
+    const est = estimateShasCost({
+      amudim: stats.total,
+      byMark: self.byMark,
+      byEnrichment: self.byEnrichment,
+      marks: stats.marks,
+      enrichments: stats.enrichments,
+      gatewayByModel: cost.aiGateway?.byModel,
+    });
+    if (!est.available) return { available: false as const };
+    return {
+      available: true as const,
+      remainingUsd: est.grossed.remainingUsd,
+      fullShasUsd: est.grossed.fullShasUsd,
+      incurredUsd: est.grossed.incurredUsd,
+      perAmudUsd: est.grossed.perAmudUsd,
+      amudim: est.amudim,
+    };
+  });
+});
 app.get('/api/usage/telemetry', (c) =>
   serveUsageSection(c, c.env.CACHE, 'usage-telemetry:v1', 30_000, () =>
     buildTelemetrySection(c.env.CACHE),
@@ -11420,10 +11475,15 @@ async function processEnrichmentJob(
         paused: true,
         scope,
         total_ms: totalMs,
+        ...pausedAiFields(scope),
       });
       return;
     }
     const errorMsg = String((err as Error)?.message ?? err);
+    // Out-of-credits / provider outage surfaces here (it throws past the budget
+    // gate). Tag the polled job record so the client's shared banner can explain
+    // it instead of showing a bare failure.
+    const unavailable = classifyAiUnavailable(err);
     console.error(
       '[queue] job failed',
       job.runId,
@@ -11438,6 +11498,7 @@ async function processEnrichmentJob(
       status: 'error',
       error: errorMsg,
       total_ms: totalMs,
+      ...(unavailable ? { aiUnavailable: true as const, reason: unavailable.reason } : {}),
     });
     const enqueueTs = enqueueTsFromRunId(job.runId);
     await recordRecentJobError(env, {

--- a/packages/talmud/tests/__snapshots__/run-contract.test.ts.snap
+++ b/packages/talmud/tests/__snapshots__/run-contract.test.ts.snap
@@ -84,8 +84,10 @@ exports[`POST /api/run — contract > d. experimental gate: cold miss on the cha
 
 exports[`POST /api/run — contract > e. budget paused: 429 with paused/scope/retryAfter, nothing enqueued 1`] = `
 {
+  "aiUnavailable": true,
   "error": "AI generation is paused for now (daily budget reached). Please try again tomorrow.",
   "paused": true,
+  "reason": "daily-cap",
   "retryAfter": "NORMALIZED",
   "scope": "all",
   "status": "error",

--- a/packages/tanach/src/client/App.tsx
+++ b/packages/tanach/src/client/App.tsx
@@ -1,3 +1,5 @@
+import { AiStatusBanner } from '@corpus/ui/AiStatusBanner';
+import { aiStatus, noteAiResponse, noteAiSuccess } from '@corpus/ui/aiStatus';
 import { Button } from '@corpus/ui/Button';
 import { Drawer } from '@corpus/ui/Drawer';
 import { fitBbox, GeoMap } from '@corpus/ui/GeoMap';
@@ -476,7 +478,15 @@ export function App(): JSX.Element {
     const res = await fetch(
       `/api/translate?q=${encodeURIComponent(w.he)}&ctx=${encodeURIComponent(w.ctx)}`,
     );
-    return res.ok ? (((await res.json()) as { translation?: string }).translation ?? null) : null;
+    if (res.ok) {
+      noteAiSuccess();
+      return ((await res.json()) as { translation?: string }).translation ?? null;
+    }
+    // A paused AI service (out of credits / cost cap) comes back as the shared
+    // { aiUnavailable, reason } envelope: raise the banner that explains it
+    // rather than leaving the popup showing a bare "—".
+    noteAiResponse(await res.json().catch(() => null));
+    return null;
   });
   const onTextSelect = () => {
     const g = window.getSelection();
@@ -748,6 +758,14 @@ export function App(): JSX.Element {
         'view-mikraot': loc().view === 'mikraot',
       }}
     >
+      <AiStatusBanner
+        sponsor={() => ({
+          message:
+            'This is a self-funded project (about $300/week of AI). If you would like to help keep its AI features running, get in touch.',
+          ctaLabel: 'Sponsor / get in touch',
+          ctaHref: 'mailto:shaunregenbaum@gmail.com?subject=Sponsoring%20the%20Tanach%20project',
+        })}
+      />
       <header class="topbar">
         <span class="brand">Tanach</span>
         <select
@@ -971,7 +989,9 @@ export function App(): JSX.Element {
               <span class="xlate-en muted">…</span>
             </Show>
             <Show when={!translation.loading}>
-              <span class="xlate-en">{translation() ?? '—'}</span>
+              <span class="xlate-en" classList={{ muted: !translation() && !!aiStatus() }}>
+                {translation() ?? (aiStatus() ? 'AI paused' : '—')}
+              </span>
             </Show>
           </div>
         )}

--- a/packages/tanach/src/worker/index.ts
+++ b/packages/tanach/src/worker/index.ts
@@ -12,6 +12,7 @@
  * the built Solid client (the ASSETS binding, SPA fallback).
  */
 
+import { aiUnavailableMessage, classifyAiUnavailable } from '@corpus/core/llm/ai-status';
 import { costSplitUsd } from '@corpus/core/llm/pricing';
 import { flattenPieces } from '@corpus/core/sefaria/client';
 import type { StoredArtifact } from '@corpus/core/store/envelope';
@@ -41,7 +42,22 @@ const app = new Hono<{ Bindings: Env }>();
  *  the legacy `Producer failed: …` 502. */
 function runErrorResponse(c: Context<{ Bindings: Env }>, e: unknown) {
   if (e instanceof TanachSourceError) return c.json({ error: e.message }, e.status);
+  const ai = aiUnavailableResponse(c, e);
+  if (ai) return ai;
   return c.json({ error: `Producer failed: ${(e as Error).message}` }, 502);
+}
+
+/** When a failure is an "AI features paused" state (out of credits, daily/hourly
+ *  cost cap, provider blip), respond with a stable envelope the client banner
+ *  recognises (`aiUnavailable` + `reason`), at 503. Returns null for ordinary
+ *  failures so the caller falls back to its usual error response. */
+function aiUnavailableResponse(c: Context<{ Bindings: Env }>, e: unknown) {
+  const u = classifyAiUnavailable(e);
+  if (!u) return null;
+  return c.json(
+    { error: aiUnavailableMessage(u.reason), aiUnavailable: true as const, reason: u.reason },
+    503,
+  );
 }
 
 app.get('/api/chapter/:book/:chapter', async (c) => {
@@ -404,6 +420,8 @@ app.get('/api/translate', async (c) => {
   try {
     result = await translateHebrew(c.env, q, ctx);
   } catch (e) {
+    const ai = aiUnavailableResponse(c, e);
+    if (ai) return ai;
     return c.json({ error: `Translate failed: ${(e as Error).message}` }, 502);
   }
   if (!result.translation) return c.json({ error: 'No translation' }, 502);

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -20,6 +20,8 @@
     "./inspector.css": "./src/inspector.css",
     "./usage.css": "./src/usage.css",
     "./format": "./src/format.ts",
+    "./aiStatus": "./src/aiStatus.ts",
+    "./AiStatusBanner": "./src/AiStatusBanner.tsx",
     "./Pill": "./src/Pill.tsx",
     "./Drawer": "./src/Drawer.tsx",
     "./Button": "./src/Button.tsx",

--- a/packages/ui/src/AiStatusBanner.tsx
+++ b/packages/ui/src/AiStatusBanner.tsx
@@ -1,0 +1,119 @@
+/**
+ * @corpus/ui — AiStatusBanner.
+ *
+ * A full-width strip that appears when AI features are paused, reading the
+ * shared `aiStatus` signal. Corpus-agnostic: the headline copy is keyed by the
+ * reason, and the optional sponsor block (the funding ask + a call-to-action) is
+ * supplied by each app via the `sponsor` render function, so the talmud app can
+ * pass its live "cost to finish Shas" figure while tanach passes its own.
+ *
+ * The framing is deliberately about COST CONTROL, not failure: spend pauses
+ * (credits / daily cap / hourly cap) explain that AI is capped to keep the
+ * project sustainable; only genuine provider blips read as "temporarily
+ * unavailable". Styling: `.ui-banner` in components.css.
+ */
+
+import { createMemo, type JSX, Show } from 'solid-js';
+import { type AiUnavailableReason, aiStatus, dismissAiStatus } from './aiStatus.ts';
+
+export interface SponsorInfo {
+  /** Prose explaining the funding situation / the ask. */
+  message: string;
+  /** Call-to-action label (e.g. "Sponsor / get in touch"). */
+  ctaLabel?: string;
+  /** mailto: or https: target for the CTA. */
+  ctaHref?: string;
+}
+
+export interface AiStatusBannerProps {
+  /** Per-reason sponsor block. Return undefined to omit it for a given reason
+   *  (e.g. transient provider blips, where a funding ask makes no sense). */
+  sponsor?: (reason: AiUnavailableReason) => SponsorInfo | undefined;
+}
+
+/** Reasons where a spending-related sponsor ask is appropriate. */
+const SPEND_REASONS: ReadonlySet<AiUnavailableReason> = new Set([
+  'credits',
+  'daily-cap',
+  'hourly-cap',
+]);
+
+function headline(reason: AiUnavailableReason): string {
+  switch (reason) {
+    case 'credits':
+      return 'AI features are paused — the project is out of AI credits right now.';
+    case 'daily-cap':
+      return "AI features are paused for today — there's a daily spending cap that keeps this project sustainable.";
+    case 'hourly-cap':
+      return "AI features are paused briefly — there's an hourly spending limit to keep costs in check.";
+    case 'rate-limit':
+      return 'AI features are busy right now — please try again in a moment.';
+    case 'provider':
+      return 'AI features are temporarily unavailable — please try again shortly.';
+  }
+}
+
+/** A short "when will it be back" hint, derived from the reason alone (the
+ *  budget caps roll over predictably — daily by UTC day, hourly by the hour). */
+function resumeHint(reason: AiUnavailableReason): string | null {
+  if (reason === 'daily-cap') return "They'll be back tomorrow.";
+  if (reason === 'hourly-cap') return 'Back within the hour.';
+  return null;
+}
+
+export function AiStatusBanner(props: AiStatusBannerProps): JSX.Element {
+  const st = aiStatus;
+  const sponsor = createMemo(() => {
+    const s = st();
+    if (!s || !props.sponsor) return undefined;
+    if (!SPEND_REASONS.has(s.reason)) return undefined;
+    return props.sponsor(s.reason);
+  });
+  const hint = createMemo(() => {
+    const s = st();
+    return s ? resumeHint(s.reason) : null;
+  });
+
+  return (
+    <Show when={st()}>
+      {(s) => (
+        <div class="ui-banner" role="status" aria-live="polite">
+          <div class="ui-banner-inner">
+            <div class="ui-banner-text">
+              <p class="ui-banner-line">
+                <span class="ui-banner-dot" aria-hidden="true" />
+                {headline(s().reason)}
+                <Show when={hint()}>
+                  {' '}
+                  <span class="ui-banner-hint">{hint()}</span>
+                </Show>
+              </p>
+              <Show when={sponsor()}>
+                {(sp) => (
+                  <p class="ui-banner-sponsor">
+                    {sp().message}
+                    <Show when={sp().ctaHref && sp().ctaLabel}>
+                      {' '}
+                      <a class="ui-banner-cta" href={sp().ctaHref}>
+                        {sp().ctaLabel}
+                      </a>
+                    </Show>
+                  </p>
+                )}
+              </Show>
+            </div>
+            <button
+              type="button"
+              class="ui-banner-close"
+              aria-label="Dismiss"
+              title="Dismiss"
+              onClick={() => dismissAiStatus()}
+            >
+              &times;
+            </button>
+          </div>
+        </div>
+      )}
+    </Show>
+  );
+}

--- a/packages/ui/src/aiStatus.ts
+++ b/packages/ui/src/aiStatus.ts
@@ -1,0 +1,82 @@
+/**
+ * @corpus/ui — shared "AI features unavailable" status signal.
+ *
+ * A module-level Solid signal both apps (talmud, tanach) drive when an AI call
+ * comes back paused (out of credits, daily/hourly cost cap, provider blip). The
+ * <AiStatusBanner/> reads it; the apps' fetch error handling flips it via
+ * `noteAiResponse(json)` (which recognises the worker's `{ aiUnavailable, reason }`
+ * envelope) or `reportAiUnavailable(reason)` directly. One module instance per
+ * app bundle, so every importer in an app shares the same banner state.
+ *
+ * The reason vocabulary mirrors `@corpus/core/llm/ai-status` — kept as a plain
+ * string union here so the UI package needs no dependency on core.
+ */
+
+import { createSignal } from 'solid-js';
+
+export type AiUnavailableReason =
+  | 'credits'
+  | 'daily-cap'
+  | 'hourly-cap'
+  | 'rate-limit'
+  | 'provider';
+
+export interface AiStatus {
+  reason: AiUnavailableReason;
+  /** Epoch ms this status was reported. */
+  at: number;
+}
+
+/** The worker error envelope the AI routes emit on a paused call. The banner
+ *  derives its "back tomorrow / within the hour" hint from `reason` alone, so no
+ *  lift-time field travels in the contract (talmud's legacy `retryAfter` seconds
+ *  field is unrelated and stays on its own pause responses). */
+export interface AiUnavailableEnvelope {
+  aiUnavailable?: boolean;
+  reason?: AiUnavailableReason;
+  error?: string;
+}
+
+const [status, setStatus] = createSignal<AiStatus | null>(null);
+
+/** Once the user closes the banner, stay quiet until AI demonstrably recovers
+ *  (a later successful AI call calls `noteAiSuccess`). Not reactive — it only
+ *  gates whether a fresh failure is allowed to re-open the banner. */
+let dismissed = false;
+
+/** Reactive accessor for the current AI-unavailable status (or null). */
+export const aiStatus = status;
+
+/** Flip the banner on for a known reason. No-op while the user has it dismissed
+ *  (until `noteAiSuccess` resets that). */
+export function reportAiUnavailable(reason: AiUnavailableReason): void {
+  if (dismissed) return;
+  setStatus({ reason, at: Date.now() });
+}
+
+/**
+ * Inspect a parsed response body; if it is the worker's AI-unavailable envelope,
+ * raise the banner and return true. Safe to call on every failed AI fetch.
+ */
+export function noteAiResponse(body: unknown): boolean {
+  if (!body || typeof body !== 'object') return false;
+  const e = body as AiUnavailableEnvelope;
+  if (e.aiUnavailable && e.reason) {
+    reportAiUnavailable(e.reason);
+    return true;
+  }
+  return false;
+}
+
+/** AI worked — clear the banner and re-arm it for future failures. Call on any
+ *  successful AI response. */
+export function noteAiSuccess(): void {
+  dismissed = false;
+  if (status() !== null) setStatus(null);
+}
+
+/** User closed the banner: hide it and keep it hidden until AI recovers. */
+export function dismissAiStatus(): void {
+  dismissed = true;
+  setStatus(null);
+}

--- a/packages/ui/src/components.css
+++ b/packages/ui/src/components.css
@@ -163,3 +163,74 @@
   background: var(--accent);
   color: #fff;
 }
+
+/* ---- AiStatusBanner (AI-paused notice) ----
+ * A full-width strip in normal flow at the top of the app, so it pushes content
+ * down rather than overlapping a fixed/sticky top bar. Component tokens
+ * (--banner-*) fall back to a warm, low-alarm tint built from the theme. */
+.ui-banner {
+  width: 100%;
+  background: var(--banner-bg, var(--surface-sunk));
+  border-bottom: 1px solid var(--banner-border, var(--line));
+  color: var(--banner-fg, var(--fg));
+  font-family: var(--font-ui);
+}
+.ui-banner-inner {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 9px 16px;
+}
+.ui-banner-text {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.ui-banner-line {
+  margin: 0;
+  font-size: 13.5px;
+  line-height: 1.5;
+  color: var(--banner-fg, var(--fg));
+}
+.ui-banner-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  margin-inline-end: 8px;
+  border-radius: 50%;
+  background: var(--banner-accent, var(--accent));
+  vertical-align: middle;
+}
+.ui-banner-hint {
+  color: var(--muted);
+}
+.ui-banner-sponsor {
+  margin: 4px 0 0;
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--muted);
+}
+.ui-banner-cta {
+  color: var(--banner-accent, var(--accent));
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  white-space: nowrap;
+}
+.ui-banner-cta:hover {
+  color: var(--accent-strong, var(--accent));
+}
+.ui-banner-close {
+  flex: none;
+  border: 0;
+  background: none;
+  font-size: 20px;
+  line-height: 1;
+  padding: 0 2px;
+  color: var(--muted);
+  cursor: pointer;
+}
+.ui-banner-close:hover {
+  color: var(--banner-fg, var(--fg));
+}


### PR DESCRIPTION
## Why

The reported bug — **single-word translation in tanach** — was the visible symptom of a wider issue: the AI gateway is **out of OpenRouter credits** right now, so every uncached AI call 502s. Translation has no cache cushion, so it failed most loudly (the popup showed a bare `—`). The translate producer itself is fine; the account just ran dry.

There was no clear, user-facing way to communicate any AI-paused state — neither "out of credits" nor the internal **$300/day / $10/hour cost caps**. This adds one, shared between talmud and tanach since both hit the same gateway and the same failure modes.

## What

**`@corpus/core/llm/ai-status.ts`** — pure `classifyAiUnavailable(err)` → `{ reason }` where reason ∈ `credits | daily-cap | hourly-cap | rate-limit | provider`. Reads the existing typed `LLMError` (402 → credits) / `BudgetPausedError` (scope → daily/hourly-cap). Both apps already funnel every paid call through the same `runLLM`. Unit-tested.

**`@corpus/ui`** — a corpus-agnostic `AiStatusBanner` (reason-aware copy, dismissible, `role="status"`, takes a per-reason `sponsor` render-prop) + a module-level `aiStatus` signal both apps drive (`reportAiUnavailable` / `noteAiResponse` / `noteAiSuccess` / `dismissAiStatus`). Styles in `components.css` (`.ui-banner`, themed via tokens).

**Workers** return a stable `{ aiUnavailable: true, reason }` envelope (503) on a paused call:
- tanach: `/api/translate` + the shared `runErrorResponse`.
- talmud: budget pre-check pause responses gain `aiUnavailable`/`reason`; the queued-job error record is tagged so **out-of-credits surfaces via `run-status`** (talmud generation is async).

**Talmud `GET /api/shas-cost`** (SWR-6h) reuses `estimateShasCost` — the *same model the `/usage` page renders* — so the sponsorship ask is grounded in the **live** "cost to finish Shas" figure (currently ~\$16k remaining at full depth), never a hand-typed number. This is also talmud's first `@corpus/ui` component adoption.

**Clients** raise the banner where run/run-status/translate bodies are already inspected, and clear it on the next successful AI call. Tanach's translate popup now shows `AI paused` instead of `—`.

## Framing

Per the chosen direction, the banner frames spend pauses as **cost control**, not failure, and the out-of-credits / cap cases carry a **self-funding + sponsorship** ask with a mailto CTA. The dollar figure is the real one from usage, fetched live.

## Verification

- `pnpm typecheck` — clean (4/4 packages)
- `pnpm test` — green (core 124, tanach 64, talmud 2618); one `run-contract` snapshot updated to reflect the additive `aiUnavailable`/`reason` fields on the `/api/run` pause body
- `biome ci .` — clean
- Confirmed against live prod that the current failure is `OpenRouter HTTP 402: Insufficient credits` (daily budget spend is \$0, so it is genuinely credits, not the cap)

## Note

This makes the outage **legible**; it does not fix it. The actual unblock is topping up OpenRouter credits.