### PR TITLE
Cost-control: pause expensive producers on cold loads + track @cf Workers AI spend

### DIFF
--- a/packages/core/src/llm/ai-status.ts
+++ b/packages/core/src/llm/ai-status.ts
@@ -20,6 +20,7 @@ export type AiUnavailableReason =
   | 'credits' // OpenRouter prepaid balance exhausted (HTTP 402)
   | 'daily-cap' // our daily spend cap reached (BudgetPausedError scope 'all')
   | 'hourly-cap' // our hourly custom-question cap reached (scope 'custom')
+  | 'cost-control' // a specific expensive producer is paused by config (PAUSED_PRODUCERS) to cap spend
   | 'rate-limit' // provider 429 (not our cap) — transient overload
   | 'provider'; // provider 5xx / upstream outage — transient
 
@@ -81,6 +82,8 @@ export function aiUnavailableMessage(reason: AiUnavailableReason): string {
       return "AI features are paused — today's AI budget has been reached. They'll be back tomorrow.";
     case 'hourly-cap':
       return "AI features are paused — this hour's AI budget has been reached. Try again shortly.";
+    case 'cost-control':
+      return 'This AI study note is paused to control costs right now.';
     case 'rate-limit':
       return 'AI features are busy right now. Please try again in a moment.';
     case 'provider':

--- a/packages/core/src/llm/settings.ts
+++ b/packages/core/src/llm/settings.ts
@@ -37,20 +37,27 @@ export interface ModelPreset {
 }
 
 export const MODEL_PRESETS: ModelPreset[] = [
-  // Workers AI (@cf/*) bills in neurons, not per-token list prices — left
-  // unpriced; lean on the AI Gateway analytics figure for these.
+  // Workers AI (@cf/*) bills in neurons; the values below are Cloudflare's
+  // published per-1M-token list rates for each model, recorded so @cf spend is
+  // NOT invisible: pricing.ts reads them, so these calls show up on /usage and
+  // count against the budget guard (instead of recording as $0). The AI Gateway
+  // analytics figure stays authoritative; this is the self-tracked estimate.
   {
     id: '@cf/moonshotai/kimi-k2.5',
     vendor: 'Cloudflare/Moonshot',
     label: 'Kimi K2.5 (Workers AI)',
     notes:
-      'Free (neuron-billed) but dropped from prod over Workers AI concurrency limits — selectable, not the default/fallback',
+      '$0.60/$3.00 per 1M (neuron-billed). Dropped from prod over Workers AI concurrency limits — selectable, not the default/fallback',
+    inputPer1M: 0.6,
+    outputPer1M: 3.0,
   },
   {
     id: '@cf/google/gemma-4-26b-a4b-it',
     vendor: 'Cloudflare/Google',
     label: 'Gemma 4 26B (Workers AI)',
-    notes: 'Fast, no thinking; used for translate + era',
+    notes: '$0.10/$0.30 per 1M (neuron-billed). Fast, no thinking; used for translate + era',
+    inputPer1M: 0.1,
+    outputPer1M: 0.3,
   },
   {
     id: 'openrouter/deepseek/deepseek-v4-flash',

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -3,7 +3,7 @@ import { slugTractate } from '@corpus/core/cache/keys';
 import { continuationLink, type FlowEdge } from '@corpus/core/context/link';
 import { coordLabel } from '@corpus/core/context/types';
 import { gatewayActive, gatewayStatus, wrapEnv } from '@corpus/core/llm/ai-gateway';
-import { classifyAiUnavailable } from '@corpus/core/llm/ai-status';
+import { aiUnavailableMessage, classifyAiUnavailable } from '@corpus/core/llm/ai-status';
 import {
   type BudgetScope,
   budgetStatus,
@@ -5368,6 +5368,38 @@ export function isExperimentalLlmWarm(job: { mark_id?: string; enrichment_id?: s
 }
 
 /**
+ * Cost-control pause: a configurable set of expensive producers (the
+ * `PAUSED_PRODUCERS` env var — comma/space-separated mark/enrichment ids) is
+ * held back from generating on cold, non-explicit reader loads to cap spend
+ * while the project is self-funded. Cached results still serve; a trusted
+ * explicit warm (bypass_cache / studio) still runs. Fully reversible: clear the
+ * env var to resume full generation. Kept in sync across wrangler.toml (reader)
+ * and wrangler.generator.toml (queue consumer).
+ */
+export function parsePausedProducers(env: { PAUSED_PRODUCERS?: string }): Set<string> {
+  const raw = env.PAUSED_PRODUCERS;
+  if (!raw) return new Set();
+  return new Set(
+    raw
+      .split(/[\s,]+/)
+      .map((s) => s.trim())
+      .filter(Boolean),
+  );
+}
+
+/** The paused producer id for a job (enrichment id takes precedence over mark
+ *  id), or null when nothing about the job is paused / nothing is configured. */
+export function costPausedProducerId(
+  env: { PAUSED_PRODUCERS?: string },
+  job: { mark_id?: string; enrichment_id?: string },
+): string | null {
+  const paused = parsePausedProducers(env);
+  if (paused.size === 0) return null;
+  const id = job.enrichment_id ?? job.mark_id;
+  return id && paused.has(id) ? id : null;
+}
+
+/**
  * POST /api/run — async producer.
  *
  * 1. Validate body.
@@ -5465,6 +5497,12 @@ app.post('/api/run', async (c) => {
   const rawWarmExperimental = (raw as { warm_experimental?: unknown }).warm_experimental === true;
   const explicitWarm = job.bypass_cache || (trusted && rawWarmExperimental);
   const skipExperimentalWarm = !explicitWarm && isExperimentalLlmWarm(job);
+  // Cost-control pause (PAUSED_PRODUCERS): like the experimental gate, but
+  // config-driven and reader-facing. On a cold, non-explicit load of a paused
+  // producer we serve any cached/stale value (the hot + SWR paths above/below)
+  // but never START a paid run — and surface the shared AI-paused banner
+  // (reason 'cost-control'). A trusted explicit warm still runs.
+  const costPaused = !explicitWarm ? costPausedProducerId(c.env, job) : null;
 
   // Stale-while-revalidate: on a version-bump miss, serve the PREVIOUS version's
   // cached value (tagged refreshing) while the new one recomputes in the
@@ -5505,7 +5543,11 @@ app.post('/api/run', async (c) => {
         // budget-paused stays stale until budget frees).
         const customRun = !!(job.enrichment_id.endsWith('.qa') && job.user_question);
         let refreshing = false;
-        if (!skipExperimentalWarm && (await checkBudget(c.env, { custom: customRun })).ok) {
+        if (
+          !skipExperimentalWarm &&
+          !costPaused &&
+          (await checkBudget(c.env, { custom: customRun })).ok
+        ) {
           job.runId = await makeRunId(job);
           await c.env.ENRICHMENT_QUEUE.send(job);
           refreshing = true;
@@ -5524,6 +5566,25 @@ app.post('/api/run', async (c) => {
   // "not generated" rather than polling a run that will never start.
   if (skipExperimentalWarm) {
     return c.json({ status: 'skipped', reason: 'experimental', experimental: true, warmed: false });
+  }
+
+  // Cold miss on a cost-paused producer: refuse the paid run and return the
+  // shared AI-paused envelope so the reader's banner explains why (reason
+  // 'cost-control'). `paused: true` routes it through the client's existing
+  // budget-pause handling (the card shows the paused state); cached hits above
+  // already served, and a trusted explicit warm bypassed this. Reversible via
+  // the PAUSED_PRODUCERS env var.
+  if (costPaused) {
+    return c.json(
+      {
+        status: 'error',
+        error: aiUnavailableMessage('cost-control'),
+        paused: true,
+        aiUnavailable: true as const,
+        reason: 'cost-control' as const,
+      },
+      503,
+    );
   }
 
   if (!c.env.ENRICHMENT_QUEUE) {
@@ -11404,6 +11465,17 @@ async function processEnrichmentJob(
       });
       console.log(
         `[queue] deep-warm ${job.tractate}/${job.page} lang=${rc.lang} marks=${stats.marks} enqueued=${stats.enqueued} skipped=${stats.skipped} bridges=${stats.bridges} cross=${stats.cross}`,
+      );
+      return;
+    }
+    // Cost-control backstop: never spend on a paused producer from a background
+    // enqueue (the adjacent-daf idle prefetch, deep-warm sub-jobs). The reader's
+    // on-demand path is already gated at /api/run (with the banner); these
+    // background jobs have no poller, so we just skip silently. A trusted
+    // bypass_cache warm still runs. Reversible via PAUSED_PRODUCERS.
+    if (!job.bypass_cache && costPausedProducerId(wrapped, job)) {
+      console.log(
+        `[queue] skip cost-paused ${job.enrichment_id ?? job.mark_id} ${job.tractate}/${job.page}`,
       );
       return;
     }

--- a/packages/talmud/src/worker/types.ts
+++ b/packages/talmud/src/worker/types.ts
@@ -90,6 +90,13 @@ export interface Bindings {
   // Spend-budget overrides (USD) read by ./budget. Default 300 / 10 when unset.
   DAILY_BUDGET_USD?: string;
   HOURLY_CUSTOM_BUDGET_USD?: string;
+  // Cost control: comma/space-separated producer ids (mark or enrichment) that
+  // are PAUSED on cold, non-explicit reader loads to cap spend. A paused
+  // producer's /api/run returns the shared AI-paused envelope (reason
+  // 'cost-control') instead of starting a paid run, and the queue consumer skips
+  // background warms of it; cached results still serve and a trusted bypass warm
+  // still runs. Empty/unset => nothing paused (full generation). Reversible.
+  PAUSED_PRODUCERS?: string;
   // Which deployment this is: "generator" (talmud-gen — queue consumer +
   // DafWarmWorkflow host + heavy crons) or "reader"/unset (talmud — read-only,
   // runs only the health-watch cron). Read by scheduled() in index.ts to route

--- a/packages/talmud/tests/budget.test.ts
+++ b/packages/talmud/tests/budget.test.ts
@@ -63,9 +63,19 @@ describe('computeSpendUsd', () => {
       }),
     ).toBeCloseTo(0.42, 6);
   });
-  it('returns 0 for unpriced (@cf/*) models with no billed cost', () => {
+  it('estimates spend for a priced Workers AI (@cf) model — no longer invisible', () => {
+    // gemma-4 = $0.10 / $0.30 per 1M; 1M in + 1M out = 0.40. @cf spend now counts
+    // against the budget instead of recording as $0.
     expect(
       computeSpendUsd('@cf/google/gemma-4-26b-a4b-it', {
+        prompt_tokens: 1_000_000,
+        completion_tokens: 1_000_000,
+      }),
+    ).toBeCloseTo(0.4, 6);
+  });
+  it('returns 0 for a model with no list price and no billed cost', () => {
+    expect(
+      computeSpendUsd('@cf/meta/llama-3.1-8b-instruct-fp8', {
         prompt_tokens: 1000,
         completion_tokens: 1000,
       }),
@@ -169,16 +179,33 @@ describe('defensive re-derivation', () => {
 });
 
 describe('unpriced calls', () => {
-  it('do not move the counters', async () => {
+  it('do not move the counters (model with no list price)', async () => {
     const { kv, store } = makeFakeKV();
     const env: BudgetEnv = { CACHE: kv };
     await recordSpend(
       env,
-      { model: '@cf/google/gemma-4-26b-a4b-it', usage: { prompt_tokens: 9999 }, custom: true },
+      { model: '@cf/meta/llama-3.1-8b-instruct-fp8', usage: { prompt_tokens: 9999 }, custom: true },
       T,
     );
     expect(store.has(`budget:v1:total:${DAY}`)).toBe(false);
     expect(store.has(`budget:v1:custom:${HOUR}`)).toBe(false);
+  });
+});
+
+describe('priced Workers AI (@cf) calls', () => {
+  it('move the counters — @cf spend is tracked against the budget', async () => {
+    const { kv, store } = makeFakeKV();
+    const env: BudgetEnv = { CACHE: kv };
+    await recordSpend(
+      env,
+      {
+        model: '@cf/google/gemma-4-26b-a4b-it',
+        usage: { prompt_tokens: 1_000_000, completion_tokens: 1_000_000 },
+        custom: false,
+      },
+      T,
+    );
+    expect(store.has(`budget:v1:total:${DAY}`)).toBe(true);
   });
 });
 

--- a/packages/talmud/tests/cost-attribution.test.ts
+++ b/packages/talmud/tests/cost-attribution.test.ts
@@ -24,9 +24,23 @@ describe('costSplitUsd', () => {
     expect((costInUsd ?? 0) + (costOutUsd ?? 0)).toBeCloseTo(total as number, 9);
   });
 
-  it('returns null for both sides on an unpriced model (Workers AI)', () => {
+  it('splits a priced Workers AI (@cf) model — @cf spend is no longer invisible', () => {
+    // kimi-k2.5 = $0.60 / $3.00 per 1M; recorded in MODEL_PRESETS so /usage + the
+    // budget guard see Workers AI spend instead of $0.
+    const { costInUsd, costOutUsd } = costSplitUsd('@cf/moonshotai/kimi-k2.5', {
+      prompt_tokens: 1000,
+      completion_tokens: 1000,
+    });
+    expect(costInUsd).toBeCloseTo(0.0006, 9);
+    expect(costOutUsd).toBeCloseTo(0.003, 9);
+  });
+
+  it('returns null for both sides on a model with no list price', () => {
     expect(
-      costSplitUsd('@cf/moonshotai/kimi-k2.5', { prompt_tokens: 1000, completion_tokens: 1000 }),
+      costSplitUsd('@cf/meta/llama-3.1-8b-instruct-fp8', {
+        prompt_tokens: 1000,
+        completion_tokens: 1000,
+      }),
     ).toEqual({ costInUsd: null, costOutUsd: null });
   });
 

--- a/packages/talmud/tests/paused-producers.test.ts
+++ b/packages/talmud/tests/paused-producers.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { costPausedProducerId, parsePausedProducers } from '../src/worker/index';
+
+// Cost control: the PAUSED_PRODUCERS env var holds back a configured set of
+// expensive producers on cold reader loads (the /api/run gate returns the shared
+// AI-paused banner envelope; the queue consumer skips background warms). This
+// pins the parsing + match semantics so the gate can't silently drift.
+describe('PAUSED_PRODUCERS — cost-control producer pause', () => {
+  const env = {
+    PAUSED_PRODUCERS: 'tidbit.essay, daf-background.concepts ,rishonim.synthesis',
+  };
+
+  it('parses a comma/space-separated list, trimming blanks', () => {
+    expect(parsePausedProducers(env)).toEqual(
+      new Set(['tidbit.essay', 'daf-background.concepts', 'rishonim.synthesis']),
+    );
+  });
+
+  it('matches a paused enrichment id', () => {
+    expect(costPausedProducerId(env, { enrichment_id: 'tidbit.essay' })).toBe('tidbit.essay');
+    expect(costPausedProducerId(env, { enrichment_id: 'daf-background.concepts' })).toBe(
+      'daf-background.concepts',
+    );
+  });
+
+  it('prefers enrichment_id over mark_id', () => {
+    expect(
+      costPausedProducerId(env, { mark_id: 'rabbi', enrichment_id: 'rishonim.synthesis' }),
+    ).toBe('rishonim.synthesis');
+  });
+
+  it('returns null for a producer not in the list', () => {
+    expect(costPausedProducerId(env, { enrichment_id: 'argument.synthesis' })).toBeNull();
+    expect(costPausedProducerId(env, { mark_id: 'rabbi' })).toBeNull();
+  });
+
+  it('returns null / empty when nothing is configured (default = full generation)', () => {
+    expect(parsePausedProducers({}).size).toBe(0);
+    expect(parsePausedProducers({ PAUSED_PRODUCERS: '' }).size).toBe(0);
+    expect(costPausedProducerId({}, { enrichment_id: 'tidbit.essay' })).toBeNull();
+  });
+});

--- a/packages/talmud/wrangler.generator.toml
+++ b/packages/talmud/wrangler.generator.toml
@@ -52,6 +52,10 @@ SPINE_VIEW_WARM_SHAS = "1"
 # Spend budget — enforced at the runLLM chokepoint, which now lives here.
 DAILY_BUDGET_USD = "300"
 HOURLY_CUSTOM_BUDGET_USD = "10"
+# Cost control — the queue consumer (hosted here) skips background warms of these
+# paused producers. KEEP IN SYNC with wrangler.toml (the reader gates /api/run +
+# shows the banner from the same list). Set to "" to resume full generation.
+PAUSED_PRODUCERS = "tidbit.essay,daf-background.concepts,rishonim.synthesis,argument-move.suggested-questions,pesukim.suggested-questions,aggadata.suggested-questions"
 # Role flag read by the shared scheduled() handler in index.ts: 'generator' runs
 # the heavy warm/yomi crons (here), 'reader' runs only the lightweight health
 # watch (in wrangler.toml). Keeps heavy warming off the reader's isolate pool.

--- a/packages/talmud/wrangler.toml
+++ b/packages/talmud/wrangler.toml
@@ -102,6 +102,15 @@ CF_ZONE_TAG = "4808b439c50e3a42494ae7e0b2fa1bec,af7b181368ea154cd40b55404b47d818
 # STUDIO_SECRET`); unset => everyone is treated as untrusted (fail-safe).
 DAILY_BUDGET_USD = "300"
 HOURLY_CUSTOM_BUDGET_USD = "10"
+# Cost control: producer ids (mark/enrichment, comma-separated) PAUSED while the
+# project is self-funded. On a cold/uncomputed page these do NOT start a paid run
+# — the reader sees the shared "AI paused — sponsor" banner (reason
+# 'cost-control') instead, and any already-cached result still serves. The queue
+# consumer also skips background warms of them, so the daily Daf Yomi warm runs
+# leaner (its core cards still generate; these paused extras don't). Fully
+# reversible: set to "" to resume full generation. KEEP IN SYNC with
+# wrangler.generator.toml (the queue consumer reads this there).
+PAUSED_PRODUCERS = "tidbit.essay,daf-background.concepts,rishonim.synthesis,argument-move.suggested-questions,pesukim.suggested-questions,aggadata.suggested-questions"
 # Role flag (see scheduled() in index.ts). 'reader' = run only the health watch
 # on the */5 cron; the talmud-gen worker sets 'generator' and runs heavy warming.
 WORKER_ROLE = "reader"

--- a/packages/ui/src/AiStatusBanner.tsx
+++ b/packages/ui/src/AiStatusBanner.tsx
@@ -36,6 +36,7 @@ const SPEND_REASONS: ReadonlySet<AiUnavailableReason> = new Set([
   'credits',
   'daily-cap',
   'hourly-cap',
+  'cost-control',
 ]);
 
 function headline(reason: AiUnavailableReason): string {
@@ -46,6 +47,8 @@ function headline(reason: AiUnavailableReason): string {
       return "AI features are paused for today — there's a daily spending cap that keeps this project sustainable.";
     case 'hourly-cap':
       return "AI features are paused briefly — there's an hourly spending limit to keep costs in check.";
+    case 'cost-control':
+      return 'Some AI study notes are paused on not-yet-computed pages to keep this project affordable.';
     case 'rate-limit':
       return 'AI features are busy right now — please try again in a moment.';
     case 'provider':

--- a/packages/ui/src/aiStatus.ts
+++ b/packages/ui/src/aiStatus.ts
@@ -18,6 +18,7 @@ export type AiUnavailableReason =
   | 'credits'
   | 'daily-cap'
   | 'hourly-cap'
+  | 'cost-control'
   | 'rate-limit'
   | 'provider';
 


### PR DESCRIPTION
## Why

The project's AI spend is concentrated in **on-demand generation on cold/unseen pages** (a reader — or the idle adjacent-daf prefetch — opens an uncomputed daf and the app generates everything live). There is no ongoing whole-Shas LLM warming; the only scheduled LLM warm is the daily Daf Yomi. So the lever is: stop generating the *expensive* extras on cold pages, show the reader why, and keep the daily working.

Separately, Workers AI (`@cf/*`) spend was recording as **$0** in our own ledger and was invisible to the `$300/day` budget guard (the presets carried no list price), even though the AI Gateway bills it.

Builds directly on **#517** (shared AI-paused banner + `{aiUnavailable, reason}` envelope + `aiStatus` signal + sponsorship framing) — this just adds one new reason and a producer-level pause gate.

## What

**1. `PAUSED_PRODUCERS` (env var) — pause expensive producers on cold loads.** Reversible, additive.
- A new `cost-control` reason in `@corpus/core` `ai-status` and `@corpus/ui` `AiStatusBanner` (shown with the sponsor ask, like the other spend reasons).
- `/api/run`: on a cold, non-explicit load of a paused producer, refuse to start the paid run and return the shared `{ aiUnavailable, reason: 'cost-control' }` envelope. The client's existing `runProducer`/`noteAiResponse` raises the banner; `paused: true` routes the card through the existing budget-pause handling. **Cached results still serve** (hot + SWR paths run first), and a **trusted bypass warm still runs**.
- Queue consumer backstop: skip background warms of paused producers (idle prefetch + deep-warm sub-jobs), so the daily Daf Yomi warm runs leaner too (core cards still generate; the paused extras don't).
- Default list (in `wrangler.toml` + `wrangler.generator.toml`, kept in sync): `tidbit.essay`, `daf-background.concepts`, `rishonim.synthesis`, `argument-move.suggested-questions`, `pesukim.suggested-questions`, `aggadata.suggested-questions`. Tune or clear the var to adjust / fully resume — no code change, no data loss (nothing cached is touched).

**2. Track `@cf` Workers AI spend.** Record Cloudflare's published list rates on the `@cf` presets (`kimi-k2.5` $0.60/$3.00, `gemma-4` $0.10/$0.30) so `pricing.ts` returns real dollars — Workers AI spend now shows on `/usage` and counts against the daily budget guard instead of $0.

## Verification
- `pnpm typecheck` — clean (4/4)
- `pnpm test` — green (talmud 2626, tanach 64, core). New `paused-producers.test.ts` pins the parse/match; `budget` + `cost-attribution` tests updated to the now-priced `@cf` behavior (a model with no list price still returns null/0).
- `pnpm lint` (Biome) — clean.

## Reversibility
Set `PAUSED_PRODUCERS = ""` in both wrangler configs and redeploy to resume full generation. The pricing change is data-only.

## Notes
- Default behavior with an empty `PAUSED_PRODUCERS` is unchanged (full generation).
- Does **not** add thinking-model / Workers-AI-fallback support (kimi-class reasoning models are a separate follow-up); this is the cost-stop + tracking only.