### PR TITLE
Classify OpenRouter 403 key-limit as an AI pause; surface pill failures in tanach

### DIFF
--- a/packages/core/src/llm/ai-status.ts
+++ b/packages/core/src/llm/ai-status.ts
@@ -18,6 +18,7 @@ import { LLMError } from './llm-error';
 
 export type AiUnavailableReason =
   | 'credits' // OpenRouter prepaid balance exhausted (HTTP 402)
+  | 'key-limit' // the API key's own periodic spending cap tripped (OpenRouter 403 "Key limit exceeded")
   | 'daily-cap' // our daily spend cap reached (BudgetPausedError scope 'all')
   | 'hourly-cap' // our hourly custom-question cap reached (scope 'custom')
   | 'cost-control' // a specific expensive producer is paused by config (PAUSED_PRODUCERS) to cap spend
@@ -38,6 +39,13 @@ export interface AiUnavailable {
 const CREDITS_RE =
   /insufficient credits|out of credits|requires more credits|add more (credits|using)/i;
 
+// OpenRouter returns 403 with "Key limit exceeded (weekly limit)" when the API
+// key's own spending cap trips — credits exist, but the key refuses to spend
+// them. A bare 403 (a genuine auth/permission error) must NOT match, so the
+// message is the signal, same fallback rationale as CREDITS_RE. This bit prod
+// for days as unexplained "random" load failures before it was classified.
+const KEY_LIMIT_RE = /key limit exceeded/i;
+
 /**
  * Map an error to an AI-unavailable reason, or `null` when it is an ordinary
  * failure (a real bug, a 4xx that isn't payment, a malformed request) that
@@ -53,14 +61,16 @@ export function classifyAiUnavailable(err: unknown): AiUnavailable | null {
   }
   if (err instanceof LLMError) {
     if (err.status === 402 || CREDITS_RE.test(err.message)) return { reason: 'credits' };
+    if (KEY_LIMIT_RE.test(err.message)) return { reason: 'key-limit' };
     if (err.status === 429) return { reason: 'rate-limit' };
     if (err.status >= 500) return { reason: 'provider' };
     return null; // other 4xx: client/config error, not a spend pause
   }
   // Foreign throwable (raw fetch / provider body re-thrown without a status):
-  // last-resort sniff for the out-of-credits signal only.
+  // last-resort sniff for the spend-pause signals only.
   const msg = err instanceof Error ? err.message : typeof err === 'string' ? err : '';
   if (CREDITS_RE.test(msg)) return { reason: 'credits' };
+  if (KEY_LIMIT_RE.test(msg)) return { reason: 'key-limit' };
   return null;
 }
 
@@ -78,6 +88,8 @@ export function aiUnavailableMessage(reason: AiUnavailableReason): string {
   switch (reason) {
     case 'credits':
       return 'AI features are paused — the project is out of AI credits right now.';
+    case 'key-limit':
+      return "AI features are paused — this period's AI spending limit has been reached. They'll be back when the budget resets.";
     case 'daily-cap':
       return "AI features are paused — today's AI budget has been reached. They'll be back tomorrow.";
     case 'hourly-cap':

--- a/packages/core/tests/ai-status.test.ts
+++ b/packages/core/tests/ai-status.test.ts
@@ -23,6 +23,27 @@ describe('classifyAiUnavailable', () => {
     expect(classifyAiUnavailable(err)).toEqual({ reason: 'credits' });
   });
 
+  it('maps OpenRouter 403 "Key limit exceeded" to key-limit', () => {
+    // The exact shape prod emitted when the key's weekly cap tripped (2026-07).
+    const err = new LLMError(
+      403,
+      'OpenRouter HTTP 403: {"error":{"message":"Key limit exceeded (weekly limit). Manage it using https://openrouter.ai/...","code":403}}',
+    );
+    expect(classifyAiUnavailable(err)).toEqual({ reason: 'key-limit' });
+  });
+
+  it('maps a re-wrapped key-limit message without a status to key-limit', () => {
+    // tanach's producer path wraps the LLMError, losing the type + status.
+    const err = new Error(
+      'Producer failed: OpenRouter HTTP 403: Key limit exceeded (weekly limit).',
+    );
+    expect(classifyAiUnavailable(err)).toEqual({ reason: 'key-limit' });
+  });
+
+  it('does NOT treat a bare 403 (real auth error) as a spend pause', () => {
+    expect(classifyAiUnavailable(new LLMError(403, 'OpenRouter HTTP 403: forbidden'))).toBeNull();
+  });
+
   it('maps the daily budget pause to daily-cap and carries the lift time', () => {
     const err = new BudgetPausedError('all', 1_700_000_000_000, 'daily spend over trip');
     expect(classifyAiUnavailable(err)).toEqual({
@@ -58,6 +79,7 @@ describe('classifyAiUnavailable', () => {
   it('has a message for every reason', () => {
     const reasons: AiUnavailableReason[] = [
       'credits',
+      'key-limit',
       'daily-cap',
       'hourly-cap',
       'rate-limit',

--- a/packages/tanach/src/client/App.tsx
+++ b/packages/tanach/src/client/App.tsx
@@ -636,27 +636,38 @@ export function App(): JSX.Element {
     setPerekPill(null);
     setInspectOpen((v) => !v);
   };
+  // Pill fetches share the translate popup's error discipline: a failure body
+  // may be the worker's { aiUnavailable, reason } envelope (spend pause, key
+  // limit, provider outage) — feed it to the shared banner so the reader learns
+  // WHY instead of a bare "couldn't load"; a success re-arms/clears the banner.
+  const fetchPill = async <T,>(url: string): Promise<T | null> => {
+    const res = await fetch(url);
+    if (res.ok) {
+      noteAiSuccess();
+      return (await res.json()) as T;
+    }
+    noteAiResponse(await res.json().catch(() => null));
+    return null;
+  };
   const [overview] = createResource(
     () => (perekPill() === 'overview' ? chapterKey() : undefined),
-    async (k) => {
-      const res = await fetch(`/api/overview/${encodeURIComponent(k.book)}/${k.chapter}`);
-      return res.ok ? ((await res.json()) as Overview) : null;
-    },
+    (k) => fetchPill<Overview>(`/api/overview/${encodeURIComponent(k.book)}/${k.chapter}`),
   );
   const [geography] = createResource(
     () => (perekPill() === 'geography' ? chapterKey() : undefined),
-    async (k) => {
-      const res = await fetch(`/api/geography/${encodeURIComponent(k.book)}/${k.chapter}`);
-      return res.ok ? ((await res.json()) as PerekGeography) : null;
-    },
+    (k) => fetchPill<PerekGeography>(`/api/geography/${encodeURIComponent(k.book)}/${k.chapter}`),
   );
   const [tidbit] = createResource(
     () => (perekPill() === 'tidbit' ? chapterKey() : undefined),
-    async (k) => {
-      const res = await fetch(`/api/tidbit/${encodeURIComponent(k.book)}/${k.chapter}`);
-      return res.ok ? ((await res.json()) as PerekTidbit) : null;
-    },
+    (k) => fetchPill<PerekTidbit>(`/api/tidbit/${encodeURIComponent(k.book)}/${k.chapter}`),
   );
+  // Drawer copy for a failed pill fetch. "Try reopening" is only honest advice
+  // for a transient blip — while AI is paused (banner up), reopening cannot
+  // help, so say what's actually happening instead.
+  const pillError = (what: string) =>
+    aiStatus()
+      ? `AI generation is paused right now, so the ${what} for this chapter isn't available yet. Chapters that were already generated still work.`
+      : `Couldn't load the ${what} — try reopening.`;
   // Only the tidbit for the chapter on screen (createResource retains the prior
   // value across a refetch — same guard as overview/geography).
   const currentTidbit = createMemo(() => {
@@ -1043,7 +1054,7 @@ export function App(): JSX.Element {
               </Show>
               {/* fetched but failed (overview() is null, not undefined) */}
               <Show when={!overview.loading && overview() === null}>
-                <p class="comm-muted">Couldn't load the overview — try reopening.</p>
+                <p class="comm-muted">{pillError('overview')}</p>
               </Show>
             </Show>
             <Show when={pill === 'geography'}>
@@ -1080,7 +1091,7 @@ export function App(): JSX.Element {
                 )}
               </Show>
               <Show when={!geography.loading && geography() === null}>
-                <p class="comm-muted">Couldn't load the geography — try reopening.</p>
+                <p class="comm-muted">{pillError('geography')}</p>
               </Show>
             </Show>
             <Show when={pill === 'tidbit'}>
@@ -1114,7 +1125,7 @@ export function App(): JSX.Element {
                 )}
               </Show>
               <Show when={!tidbit.loading && tidbit() === null}>
-                <p class="comm-muted">Couldn't load the tidbit — try reopening.</p>
+                <p class="comm-muted">{pillError('tidbit')}</p>
               </Show>
             </Show>
           </Drawer>

--- a/packages/ui/src/AiStatusBanner.tsx
+++ b/packages/ui/src/AiStatusBanner.tsx
@@ -34,6 +34,7 @@ export interface AiStatusBannerProps {
 /** Reasons where a spending-related sponsor ask is appropriate. */
 const SPEND_REASONS: ReadonlySet<AiUnavailableReason> = new Set([
   'credits',
+  'key-limit',
   'daily-cap',
   'hourly-cap',
   'cost-control',
@@ -43,6 +44,8 @@ function headline(reason: AiUnavailableReason): string {
   switch (reason) {
     case 'credits':
       return 'AI features are paused — the project is out of AI credits right now.';
+    case 'key-limit':
+      return "AI features are paused — this period's AI spending limit has been reached, to keep the project sustainable.";
     case 'daily-cap':
       return "AI features are paused for today — there's a daily spending cap that keeps this project sustainable.";
     case 'hourly-cap':
@@ -61,6 +64,7 @@ function headline(reason: AiUnavailableReason): string {
 function resumeHint(reason: AiUnavailableReason): string | null {
   if (reason === 'daily-cap') return "They'll be back tomorrow.";
   if (reason === 'hourly-cap') return 'Back within the hour.';
+  if (reason === 'key-limit') return "They'll be back when the budget resets.";
   return null;
 }
 

--- a/packages/ui/src/aiStatus.ts
+++ b/packages/ui/src/aiStatus.ts
@@ -16,6 +16,7 @@ import { createSignal } from 'solid-js';
 
 export type AiUnavailableReason =
   | 'credits'
+  | 'key-limit'
   | 'daily-cap'
   | 'hourly-cap'
   | 'cost-control'


### PR DESCRIPTION
## Why

The prod OpenRouter key hit its **weekly spending cap** and every cold generation failed with `OpenRouter HTTP 403: Key limit exceeded (weekly limit)`. `classifyAiUnavailable` only recognized 402 (credits), 429, and 5xx — a 403 key-limit fell through to "ordinary bug", so the shared AI-paused banner never rose. Readers experienced it as random breakage: talmud load bars stalled mid-daf ("Analyzing daf — 9 of 11 anchors") while doomed jobs churned the queue, and tanach pills showed "Couldn't load the geography — try reopening."

## What

- **core** (`ai-status.ts`): new `'key-limit'` reason. Classified by message (`/key limit exceeded/i`) rather than bare status — a genuine 403 auth error must NOT read as a spend pause — and also in the foreign-throwable fallback, since tanach's producer path re-wraps the LLMError and loses the status. Tests pin the exact prod error shape.
- **ui**: banner headline, resume hint, and sponsor-block eligibility for `'key-limit'`.
- **tanach**: the overview/geography/tidbit pill fetches adopt the translate popup's error discipline — feed the failure body to `noteAiResponse` (banner explains why) and `noteAiSuccess` on recovery; drawer copy says AI is paused instead of the misleading "try reopening" while the banner is up.

## Testing

`pnpm typecheck`, `pnpm test` (core 127 / talmud 2630 / tanach 64), `pnpm lint` all green. New unit tests cover the 403 key-limit (typed + re-wrapped) and the bare-403 non-match.