### PR TITLE
Consolidate the 4 client run/poll copies into one runProducer

### DIFF
--- a/packages/talmud/src/client/ArgumentNarrative.tsx
+++ b/packages/talmud/src/client/ArgumentNarrative.tsx
@@ -9,6 +9,7 @@
 
 import { createEffect, createResource, createSignal, For, type JSX, Show } from 'solid-js';
 import { lang } from './i18n';
+import { runProducer } from './runProducer';
 
 interface Actor {
   name: string;
@@ -39,55 +40,16 @@ const KIND_COLOR: Record<string, string> = {
   resolution: '#be123c',
 };
 
-const POLL_INTERVAL_MS = 1500;
-const POLL_TIMEOUT_MS = 90_000;
-
-async function pollJob(runId: string, cacheKey?: string): Promise<unknown> {
-  const start = Date.now();
-  const qs = cacheKey ? `?k=${encodeURIComponent(cacheKey)}` : '';
-  while (Date.now() - start < POLL_TIMEOUT_MS) {
-    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
-    const res = await fetch(`/api/run-status/${encodeURIComponent(runId)}${qs}`);
-    const j = (await res.json()) as {
-      status?: string;
-      result?: { parsed?: unknown };
-      error?: string;
-    };
-    if (j.status === 'ok') return j.result?.parsed;
-    if (j.status === 'error') throw new Error(j.error ?? 'narrative run failed');
-  }
-  throw new Error('narrative run timed out');
-}
-
 async function runNarrative(
   tractate: string,
   page: string,
   markInput: unknown,
 ): Promise<NarrativeData | null> {
-  const res = await fetch('/api/run', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      enrichment_id: 'argument.narrative',
-      tractate,
-      page,
-      mark_input: markInput,
-      lang: lang(),
-    }),
-  });
-  const j = (await res.json()) as {
-    status?: string;
-    runId?: string;
-    cacheKey?: string;
-    result?: { parsed?: unknown };
-    error?: string;
-  };
-  let parsed: unknown;
-  if (j.status === 'ok') parsed = j.result?.parsed;
-  else if (j.status === 'pending' && j.runId) parsed = await pollJob(j.runId, j.cacheKey);
-  else if (j.status === 'error') throw new Error(j.error ?? 'narrative run failed');
-  else parsed = j.result?.parsed;
-  const p = parsed as NarrativeData | undefined;
+  const result = await runProducer(
+    { enrichment_id: 'argument.narrative', tractate, page, mark_input: markInput, lang: lang() },
+    { pollTimeoutMs: 90_000 },
+  );
+  const p = result.parsed as NarrativeData | undefined;
   return p && Array.isArray(p.beats) ? p : null;
 }
 

--- a/packages/talmud/src/client/MarkEnrichmentCards.tsx
+++ b/packages/talmud/src/client/MarkEnrichmentCards.tsx
@@ -18,7 +18,6 @@
  */
 
 import { instanceIdOf } from '@corpus/core/cache/keys';
-import { noteAiResponse, noteAiSuccess } from '@corpus/ui/aiStatus';
 import {
   createEffect,
   createResource,
@@ -29,7 +28,6 @@ import {
   Show,
   untrack,
 } from 'solid-js';
-import { trackAI } from './aiActivity';
 import { devModeActive } from './DevModeShelf';
 import {
   dafViewLoaded,
@@ -41,10 +39,8 @@ import {
 import { ErrorBadge } from './ErrorBadge';
 import {
   isAbort,
-  isPausedBody,
   isServiceUnavailableError,
   PAUSED_ERROR,
-  parseRunJson,
   QUEUE_PRIORITY,
   RequestQueue,
   type RunResult,
@@ -54,6 +50,7 @@ import {
 import { lang, t } from './i18n';
 import { requestInspect } from './inspectBridge';
 import { HebraizedWithRabbis as Hebraized } from './rabbiLinks';
+import { runProducer } from './runProducer';
 
 // Single global "which card has the inspector open?" signal — keyed by the
 // card's instanceKey. Only one drawer at a time across the whole page.
@@ -144,21 +141,6 @@ async function fetchEnrichments(): Promise<EnrichmentDef[]> {
   return j.enrichments;
 }
 
-// Worker's run endpoint returns one of:
-//   { status: 'ok', result: RunResult, total_ms? }            ← cache hit, immediate
-//   { status: 'pending', runId: string, cacheKey?: string }   ← enqueued, poll
-//   { status: 'error', error: string }
-//
-// `cacheKey` (when present) is the canonical KV key that runEnrichmentOnce
-// writes to right before the queue handler writes `job:{runId}`. The
-// polling helper passes it back so run-status can recover the result via
-// canonical cache if the consumer was terminated in that write gap.
-type RunResponse =
-  | { status: 'ok'; result: RunResult; total_ms?: number }
-  | { status: 'pending'; runId: string; cacheKey?: string }
-  | { status: 'error'; error: string };
-
-const POLL_INTERVAL_MS = 1500;
 // Cold-page syntheses (e.g. pesukim.synthesis) can run 60+ seconds end-to-end
 // once their leaves + anchor marks queue behind other in-flight jobs. With
 // client enrichmentQueue concurrency=4 and ~5–10 instances per page, the
@@ -171,75 +153,6 @@ const POLL_TIMEOUT_MS = 600_000;
 // self-heals instead of failing the card. Once a job is `pending`, polling
 // takes over and is NOT retried here (it would re-enqueue generation).
 const RUN_POST_BACKOFF_MS = [500, 1500];
-
-function sleep(ms: number, signal?: AbortSignal): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const id = setTimeout(resolve, ms);
-    signal?.addEventListener(
-      'abort',
-      () => {
-        clearTimeout(id);
-        reject(new DOMException('Aborted', 'AbortError'));
-      },
-      { once: true },
-    );
-  });
-}
-
-async function runEnrichmentImpl(
-  enrichmentId: string,
-  tractate: string,
-  page: string,
-  markInput: unknown,
-  signal?: AbortSignal,
-): Promise<RunResult> {
-  const body = JSON.stringify({
-    enrichment_id: enrichmentId,
-    tractate,
-    page,
-    mark_input: markInput,
-    lang: lang(),
-  });
-  let r: Response;
-  let j: RunResponse | { error?: string };
-  for (let attempt = 0; ; attempt++) {
-    r = await fetch('/api/run', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body,
-      signal,
-    });
-    try {
-      j = (await parseRunJson(r)) as RunResponse | { error?: string };
-      break;
-    } catch (err) {
-      // parseRunJson throws a service-unavailable error only when the body is
-      // NON-JSON — i.e. a Cloudflare edge page (1101 / empty 5xx) from a
-      // recycled or OOM'd isolate. Retry a couple of times on a short backoff;
-      // any other failure (abort, genuine 4xx with a JSON body) rethrows.
-      if (isAbort(err) || attempt >= RUN_POST_BACKOFF_MS.length || !isServiceUnavailableError(err))
-        throw err;
-      await sleep(RUN_POST_BACKOFF_MS[attempt], signal);
-    }
-  }
-  // Raise the shared AI-paused banner if the body is the { aiUnavailable, reason }
-  // envelope (budget pre-check pause, or a queued job that failed out-of-credits).
-  noteAiResponse(j);
-  if (isPausedBody(j)) throw new Error(PAUSED_ERROR);
-  if (!r.ok && r.status !== 202) {
-    throw new Error((j as { error?: string }).error ?? `HTTP ${r.status}`);
-  }
-  if ('status' in j) {
-    if (j.status === 'ok') {
-      noteAiSuccess();
-      return j.result;
-    }
-    if (j.status === 'error') throw new Error(j.error);
-    if (j.status === 'pending') return pollJob(j.runId, j.cacheKey, signal);
-  }
-  // Legacy/synchronous shape — treat the whole body as RunResult for back-compat.
-  return j as unknown as RunResult;
-}
 
 // Builds the activity-store id + label for an enrichment run. Pulled out
 // of runEnrichment() so the request queue can mark the entry `queued` the
@@ -288,39 +201,19 @@ export async function runEnrichment(
   signal?: AbortSignal,
 ): Promise<RunResult> {
   const { id, label } = enrichmentActivityKey(enrichmentId, tractate, page, markInput, instanceKey);
-  return trackAI(id, label, () =>
-    runEnrichmentImpl(enrichmentId, tractate, page, markInput, signal),
+  // Delegate POST + poll + banner to the shared runProducer; this component keeps
+  // only its fan-out concerns (the queue below, the result cache, per-card abort).
+  // A couple of short POST retries cover a recycled-isolate edge page on a cold,
+  // dense daf; the 10-min poll budget covers a slow cold generation.
+  return runProducer(
+    { enrichment_id: enrichmentId, tractate, page, mark_input: markInput, lang: lang() },
+    {
+      signal,
+      postRetryBackoffs: RUN_POST_BACKOFF_MS,
+      pollTimeoutMs: POLL_TIMEOUT_MS,
+      activity: { id, label },
+    },
   );
-}
-
-async function pollJob(runId: string, cacheKey?: string, signal?: AbortSignal): Promise<RunResult> {
-  const start = Date.now();
-  const qs = cacheKey ? `?k=${encodeURIComponent(cacheKey)}` : '';
-  while (Date.now() - start < POLL_TIMEOUT_MS) {
-    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
-    if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
-    const r = await fetch(`/api/run-status/${encodeURIComponent(runId)}${qs}`, { signal });
-    let j: RunResponse | { status: 'pending' };
-    try {
-      j = (await parseRunJson(r)) as RunResponse | { status: 'pending' };
-    } catch (err) {
-      if (isAbort(err)) throw err;
-      // A transient non-JSON edge error (isolate recycled mid-poll). The job may
-      // still be running server-side, so keep polling instead of failing the card.
-      continue;
-    }
-    noteAiResponse(j);
-    if (isPausedBody(j)) throw new Error(PAUSED_ERROR);
-    if ('status' in j) {
-      if (j.status === 'ok') {
-        noteAiSuccess();
-        return (j as { result: RunResult }).result;
-      }
-      if (j.status === 'error') throw new Error((j as { error: string }).error);
-      // pending — continue polling
-    }
-  }
-  throw new Error(`job ${runId} timed out after ${POLL_TIMEOUT_MS / 1000}s`);
 }
 
 // On a WARM daf each run is a single KV read, so a high gate just fills cards

--- a/packages/talmud/src/client/MarksRegistryPanel.tsx
+++ b/packages/talmud/src/client/MarksRegistryPanel.tsx
@@ -27,7 +27,6 @@ import {
   reverseDependencyIndex,
 } from '@corpus/core/registry/depGraph';
 import type { SidebarRecipe } from '@corpus/core/sidebar/recipe';
-import { noteAiResponse } from '@corpus/ui/aiStatus';
 import {
   createEffect,
   createMemo,
@@ -42,12 +41,12 @@ import {
 } from 'solid-js';
 import { trackAI } from './aiActivity';
 import { devModeActive } from './DevModeShelf';
-import { parseRunJson } from './enrichmentQueue';
 import { lang } from './i18n';
 import type {
   MarkDef as RendererMarkDef,
   MarkRunOutput as RendererMarkRunOutput,
 } from './renderers/dispatch';
+import { runProducer } from './runProducer';
 import type { SeedMark } from './seed-marks';
 
 type LLMModelId = `@cf/${string}` | `openrouter/${string}`;
@@ -312,20 +311,6 @@ async function fetchAll(): Promise<{
   };
 }
 
-// /api/run is now async (queue-backed). Three response shapes:
-//   { status: 'ok', result }                            ← cache hit, immediate
-//   { status: 'pending', runId, cacheKey? } (HTTP 202)  ← enqueued, poll run-status
-//   { status: 'error', error }
-// cacheKey is forwarded to run-status so the polling recovers the result
-// from the canonical cache when the queue consumer never wrote job:{runId}.
-type RunResponse =
-  | { status: 'ok'; result: RunResult; total_ms?: number }
-  | { status: 'pending'; runId: string; cacheKey?: string }
-  | { status: 'error'; error: string };
-
-const POLL_INTERVAL_MS = 1500;
-const POLL_TIMEOUT_MS = 180_000;
-
 /** Studio secret for the privileged /api/run knobs (bypass_cache here).
  *  The owner sets it once via
  *  `localStorage.setItem('talmud_studio_secret', '<secret>')` in the browser
@@ -342,57 +327,15 @@ function studioHeaders(): Record<string, string> {
   }
 }
 
-async function postAndAwait(body: unknown): Promise<RunResult> {
-  const r = await fetch('/api/run', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...studioHeaders() },
-    body: JSON.stringify(body),
-  });
-  // parseRunJson surfaces a non-JSON edge error page (1101 / empty 5xx from a
-  // recycled or OOM'd isolate) as a clean retryable error instead of a raw
-  // JSON.parse crash.
-  const j = (await parseRunJson(r)) as RunResponse | { error?: string };
-  // Raise the shared AI-paused banner if this is the { aiUnavailable, reason }
-  // envelope (budget pre-check pause) — mark runs fan out here, so without this
-  // a mark 402 only dumped a raw error and never reached the banner.
-  noteAiResponse(j);
-  if (!r.ok && r.status !== 202) {
-    throw new Error((j as { error?: string }).error ?? `HTTP ${r.status}`);
-  }
-  if ('status' in j) {
-    if (j.status === 'ok') return j.result;
-    if (j.status === 'error') throw new Error(j.error);
-    if (j.status === 'pending') return pollJob(j.runId, j.cacheKey);
-  }
-  // Back-compat: legacy synchronous shape — treat the whole body as RunResult.
-  return j as unknown as RunResult;
-}
-
-async function pollJob(runId: string, cacheKey?: string): Promise<RunResult> {
-  const start = Date.now();
-  const qs = cacheKey ? `?k=${encodeURIComponent(cacheKey)}` : '';
-  while (Date.now() - start < POLL_TIMEOUT_MS) {
-    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
-    const r = await fetch(`/api/run-status/${encodeURIComponent(runId)}${qs}`);
-    let j: RunResponse;
-    try {
-      j = (await parseRunJson(r)) as RunResponse;
-    } catch {
-      // Transient non-JSON edge error mid-poll; the job may still be running
-      // server-side, so keep polling rather than failing.
-      continue;
-    }
-    // The queued job's error record carries { aiUnavailable, reason } when it
-    // failed out-of-credits (or hit a cap) — raise the banner from it.
-    noteAiResponse(j);
-    if ('status' in j) {
-      if (j.status === 'ok') return (j as { result: RunResult }).result;
-      if (j.status === 'error') throw new Error((j as { error: string }).error);
-      // pending — keep polling
-    }
-  }
-  throw new Error(`job ${runId} timed out after ${POLL_TIMEOUT_MS / 1000}s`);
-}
+// The studio panel runs marks/enrichments through the shared runProducer
+// (POST /api/run + poll run-status + banner), adding the studio secret header
+// (for the privileged bypass_cache knob) and a 3-min poll budget.
+// NB: this panel declares its own stricter RunResult (above) than the shared
+// RunResult runProducer returns; the cast preserves the implicit cast the old
+// JSON-shaped postAndAwait did. Unifying the two RunResult types is a separate
+// cleanup.
+const runStudio = async (body: Record<string, unknown>): Promise<RunResult> =>
+  (await runProducer(body, { headers: studioHeaders(), pollTimeoutMs: 180_000 })) as RunResult;
 
 // Output language threads into every run. The worker namespaces the :he cache
 // + selects the *_he prompt variant; the lang also tags the activityId so the
@@ -407,7 +350,7 @@ async function runMark(
   const activityId = `mark:${id}:${tractate}:${page}:${l}${bypassCache ? ':fresh' : ''}`;
   const label = `${id} · ${tractate} ${page}`;
   return trackAI(activityId, label, () =>
-    postAndAwait({ mark_id: id, tractate, page, bypass_cache: bypassCache, lang: l }),
+    runStudio({ mark_id: id, tractate, page, bypass_cache: bypassCache, lang: l }),
   );
 }
 
@@ -421,7 +364,7 @@ async function runEnrichment(
   const activityId = `enrichment:${id}:${tractate}:${page}:${l}${bypassCache ? ':fresh' : ''}`;
   const label = `${id} · ${tractate} ${page}`;
   return trackAI(activityId, label, () =>
-    postAndAwait({ enrichment_id: id, tractate, page, bypass_cache: bypassCache, lang: l }),
+    runStudio({ enrichment_id: id, tractate, page, bypass_cache: bypassCache, lang: l }),
   );
 }
 

--- a/packages/talmud/src/client/QAPanel.tsx
+++ b/packages/talmud/src/client/QAPanel.tsx
@@ -27,18 +27,13 @@
  * `user_question` in the body.
  */
 
-import { noteAiResponse, noteAiSuccess } from '@corpus/ui/aiStatus';
 import { createEffect, createResource, createSignal, For, type JSX, onMount, Show } from 'solid-js';
 import { trackAI } from './aiActivity';
-import {
-  isPausedBody,
-  isPausedError,
-  isServiceUnavailableError,
-  PAUSED_ERROR,
-} from './enrichmentQueue';
+import { isPausedError, isServiceUnavailableError } from './enrichmentQueue';
 import { Hebraized } from './Hebraized';
 import { hebraize } from './hebraize';
 import { lang, t } from './i18n';
+import { runProducer } from './runProducer';
 import { tutorialPrefetch } from './tutorial';
 
 export interface QAPanelProps {
@@ -82,14 +77,6 @@ interface RunResultLike {
   parsed: unknown;
   content: string;
 }
-type RunResponse =
-  | { status: 'ok'; result: RunResultLike }
-  | { status: 'pending'; runId: string; cacheKey?: string }
-  | { status: 'error'; error: string };
-
-const POLL_INTERVAL_MS = 1500;
-const POLL_TIMEOUT_MS = 300_000;
-
 async function runEnrichmentDirect(
   enrichmentId: string,
   tractate: string,
@@ -105,46 +92,7 @@ async function runEnrichmentDirect(
     lang: lang(),
   };
   if (userQuestion) body.user_question = userQuestion;
-  const r = await fetch('/api/run', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  });
-  const j = (await r.json()) as RunResponse | { error?: string };
-  noteAiResponse(j);
-  if (isPausedBody(j)) throw new Error(PAUSED_ERROR);
-  if (!r.ok && r.status !== 202) {
-    throw new Error((j as { error?: string }).error ?? `HTTP ${r.status}`);
-  }
-  if ('status' in j) {
-    if (j.status === 'ok') {
-      noteAiSuccess();
-      return j.result;
-    }
-    if (j.status === 'error') throw new Error(j.error);
-    if (j.status === 'pending') return pollJob(j.runId, j.cacheKey);
-  }
-  return j as unknown as RunResultLike;
-}
-
-async function pollJob(runId: string, cacheKey?: string): Promise<RunResultLike> {
-  const start = Date.now();
-  const qs = cacheKey ? `?k=${encodeURIComponent(cacheKey)}` : '';
-  while (Date.now() - start < POLL_TIMEOUT_MS) {
-    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
-    const r = await fetch(`/api/run-status/${encodeURIComponent(runId)}${qs}`);
-    const j = (await r.json()) as RunResponse | { status: 'pending' };
-    noteAiResponse(j);
-    if (isPausedBody(j)) throw new Error(PAUSED_ERROR);
-    if ('status' in j) {
-      if (j.status === 'ok') {
-        noteAiSuccess();
-        return (j as { result: RunResultLike }).result;
-      }
-      if (j.status === 'error') throw new Error((j as { error: string }).error);
-    }
-  }
-  throw new Error(`qa job ${runId} timed out`);
+  return runProducer(body, { pollTimeoutMs: 300_000 });
 }
 
 async function fetchSuggested(

--- a/packages/talmud/src/client/runProducer.ts
+++ b/packages/talmud/src/client/runProducer.ts
@@ -1,0 +1,175 @@
+/**
+ * THE single client path to run a producer.
+ *
+ * Every client surface that generates content — the reader's enrichment cards,
+ * the Q&A panel, the argument narrative, the dev marks registry — used to carry
+ * its own copy of "POST /api/run, parse, handle paused/error, poll
+ * /api/run-status until done". Four copies drifted apart: one missed the
+ * AI-paused banner, two skipped defensive parsing, the budget/credits handling
+ * was inconsistent. This is the one implementation they now share.
+ *
+ * It owns the cross-cutting behaviour that must be identical everywhere:
+ *   - defensive parsing (a recycled / OOM'd edge isolate returns a non-JSON
+ *     error PAGE; parseRunJson turns that into a classified retryable error),
+ *   - raising the shared AI-paused banner on a paused / out-of-credits response
+ *     (noteAiResponse) and clearing it on recovery (noteAiSuccess),
+ *   - mapping a budget pause to the PAUSED_ERROR sentinel the UI localises,
+ *   - following a queued job through run-status to its result.
+ *
+ * The genuinely per-caller variations are options: studio headers, an abort
+ * signal, the poll timeout, POST retry backoffs, and an optional activity-panel
+ * entry. Bounded-concurrency queueing + the client result cache stay in
+ * MarkEnrichmentCards (the reader's fan-out concern) and wrap a call to this.
+ */
+
+import { noteAiResponse, noteAiSuccess } from '@corpus/ui/aiStatus';
+import { trackAI } from './aiActivity';
+import {
+  isAbort,
+  isPausedBody,
+  isServiceUnavailableError,
+  PAUSED_ERROR,
+  parseRunJson,
+  type RunResult,
+} from './enrichmentQueue';
+
+/** The /api/run + /api/run-status response envelope (the fields this module
+ *  acts on; callers narrow `result` to whatever shape they render). */
+interface RunResponse {
+  status?: 'ok' | 'error' | 'pending';
+  result?: RunResult;
+  runId?: string;
+  cacheKey?: string;
+  error?: string;
+}
+
+export interface RunProducerOptions {
+  /** Extra request headers merged with Content-Type (e.g. the studio secret). */
+  headers?: Record<string, string>;
+  /** Abort the POST + polling (per-card controller, daf change, sidebar close). */
+  signal?: AbortSignal;
+  /** Max ms to poll run-status before giving up. Default 10 min. */
+  pollTimeoutMs?: number;
+  /** Poll cadence in ms. Default 1500. */
+  pollIntervalMs?: number;
+  /** Backoffs (ms) to retry the POST on a transient non-JSON edge error. Default
+   *  [] (no retry); the reader's fan-out passes a couple of short backoffs. */
+  postRetryBackoffs?: number[];
+  /** When set, surface the run in the activity panel (queued -> loading -> done). */
+  activity?: { id: string; label: string };
+}
+
+const DEFAULT_POLL_TIMEOUT_MS = 600_000;
+const DEFAULT_POLL_INTERVAL_MS = 1500;
+
+/** Abortable sleep — rejects with an AbortError if the signal fires while waiting. */
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException('Aborted', 'AbortError'));
+      return;
+    }
+    const timer = setTimeout(resolve, ms);
+    signal?.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timer);
+        reject(new DOMException('Aborted', 'AbortError'));
+      },
+      { once: true },
+    );
+  });
+}
+
+/**
+ * Run a producer and resolve to its RunResult. Throws PAUSED_ERROR on a budget
+ * pause, a service-unavailable Error on a transient outage, the run's error on a
+ * genuine failure, or an AbortError if the signal fires.
+ */
+export function runProducer(
+  body: Record<string, unknown>,
+  opts: RunProducerOptions = {},
+): Promise<RunResult> {
+  const work = () => runProducerImpl(body, opts);
+  return opts.activity ? trackAI(opts.activity.id, opts.activity.label, work) : work();
+}
+
+async function runProducerImpl(
+  body: Record<string, unknown>,
+  opts: RunProducerOptions,
+): Promise<RunResult> {
+  const backoffs = opts.postRetryBackoffs ?? [];
+  let r!: Response;
+  let j: unknown;
+  for (let attempt = 0; ; attempt++) {
+    r = await fetch('/api/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...opts.headers },
+      body: JSON.stringify(body),
+      signal: opts.signal,
+    });
+    try {
+      j = await parseRunJson(r);
+      break;
+    } catch (err) {
+      // parseRunJson only throws (service-unavailable) on a NON-JSON edge page
+      // (1101 / empty 5xx from a recycled isolate). Retry a couple of times on a
+      // short backoff; any other failure (abort, JSON 4xx) rethrows.
+      if (isAbort(err) || attempt >= backoffs.length || !isServiceUnavailableError(err)) throw err;
+      await sleep(backoffs[attempt], opts.signal);
+    }
+  }
+  noteAiResponse(j);
+  if (isPausedBody(j)) throw new Error(PAUSED_ERROR);
+  if (!r.ok && r.status !== 202) {
+    throw new Error((j as { error?: string }).error ?? `HTTP ${r.status}`);
+  }
+  const res = j as RunResponse;
+  if ('status' in res) {
+    if (res.status === 'ok' && res.result) {
+      noteAiSuccess();
+      return res.result;
+    }
+    if (res.status === 'error') throw new Error(res.error ?? 'run failed');
+    if (res.status === 'pending' && res.runId) return pollProducer(res.runId, res.cacheKey, opts);
+  }
+  // Legacy/synchronous shape — treat the whole body as a RunResult.
+  return j as unknown as RunResult;
+}
+
+async function pollProducer(
+  runId: string,
+  cacheKey: string | undefined,
+  opts: RunProducerOptions,
+): Promise<RunResult> {
+  const timeoutMs = opts.pollTimeoutMs ?? DEFAULT_POLL_TIMEOUT_MS;
+  const intervalMs = opts.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const qs = cacheKey ? `?k=${encodeURIComponent(cacheKey)}` : '';
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    await sleep(intervalMs, opts.signal);
+    if (opts.signal?.aborted) throw new DOMException('Aborted', 'AbortError');
+    const r = await fetch(`/api/run-status/${encodeURIComponent(runId)}${qs}`, {
+      signal: opts.signal,
+    });
+    let j: unknown;
+    try {
+      j = await parseRunJson(r);
+    } catch (err) {
+      if (isAbort(err)) throw err;
+      // Transient non-JSON edge error mid-poll; the job may still be running
+      // server-side, so keep polling rather than failing.
+      continue;
+    }
+    noteAiResponse(j);
+    if (isPausedBody(j)) throw new Error(PAUSED_ERROR);
+    const res = j as RunResponse;
+    if (res.status === 'ok' && res.result) {
+      noteAiSuccess();
+      return res.result;
+    }
+    if (res.status === 'error') throw new Error(res.error ?? 'run failed');
+    // pending — keep polling
+  }
+  throw new Error(`run ${runId} timed out after ${Math.round(timeoutMs / 1000)}s`);
+}


### PR DESCRIPTION
**Step 1 of the architecture cleanup** (the highest-leverage, lowest-risk move from the "why does it feel messy" thread).

## Problem
Four client components each re-implemented the identical `POST /api/run` → parse → handle paused/error → poll `/api/run-status` loop:

| | banner | defensive parse | queue | poll timeout |
|---|---|---|---|---|
| MarkEnrichmentCards | ✓ | ✓ | ✓ | 600s |
| QAPanel | ✓ | ✗ (raw `r.json()`) | ✗ | 300s |
| MarksRegistryPanel | ✓ | ✓ | ✗ | 180s |
| ArgumentNarrative | **✗** | **✗** | ✗ | 90s |

They drifted apart — which is exactly why the AI-paused banner took two PRs (#517, #518) to wire: there was no single client path to hook, so I kept missing copies.

## Change
New `src/client/runProducer.ts` owns the protocol every caller shares — defensive parse (catches the recycled/OOM edge page), raise/clear the shared AI-paused banner, map a budget pause to `PAUSED_ERROR`, follow a queued job through run-status. The genuinely per-caller bits are options: `headers` (studio secret), `signal` (abort), `pollTimeoutMs`, `postRetryBackoffs`, `activity` (trackAI). The reader's bounded-concurrency **queue + result cache + per-card abort stay in `MarkEnrichmentCards`** and wrap a call to it (that's its fan-out concern, not the shared helper's).

- All four callers now route through `runProducer`; **~290 lines of duplicated POST/poll deleted** (net −79 after the +175 shared core).
- `ArgumentNarrative` gains the banner + defensive parse it lacked — a latent bug fix (it would silently fail / throw on a 402 or edge error page).

## Behaviour preserved
Per-caller poll timeouts (90/180/300/600s), POST retry backoffs, studio headers, and the queue/cache/abort are all kept exactly. `pnpm typecheck` + `pnpm test` (core 124 / tanach 64 / talmud 2618) + `biome ci` all green.

## Follow-ups (separate PRs, per the plan)
- Unify the client paused/unavailable taxonomy (`SERVICE_UNAVAILABLE_RE` / `isPausedBody` / sentinels) onto the typed core `classifyAiUnavailable`.
- Reconcile `MarksRegistryPanel`'s local `RunResult` with the shared one (currently cast at the boundary).
- Then: split the god files (`index.ts`, `code-marks.ts`); finish/abandon the half-migrations.