### PR TITLE
Collapse the 3 RunResult type copies into one

### DIFF
--- a/packages/talmud/src/client/MarksRegistryPanel.tsx
+++ b/packages/talmud/src/client/MarksRegistryPanel.tsx
@@ -41,6 +41,7 @@ import {
 } from 'solid-js';
 import { trackAI } from './aiActivity';
 import { devModeActive } from './DevModeShelf';
+import type { RunResult } from './enrichmentQueue';
 import { lang } from './i18n';
 import type {
   MarkDef as RendererMarkDef,
@@ -153,36 +154,6 @@ export interface MarkStatusEntry {
 const [globalMarkStatuses, setGlobalMarkStatuses] = createSignal<MarkStatusEntry[]>([]);
 export function markStatuses() {
   return globalMarkStatuses();
-}
-
-export interface RunResult {
-  content: string;
-  reasoning?: string;
-  parsed: unknown;
-  parse_error: string | null;
-  model: LLMModelId;
-  transport: string;
-  attempts: number;
-  usage: {
-    prompt_tokens?: number;
-    completion_tokens?: number;
-    total_tokens?: number;
-    cost?: number;
-  } | null;
-  elapsed_ms: number;
-  resolved: { system_prompt: string; user_prompt: string };
-  total_ms: number;
-  /** True when the worker served this from the KV cache (no LLM call). On a
-   *  hit total_ms is injected as 0, but elapsed_ms still carries the original
-   *  generation time from when the result was first computed. */
-  cache_hit?: boolean;
-  /** "Serve-but-don't-write" — the worker assembled this result while a
-   *  dependency wasn't ready yet (e.g. the geography computed mark read the
-   *  rabbi/places mark caches before they warmed) and so did NOT pin it to the
-   *  cache. The run loop treats a transient result as not-yet-final and
-   *  re-fires the mark once its dependency marks reach 'ok', so the empty model
-   *  isn't left pinned in the UI until a manual reload. */
-  transient?: boolean;
 }
 
 export type RunState =
@@ -330,12 +301,10 @@ function studioHeaders(): Record<string, string> {
 // The studio panel runs marks/enrichments through the shared runProducer
 // (POST /api/run + poll run-status + banner), adding the studio secret header
 // (for the privileged bypass_cache knob) and a 3-min poll budget.
-// NB: this panel declares its own stricter RunResult (above) than the shared
-// RunResult runProducer returns; the cast preserves the implicit cast the old
-// JSON-shaped postAndAwait did. Unifying the two RunResult types is a separate
-// cleanup.
-const runStudio = async (body: Record<string, unknown>): Promise<RunResult> =>
-  (await runProducer(body, { headers: studioHeaders(), pollTimeoutMs: 180_000 })) as RunResult;
+// The studio panel runs through the shared runProducer, adding the studio secret
+// header (for the privileged bypass_cache knob) and a 3-min poll budget.
+const runStudio = (body: Record<string, unknown>): Promise<RunResult> =>
+  runProducer(body, { headers: studioHeaders(), pollTimeoutMs: 180_000 });
 
 // Output language threads into every run. The worker namespaces the :he cache
 // + selects the *_he prompt variant; the lang also tags the activityId so the

--- a/packages/talmud/src/client/QAPanel.tsx
+++ b/packages/talmud/src/client/QAPanel.tsx
@@ -29,7 +29,7 @@
 
 import { createEffect, createResource, createSignal, For, type JSX, onMount, Show } from 'solid-js';
 import { trackAI } from './aiActivity';
-import { isPausedError, isServiceUnavailableError } from './enrichmentQueue';
+import { isPausedError, isServiceUnavailableError, type RunResult } from './enrichmentQueue';
 import { Hebraized } from './Hebraized';
 import { hebraize } from './hebraize';
 import { lang, t } from './i18n';
@@ -73,17 +73,13 @@ interface QAAnswer {
   confidence: 'high' | 'medium' | 'low';
 }
 
-interface RunResultLike {
-  parsed: unknown;
-  content: string;
-}
 async function runEnrichmentDirect(
   enrichmentId: string,
   tractate: string,
   page: string,
   markInput: unknown,
   userQuestion?: string,
-): Promise<RunResultLike> {
+): Promise<RunResult> {
   const body: Record<string, unknown> = {
     enrichment_id: enrichmentId,
     tractate,

--- a/packages/talmud/src/client/enrichmentQueue.ts
+++ b/packages/talmud/src/client/enrichmentQueue.ts
@@ -14,6 +14,8 @@ import { queueActivity } from './aiActivity';
 
 export interface RunResult {
   content: string;
+  /** The model's chain-of-thought, when the producer ran a thinking model. */
+  reasoning?: string;
   parsed: unknown;
   parse_error: string | null;
   model: string;
@@ -48,6 +50,12 @@ export interface RunResult {
    *  cache write — who decided (human/rule/ai), producer + recipe hash, input
    *  refs, cost. Absent on entries written before the stamp existed. */
   provenance?: Provenance;
+  /** "Serve-but-don't-write" — the worker assembled this while a dependency
+   *  wasn't ready yet (e.g. a computed mark read its source mark caches before
+   *  they warmed) and so did NOT pin it. The marks-registry run loop treats a
+   *  transient `ok` as not-yet-final and re-fires once the deps settle, so the
+   *  empty model isn't left pinned until a manual reload. */
+  transient?: boolean;
 }
 
 /** True for an AbortError (DOMException or any error whose name is set). */

--- a/packages/talmud/tests/transient-refire.test.ts
+++ b/packages/talmud/tests/transient-refire.test.ts
@@ -8,8 +8,8 @@
 // decision behind that effect.
 
 import { describe, expect, it } from 'vitest';
+import type { RunResult } from '../src/client/enrichmentQueue';
 import {
-  type RunResult,
   type RunState,
   shouldRefireTransientMark,
   TRANSIENT_REFIRE_CAP,


### PR DESCRIPTION
**Step 2 of the cleanup.** The run/poll + AI-paused-banner *taxonomy* was already unified in #519; this finishes the **type** side and removes the cast I left there.

`RunResult` was defined three times in `packages/talmud/src/client`:
- the canonical one in `enrichmentQueue.ts`,
- a stricter local copy in `MarksRegistryPanel` (whose extra **required** fields — `transport`/`attempts`/`elapsed_ms`/`resolved` — are read **nowhere**), which forced the `as RunResult` cast in #519,
- QAPanel's narrow `RunResultLike`.

## Change
- `enrichmentQueue.RunResult` gains `reasoning?` + `transient?` (additive, optional).
- `MarksRegistryPanel` and `QAPanel` import the canonical type; their local `RunResult` / `RunResultLike` are deleted; the #519 `runStudio` cast is gone.

## Behaviour preserved
The dropped fields are unread; `model` (`string` vs the local `LLMModelId`) is read nowhere off a `RunResult`; `transient` stays a truthy optional flag; `resolved` was already guarded. typecheck + 2618 talmud tests green.

## Review
Reviewed with `codex exec --sandbox read-only`, which caught a real miss my checks didn't: `tests/transient-refire.test.ts` imported `type RunResult` from `MarksRegistryPanel` (whose export this removes). It slipped past typecheck (talmud's tsconfig only includes `src/**`) and tests (type-only import, elided at runtime). Fixed to import from `enrichmentQueue`.

Noted follow-up (not in this PR): tests aren't typechecked — repointing the test was the immediate fix, but adding `tests/**` to the typecheck would catch this class of dangling type import.