### PR TITLE
Circuit breaker: fail fast while the AI provider is down

### DIFF
--- a/packages/talmud/src/worker/ai-down.ts
+++ b/packages/talmud/src/worker/ai-down.ts
@@ -1,0 +1,110 @@
+/**
+ * Provider-down circuit breaker (the "ai-down" sentinel).
+ *
+ * When the LLM provider refuses to spend — out of credits, the API key's own
+ * spending cap tripped (the 2026-07 weekly key-limit incident), a rate-limit
+ * wave, an upstream outage — every enqueued job is doomed, but without a
+ * breaker the system keeps paying for the discovery: /api/run enqueues, the
+ * client polls for minutes, deep-warm fans out dozens of children, and the
+ * queue churns through failures (25-78s queue waits were observed while the
+ * reader's load bar sat stalled mid-daf).
+ *
+ * The queue consumer writes this short-TTL KV sentinel when a failure
+ * classifies as AI-unavailable; the enqueue paths read it and fail fast with
+ * the same `{ paused, aiUnavailable, reason }` envelope the budget gate uses,
+ * so the client shows the shared "AI paused" banner in one round-trip instead
+ * of a silently-stuck progress bar.
+ *
+ * TTL by severity: a hard spend pause (credits / key-limit) lifts on a human
+ * action or a budget reset, so 5 minutes of back-pressure is safe; a transient
+ * provider blip (429 / 5xx) gets only 60s so recovery is probed quickly.
+ * Trusted explicit runs (bypass_cache / studio re-runs) always go through —
+ * they are the recovery probe.
+ */
+
+import type { AiUnavailableReason } from '@corpus/core/llm/ai-status';
+
+const AI_DOWN_KEY = 'ai-down:v1';
+const HARD_TTL_S = 300;
+const SOFT_TTL_S = 60;
+
+export interface AiDownState {
+  reason: AiUnavailableReason;
+  /** Epoch ms of the failure that raised (or last would have refreshed) it. */
+  at: number;
+}
+
+/** Spend pauses that cannot self-heal within seconds: nothing succeeds until
+ *  credits are added / the key's cap lifts, so queued jobs may be failed
+ *  without trying. Budget caps (daily/hourly) never reach the sentinel — the
+ *  existing checkBudget gate owns those before anything is enqueued. */
+export function isHardAiPause(reason: AiUnavailableReason): boolean {
+  return reason === 'credits' || reason === 'key-limit';
+}
+
+/** Raise the sentinel after a classified AI-unavailable failure. At most one
+ *  write per TTL window — same-key KV writes are rate-limited (1/s), and a
+ *  failure storm would otherwise hammer this one key from every consumer —
+ *  EXCEPT to upgrade a soft blip to a hard spend pause (a rate-limit sentinel
+ *  must not mask a key-limit that surfaces seconds later: the hard reason
+ *  carries the longer TTL and the consumer short-circuit). */
+export async function noteAiDown(
+  cache: KVNamespace | undefined,
+  reason: AiUnavailableReason,
+): Promise<void> {
+  if (!cache) return;
+  try {
+    const existing = await readAiDown(cache);
+    const upgrade = existing && isHardAiPause(reason) && !isHardAiPause(existing.reason);
+    if (existing && !upgrade) return;
+    const state: AiDownState = { reason, at: Date.now() };
+    await cache.put(AI_DOWN_KEY, JSON.stringify(state), {
+      expirationTtl: isHardAiPause(reason) ? HARD_TTL_S : SOFT_TTL_S,
+    });
+  } catch {
+    /* best-effort — the breaker is an optimization, never a failure source */
+  }
+}
+
+/** LLM transports whose fresh success proves the provider recovered.
+ *  Deterministic producers ('computed'/'graph'/'lookup') never touch the
+ *  provider, so their successes say nothing about it. */
+const LLM_TRANSPORTS: ReadonlySet<string> = new Set(['openrouter-gateway', 'workers-ai']);
+export function transportProvesAiUp(transport: unknown): boolean {
+  return typeof transport === 'string' && LLM_TRANSPORTS.has(transport);
+}
+
+/** Lower the sentinel once a fresh LLM generation proves the provider
+ *  recovered — the TTL would clear it anyway; this shortens the tail so
+ *  readers aren't fail-fasted for minutes after a human fixes the key/credits.
+ *  `startedAtMs` is when the succeeding run began: only a sentinel raised
+ *  BEFORE that is disproven by the success. A sentinel raised mid-run (a
+ *  concurrent failure, possibly a soft→hard upgrade) is newer information and
+ *  is left standing — KV has no CAS, so this timestamp check is what keeps a
+ *  racing clear from wiping a just-raised hard pause. Read-first also keeps
+ *  the healthy path at one KV read, not a same-key delete per job. */
+export async function clearAiDown(
+  cache: KVNamespace | undefined,
+  startedAtMs: number,
+): Promise<void> {
+  if (!cache) return;
+  try {
+    const existing = await readAiDown(cache);
+    if (existing && existing.at <= startedAtMs) await cache.delete(AI_DOWN_KEY);
+  } catch {
+    /* best-effort */
+  }
+}
+
+/** Read the sentinel; expired/missing/corrupt all read as "not down". */
+export async function readAiDown(cache: KVNamespace | undefined): Promise<AiDownState | null> {
+  if (!cache) return null;
+  try {
+    const raw = await cache.get(AI_DOWN_KEY);
+    if (!raw) return null;
+    const v = JSON.parse(raw) as AiDownState | null;
+    return v && typeof v.reason === 'string' && typeof v.at === 'number' ? v : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -114,6 +114,7 @@ import {
   type YerushalmiFloorGroup,
 } from '../lib/yerushalmiAlign';
 import { type CuratedYerushalmiParallel, curatedParallelsForDaf } from '../lib/yerushalmiParallels';
+import { clearAiDown, isHardAiPause, noteAiDown, readAiDown, transportProvesAiUp } from './ai-down';
 import { fetchGatewayCost } from './aigw-analytics';
 import { runBacklogBackfill } from './backfill-backlog';
 import { gcStaleCache } from './cache-gc';
@@ -5489,6 +5490,9 @@ app.post('/api/run', async (c) => {
   // warm_experimental flag.
   const rawWarmExperimental = (raw as { warm_experimental?: unknown }).warm_experimental === true;
   const explicitWarm = job.bypass_cache || (trusted && rawWarmExperimental);
+  // Carry the exemption to the consumer: a trusted explicit run must survive
+  // the ai-down circuit breaker end-to-end (route gate AND consumer gate).
+  if (explicitWarm) job.explicit = true;
   const skipExperimentalWarm = !explicitWarm && isExperimentalLlmWarm(job);
   // Cost-control pause (PAUSED_PRODUCERS): like the experimental gate, but
   // config-driven and reader-facing. On a cold, non-explicit load of a paused
@@ -5539,6 +5543,7 @@ app.post('/api/run', async (c) => {
         if (
           !skipExperimentalWarm &&
           !costPaused &&
+          (explicitWarm || !(await readAiDown(c.env.CACHE))) &&
           (await checkBudget(c.env, { custom: customRun })).ok
         ) {
           job.runId = await makeRunId(job);
@@ -5578,6 +5583,28 @@ app.post('/api/run', async (c) => {
       },
       503,
     );
+  }
+
+  // Provider-down circuit breaker: while the sentinel is up (out of credits,
+  // key spending cap, provider outage — raised by the queue consumer's failure
+  // classification) a cold run cannot succeed, so answer with the explained
+  // paused envelope NOW instead of enqueueing a doomed job the client would
+  // poll for minutes. Cached/SWR content already served above; a trusted
+  // explicit warm still goes through (it is the recovery probe).
+  if (!explicitWarm) {
+    const down = await readAiDown(c.env.CACHE);
+    if (down) {
+      return c.json(
+        {
+          status: 'error',
+          error: aiUnavailableMessage(down.reason),
+          paused: true,
+          aiUnavailable: true as const,
+          reason: down.reason,
+        },
+        503,
+      );
+    }
   }
 
   if (!c.env.ENRICHMENT_QUEUE) {
@@ -11326,6 +11353,27 @@ async function processEnrichmentJob(
     cache.put(jobKey, JSON.stringify(payload), { expirationTtl: 3600 });
 
   try {
+    // Circuit breaker: under a HARD spend pause (credits / key limit) the LLM
+    // call cannot succeed until a human acts, so fail the job immediately with
+    // the explained envelope — pollers resolve in one tick instead of watching
+    // the queue churn. A deep-warm skips on ANY pause: it is a pure LLM fan-out
+    // of dozens of children, so even a 60s blip would flood the queue with
+    // failures. Ordinary jobs still try under a soft pause (they may land after
+    // the blip), and trusted explicit re-runs always try — they probe recovery.
+    if (!job.bypass_cache && !job.explicit) {
+      const down = await readAiDown(cache);
+      if (down && (isHardAiPause(down.reason) || job.warm_deep)) {
+        console.log(`[queue] skip (ai-down: ${down.reason})`, job.runId);
+        await writeResult({
+          status: 'error',
+          error: aiUnavailableMessage(down.reason),
+          paused: true,
+          aiUnavailable: true as const,
+          reason: down.reason,
+        });
+        return;
+      }
+    }
     if (job.warm_deep) {
       const only = job.rewarm_only?.length ? new Set(job.rewarm_only) : undefined;
       // Staleness-driven re-warm: evict the FULL cascade's entries (incl.
@@ -11363,6 +11411,10 @@ async function processEnrichmentJob(
         return;
       }
       const result = await runMarkOnce(rc, def, job.tractate, job.page, job.bypass_cache === true);
+      // A fresh LLM generation (not a cache hit, not a deterministic/computed
+      // producer) proves the provider recovered — lower the circuit breaker
+      // instead of waiting out its TTL.
+      if (!result.cache_hit && transportProvesAiUp(result.transport)) await clearAiDown(cache, t0);
       await writeResult({
         status: 'ok',
         result: { kind: 'mark', ...result, definition: def, total_ms: Date.now() - t0 },
@@ -11402,6 +11454,9 @@ async function processEnrichmentJob(
       undefined,
       job.user_question,
     );
+    // Same recovery signal as the mark branch: a fresh LLM generation lowers
+    // the circuit breaker.
+    if (!result.cache_hit && transportProvesAiUp(result.transport)) await clearAiDown(cache, t0);
     await writeResult({
       status: 'ok',
       result: { kind: 'enrichment', ...result, definition: def, total_ms: Date.now() - t0 },
@@ -11431,8 +11486,10 @@ async function processEnrichmentJob(
     const errorMsg = String((err as Error)?.message ?? err);
     // Out-of-credits / provider outage surfaces here (it throws past the budget
     // gate). Tag the polled job record so the client's shared banner can explain
-    // it instead of showing a bare failure.
+    // it instead of showing a bare failure — and raise the ai-down sentinel so
+    // the enqueue paths fail fast instead of feeding the queue more doomed work.
     const unavailable = classifyAiUnavailable(err);
+    if (unavailable) await noteAiDown(cache, unavailable.reason);
     console.error(
       '[queue] job failed',
       job.runId,

--- a/packages/talmud/src/worker/types.ts
+++ b/packages/talmud/src/worker/types.ts
@@ -19,6 +19,11 @@ export interface JobMessage {
   model_override?: string;
   mark_input?: unknown;
   bypass_cache?: boolean;
+  /** Trusted explicit run (bypass_cache or a studio warm_experimental): exempt
+   *  from the ai-down circuit breaker at the consumer, so a deliberate re-run
+   *  can probe recovery while the sentinel is still up. Set server-side only —
+   *  public callers can't reach the knobs that imply it. */
+  explicit?: boolean;
   /** Free-text input that becomes part of the enrichment's cache key (via
    *  qualifierHash) and is exposed to its prompt as {{user_question}}. Used
    *  by argument-move.qa today. Empty/undefined means a vanilla run. */

--- a/packages/talmud/tests/ai-down.test.ts
+++ b/packages/talmud/tests/ai-down.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import {
+  clearAiDown,
+  isHardAiPause,
+  noteAiDown,
+  readAiDown,
+  transportProvesAiUp,
+} from '../src/worker/ai-down';
+
+// Minimal in-memory KVNamespace covering the get/put surface the sentinel uses
+// (mirrors observed-place-filter.test.ts), capturing TTLs for assertion.
+function fakeKV() {
+  const store = new Map<string, string>();
+  const ttls = new Map<string, number | undefined>();
+  const kv = {
+    async get(key: string) {
+      return store.get(key) ?? null;
+    },
+    async put(key: string, value: string, opts?: { expirationTtl?: number }) {
+      store.set(key, value);
+      ttls.set(key, opts?.expirationTtl);
+    },
+    async delete(key: string) {
+      store.delete(key);
+    },
+  } as unknown as KVNamespace;
+  return { kv, store, ttls };
+}
+
+describe('ai-down sentinel', () => {
+  it('round-trips a raised sentinel', async () => {
+    const { kv } = fakeKV();
+    expect(await readAiDown(kv)).toBeNull();
+    await noteAiDown(kv, 'key-limit');
+    const down = await readAiDown(kv);
+    expect(down?.reason).toBe('key-limit');
+    expect(typeof down?.at).toBe('number');
+  });
+
+  it('uses the long TTL for hard spend pauses and the short one for blips', async () => {
+    const hard = fakeKV();
+    await noteAiDown(hard.kv, 'credits');
+    expect(hard.ttls.get('ai-down:v1')).toBe(300);
+
+    const soft = fakeKV();
+    await noteAiDown(soft.kv, 'provider');
+    expect(soft.ttls.get('ai-down:v1')).toBe(60);
+  });
+
+  it('writes at most once per TTL window (same-key KV writes are rate-limited)', async () => {
+    const { kv, store } = fakeKV();
+    await noteAiDown(kv, 'key-limit');
+    const first = store.get('ai-down:v1');
+    await noteAiDown(kv, 'provider'); // storm continues — must not overwrite
+    expect(store.get('ai-down:v1')).toBe(first);
+    await noteAiDown(kv, 'credits'); // hard-to-hard: also no rewrite
+    expect(store.get('ai-down:v1')).toBe(first);
+  });
+
+  it('upgrades a soft blip to a hard spend pause (but never downgrades)', async () => {
+    const { kv, ttls } = fakeKV();
+    await noteAiDown(kv, 'rate-limit');
+    expect(ttls.get('ai-down:v1')).toBe(60);
+    await noteAiDown(kv, 'key-limit'); // the hard failure must not be masked
+    expect((await readAiDown(kv))?.reason).toBe('key-limit');
+    expect(ttls.get('ai-down:v1')).toBe(300);
+  });
+
+  it('clears when the succeeding run started after the sentinel rose', async () => {
+    const { kv } = fakeKV();
+    await clearAiDown(kv, Date.now()); // nothing raised: no-op
+    await noteAiDown(kv, 'credits');
+    await clearAiDown(kv, Date.now() + 1); // run began after the failure: disproves it
+    expect(await readAiDown(kv)).toBeNull();
+    await clearAiDown(undefined, Date.now()); // no cache binding: silent no-op
+  });
+
+  it('leaves a sentinel raised MID-run standing (a concurrent failure is newer info)', async () => {
+    const { kv } = fakeKV();
+    const runStart = Date.now() - 60_000; // job began a minute ago
+    await noteAiDown(kv, 'key-limit'); // raised while the job was running
+    await clearAiDown(kv, runStart);
+    expect((await readAiDown(kv))?.reason).toBe('key-limit');
+  });
+
+  it('only LLM transports prove the provider is up', () => {
+    expect(transportProvesAiUp('openrouter-gateway')).toBe(true);
+    expect(transportProvesAiUp('workers-ai')).toBe(true);
+    expect(transportProvesAiUp('computed')).toBe(false);
+    expect(transportProvesAiUp('graph')).toBe(false);
+    expect(transportProvesAiUp('lookup')).toBe(false);
+    expect(transportProvesAiUp(undefined)).toBe(false);
+  });
+
+  it('reads a corrupt or missing sentinel as "not down"', async () => {
+    const { kv, store } = fakeKV();
+    store.set('ai-down:v1', 'not json');
+    expect(await readAiDown(kv)).toBeNull();
+    store.set('ai-down:v1', JSON.stringify({ nope: true }));
+    expect(await readAiDown(kv)).toBeNull();
+    expect(await readAiDown(undefined)).toBeNull();
+    await noteAiDown(undefined, 'credits'); // no cache binding: silent no-op
+  });
+
+  it('classifies hard vs soft pauses', () => {
+    expect(isHardAiPause('credits')).toBe(true);
+    expect(isHardAiPause('key-limit')).toBe(true);
+    expect(isHardAiPause('rate-limit')).toBe(false);
+    expect(isHardAiPause('provider')).toBe(false);
+    expect(isHardAiPause('cost-control')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why

Part 2 of the error-handling fixes from the weekly key-limit incident (part 1: #525). Classification alone explains failures; this PR stops the system from *paying* for them. Previously a provider-side pause meant: /api/run enqueued doomed jobs, clients polled run-status for up to 10 minutes (the stalled "Analyzing daf — 9 of 11 anchors" bar), and deep-warm fan-outs kept flooding the queue (25–78s queue waits observed in /api/admin/recent-errors).

## What

A short-TTL KV sentinel (`ai-down:v1`) raised by the queue consumer whenever a failure classifies as AI-unavailable, read by the enqueue paths:

- **/api/run**: cold miss while the sentinel is up → immediate 503 with the same `{ paused, aiUnavailable, reason }` envelope the cost-control/budget gates use. The shared banner rises in one round-trip; cached + SWR-stale content still serves.
- **SWR path**: skips enqueueing recompute jobs while down.
- **Queue consumer**: fails already-queued jobs instantly under a **hard** pause (credits / key-limit — nothing succeeds until a human acts, so pollers resolve in one tick with the explained envelope); skips **deep-warm fan-outs under any pause** (dozens of children); ordinary jobs still try under a soft blip (rate-limit / provider, 60s TTL vs 300s hard).
- **Exemptions**: trusted explicit runs (`bypass_cache` / studio `warm_experimental`, carried as `JobMessage.explicit`) always go through — they are the recovery probe.
- **Recovery**: a fresh generation over a real LLM transport (`openrouter-gateway` / `workers-ai`, not `computed`/`graph`/`lookup`) whose run started after the sentinel rose clears it early; TTL is the backstop. A soft sentinel upgrades to hard (never downgrades), and the timestamp check keeps a racing clear from wiping a just-raised hard pause (KV has no CAS).

With #525 + this: the whole incident would have presented as the banner on both apps within seconds, cards showing paused with cached content still served, and zero queue churn.

## Testing

`pnpm typecheck`, `pnpm test` (talmud 2639, incl. new ai-down suite: TTLs, single-write window, soft→hard upgrade, mid-run clear race, transport gating), `pnpm lint` all green.