### PR TITLE
/api/run: collapse whole-daf mark_input at the route, before key derivation

### DIFF
--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -5476,6 +5476,20 @@ app.post('/api/run', async (c) => {
     lang: body.lang === 'he' ? 'he' : undefined,
   };
 
+  // Whole-daf enrichments have exactly ONE instance per daf: collapse whatever
+  // mark_input the caller sent (usually none) to the canonical {fields:{}}
+  // BEFORE any key/id derivation, so the hot-path cache check, the SWR read,
+  // the runId, and the returned polling cacheKey all target the entry the
+  // consumer actually writes (runEnrichmentOnce applies the same collapse).
+  // Without this a bare POST /api/run on an already-cached whole-daf enrichment
+  // missed the hot path (instanceIdOf(undefined) is a different hash) and took
+  // a pointless queue round-trip, and its ?k= fallback named a key that is
+  // never written.
+  if (job.enrichment_id) {
+    const wdDef = await loadEnrichmentDef(c.env, job.enrichment_id);
+    if (wdDef && isWholeDafEnrichment(wdDef)) job.mark_input = { fields: {} };
+  }
+
   // Hot path: canonical cache hit short-circuits the queue entirely. The
   // store read maps a corrupt entry to a miss (same as the old inline parse),
   // so a corrupt cache falls through to enqueue exactly as before.

--- a/packages/talmud/tests/whole-daf-enrichment.test.ts
+++ b/packages/talmud/tests/whole-daf-enrichment.test.ts
@@ -72,3 +72,17 @@ describe('isWholeDafEnrichment — which enrichments collapse to {fields:{}}', (
     expect(isWholeDafEnrichment(flat as unknown as EnrichmentDefinition)).toBe(true);
   });
 });
+
+// The canonical whole-daf instance hash the entire collapse scheme converges
+// on. The KV cleanups keep exactly this id; the /api/run route collapses bare
+// mark_input to {fields:{}} so its keys land here too. If instanceIdOf's
+// derivation ever changes, every guard above silently targets the wrong key —
+// this pins it byte-for-byte, alongside the undefined-input hash whose
+// divergence caused the bare-run miss.
+describe('canonical whole-daf instance id', () => {
+  it('instanceIdOf({fields:{}}) is the pinned canonical hash', async () => {
+    const { instanceIdOf } = await import('@corpus/core/cache/keys');
+    expect(await instanceIdOf({ fields: {} })).toBe('f35cd02cd97b');
+    expect(await instanceIdOf(undefined)).not.toBe('f35cd02cd97b');
+  });
+});


### PR DESCRIPTION
Companion to #534. Verified live post-#534: the consumer/dep leg is fixed (a queued whole-daf job cache-hits the canonical entry — provably, since credits are at zero and no LLM call could have succeeded). But the route still derived keys from the raw `mark_input`: a bare `POST /api/run` on `daf-background.concepts` hashed `instanceIdOf(undefined)` (`74234e98afe7`), missed the hot path on a cached piece, took a needless queue round-trip, and returned a `?k=` fallback pointing at a never-written key.

Fix: normalize `job.mark_input` → `{fields:{}}` right after job construction when the enrichment is whole-daf (`isWholeDafEnrichment`, both-shapes-aware since #534) — one chokepoint inherited by the hot-path check, the SWR read, `makeRunId`, and the enqueued job. New test pins `instanceIdOf({fields:{}}) === 'f35cd02cd97b'` byte-for-byte, the id every guard and the KV cleanups converge on.

`pnpm typecheck` + 2655 tests + `biome check` green.