### PR TITLE
Unpause daf-background.concepts (the Background terms glossary)

### DIFF
--- a/packages/talmud/wrangler.generator.toml
+++ b/packages/talmud/wrangler.generator.toml
@@ -55,7 +55,7 @@ HOURLY_CUSTOM_BUDGET_USD = "10"
 # Cost control — the queue consumer (hosted here) skips background warms of these
 # paused producers. KEEP IN SYNC with wrangler.toml (the reader gates /api/run +
 # shows the banner from the same list). Set to "" to resume full generation.
-PAUSED_PRODUCERS = "tidbit.essay,daf-background.concepts,rishonim.synthesis,argument-move.suggested-questions,pesukim.suggested-questions,aggadata.suggested-questions"
+PAUSED_PRODUCERS = "tidbit.essay,rishonim.synthesis,argument-move.suggested-questions,pesukim.suggested-questions,aggadata.suggested-questions"
 # Role flag read by the shared scheduled() handler in index.ts: 'generator' runs
 # the heavy warm/yomi crons (here), 'reader' runs only the lightweight health
 # watch (in wrangler.toml). Keeps heavy warming off the reader's isolate pool.

--- a/packages/talmud/wrangler.toml
+++ b/packages/talmud/wrangler.toml
@@ -110,7 +110,7 @@ HOURLY_CUSTOM_BUDGET_USD = "10"
 # leaner (its core cards still generate; these paused extras don't). Fully
 # reversible: set to "" to resume full generation. KEEP IN SYNC with
 # wrangler.generator.toml (the queue consumer reads this there).
-PAUSED_PRODUCERS = "tidbit.essay,daf-background.concepts,rishonim.synthesis,argument-move.suggested-questions,pesukim.suggested-questions,aggadata.suggested-questions"
+PAUSED_PRODUCERS = "tidbit.essay,rishonim.synthesis,argument-move.suggested-questions,pesukim.suggested-questions,aggadata.suggested-questions"
 # Role flag (see scheduled() in index.ts). 'reader' = run only the health watch
 # on the */5 cron; the talmud-gen worker sets 'generator' and runs heavy warming.
 WORKER_ROLE = "reader"


### PR DESCRIPTION
The Background card's grouped terms list (`daf-background.concepts`) was in the cost-control pause set (#521), so dapim generated since then show only the one-sentence orientation plus "No background terms surfaced for this daf yet." The terms are the useful part of the card — resume generating them on cold dapim.

The other expensive producers (tidbit.essay, rishonim.synthesis, the three *.suggested-questions) stay paused. Both wrangler configs updated in sync (reader route gate + queue-consumer backstop).