### PR TITLE
Fix reader OOMs from /usage: reader never runs the cache-stats scan; generator cron owns refresh

### DIFF
--- a/packages/talmud/src/worker/cache-stats.ts
+++ b/packages/talmud/src/worker/cache-stats.ts
@@ -14,9 +14,11 @@
  *      raw count only.
  *
  * Reads are expensive (each prefix is paginated via kv.list at 1000 keys
- * per page), so callers should memoize the result. We stash the latest
- * result under CACHE_STATS_KEY and the /api/admin/cache-stats endpoint
- * short-circuits on `generatedAt < 60s ago`.
+ * per page) and the value samples hold real cached entries in memory, so
+ * computeCacheStats runs ONLY from the generator's warm cron (warm-cron
+ * refreshStats), which stashes the result under CACHE_STATS_KEY. The reader's
+ * /api/admin/cache-stats serves that copy verbatim and never recomputes —
+ * the scan has OOM'd reader isolates (128 MB).
  */
 
 import { BAVEL_SHAPE, GEO_CITIES, ISRAEL_SHAPE } from '../client/geoShapes';
@@ -42,7 +44,6 @@ import { getWarmTotal } from './warm-cron';
 // sub-source + each DafYomi content type), tagged with its origin (HB/Sefaria/
 // DY). The old 4-bucket `source` is kept for back-compat.
 export const CACHE_STATS_KEY = 'cache-stats:v8';
-const FRESH_MS = 60_000;
 
 export type SourceOrigin = 'HB' | 'Sefaria' | 'DY' | 'Wikipedia' | 'Custom';
 /** One named content piece in Content-In: where it comes from, how many dapim
@@ -280,6 +281,23 @@ const DAFYOMI_TYPES = [
   'revach',
 ] as const;
 
+// Read KV values in small sequential batches, streaming each raw value to
+// `onValue` and dropping it immediately. One Promise.all over hundreds of keys
+// holds every value in memory at once — with large values (hb HTML pages,
+// commentary bundles) that peak has OOM'd 128 MB isolates.
+const VALUE_READ_BATCH = 25;
+
+async function readValuesBatched(
+  cache: KVNamespace,
+  keys: string[],
+  onValue: (raw: string) => void,
+): Promise<void> {
+  for (let i = 0; i < keys.length; i += VALUE_READ_BATCH) {
+    const raws = await Promise.all(keys.slice(i, i + VALUE_READ_BATCH).map((k) => cache.get(k)));
+    for (const raw of raws) if (raw != null) onValue(raw);
+  }
+}
+
 /**
  * Sample DafYomi entries once and tally, per content type, how many of the
  * sampled dapim carry it (in either amud, with a non-empty block). Also reports
@@ -306,20 +324,18 @@ async function sampleDafyomiTypes(
     if (res.list_complete || !res.cursor) break;
     cursor = res.cursor;
   }
-  const raws = await Promise.all(keys.map((k) => cache.get(k)));
   const byType: Record<string, number> = {};
   let sampled = 0;
   let alignedAny = 0;
-  for (const raw of raws) {
-    if (raw == null) continue;
+  await readValuesBatched(cache, keys, (raw) => {
     sampled++;
     let v: unknown;
     try {
       v = JSON.parse(raw);
     } catch {
-      continue;
+      return;
     }
-    if (failed(v)) continue;
+    if (failed(v)) return;
     const d = v as { amudim?: { a?: Record<string, unknown>; b?: Record<string, unknown> } };
     const present = new Set<string>();
     for (const amud of [d.amudim?.a, d.amudim?.b]) {
@@ -331,7 +347,7 @@ async function sampleDafyomiTypes(
     }
     if (present.size > 0) alignedAny++;
     for (const t of present) byType[t] = (byType[t] ?? 0) + 1;
-  }
+  });
   return { sampled, alignedAny, byType };
 }
 
@@ -364,20 +380,18 @@ export async function sampleAligned(
     cursor = res.cursor;
   }
   if (keys.length === 0) return null;
-  const raws = await Promise.all(keys.map((k) => cache.get(k)));
   let sampled = 0;
   let aligned = 0;
-  for (const raw of raws) {
-    if (raw == null) continue;
+  await readValuesBatched(cache, keys, (raw) => {
     sampled++;
     let v: unknown;
     try {
       v = JSON.parse(raw);
     } catch {
-      continue;
+      return;
     }
     if (isAligned(v)) aligned++;
-  }
+  });
   if (sampled === 0) return null;
   return { sampled, aligned, pct: Math.round((aligned / sampled) * 1000) / 10 };
 }
@@ -591,26 +605,15 @@ export async function computeCacheStats(cache: KVNamespace): Promise<CacheStats>
     dafyomiCount,
     obsSlices,
     obsRabbis,
-    hbAligned,
-    gemaraAligned,
-    commentariesAligned,
     rishonimCount,
     mishnaCount,
     yeruCount,
     halRefsCount,
     topicsCount,
-    rishonimAligned,
-    mishnaAligned,
-    yeruAligned,
-    halRefsAligned,
-    topicsAligned,
     parallelsCount,
     commWorksCount,
-    parallelsAligned,
-    commWorksAligned,
     pasukCount,
     rabbiEnrichedCount,
-    dyTypes,
   ] = await Promise.all([
     countPrefix(cache, 'hb:v2:'),
     countPrefix(cache, 'ctx:gemara:v1:'),
@@ -619,36 +622,47 @@ export async function computeCacheStats(cache: KVNamespace): Promise<CacheStats>
     // `rabbi-obs:v1:` matches slice keys only (dirty keys are `rabbi-obs-dirty:v1:`).
     countPrefix(cache, 'rabbi-obs:v1:'),
     countPrefix(cache, 'rabbi-obs-dirty:v1:'),
-    // Sampled "% aligned" per source — bounded value reads, not a full scan.
-    sampleAligned(cache, 'hb:v2:', alignedHebrewBooks),
-    sampleAligned(cache, 'ctx:gemara:v1:', alignedGemara),
-    sampleAligned(cache, 'ctx:commentaries:v1:', alignedCommentaries),
-    // Extra Sefaria sub-sources (raw array/map values — nonEmptyValue = the daf
-    // actually has a mishnah / yerushalmi parallel / rishonim / refs / topics).
+    // Extra Sefaria sub-sources.
     countPrefix(cache, 'rishonim:v4:'),
     countPrefix(cache, 'mishna-bundle:v1:'),
     countPrefix(cache, 'yerushalmi:v1:'),
     countPrefix(cache, 'halacha-refs:v3:'),
     countPrefix(cache, 'daf-topics:v1:'),
-    sampleAligned(cache, 'rishonim:v4:', nonEmptyValue),
-    sampleAligned(cache, 'mishna-bundle:v1:', nonEmptyValue),
-    sampleAligned(cache, 'yerushalmi:v1:', nonEmptyValue),
-    sampleAligned(cache, 'halacha-refs:v3:', nonEmptyValue),
-    sampleAligned(cache, 'daf-topics:v1:', nonEmptyValue),
     // Talmud↔Talmud parallels (Mesorat HaShas, Sefaria) + the broad commentary
     // -spine works list (Sefaria links-with-text). Both per-daf source fetches.
     countPrefix(cache, 'talmud-parallels:v1:'),
     countPrefix(cache, 'commentaries:v1:'),
-    sampleAligned(cache, 'talmud-parallels:v1:', nonEmptyValue),
-    sampleAligned(cache, 'commentaries:v1:', alignedCommentaryWorks),
     // Per-ENTITY source fetches (keyed per verse / per rabbi, not per daf) — no
     // /dapim denominator, so the dashboard shows their cached counts. (Rabbi
     // Wikipedia/Wikidata bios live in the bundled rabbi dataset — see the rabbi
     // coverage block — not a per-rabbi KV cache, so they aren't sources here.)
     countPrefix(cache, 'pasuk:v4:'), // Tanach verse text (Sefaria)
     countPrefix(cache, 'rabbi-enriched:v1:'), // rabbi topic links (Sefaria)
-    sampleDafyomiTypes(cache),
   ]);
+
+  // Sampled "% aligned" per source — bounded value reads, not a full scan.
+  // Run SEQUENTIALLY, unlike the metadata-only counts above: each sample reads
+  // hundreds of real cached values (hb HTML pages, commentary bundles), and
+  // running all of them in one Promise.all held ~3000 values simultaneously —
+  // the peak that OOM'd 128 MB isolates and left this scan failing for days.
+  // Sequential samples + sub-batched reads bound the peak to one small batch.
+  const hbAligned = await sampleAligned(cache, 'hb:v2:', alignedHebrewBooks);
+  const gemaraAligned = await sampleAligned(cache, 'ctx:gemara:v1:', alignedGemara);
+  const commentariesAligned = await sampleAligned(
+    cache,
+    'ctx:commentaries:v1:',
+    alignedCommentaries,
+  );
+  // Raw array/map values — nonEmptyValue = the daf actually has a mishnah /
+  // yerushalmi parallel / rishonim / refs / topics.
+  const rishonimAligned = await sampleAligned(cache, 'rishonim:v4:', nonEmptyValue);
+  const mishnaAligned = await sampleAligned(cache, 'mishna-bundle:v1:', nonEmptyValue);
+  const yeruAligned = await sampleAligned(cache, 'yerushalmi:v1:', nonEmptyValue);
+  const halRefsAligned = await sampleAligned(cache, 'halacha-refs:v3:', nonEmptyValue);
+  const topicsAligned = await sampleAligned(cache, 'daf-topics:v1:', nonEmptyValue);
+  const parallelsAligned = await sampleAligned(cache, 'talmud-parallels:v1:', nonEmptyValue);
+  const commWorksAligned = await sampleAligned(cache, 'commentaries:v1:', alignedCommentaryWorks);
+  const dyTypes = await sampleDafyomiTypes(cache);
   const dafyomiAligned: AlignedSample | null =
     dyTypes.sampled > 0
       ? {
@@ -943,12 +957,6 @@ export async function readCachedCacheStats(cache: KVNamespace): Promise<CacheSta
   } catch {
     return null;
   }
-}
-
-export function isFresh(stats: CacheStats): boolean {
-  const t = Date.parse(stats.generatedAt);
-  if (Number.isNaN(t)) return false;
-  return Date.now() - t < FRESH_MS;
 }
 
 export async function writeCachedCacheStats(cache: KVNamespace, stats: CacheStats): Promise<void> {

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -152,13 +152,7 @@ import {
   qualifierHash,
   recipeHash,
 } from './cache-keys';
-import {
-  cacheGcTargets,
-  computeCacheStats,
-  isFresh,
-  readCachedCacheStats,
-  writeCachedCacheStats,
-} from './cache-stats';
+import { cacheGcTargets, readCachedCacheStats } from './cache-stats';
 import { fetchZoneActivity } from './cf-zone-analytics';
 import { coalesce } from './coalesce';
 import {
@@ -6336,31 +6330,14 @@ app.post('/api/admin/strip-ttl', async (c) => {
 app.get('/api/admin/cache-stats', async (c) => {
   const cache = c.env.CACHE;
   if (!cache) return c.json({ error: 'no cache binding' }, 503);
+  // Serve the generator-maintained copy verbatim, stale or not. The READER
+  // never runs computeCacheStats: the scan holds thousands of KV values and
+  // has OOM'd reader isolates (128 MB) — the generator's warm cron owns
+  // refresh (warm-cron refreshStats), same split as the queue/workflow work.
+  // The copy is written without TTL, so once populated a miss can't recur.
   const cached = await readCachedCacheStats(cache);
-  // Stale-while-revalidate: computeCacheStats scans dozens of KV prefixes and
-  // can take several seconds, so never block a page load on it once we have
-  // ANY cached copy. Serve the cached value immediately; if it's past the 60s
-  // freshness window, recompute in the background so the next load is fresh.
-  // (A cron also refreshes this, so the background recompute is just a backstop
-  // for gaps between cron runs.) Only a true cold miss blocks on the scan.
-  if (cached) {
-    if (!isFresh(cached)) {
-      c.executionCtx.waitUntil(
-        (async () => {
-          try {
-            const fresh = await computeCacheStats(cache);
-            await writeCachedCacheStats(cache, fresh);
-          } catch (err) {
-            console.warn('[cache-stats] background refresh failed:', err);
-          }
-        })(),
-      );
-    }
-    return c.json(cached);
-  }
-  const stats = await computeCacheStats(cache);
-  await writeCachedCacheStats(cache, stats);
-  return c.json(stats);
+  if (cached) return c.json(cached);
+  return c.json({ error: 'cache stats not yet computed (generator cron populates them)' }, 503);
 });
 
 // GC orphaned cache entries (those left at a superseded cache_version after a
@@ -7277,17 +7254,20 @@ app.get('/api/usage/cost', (c) =>
 // (estimateShasCost over the cost rollup + cache coverage). Surfaced as a tiny
 // public summary so the AI-paused banner can ground its sponsorship ask in the
 // real remaining figure rather than a hand-typed number. SWR-cached 6h: the
-// estimate drifts slowly and computeCacheStats scans dozens of KV prefixes.
+// estimate drifts slowly (coverage comes from the cron-maintained stats copy).
 app.get('/api/shas-cost', (c) => {
   const cache = c.env.CACHE;
   if (!cache) return c.json({ error: 'no cache binding' }, 503);
   return serveUsageSection(c, cache, 'shas-cost:v1', 6 * 60 * 60 * 1000, async () => {
     const [cost, stats] = await Promise.all([
       buildCostSection(c, cache),
-      readCachedCacheStats(cache).then((s) => s ?? computeCacheStats(cache)),
+      // Cron-maintained copy only — never computeCacheStats on the reader
+      // (the scan has OOM'd reader isolates). Missing only on a fresh
+      // namespace; degrade the same way as "no cost data yet".
+      readCachedCacheStats(cache),
     ]);
     const self = cost.selfTracked;
-    if (!self || self.totals.costUsd <= 0) return { available: false as const };
+    if (!stats || !self || self.totals.costUsd <= 0) return { available: false as const };
     const est = estimateShasCost({
       amudim: stats.total,
       byMark: self.byMark,
@@ -7397,7 +7377,10 @@ app.get('/api/usage/daf/:tractate/:page', (c) => {
   const tractate = c.req.param('tractate');
   const page = c.req.param('page');
   return serveUsageSection(c, cache, `usage-daf:v1:${tractate}:${page}`, 60_000, async () => {
-    const stats = (await readCachedCacheStats(cache)) ?? (await computeCacheStats(cache));
+    // Cron-maintained copy only — never computeCacheStats on the reader (the
+    // scan has OOM'd reader isolates). Throwing keeps the miss uncached.
+    const stats = await readCachedCacheStats(cache);
+    if (!stats) throw new Error('cache stats not yet computed (generator cron populates them)');
     return dafCostReport(cache, stats.marks, tractate, page);
   });
 });

--- a/packages/talmud/src/worker/warm-cron.ts
+++ b/packages/talmud/src/worker/warm-cron.ts
@@ -337,6 +337,12 @@ export async function runWarmCron(env: WarmEnv): Promise<void> {
   // so the phase loops forever instead of latching done: any entry that
   // expires gets refilled on the next walk-through.
   await runSefariaPhase(env);
+  // This cron (on the generator) is the ONLY writer of the cache-stats copy:
+  // the reader serves it verbatim and never recomputes, because the scan has
+  // OOM'd reader isolates. Without this call nothing refreshes it post-HB —
+  // the copy once sat 8 days stale while the reader's old SWR backstop
+  // OOM-failed on every attempt.
+  await refreshStats(cache);
 }
 
 async function runHbPhase(env: WarmEnv, cursor: WarmCursor): Promise<void> {


### PR DESCRIPTION
## Why

The worker-health alerts (1 exceededMemory on `talmud`, 07-05 15:53 UTC) trace to the **/usage dashboard, not generation** — talmud-gen has had zero memory events since the #513 split. Observability shows all four memory-limit events this week on `GET /api/usage/backlog` (the fatal one) and `GET /api/admin/cache-stats`.

Mechanism: `/api/admin/cache-stats` kept a 60s SWR freshness window whose background `computeCacheStats` ran **on the reader isolate** via `waitUntil`. That scan reads ~10 value samples x 300 KV entries in one `Promise.all` — hb HTML pages, commentary bundles — holding ~3000 values in memory at once. It has OOM-failed on **every attempt since 06-29** (the live copy sat 8 days stale: `generatedAt: 2026-06-29T07:15Z`), and on 07-05 it took a co-tenant `/api/usage/backlog` request down with the isolate (adjacent ray IDs, same second — one /usage page load). Post-#513, nothing else refreshes the copy: `refreshStats` only ran in the long-completed HB warm phase.

## What

- **Reader never runs the scan.** `/api/admin/cache-stats` serves the cron-maintained copy verbatim (it is written without TTL, so once populated a miss can't recur; 503 only on a never-populated namespace). The `/api/shas-cost` and `/api/usage/daf/:t/:p` cold-miss fallbacks to `computeCacheStats` are removed too — they degrade the same way as "no data yet".
- **Generator owns refresh.** The warm cron calls `refreshStats` after `runSefariaPhase` — the steady-state warm tick (every ~15 min under the heavy-phase rotation) now keeps the copy fresh, instead of nothing.
- **The scan itself is memory-flat** so the generator's refresh actually succeeds: value samples run sequentially and read in 25-value batches (`readValuesBatched`), bounding peak memory to one small batch instead of nine 300-value samples in flight; metadata-only `countPrefix` calls stay parallel. Same output shape, same sample sizes.
- Drop the now-unused `isFresh`/`FRESH_MS`.

## Verification

- typecheck, 2630 unit tests, biome all green; codex read-only review found no defects.
- Client `sectionResource` already degrades on a non-OK cache-stats response (falls back to the stored snapshot).
- Post-deploy check: `/api/admin/cache-stats` `generatedAt` should move within ~15 min of the generator's next warm tick, and the exceededMemory alerts should stop.