### PR TITLE
AI-paused banner: route mark failures in, stop raw 402 leaks

### DIFF
--- a/packages/talmud/src/client/DafLoadProgress.tsx
+++ b/packages/talmud/src/client/DafLoadProgress.tsx
@@ -13,6 +13,7 @@
  * shared component owns the render + the auto-show/hide behaviour.
  */
 
+import { aiStatus } from '@corpus/ui/aiStatus';
 import { LoadProgress, type LoadProgressNotice } from '@corpus/ui/LoadProgress';
 import { createMemo, type JSX } from 'solid-js';
 import { loadNotice, prefetchProgress } from './dafPrefetch';
@@ -93,6 +94,10 @@ export default function DafLoadProgress(props: DafLoadProgressProps = {}): JSX.E
   // Top-level notice: a budget pause or a wave of failures, so generation
   // problems don't read as a silently-stuck bar.
   const notice = createMemo<LoadProgressNotice | null>(() => {
+    // When the shared AI-paused banner is up it's the single, clear explanation
+    // (out of credits / cost cap) — don't also show the generic "couldn't be
+    // generated" / "paused" line, which would just repeat it.
+    if (aiStatus()) return null;
     const kind = loadNotice(prefetchProgress());
     if (!kind) return null;
     return { kind, text: kind === 'paused' ? t('dafLoad.paused') : t('dafLoad.failed') };

--- a/packages/talmud/src/client/DafViewer.tsx
+++ b/packages/talmud/src/client/DafViewer.tsx
@@ -38,6 +38,7 @@ import { readDevMode, setDevModeActive } from './DevModeShelf';
 import { cancelPrefetch, prefetchDaf } from './dafPrefetch';
 import { setDafRunsTarget } from './dafRunsStore';
 import { openDafView } from './dafViewStore';
+import { isServiceUnavailableError } from './enrichmentQueue';
 import { ensureMasechetIncipit } from './ensureMasechetIncipit';
 import { GutterIcons, type GutterKind } from './GutterIcons';
 import { GutterOverlay } from './GutterOverlay';
@@ -3602,8 +3603,14 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
       </header>
 
       {/* Mark errors still surface explicitly — the progress bar abstracts
-          them into its count, but a failed anchor is worth naming. */}
-      <Show when={markStatuses().some((s) => s.kind === 'error')}>
+          them into its count, but a failed anchor is worth naming. AI-paused
+          failures (out of credits / cost cap / provider blip) are EXCLUDED:
+          they dump a raw provider string ("OpenRouter HTTP 402: …") and are
+          already explained by the shared AiStatusBanner, so naming each one here
+          is just noise. Genuine bugs still surface. */}
+      <Show
+        when={markStatuses().some((s) => s.kind === 'error' && !isServiceUnavailableError(s.error))}
+      >
         <section
           style={{
             'margin-bottom': '1rem',
@@ -3619,7 +3626,11 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
             color: '#c33',
           }}
         >
-          <For each={markStatuses().filter((s) => s.kind === 'error')}>
+          <For
+            each={markStatuses().filter(
+              (s) => s.kind === 'error' && !isServiceUnavailableError(s.error),
+            )}
+          >
             {(s) => (
               <span>
                 {s.label || s.id}: {s.error}

--- a/packages/talmud/src/client/MarksRegistryPanel.tsx
+++ b/packages/talmud/src/client/MarksRegistryPanel.tsx
@@ -27,6 +27,7 @@ import {
   reverseDependencyIndex,
 } from '@corpus/core/registry/depGraph';
 import type { SidebarRecipe } from '@corpus/core/sidebar/recipe';
+import { noteAiResponse } from '@corpus/ui/aiStatus';
 import {
   createEffect,
   createMemo,
@@ -351,6 +352,10 @@ async function postAndAwait(body: unknown): Promise<RunResult> {
   // recycled or OOM'd isolate) as a clean retryable error instead of a raw
   // JSON.parse crash.
   const j = (await parseRunJson(r)) as RunResponse | { error?: string };
+  // Raise the shared AI-paused banner if this is the { aiUnavailable, reason }
+  // envelope (budget pre-check pause) — mark runs fan out here, so without this
+  // a mark 402 only dumped a raw error and never reached the banner.
+  noteAiResponse(j);
   if (!r.ok && r.status !== 202) {
     throw new Error((j as { error?: string }).error ?? `HTTP ${r.status}`);
   }
@@ -377,6 +382,9 @@ async function pollJob(runId: string, cacheKey?: string): Promise<RunResult> {
       // server-side, so keep polling rather than failing.
       continue;
     }
+    // The queued job's error record carries { aiUnavailable, reason } when it
+    // failed out-of-credits (or hit a cap) — raise the banner from it.
+    noteAiResponse(j);
     if ('status' in j) {
       if (j.status === 'ok') return (j as { result: RunResult }).result;
       if (j.status === 'error') throw new Error((j as { error: string }).error);

--- a/packages/talmud/src/client/enrichmentQueue.ts
+++ b/packages/talmud/src/client/enrichmentQueue.ts
@@ -78,7 +78,7 @@ export function isPausedError(err: unknown): boolean {
 // poll timeout. Deliberately narrow: a parse/schema/validation error is a real
 // bug and should still surface loudly.
 const SERVICE_UNAVAILABLE_RE =
-  /openrouter|user not found|no endpoints|HTTP\s*40[13]\b|HTTP\s*5\d\d\b|InferenceUpstreamError|timed out|fetch failed|network|temporarily unavailable|AiError|budget exhausted/i;
+  /openrouter|insufficient credits|user not found|no endpoints|HTTP\s*40[123]\b|HTTP\s*5\d\d\b|InferenceUpstreamError|timed out|fetch failed|network|temporarily unavailable|AiError|budget exhausted/i;
 
 /** True when an error string / Error signals the AI service is unavailable
  *  (provider auth/outage/timeout) rather than a genuine bug. Excludes the

--- a/packages/ui/src/aiStatus.ts
+++ b/packages/ui/src/aiStatus.ts
@@ -44,12 +44,21 @@ const [status, setStatus] = createSignal<AiStatus | null>(null);
  *  gates whether a fresh failure is allowed to re-open the banner. */
 let dismissed = false;
 
+/** When the last failure was reported (epoch ms). A success only CLEARS the
+ *  banner once it has been failure-free for this grace window — otherwise the
+ *  reader's parallel card fan-out (some cards cached-OK, some 402) would flicker
+ *  the banner as successes and failures resolve within a second of each other.
+ *  After genuine recovery (a new daf with no failures) the next success clears. */
+let lastFailureAt = 0;
+const RECOVERY_GRACE_MS = 4000;
+
 /** Reactive accessor for the current AI-unavailable status (or null). */
 export const aiStatus = status;
 
 /** Flip the banner on for a known reason. No-op while the user has it dismissed
  *  (until `noteAiSuccess` resets that). */
 export function reportAiUnavailable(reason: AiUnavailableReason): void {
+  lastFailureAt = Date.now();
   if (dismissed) return;
   setStatus({ reason, at: Date.now() });
 }
@@ -68,11 +77,13 @@ export function noteAiResponse(body: unknown): boolean {
   return false;
 }
 
-/** AI worked — clear the banner and re-arm it for future failures. Call on any
- *  successful AI response. */
+/** AI worked — re-arm the banner for future failures, and clear it once AI has
+ *  recovered (no failure within the grace window). The grace check stops a
+ *  near-simultaneous success from clearing a banner a parallel failure just
+ *  raised. Call on any successful AI response. */
 export function noteAiSuccess(): void {
   dismissed = false;
-  if (status() !== null) setStatus(null);
+  if (status() !== null && Date.now() - lastFailureAt > RECOVERY_GRACE_MS) setStatus(null);
 }
 
 /** User closed the banner: hide it and keep it hidden until AI recovers. */


### PR DESCRIPTION
Follow-up to #517. On a daf where marks fail out of credits, the reader still showed the raw provider error and the banner did not appear:

> Rabbis: OpenRouter HTTP 402: {"error":{"message":"Insufficient credits. Add more using https://openrouter.ai/settings/credits","code":402}}

plus a generic "Some content couldn't be generated just now."

Root cause: mark runs fan out through `MarksRegistryPanel.postAndAwait`, which (unlike the enrichment cards + QA panel wired in #517) never called `noteAiResponse`. So the `{ aiUnavailable, reason }` envelope on the queued-job error record was ignored, the banner never lit up, and `DafViewer`'s red bar printed the raw string verbatim.

## Fix

- **`MarksRegistryPanel`** — `noteAiResponse(j)` on the `/api/run` POST body and each `run-status` poll body, so a mark 402 raises the shared banner.
- **`DafViewer`** — the red per-mark error bar now **excludes** service-unavailable errors (`isServiceUnavailableError`); they're explained by the banner. Only genuine bugs are named. No more raw `OpenRouter HTTP 402: …` text.
- **`DafLoadProgress`** — suppress the generic "couldn't be generated / paused" notice while the banner is up (it just repeated it).
- **`enrichmentQueue`** — `SERVICE_UNAVAILABLE_RE` now matches `HTTP 402` + `insufficient credits` (was `401/403` only).
- **`aiStatus.noteAiSuccess`** — only clears the banner after a recovery grace window, so the reader's parallel card fan-out (some cached-OK, some 402 during an outage) can't flicker the banner; genuine recovery still clears it.

## Verification

- `pnpm typecheck` clean (4/4), `pnpm test` green (core 124 / tanach 64 / talmud 2618), `biome ci` clean.
- Reproduced the leak live on cold Me'ilah 2a (raw `Rabbis: …402`, no banner); these changes route it to the banner and drop the raw text. Will re-verify on prod after deploy.