### PR TITLE
Health cron: whole-daf cache-key leak sentinel

### DIFF
--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -299,6 +299,7 @@ import {
   sefariaWarmProgressProcessed,
   warmProgressProcessed,
 } from './warm-cron';
+import { checkWholeDafLeakAndAlert } from './whole-daf-leak-watch';
 import { lookupGloss } from './word-glosses';
 import { checkWorkerHealthAndAlert, fetchWorkerOutcomes } from './worker-health';
 import {
@@ -11794,6 +11795,10 @@ export default {
       // (exceededMemory — the cold-daf OOM) appeared in the last window.
       // Self-contained + best-effort; never throws into the cron.
       ctx.waitUntil(checkWorkerHealthAndAlert(wrapped, Date.now()));
+      // Whole-daf cache-key leak sentinel: alert if any whole-daf enrichment
+      // key exists under a non-canonical instance id (the #426/#534 silent
+      // ~20x-per-daf spend class). Same best-effort contract.
+      ctx.waitUntil(checkWholeDafLeakAndAlert(wrapped, Date.now()));
       return;
     }
 

--- a/packages/talmud/src/worker/whole-daf-leak-watch.ts
+++ b/packages/talmud/src/worker/whole-daf-leak-watch.ts
@@ -1,0 +1,129 @@
+/**
+ * Whole-daf cache-key leak sentinel.
+ *
+ * A whole-daf enrichment (daf-background.concepts, argument-overview.flow, …)
+ * must cache under EXACTLY ONE instance id per daf+lang: instanceIdOf({fields:{}}).
+ * Twice now a code path has run these with a caller-derived instance instead —
+ * #426 (the dependency walk inheriting the parent's markInput) and #534 (the
+ * same collapse silently disabled by the KV-flat def shape) — and each time the
+ * result was the identical piece regenerated and re-paid ~20x per daf, visible
+ * only as a mysterious spend spike. The failure mode is a SILENT one: nothing
+ * errors, the reader renders fine, money burns.
+ *
+ * So the health cron audits the invariant itself: list each whole-daf
+ * enrichment's current-version keys and alert (once per day, same dedupe
+ * pattern as the OOM watch) if ANY key carries a non-canonical instance id.
+ * A leaked key can only exist if some path ran without the collapse — catching
+ * it within minutes of the first leaked write instead of at the next invoice.
+ *
+ * Cost: one bounded KV list per producer per tick (~6 lists / 5 min), zero
+ * reads of values. Pure classification helpers exported for tests.
+ */
+
+import { instanceIdOf } from '@corpus/core/cache/keys';
+import { CODE_ENRICHMENTS, CODE_MARKS } from './code-marks';
+import { wholeDafEnrichmentIds } from './workflow-warm';
+
+interface LeakWatchEnv {
+  CACHE?: KVNamespace;
+  EMAIL?: {
+    send(msg: { from: string; to: string; subject: string; text: string }): Promise<unknown>;
+  };
+}
+
+/** The whole-daf enrichment ids to audit, with their CURRENT cache_version
+ *  (superseded-version keys linger until TTL and are harmless — only the
+ *  current version can accumulate new leaked writes). */
+export function leakWatchTargets(): { id: string; version: string }[] {
+  const marksLite = CODE_MARKS.map((m) => ({
+    id: m.id,
+    anchor: (m as { anchor?: string }).anchor,
+  }));
+  const enrichLite = CODE_ENRICHMENTS.map((e) => ({
+    id: e.id,
+    scope: e.scope,
+    target_mark: e.target_mark,
+    demand_driven: (e as { demand_driven?: boolean }).demand_driven,
+  }));
+  const wholeDaf = new Set(wholeDafEnrichmentIds(marksLite, enrichLite));
+  return CODE_ENRICHMENTS.filter((e) => wholeDaf.has(e.id)).map((e) => ({
+    id: e.id,
+    version: String((e as { cache_version?: string | number }).cache_version ?? ''),
+  }));
+}
+
+/** Classify one producer's listed key names: return the ones whose instance id
+ *  is NOT the canonical whole-daf id. Key shape (frozen by cache/keys.ts):
+ *  `enrich:{id}:{version}:[he:]{instanceId}:{tractate}:{page}` — the lang
+ *  segment follows the version when present. */
+export function leakedKeys(names: string[], prefix: string, canonicalIid: string): string[] {
+  const out: string[] = [];
+  for (const name of names) {
+    if (!name.startsWith(prefix)) continue;
+    const rest = name.slice(prefix.length).split(':');
+    const iid = rest[0] === 'he' ? rest[1] : rest[0];
+    if (iid !== canonicalIid) out.push(name);
+  }
+  return out;
+}
+
+const LIST_PAGE_LIMIT = 1000;
+const MAX_PAGES_PER_TARGET = 3;
+
+/**
+ * Audit every whole-daf enrichment's key family; email once per day if any
+ * non-canonical key exists. Best-effort and self-contained: failures are
+ * logged, never thrown into the cron.
+ */
+export async function checkWholeDafLeakAndAlert(env: LeakWatchEnv, nowMs: number): Promise<void> {
+  const cache = env.CACHE;
+  if (!cache) return;
+  try {
+    const canonicalIid = await instanceIdOf({ fields: {} });
+    const found: string[] = [];
+    for (const t of leakWatchTargets()) {
+      const prefix = `enrich:${t.id}:${t.version}:`;
+      let cursor: string | undefined;
+      for (let page = 0; page < MAX_PAGES_PER_TARGET; page++) {
+        const res = await cache.list({ prefix, limit: LIST_PAGE_LIMIT, cursor });
+        found.push(
+          ...leakedKeys(
+            res.keys.map((k) => k.name),
+            prefix,
+            canonicalIid,
+          ),
+        );
+        if (res.list_complete) break;
+        cursor = res.cursor;
+      }
+    }
+    if (found.length === 0) return;
+
+    console.error('[leak-watch] non-canonical whole-daf keys:', found.length, found.slice(0, 5));
+    const dayBucket = Math.floor(nowMs / 86_400_000);
+    const dedupeKey = `health-alert:wholedaf-leak:${dayBucket}`;
+    if (await cache.get(dedupeKey)) return; // already alerted today
+    if (env.EMAIL) {
+      await env.EMAIL.send({
+        from: 'health@shaunregenbaum.com',
+        to: 'shaunregenbaum@gmail.com',
+        subject: `[talmud] whole-daf cache-key LEAK: ${found.length} non-canonical key(s)`,
+        text:
+          `${found.length} whole-daf enrichment cache key(s) exist under a NON-canonical ` +
+          `instance id — some code path is running a whole-daf enrichment with a caller-derived ` +
+          `instance instead of the {fields:{}} collapse. This is the #426/#534 leak class: the ` +
+          `identical piece regenerates (and bills) once per calling section/rabbi, ~20x per daf.\n\n` +
+          `First offenders:\n${found
+            .slice(0, 8)
+            .map((k) => `  ${k}`)
+            .join('\n')}\n\n` +
+          `Check isWholeDafEnrichment call sites (it must read BOTH def shapes: target_mark and ` +
+          `mark) and any new run path that derives a cache key from raw mark_input.\n` +
+          `Spend: https://talmud.shaunregenbaum.com/usage\n`,
+      });
+    }
+    await cache.put(dedupeKey, '1', { expirationTtl: 86_400 });
+  } catch (err) {
+    console.error('[leak-watch] failed:', err);
+  }
+}

--- a/packages/talmud/tests/whole-daf-leak-watch.test.ts
+++ b/packages/talmud/tests/whole-daf-leak-watch.test.ts
@@ -1,0 +1,68 @@
+import { instanceIdOf } from '@corpus/core/cache/keys';
+import { describe, expect, it } from 'vitest';
+import { leakedKeys, leakWatchTargets } from '../src/worker/whole-daf-leak-watch';
+
+// The sentinel exists because this leak class shipped twice (#426, #534) and
+// burned real money both times, silently. These tests pin its two pure parts:
+// which producers it audits, and how it classifies a listed key.
+
+describe('leakWatchTargets', () => {
+  it('audits exactly the whole-daf enrichments, each with its current version', () => {
+    const targets = leakWatchTargets();
+    const ids = targets.map((t) => t.id).sort();
+    expect(ids).toEqual(
+      [
+        'argument-overview.flow',
+        'argument-overview.synthesis',
+        'biyun.essay',
+        'daf-background.concepts',
+        'daf-background.synthesis',
+        'tidbit.essay',
+      ].sort(),
+    );
+    for (const t of targets) expect(t.version, t.id).toMatch(/^\d+$/);
+  });
+});
+
+describe('leakedKeys', () => {
+  const PREFIX = 'enrich:daf-background.concepts:5:';
+  const CANON = 'f35cd02cd97b';
+
+  it('keeps canonical EN and HE keys quiet', () => {
+    expect(
+      leakedKeys(
+        [
+          `${PREFIX}${CANON}:chullin:75a`,
+          `${PREFIX}he:${CANON}:chullin:75a`,
+          `${PREFIX}${CANON}:berakhot:2b`,
+        ],
+        PREFIX,
+        CANON,
+      ),
+    ).toEqual([]);
+  });
+
+  it('flags per-rabbi / per-section keys — the real leak fingerprints', () => {
+    const bad = [
+      `${PREFIX}rabbi_elazar:chullin:74b`, // rabbi.synthesis parent (seen live)
+      `${PREFIX}abaye_s_ruling_on_training_a_minor:chagigah:6a`, // argument section (seen live)
+      `${PREFIX}74234e98afe7:arakhin:16a`, // instanceIdOf(undefined) — the bare-run family
+      `${PREFIX}he:rava:chullin:74b`, // leaked under the he namespace too
+    ];
+    expect(leakedKeys([...bad, `${PREFIX}${CANON}:chullin:74b`], PREFIX, CANON)).toEqual(bad);
+  });
+
+  it('ignores names outside the prefix (other producers, superseded versions)', () => {
+    expect(
+      leakedKeys(
+        ['enrich:daf-background.concepts:4:rava:chullin:74b', 'enrich:rabbi.synthesis:3:rava:x:y'],
+        PREFIX,
+        CANON,
+      ),
+    ).toEqual([]);
+  });
+
+  it('the pinned canonical constant IS instanceIdOf({fields:{}})', async () => {
+    expect(await instanceIdOf({ fields: {} })).toBe(CANON);
+  });
+});


### PR DESCRIPTION
Answering "are you 100% sure the leak is fixed?" with a machine instead of a promise.

The #426/#534 leak class fails silently — nothing errors, readers render fine, and the identical whole-daf piece regenerates (and bills) once per calling section/rabbi. It shipped twice through two different holes. Current live evidence says the fix holds (7 real cold dapim generated post-fix — Berakhot 21a–22a, Taanit 20b–22a — produced 7 canonical keys and **zero** leaked ones, at ~$1.24/daf vs $4–5 during the leak). This PR makes that check permanent:

- `whole-daf-leak-watch.ts`: every 5 minutes the reader's health cron lists each whole-daf enrichment's current-version keys (bounded KV lists, no value reads) and emails — one alert/day, same dedupe pattern as the OOM watch — if ANY key carries a non-canonical instance id. A leaked key can only exist if some path ran without the `{fields:{}}` collapse, so the first leaked write is caught within minutes.
- Tests pin the audited producer set and classify the real fingerprints observed live (per-rabbi keys, per-section slugs, the `instanceIdOf(undefined)` bare-run family, the `he` namespace).

Also verified from code while at it: the yomi cron cannot redo work — it enqueues cache-respecting jobs (`runMarkOnce`/`runEnrichmentOnce` short-circuit on hit), so re-running a warm daf costs KV reads, not LLM calls.

`pnpm typecheck` + 2660 tests + `biome check` green.