### PR TITLE
Warm workflow: one dependency-DAG pool replaces phase/tier/batch barriers

### DIFF
--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -302,9 +302,10 @@ import {
 import { lookupGloss } from './word-glosses';
 import { checkWorkerHealthAndAlert, fetchWorkerOutcomes } from './worker-health';
 import {
+  createDagPool,
   type DafWarmParams,
   dafGenSentinelKey,
-  parallelMap,
+  expandInlineDeps,
   perInstanceEnrichments,
   topoTiers,
   wholeDafEnrichmentIds,
@@ -11599,18 +11600,22 @@ export class DafWarmWorkflow extends WorkflowEntrypoint<Bindings, DafWarmParams>
         }
       });
 
-    // Producers within a PHASE run in dependency TIERS, each tier's steps fanned
-    // out concurrently (bounded). Tiering guarantees every dep is already cached
-    // by an earlier tier, so parallelism never makes two steps regenerate the
-    // same uncached dep. This is what makes a cold daf generate in minutes (vs the
-    // ~30-60 min fully-sequential walk) while staying per-step memory-bounded.
+    // ONE dependency-DAG pool for the whole daf (replaces the marks → whole-daf
+    // → per-instance phase barriers and the per-tier chunk barriers): every
+    // producer starts the moment its OWN declared deps are done and a slot is
+    // free, so a slot never idles at an artificial boundary. Strictly ordered
+    // where a dependency actually exists — a node is released only when every
+    // declared dep has completed, so concurrent steps still never regenerate a
+    // shared uncached dep.
     //
     // STEP_CONCURRENCY (module-scoped, ratcheted by the memory-budget guard) is
-    // the per-tier in-isolate fan-out width. coalesce.ts shares same-daf source
-    // slices across the concurrent steps; 6 is the conservative "safe
-    // concurrency" the reader /api/run gate also landed on (#439, 16->6). The
-    // `[mem] warm-tier` width breadcrumb below attributes a future OOM to
-    // (daf, phase, width).
+    // the pool width — the peak concurrent in-isolate generation. Concurrent
+    // steps share THIS isolate's 128 MB (the per-step "own budget" only holds
+    // across suspension points), so the cap is a memory ceiling; coalesce.ts
+    // dedupes same-daf source slices across the concurrent steps. 6 is the
+    // conservative "safe concurrency" the reader /api/run gate also landed on
+    // (#439, 16->6). The `[mem] warm-dag` breadcrumb attributes a future OOM to
+    // (daf, node count, width).
     const markDepsOf = (id: string): string[] => {
       const def = CODE_MARKS.find((m) => m.id === id);
       return (def?.dependencies ?? []).map((d) => dependencyId(d)).filter((x): x is string => !!x);
@@ -11620,53 +11625,115 @@ export class DafWarmWorkflow extends WorkflowEntrypoint<Bindings, DafWarmParams>
       return (def?.dependencies ?? []).map((d) => dependencyId(d)).filter((x): x is string => !!x);
     };
 
-    // 1) Marks first — enrichments depend on them. Tiered so a computed mark
-    //    (e.g. geography, which reads the rabbi + places marks) runs after its
-    //    mark deps; independent extractor marks in the same tier run concurrently.
-    for (const tier of topoTiers(
-      CODE_MARKS.map((m) => m.id),
-      markDepsOf,
-    )) {
-      // [mem] breadcrumb — a tier's steps run concurrently in THIS isolate (the
-      // "own budget" only holds across suspension points), so `width` is the peak
-      // concurrent in-isolate generation that coalesce.ts must dedupe source
-      // slices across. Attributes a cold-gen OOM to (daf, phase, width).
-      console.log(
-        '[mem] warm-tier',
-        JSON.stringify({
-          phase: 'marks',
-          t: tractate,
-          p: page,
-          lang,
-          width: tier.length,
-          conc: STEP_CONCURRENCY,
-        }),
-      );
-      await parallelMap(tier, STEP_CONCURRENCY, (mid) =>
-        runStep(`mark:${mid}`, async (rc) => {
+    // Node ids are BARE producer ids (so dependency declarations map directly);
+    // per-instance units are `${enrichmentId}::${iid}`. Step names are unchanged
+    // from the tiered scheduler (`mark:x`, `enrich:x`, `enrich:x:iid`) — replay
+    // caches by name, and names never depend on completion timing.
+    const pool = createDagPool(STEP_CONCURRENCY);
+    const perInst = perInstanceEnrichments(marksLite, enrichLite);
+    const wholeDaf = wholeDafEnrichmentIds(marksLite, enrichLite);
+    const perInstByMark = new Map<string, string[]>();
+    for (const p of perInst) {
+      perInstByMark.set(p.targetMark, [...(perInstByMark.get(p.targetMark) ?? []), p.id]);
+    }
+    const perInstIds = new Set(perInst.map((p) => p.id));
+
+    // Declare EVERY node id before adding any: the pool gates a dep only if the
+    // id is already known at add() time, so without this a dep on a node
+    // registered later in this same batch would be dropped (geography is added
+    // before its `places` dep in CODE_MARKS order). Per-instance enrichments are
+    // declared as FUTURE group nodes: their units exist only after their target
+    // mark runs, but static nodes that depend on one (biyun.essay ←
+    // pesukim.synthesis/halacha.synthesis/…) must WAIT for all units instead of
+    // regenerating them inline inside one heavy step.
+    for (const m of marksLite) pool.declare(m.id);
+    for (const id of wholeDaf) pool.declare(id);
+    for (const p of perInst) pool.declare(p.id);
+
+    // A dep on a producer the warm never generates (the excluded `argument`
+    // per-instance family, e.g. biyun.essay ← argument.synthesis) is resolved
+    // INLINE by the dependent's run — which may regenerate it and, transitively,
+    // ITS inputs (argument.synthesis reads the argument-move mark). Gate the
+    // dependent on those in-graph transitive inputs instead, so inline
+    // regeneration only ever reads already-cached pieces — the guarantee the
+    // marks-before-enrichments phase barrier used to provide.
+    const graphIds = new Set<string>([
+      ...marksLite.map((m) => m.id),
+      ...wholeDaf,
+      ...perInst.map((p) => p.id),
+    ]);
+    const enrichMeta = (id: string): { targetMark?: string; deps: string[] } | undefined => {
+      const e = CODE_ENRICHMENTS.find((x) => x.id === id);
+      return e ? { targetMark: e.target_mark, deps: enrichDepsOf(id) } : undefined;
+    };
+    const gateDeps = (deps: string[]): string[] =>
+      expandInlineDeps(deps, (id) => graphIds.has(id), enrichMeta);
+
+    // Fan a completed mark out into its per-instance units. Runs in the
+    // orchestrator (not inside a step): instance reads + the instanceId hash are
+    // deterministic, so unit step NAMES replay identically across restarts.
+    // Enrichments are added in dependency order (topoTiers) so a same-mark dep
+    // (aggadata.synthesis ← aggadata.background) can reference its sibling
+    // unit ids; each enrichment then gets a no-slot "group" node that completes
+    // when all its units have, fulfilling the declare() above.
+    const addUnitsForMark = async (mid: string): Promise<void> => {
+      const eids = perInstByMark.get(mid);
+      if (!eids || eids.length === 0) return;
+      const insts = await readMarkInstances(wrapped, mid, tractate, page);
+      const withIds: { inst: unknown; iid: string }[] = [];
+      for (const inst of insts) withIds.push({ inst, iid: await instanceIdOf(inst) });
+      for (const tier of topoTiers(eids, enrichDepsOf)) {
+        for (const eid of tier) {
+          const def = await loadEnrichmentDef(wrapped, eid);
+          const unitIds: string[] = [];
+          if (def) {
+            // A dep on a SAME-mark per-instance enrichment binds per instance
+            // (the run resolves it with this unit's own mark_input); everything
+            // else (marks, whole-daf enrichments, other groups) binds by bare id.
+            const sameMark = new Set(eids);
+            const unitDeps = (iid: string): string[] =>
+              enrichDepsOf(eid).flatMap((d) =>
+                sameMark.has(d) ? [`${d}::${iid}`] : gateDeps([d]),
+              );
+            for (const { inst, iid } of withIds) {
+              const uid = `${eid}::${iid}`;
+              pool.add(uid, unitDeps(iid), () =>
+                runStep(`enrich:${eid}:${iid}`, async (rc) => {
+                  const res = await runEnrichmentOnce(rc, def, tractate, page, inst, false);
+                  return { id: eid, iid, cached: res.cache_hit ?? false };
+                }),
+              );
+              unitIds.push(uid);
+            }
+          }
+          pool.add(eid, unitIds); // the group marker (also fulfills a no-def/no-instance declare)
+        }
+      }
+    };
+
+    // Marks: the step, then the per-instance fan-out for that mark — inside the
+    // node's run, so units register before the mark counts as complete.
+    for (const m of marksLite) {
+      const mid = m.id;
+      pool.add(mid, markDepsOf(mid), async () => {
+        await runStep(`mark:${mid}`, async (rc) => {
           const def = await loadMarkDef(wrapped, mid);
           if (!def) return { id: mid, skipped: 'no-def' };
           const res = await runMarkOnce(rc, def, tractate, page, false);
           return { id: mid, cached: res.cache_hit ?? false };
-        }),
-      );
+        });
+        await addUnitsForMark(mid);
+      });
     }
 
-    // 2) Whole-daf enrichments ({fields:{}}), in dependency tiers (e.g.
-    //    argument-overview.flow before the synthesis that consumes it).
-    for (const tier of topoTiers(wholeDafEnrichmentIds(marksLite, enrichLite), enrichDepsOf)) {
-      console.log(
-        '[mem] warm-tier',
-        JSON.stringify({
-          phase: 'whole-daf',
-          t: tractate,
-          p: page,
-          lang,
-          width: tier.length,
-          conc: STEP_CONCURRENCY,
-        }),
-      );
-      await parallelMap(tier, STEP_CONCURRENCY, (id) =>
+    // Whole-daf enrichments ({fields:{}}). Deps on marks/whole-daf nodes gate
+    // directly; deps on a per-instance enrichment gate on its declared group. A
+    // dep the pool doesn't know (source ids, never-warmed producers like the
+    // excluded `argument` family) is dropped and resolves inline at run time,
+    // exactly as before.
+    for (const id of wholeDaf) {
+      if (perInstIds.has(id)) continue; // defensive: ids are disjoint by construction
+      pool.add(id, gateDeps(enrichDepsOf(id)), () =>
         runStep(`enrich:${id}`, async (rc) => {
           const def = await loadEnrichmentDef(wrapped, id);
           if (!def) return { id, skipped: 'no-def' };
@@ -11676,55 +11743,17 @@ export class DafWarmWorkflow extends WorkflowEntrypoint<Bindings, DafWarmParams>
       );
     }
 
-    // 3) Per-instance enrichments — one step per (enrichment, target instance).
-    //    Processed in enrichment dependency tiers (e.g. argument-move.synthesis
-    //    before argument-move.suggested-questions), and within a tier ALL
-    //    (enrichment, instance) steps fan out concurrently — two instances of one
-    //    enrichment are always independent, and cross-enrichment deps are already
-    //    satisfied by an earlier tier, so there is no double-generation. Instance
-    //    reads + the instanceId hash run in the orchestration (deterministic) so
-    //    step NAMES replay identically across Workflow restarts.
-    const perInst = perInstanceEnrichments(marksLite, enrichLite);
-    const byId = new Map(perInst.map((p) => [p.id, p.targetMark]));
-    for (const tier of topoTiers(
-      perInst.map((p) => p.id),
-      enrichDepsOf,
-    )) {
-      type Unit = {
-        id: string;
-        def: NonNullable<Awaited<ReturnType<typeof loadEnrichmentDef>>>;
-        inst: unknown;
-        iid: string;
-      };
-      const units: Unit[] = [];
-      for (const id of tier) {
-        const def = await loadEnrichmentDef(wrapped, id);
-        if (!def) continue;
-        const targetMark = byId.get(id);
-        if (!targetMark) continue;
-        const insts = await readMarkInstances(wrapped, targetMark, tractate, page);
-        for (const inst of insts) {
-          units.push({ id, def, inst, iid: await instanceIdOf(inst) });
-        }
-      }
-      console.log(
-        '[mem] warm-tier',
-        JSON.stringify({
-          phase: 'per-instance',
-          t: tractate,
-          p: page,
-          lang,
-          width: units.length,
-          conc: STEP_CONCURRENCY,
-        }),
-      );
-      await parallelMap(units, STEP_CONCURRENCY, (u) =>
-        runStep(`enrich:${u.id}:${u.iid}`, async (rc) => {
-          const res = await runEnrichmentOnce(rc, u.def, tractate, page, u.inst, false);
-          return { id: u.id, iid: u.iid, cached: res.cache_hit ?? false };
-        }),
-      );
-    }
+    console.log(
+      '[mem] warm-dag',
+      JSON.stringify({
+        t: tractate,
+        p: page,
+        lang,
+        marks: marksLite.length,
+        conc: STEP_CONCURRENCY,
+      }),
+    );
+    await pool.drain();
   }
 }
 

--- a/packages/talmud/src/worker/workflow-warm.ts
+++ b/packages/talmud/src/worker/workflow-warm.ts
@@ -123,20 +123,163 @@ export function topoTiers(ids: string[], depsOf: (id: string) => string[]): stri
 }
 
 /**
- * Run `fn` over `items` with bounded concurrency (sequential chunks of `limit`).
- * Used to fan out Workflow steps within a tier without launching an unbounded
- * number of concurrent step.do() invocations. Order of results matches input.
+ * Expand dependency ids for the warm DAG: a dep the pool KNOWS passes through
+ * unchanged, but a dep on a producer the warm never generates (today: the
+ * excluded `argument` per-instance family) is replaced by that producer's
+ * in-graph TRANSITIVE inputs — its target mark plus its own declared deps,
+ * recursively. The dependent's run resolves the excluded producer INLINE
+ * (regenerating it if uncached), and that inline walk reads the expanded
+ * inputs; gating on them preserves the old phase-barrier guarantee (inline
+ * regeneration only ever consumes already-cached pieces, so it can never race
+ * a scheduled step over the same uncached dependency). Unknown non-producer
+ * ids (source ids like 'gemara') expand to nothing, as before.
  */
-export async function parallelMap<T, R>(
-  items: T[],
-  limit: number,
-  fn: (item: T, index: number) => Promise<R>,
-): Promise<R[]> {
-  const out: R[] = [];
-  for (let i = 0; i < items.length; i += limit) {
-    const chunk = items.slice(i, i + limit);
-    const res = await Promise.all(chunk.map((item, j) => fn(item, i + j)));
-    out.push(...res);
-  }
+export function expandInlineDeps(
+  deps: string[],
+  known: (id: string) => boolean,
+  producerMeta: (id: string) => { targetMark?: string; deps: string[] } | undefined,
+): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const visit = (id: string): void => {
+    if (seen.has(id)) return;
+    seen.add(id);
+    if (known(id)) {
+      out.push(id);
+      return;
+    }
+    const meta = producerMeta(id);
+    if (!meta) return; // a source id — read from caches inline, nothing to gate
+    if (meta.targetMark) visit(meta.targetMark);
+    for (const d of meta.deps) visit(d);
+  };
+  for (const id of deps) visit(id);
   return out;
+}
+
+/**
+ * Bounded-width dependency-DAG scheduler — the warm Workflow's step pump.
+ *
+ * Replaces the phase barriers (marks → whole-daf → per-instance) and the
+ * per-tier chunked fan-out with ONE pool: every node starts the moment its OWN
+ * declared dependencies are done and a slot is free, so no slot ever idles at a
+ * batch, tier, or phase boundary. The width cap is unchanged (the caller passes
+ * STEP_CONCURRENCY) — concurrent steps share the workflow isolate's 128 MB, so
+ * the cap is a memory ceiling, not a scheduling choice.
+ *
+ * Semantics (strict — ordering is preserved exactly where a dependency exists):
+ * - `add(id, deps, run)` registers a runnable node. Deps referencing ids the
+ *   pool does not know (source ids like 'gemara', producers the warm never
+ *   generates) are dropped — the same out-of-set rule topoTiers used; the
+ *   runtime dependency walk resolves those inline as before.
+ * - `declare(id)` registers a FUTURE node: anything depending on it waits until
+ *   a later `add` fulfills it. Used for per-instance work that can only be
+ *   enumerated after its target mark runs — a static node that depends on a
+ *   per-instance enrichment (e.g. biyun.essay ← pesukim.synthesis) then waits
+ *   for ALL of its units instead of regenerating them inline in one step.
+ * - `add` with no `run` is a completion marker (a "group" node): it completes,
+ *   without occupying a slot, once its deps are done.
+ * - `add` may be called while draining (from inside a node's run) — that is how
+ *   a mark fans out its per-instance units.
+ * - A node failure stops new starts; in-flight nodes settle; drain() rejects.
+ *   Dependents of a failed node never run.
+ * - Deterministic: nodes are scanned in insertion order, names never depend on
+ *   completion timing (Workflow replay caches steps by name).
+ */
+export interface DagPool {
+  declare(id: string): void;
+  add(id: string, deps: string[], run?: () => Promise<unknown>): void;
+  /** Drain the pool; resolves when every declared+added node is done. Call once,
+   *  after the static nodes are added. */
+  drain(): Promise<void>;
+}
+
+interface DagNode {
+  deps: string[];
+  run?: () => Promise<unknown>;
+  status: 'declared' | 'pending' | 'running' | 'done';
+}
+
+export function createDagPool(limit: number): DagPool {
+  const nodes = new Map<string, DagNode>();
+  let inFlight = 0;
+  let failure: unknown;
+  let settle: { resolve: () => void; reject: (e: unknown) => void } | undefined;
+
+  const isDone = (id: string): boolean => nodes.get(id)?.status === 'done';
+
+  function declare(id: string): void {
+    if (!nodes.has(id)) nodes.set(id, { deps: [], status: 'declared' });
+  }
+
+  function add(id: string, deps: string[], run?: () => Promise<unknown>): void {
+    const existing = nodes.get(id);
+    if (existing && existing.status !== 'declared') throw new Error(`dag: duplicate node ${id}`);
+    const gated = deps.filter((d) => d !== id && nodes.has(d));
+    nodes.set(id, { deps: gated, run, status: 'pending' });
+    pump();
+  }
+
+  function start(n: DagNode): void {
+    n.status = 'running';
+    inFlight++;
+    void (n.run as () => Promise<unknown>)().then(
+      () => {
+        n.status = 'done';
+        inFlight--;
+        pump();
+      },
+      (err: unknown) => {
+        failure = failure ?? err ?? new Error('dag: node failed');
+        inFlight--;
+        pump();
+      },
+    );
+  }
+
+  function pump(): void {
+    if (!settle) return; // not draining yet — pre-drain adds just register
+    if (failure) {
+      if (inFlight === 0) settle.reject(failure);
+      return;
+    }
+    // Scan until a full pass makes no progress: complete free "group" markers,
+    // start runnable nodes while a slot is open. Insertion order = determinism.
+    let progressed = true;
+    while (progressed) {
+      progressed = false;
+      for (const n of nodes.values()) {
+        if (n.status !== 'pending' || !n.deps.every(isDone)) continue;
+        if (!n.run) {
+          n.status = 'done';
+          progressed = true;
+        } else if (inFlight < limit) {
+          start(n);
+          progressed = true;
+        }
+      }
+    }
+    if (inFlight > 0) return; // completions will re-pump
+    const stuck: string[] = [];
+    for (const [id, n] of nodes) if (n.status !== 'done') stuck.push(id);
+    if (stuck.length === 0) settle.resolve();
+    // Nothing running, nothing ready, nodes remain: an unfulfilled declare() or
+    // an unsatisfiable dep. Fail loudly rather than hang the workflow.
+    else
+      settle.reject(
+        new Error(
+          `dag: stalled with ${stuck.length} unrunnable node(s): ${stuck.slice(0, 8).join(', ')}`,
+        ),
+      );
+  }
+
+  function drain(): Promise<void> {
+    if (settle) return Promise.reject(new Error('dag: drain() called twice'));
+    return new Promise<void>((resolve, reject) => {
+      settle = { resolve, reject };
+      pump();
+    });
+  }
+
+  return { declare, add, drain };
 }

--- a/packages/talmud/tests/workflow-warm.test.ts
+++ b/packages/talmud/tests/workflow-warm.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
+  createDagPool,
   dafGenSentinelKey,
-  parallelMap,
+  expandInlineDeps,
   perInstanceEnrichments,
   topoTiers,
   wholeDafEnrichmentIds,
@@ -203,40 +204,257 @@ describe('topoTiers', () => {
   });
 });
 
-describe('parallelMap', () => {
-  it('runs every item and preserves result order', async () => {
-    const out = await parallelMap([1, 2, 3, 4, 5], 2, async (n) => n * 10);
-    expect(out).toEqual([10, 20, 30, 40, 50]);
+describe('expandInlineDeps', () => {
+  // The real shape: biyun.essay depends on argument.synthesis, which the warm
+  // never generates (the excluded `argument` family). Its inline regeneration
+  // reads the argument + argument-move + rabbi marks and daf-background.concepts
+  // — so the dependent must gate on THOSE.
+  const META: Record<string, { targetMark?: string; deps: string[] }> = {
+    'argument.synthesis': {
+      targetMark: 'argument',
+      deps: ['gemara', 'argument-move', 'rabbi', 'argument.background', 'daf-background.concepts'],
+    },
+    'argument.background': { targetMark: 'argument', deps: ['gemara', 'argument-move'] },
+  };
+  const KNOWN = new Set([
+    'argument',
+    'argument-move',
+    'rabbi',
+    'daf-background.concepts',
+    'rishonim.synthesis',
+  ]);
+  const known = (id: string) => KNOWN.has(id);
+  const meta = (id: string) => META[id];
+
+  it('passes known ids through unchanged', () => {
+    expect(expandInlineDeps(['rishonim.synthesis', 'rabbi'], known, meta)).toEqual([
+      'rishonim.synthesis',
+      'rabbi',
+    ]);
   });
 
-  it('never exceeds the concurrency limit in flight', async () => {
+  it('expands an excluded producer into its in-graph transitive inputs', () => {
+    const out = expandInlineDeps(['argument.synthesis'], known, meta);
+    expect(out.sort()).toEqual(['argument', 'argument-move', 'daf-background.concepts', 'rabbi']);
+  });
+
+  it('drops source ids entirely', () => {
+    expect(expandInlineDeps(['gemara', 'context'], known, meta)).toEqual([]);
+  });
+
+  it('tolerates cycles among excluded producers', () => {
+    const cyc = (id: string) =>
+      id === 'a' ? { deps: ['b'] } : id === 'b' ? { deps: ['a', 'rabbi'] } : undefined;
+    expect(expandInlineDeps(['a'], known, cyc)).toEqual(['rabbi']);
+  });
+});
+
+describe('createDagPool', () => {
+  /** A manually-resolvable run fn, to control completion order in tests. */
+  function gate() {
+    let release!: () => void;
+    let fail!: (e: unknown) => void;
+    const p = new Promise<void>((res, rej) => {
+      release = res;
+      fail = rej;
+    });
+    return { run: () => p, release, fail };
+  }
+  const tick = () => new Promise<void>((r) => setTimeout(r, 0));
+
+  it('runs every node and respects dependency order', async () => {
+    const order: string[] = [];
+    const pool = createDagPool(4);
+    pool.add('a', [], async () => {
+      order.push('a');
+    });
+    pool.add('b', ['a'], async () => {
+      order.push('b');
+    });
+    pool.add('c', ['b'], async () => {
+      order.push('c');
+    });
+    await pool.drain();
+    expect(order).toEqual(['a', 'b', 'c']);
+  });
+
+  it('never exceeds the width limit in flight', async () => {
     let inFlight = 0;
     let peak = 0;
-    await parallelMap(
-      Array.from({ length: 12 }, (_, i) => i),
-      3,
-      async (n) => {
+    const pool = createDagPool(3);
+    for (let i = 0; i < 12; i++) {
+      pool.add(`n${i}`, [], async () => {
         inFlight++;
         peak = Math.max(peak, inFlight);
-        await Promise.resolve();
-        await Promise.resolve();
+        await tick();
         inFlight--;
-        return n;
-      },
-    );
+      });
+    }
+    await pool.drain();
     expect(peak).toBeLessThanOrEqual(3);
   });
 
-  it('passes the absolute index across chunk boundaries', async () => {
-    const seen: number[] = [];
-    await parallelMap(['a', 'b', 'c', 'd', 'e'], 2, async (_item, i) => {
-      seen.push(i);
-      return i;
+  it('starts a node the moment a slot frees (sliding pool, no batch barrier)', async () => {
+    // Width 2: a slow node + a fast node start together; the third node must
+    // start as soon as the fast one finishes, NOT wait for the slow one.
+    const slow = gate();
+    const started: string[] = [];
+    const pool = createDagPool(2);
+    pool.add('slow', [], () => {
+      started.push('slow');
+      return slow.run();
     });
-    expect(seen.slice().sort((x, y) => x - y)).toEqual([0, 1, 2, 3, 4]);
+    pool.add('fast', [], async () => {
+      started.push('fast');
+    });
+    pool.add('third', [], async () => {
+      started.push('third');
+    });
+    const done = pool.drain();
+    await tick();
+    expect(started).toContain('third'); // slot freed by 'fast' — 'slow' still running
+    slow.release();
+    await done;
   });
 
-  it('is a no-op on an empty list', async () => {
-    expect(await parallelMap([], 4, async () => 1)).toEqual([]);
+  it('releases a node when ITS deps finish, not when a whole tier does', async () => {
+    // a and x are independent roots; b depends only on a. b must start while x
+    // (same "tier" as a) is still running — the barrier the tiers used to impose.
+    const x = gate();
+    const started: string[] = [];
+    const pool = createDagPool(3);
+    pool.add('x', [], () => {
+      started.push('x');
+      return x.run();
+    });
+    pool.add('a', [], async () => {
+      started.push('a');
+    });
+    pool.add('b', ['a'], async () => {
+      started.push('b');
+    });
+    const done = pool.drain();
+    await tick();
+    expect(started).toContain('b');
+    expect(started).toContain('x'); // still in flight
+    x.release();
+    await done;
+  });
+
+  it('declare(): dependents WAIT for a future node instead of dropping the dep', async () => {
+    const order: string[] = [];
+    const pool = createDagPool(2);
+    pool.declare('future');
+    pool.add('dependent', ['future'], async () => {
+      order.push('dependent');
+    });
+    pool.add('root', [], async () => {
+      order.push('root');
+      // dynamic fulfillment from inside a run — how a mark fans out its units
+      pool.add('future', [], async () => {
+        order.push('future');
+      });
+    });
+    await pool.drain();
+    expect(order).toEqual(['root', 'future', 'dependent']);
+  });
+
+  it('predeclared ids gate a dependent added BEFORE its dep (registration order is irrelevant)', async () => {
+    // The geography ← places regression: geography registers before places in
+    // CODE_MARKS order. With both predeclared, the edge must still hold.
+    const order: string[] = [];
+    const pool = createDagPool(4);
+    pool.declare('geography');
+    pool.declare('places');
+    pool.add('geography', ['places'], async () => {
+      order.push('geography');
+    });
+    pool.add('places', [], async () => {
+      order.push('places');
+    });
+    await pool.drain();
+    expect(order).toEqual(['places', 'geography']);
+  });
+
+  it('drops deps the pool does not know (source ids resolve inline at run time)', async () => {
+    const order: string[] = [];
+    const pool = createDagPool(2);
+    pool.add('n', ['gemara', 'context'], async () => {
+      order.push('n');
+    });
+    await pool.drain();
+    expect(order).toEqual(['n']);
+  });
+
+  it('group nodes (no run) complete without occupying a slot', async () => {
+    const order: string[] = [];
+    const pool = createDagPool(1); // one slot — a slot-holding group would deadlock
+    pool.add('u1', [], async () => {
+      order.push('u1');
+    });
+    pool.add('u2', [], async () => {
+      order.push('u2');
+    });
+    pool.add('group', ['u1', 'u2']);
+    pool.add('after', ['group'], async () => {
+      order.push('after');
+    });
+    await pool.drain();
+    expect(order).toEqual(['u1', 'u2', 'after']);
+  });
+
+  it('models the real shape: units fan out from a mark; a static node waits on the group', async () => {
+    // mark -> units (added dynamically) -> group; 'essay' (static) gates on the
+    // group so it sees every unit, while 'independent' overlaps with everything.
+    const order: string[] = [];
+    const pool = createDagPool(6);
+    pool.declare('synth'); // the per-instance enrichment, declared up front
+    pool.add('essay', ['synth'], async () => {
+      order.push('essay');
+    });
+    pool.add('independent', [], async () => {
+      order.push('independent');
+    });
+    pool.add('mark', [], async () => {
+      order.push('mark');
+      const unitIds: string[] = [];
+      for (const iid of ['i1', 'i2']) {
+        pool.add(`synth::${iid}`, [], async () => {
+          order.push(`synth::${iid}`);
+        });
+        unitIds.push(`synth::${iid}`);
+      }
+      pool.add('synth', unitIds);
+    });
+    await pool.drain();
+    const pos = (id: string) => order.indexOf(id);
+    expect(pos('essay')).toBeGreaterThan(pos('synth::i1'));
+    expect(pos('essay')).toBeGreaterThan(pos('synth::i2'));
+    expect(pos('essay')).toBeGreaterThan(pos('mark'));
+    expect(order).toHaveLength(5);
+  });
+
+  it('a failed node rejects drain and its dependents never run', async () => {
+    const ran: string[] = [];
+    const pool = createDagPool(2);
+    pool.add('boom', [], async () => {
+      throw new Error('boom');
+    });
+    pool.add('child', ['boom'], async () => {
+      ran.push('child');
+    });
+    await expect(pool.drain()).rejects.toThrow('boom');
+    expect(ran).toEqual([]);
+  });
+
+  it('an unfulfilled declare rejects loudly instead of hanging', async () => {
+    const pool = createDagPool(2);
+    pool.declare('never-added');
+    pool.add('dependent', ['never-added'], async () => {});
+    await expect(pool.drain()).rejects.toThrow(/stalled/);
+  });
+
+  it('an empty pool drains immediately', async () => {
+    await expect(createDagPool(2).drain()).resolves.toBeUndefined();
   });
 });


### PR DESCRIPTION
## What

Cold-daf generation ran marks → whole-daf → per-instance as sequential phases, each phase in dependency tiers, each tier in chunks of 6 that waited for the whole chunk. Three kinds of idle slot: a chunk stalls on its slowest LLM call, a tier waits for predecessors its nodes don't need, and a phase waits for ALL of the previous phase when real deps are narrow (`argument-overview.flow` needs only the `argument` mark).

`createDagPool` replaces all of it with one sliding pool: every producer starts the moment its **own** declared deps are done and a slot frees. Width cap unchanged (`STEP_CONCURRENCY = 6` — concurrent steps share the workflow isolate's 128 MB; the memory-budget-guard ratchet still applies). Wall-clock should drop meaningfully on cold dafs since slots never idle at artificial boundaries.

## Strictness (ordering preserved exactly where a dependency exists)

- All static node ids predeclared before wiring — registration order can't drop an edge (`geography ← places`).
- Per-instance enrichments are declared as future **group** nodes; units register when their target mark completes (orchestrator-side, deterministic step names), same-mark deps bound per instance; static nodes that depend on one (`biyun.essay ← pesukim.synthesis`) now wait for all its units instead of regenerating them inline inside one heavy step.
- Deps on never-warmed producers (the excluded `argument` family) expand via `expandInlineDeps` into their in-graph transitive inputs, so `biyun.essay` gates on the `argument`/`argument-move`/`rabbi` marks its inline resolution reads — the old phase-barrier guarantee, kept.
- Failure stops new starts and fails the workflow; an unfulfilled declare rejects loudly instead of hanging.
- Step names unchanged → Workflow replay caching intact.

## Review

Two rounds of adversarial review (codex, read-only): round 1 found the `geography ← places` registration-order drop and the `biyun.essay → argument.synthesis → argument-move` transitive race — both fixed with regression tests; round 2 CLEAN.

17 new tests (pool width, sliding-slot reuse, per-node release vs tier barriers, dynamic fan-out, group nodes, failure/stall paths, dep expansion). `pnpm typecheck` + 2652 tests + `biome check` green.