### PR TITLE
Raise the AI-paused banner in one round-trip on cold dafs

### DIFF
--- a/packages/talmud/src/client/ArgumentSidebar.tsx
+++ b/packages/talmud/src/client/ArgumentSidebar.tsx
@@ -17,6 +17,7 @@ import {
   TIDBIT_RECIPE,
   YERUSHALMI_RECIPE,
 } from '@corpus/core/sidebar/recipe';
+import { noteAiResponse } from '@corpus/ui/aiStatus';
 import {
   fitBbox,
   GEO_BBOX,
@@ -926,6 +927,9 @@ async function fetchOverviewFlow(
     runId?: string;
     cacheKey?: string;
   };
+  // Raise the shared AI-paused banner on a refused/failed run (this bespoke
+  // poll predates runProducer, which does this for every other surface).
+  noteAiResponse(j);
   if (j.status === 'ok') return read(j.result);
   if (j.status === 'pending' && j.runId) {
     const start = Date.now();
@@ -934,6 +938,7 @@ async function fetchOverviewFlow(
       await new Promise((res) => setTimeout(res, 1500));
       const s = await fetch(`/api/run-status/${encodeURIComponent(j.runId)}${qs}`);
       const sj = (await s.json()) as { status?: string; result?: unknown };
+      noteAiResponse(sj);
       if (sj.status === 'ok') return read(sj.result);
       if (sj.status === 'error') return null;
     }

--- a/packages/talmud/src/client/dafViewStore.ts
+++ b/packages/talmud/src/client/dafViewStore.ts
@@ -16,6 +16,7 @@
  */
 
 import { instanceIdOf } from '@corpus/core/cache/keys';
+import { noteAiResponse } from '@corpus/ui/aiStatus';
 import { createSignal } from 'solid-js';
 import type { RunResult } from './enrichmentQueue';
 
@@ -205,7 +206,12 @@ export async function openDafView(
         method: 'POST',
       },
     );
-    const resp = r.ok ? ((await r.json()) as { generating?: boolean }) : null;
+    // Parse the body even on a non-2xx: a refused trigger carries the AI-paused
+    // envelope (out of credits / budget cap / provider down) — raise the shared
+    // banner in THIS round-trip instead of leaving the reader to discover it via
+    // the cards' /api/run fallback.
+    const resp = (await r.json().catch(() => null)) as { generating?: boolean } | null;
+    if (resp) noteAiResponse(resp);
     triggered = !!resp?.generating;
   } catch {
     triggered = false;

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -3296,6 +3296,22 @@ app.post('/api/daf-generate/:tractate/:page', async (c) => {
       ...pausedAiFields(gate.scope),
     });
   }
+  // Provider-down circuit breaker: out-of-credits / key-cap / provider outage
+  // is NOT a budget pause, so the gate above passes while every Workflow step
+  // is doomed to fail. Without this check a cold daf spawns a Workflow that
+  // churns 402s, and the client sits in view-driven mode (its /api/run fan-out
+  // — the only path that raises the AI-paused banner — suppressed) until the
+  // ~40s stall detector gives up. Answer with the explained envelope NOW.
+  const down = await readAiDown(c.env.CACHE);
+  if (down) {
+    return c.json({
+      generating: false,
+      paused: true,
+      error: aiUnavailableMessage(down.reason),
+      aiUnavailable: true as const,
+      reason: down.reason,
+    });
+  }
   const cache = c.env.CACHE;
   const sentinel = dafGenSentinelKey(tractate, page, lang);
   // Single-flight: if a generation is already in flight for this daf, return it

--- a/packages/talmud/tests/daf-view-store.test.ts
+++ b/packages/talmud/tests/daf-view-store.test.ts
@@ -1,4 +1,5 @@
 import { instanceIdOf } from '@corpus/core/cache/keys';
+import { aiStatus } from '@corpus/ui/aiStatus';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   type DafViewPiece,
@@ -329,7 +330,7 @@ describe('client lookups agree with the server pieceKey format', () => {
 describe('openDafView (cold-path, view-driven)', () => {
   // Route fetches by URL so one stub serves daf-view + daf-generate.
   function routeFetch(opts: {
-    generate: { generating: boolean };
+    generate: { generating: boolean } & Record<string, unknown>;
     view: (callIdx: number) => { complete?: boolean; cached?: number; pieces?: unknown };
   }) {
     let viewCalls = 0;
@@ -384,6 +385,17 @@ describe('openDafView (cold-path, view-driven)', () => {
     });
     await openDafView('Paused', '4a', 'en');
     expect(isViewDriven('Paused', '4a', 'en')).toBe(false);
+  });
+
+  it('COLD daf + AI DOWN: the refused trigger raises the shared AI-paused banner in one round-trip', async () => {
+    expect(aiStatus()).toBeNull();
+    routeFetch({
+      generate: { generating: false, paused: true, aiUnavailable: true, reason: 'credits' },
+      view: () => ({ complete: false, cached: 0, pieces: {} }),
+    });
+    await openDafView('Down', '6a', 'en');
+    expect(isViewDriven('Down', '6a', 'en')).toBe(false); // cards fall back to /api/run
+    expect(aiStatus()?.reason).toBe('credits'); // and the banner is already up
   });
 
   it('releases view-driven when the cached count STALLS (a stuck producer)', async () => {


### PR DESCRIPTION
## Problem

With OpenRouter out of credits (live right now — the queue is full of HTTP 402s), tanach shows the shared AI-paused banner immediately but talmud takes 40+ seconds on the reader's main path. Verified live: a cold `POST /api/run` surfaces the `aiUnavailable` envelope in ~3s, so cards/Q&A banner fast — the gap is the cold-daf view-driven path:

1. `POST /api/daf-generate` only checks the **budget** gate; a provider 402 is not a budget pause, so it returns `{generating: true}` and spawns a `DafWarmWorkflow` doomed to churn failures (the exact churn the #526 breaker stops on the queue path — it was never wired into the Workflow trigger).
2. The client enters view-driven mode, which suppresses the cards' `/api/run` fan-out — the only path that raises the banner.
3. Only after the ~40s stall detector (8s poll x 4) do cards fall back and the banner finally appears.

## Fix

- **Worker:** `/api/daf-generate` reads the ai-down sentinel after the budget gate and answers `{generating: false, paused, aiUnavailable, reason}` instead of creating the Workflow.
- **Client:** `openDafView` parses the trigger response regardless of HTTP status and feeds it to `noteAiResponse` — banner in that same round-trip (also covers the budget-pause envelope the route already emitted but the client ignored).
- **Client:** `fetchOverviewFlow` (bespoke POST/poll predating `runProducer`) now calls `noteAiResponse` on both the run and run-status bodies.

## Tests

New `openDafView` case: a refused trigger carrying the paused envelope raises the shared `aiStatus` signal in one round-trip and never enters view-driven mode. `pnpm typecheck` + 2640 unit tests + `biome check` green.