### PR TITLE
Fix the resurfaced whole-daf dep cache leak (daf-background.concepts ×20/daf)

### DIFF
--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -5003,9 +5003,17 @@ const WHOLE_DAF_MARK_IDS: ReadonlySet<string> = new Set(
  *  whole-daf note (daf-background.concepts, argument-overview.flow, tidbit.essay,
  *  biyun.essay). Such an enrichment has exactly one instance per daf, so
  *  runEnrichmentOnce keys it to the canonical {fields:{}} instance for every
- *  caller. Exported for the regression test that pins this set. */
+ *  caller. MUST read BOTH def shapes: rich code defs carry `target_mark`, but
+ *  the KV-flat shape loadEnrichmentDef returns renames it to `mark`
+ *  (adaptCodeEnrichment) — and the DEPENDENCY walk loads defs through exactly
+ *  that loader, so reading only `target_mark` silently disabled the collapse
+ *  for every dep run: each per-section/per-rabbi parent re-ran and re-cached
+ *  daf-background.concepts under its own instance key (~20 paid runs per daf
+ *  of one identical whole-daf piece — the #426 leak, resurfaced through the
+ *  flat shape). Exported for the regression test that pins this set. */
 export function isWholeDafEnrichment(def: EnrichmentDefinition): boolean {
-  const targetMark = (def as { target_mark?: string }).target_mark;
+  const d = def as { target_mark?: string; mark?: string };
+  const targetMark = d.target_mark ?? d.mark;
   return def.scope === 'local' && !!targetMark && WHOLE_DAF_MARK_IDS.has(targetMark);
 }
 

--- a/packages/talmud/tests/whole-daf-enrichment.test.ts
+++ b/packages/talmud/tests/whole-daf-enrichment.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { CODE_ENRICHMENTS } from '../src/worker/code-marks';
 import { isWholeDafEnrichment } from '../src/worker/index';
+import { adaptCodeEnrichment } from '../src/worker/producer-registry';
+import type { EnrichmentDefinition } from '../src/worker/studio-schema';
 
 // runEnrichmentOnce collapses whole-daf enrichments to the single canonical
 // {fields:{}} instance for every caller. That is correct ONLY for enrichments
@@ -45,5 +47,28 @@ describe('isWholeDafEnrichment — which enrichments collapse to {fields:{}}', (
   it('does NOT flag a global-scope per-rabbi enrichment', () => {
     const def = byId('rabbi.bio');
     if (def) expect(isWholeDafEnrichment(def)).toBe(false);
+  });
+
+  // THE resurfaced-leak regression: the dependency walk loads defs through
+  // loadEnrichmentDef, whose KV-FLAT shape (adaptCodeEnrichment) renames
+  // target_mark -> mark. isWholeDafEnrichment originally read only target_mark,
+  // so every DEP run skipped the collapse and re-cached the whole-daf piece
+  // under the parent's instance key (per-rabbi/per-section keys in KV, ~20 paid
+  // runs/daf). Both shapes must classify identically, for the whole registry.
+  it('classifies the KV-flat shape (mark, not target_mark) identically to the rich shape', () => {
+    for (const rich of CODE_ENRICHMENTS) {
+      const flat = adaptCodeEnrichment(rich as never);
+      if (!flat) continue; // non-llm/computed extractors never reach the runner
+      expect(isWholeDafEnrichment(flat as unknown as EnrichmentDefinition), rich.id).toBe(
+        isWholeDafEnrichment(rich as never),
+      );
+    }
+  });
+
+  it('flat-shaped daf-background.concepts collapses (the exact leaked producer)', () => {
+    const flat = adaptCodeEnrichment(byId('daf-background.concepts') as never);
+    expect(flat).toBeTruthy();
+    expect((flat as { target_mark?: string }).target_mark).toBeUndefined(); // the trap
+    expect(isWholeDafEnrichment(flat as unknown as EnrichmentDefinition)).toBe(true);
   });
 });


### PR DESCRIPTION
## What burned the credits

Investigating why ~$50 depleted in a day: the app's cost ledger shows `daf-background.concepts` as the top spend line both days ($2.61 → $7.79, 185 → 265 calls) — ~20× more calls than dapim generated. KV confirms the mechanism: `enrich:daf-background.concepts:5:` holds **1,784 distinct instance-hashes** including per-rabbi keys (`rabbi_elazar`, `mar_zutra`) and per-section slugs, with fresh dapim (Chagigah 6a, generated this morning) carrying 15+ copies each. Every per-section/per-rabbi synthesis pulling the whole-daf glossary as a dependency regenerated and re-paid for it under its own key. Unpausing it in #530 re-exposed the leak; the pause had been masking it.

## Root cause

The #426 collapse (`runEnrichmentOnce` keys whole-daf enrichments to the canonical `{fields:{}}` instance) was intact — but gated on `isWholeDafEnrichment`, which read only the rich shape's `target_mark`. The dependency walk loads defs through `loadEnrichmentDef`, whose KV-flat shape renames `target_mark` → `mark` (`adaptCodeEnrichment`), so on the dep path the check silently returned `false` and the collapse never fired. Direct `/api/run` and Workflow runs pass `{fields:{}}` explicitly — which is why canonical keys also existed and the leak hid.

## Fix

`isWholeDafEnrichment` reads `target_mark ?? mark`. New regression tests: flat and rich shapes must classify identically across the whole registry, and the flat-shaped `daf-background.concepts` (where `target_mark` is undefined — the exact trap) must collapse. Leaked keys become unreachable (dep runs now compute the canonical key, already cached per daf) and age out.

`pnpm typecheck` + 2654 tests + `biome check` green.