### PR TITLE
Reader: never render raw error strings; fold mark failures into the load-bar notice

### DIFF
--- a/packages/talmud/src/client/DafLoadProgress.tsx
+++ b/packages/talmud/src/client/DafLoadProgress.tsx
@@ -18,6 +18,7 @@ import { LoadProgress, type LoadProgressNotice } from '@corpus/ui/LoadProgress';
 import { createMemo, type JSX } from 'solid-js';
 import { loadNotice, prefetchProgress } from './dafPrefetch';
 import { dafCacheProgress } from './dafRunsStore';
+import { isServiceUnavailableError, PAUSED_ERROR } from './enrichmentQueue';
 import { t } from './i18n';
 import { markStatuses } from './MarksRegistryPanel';
 
@@ -99,8 +100,18 @@ export default function DafLoadProgress(props: DafLoadProgressProps = {}): JSX.E
     // generated" / "paused" line, which would just repeat it.
     if (aiStatus()) return null;
     const kind = loadNotice(prefetchProgress());
-    if (!kind) return null;
-    return { kind, text: kind === 'paused' ? t('dafLoad.paused') : t('dafLoad.failed') };
+    if (kind) {
+      return { kind, text: kind === 'paused' ? t('dafLoad.paused') : t('dafLoad.failed') };
+    }
+    // Genuine mark failures land here too (the reader used to render them as a
+    // raw red "Rabbis: BUDGET_PAUSED" strip — never again): paused/outage marks
+    // are the banner's story and stay quiet, anything else gets the same
+    // localized "couldn't be generated" line as a failed prefetch wave.
+    const markFailed = markStatuses().some(
+      (m) => m.kind === 'error' && m.error !== PAUSED_ERROR && !isServiceUnavailableError(m.error),
+    );
+    if (markFailed) return { kind: 'failed', text: t('dafLoad.failed') };
+    return null;
   });
 
   return (

--- a/packages/talmud/src/client/DafViewer.tsx
+++ b/packages/talmud/src/client/DafViewer.tsx
@@ -38,7 +38,6 @@ import { readDevMode, setDevModeActive } from './DevModeShelf';
 import { cancelPrefetch, prefetchDaf } from './dafPrefetch';
 import { setDafRunsTarget } from './dafRunsStore';
 import { openDafView } from './dafViewStore';
-import { isServiceUnavailableError } from './enrichmentQueue';
 import { ensureMasechetIncipit } from './ensureMasechetIncipit';
 import { GutterIcons, type GutterKind } from './GutterIcons';
 import { GutterOverlay } from './GutterOverlay';
@@ -3602,43 +3601,10 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
         </span>
       </header>
 
-      {/* Mark errors still surface explicitly — the progress bar abstracts
-          them into its count, but a failed anchor is worth naming. AI-paused
-          failures (out of credits / cost cap / provider blip) are EXCLUDED:
-          they dump a raw provider string ("OpenRouter HTTP 402: …") and are
-          already explained by the shared AiStatusBanner, so naming each one here
-          is just noise. Genuine bugs still surface. */}
-      <Show
-        when={markStatuses().some((s) => s.kind === 'error' && !isServiceUnavailableError(s.error))}
-      >
-        <section
-          style={{
-            'margin-bottom': '1rem',
-            'max-width': '720px',
-            'margin-left': 'auto',
-            'margin-right': 'auto',
-            display: 'flex',
-            gap: '0.75rem',
-            'flex-wrap': 'wrap',
-            'align-items': 'center',
-            'justify-content': 'center',
-            'font-size': '0.75rem',
-            color: '#c33',
-          }}
-        >
-          <For
-            each={markStatuses().filter(
-              (s) => s.kind === 'error' && !isServiceUnavailableError(s.error),
-            )}
-          >
-            {(s) => (
-              <span>
-                {s.label || s.id}: {s.error}
-              </span>
-            )}
-          </For>
-        </section>
-      </Show>
+      {/* No raw error strip here: pause/outage states are the AiStatusBanner's
+          job, and genuine mark failures fold into the load bar's localized
+          notice (DafLoadProgress) — raw sentinel/provider strings ("Rabbis:
+          BUDGET_PAUSED") must never render in the reader. */}
 
       <div class="daf-layout">
         <div class="daf-cluster">


### PR DESCRIPTION
The reader rendered a red strip of raw internals — "Rabbis: BUDGET_PAUSED   Geography: BUDGET_PAUSED   Rishonim: BUDGET_PAUSED" — when mark runs were refused. #518 filtered provider-outage strings out of that strip but not the budget-pause sentinel, and any new error class would leak raw as well. (The trigger: OpenRouter ran out of credits again; the client maps ANY refused/paused run to the `BUDGET_PAUSED` sentinel, so a credits outage even mislabels itself as a budget cap.)

- The strip is removed entirely — no raw error text in the reader, ever.
- Pause/outage states remain the shared AiStatusBanner's job (it names the real reason).
- Genuine mark failures (not paused, not provider-outage) now fold into `DafLoadProgress`'s existing localized "couldn't be generated" notice, suppressed while the banner is up — same contract the prefetch cohort already had.

`pnpm typecheck` + 2652 tests + `biome check` green.