### PR TITLE
Prompt-cache telemetry: record cached_tokens through the usage pipeline

### DIFF
--- a/packages/core/src/llm/llm.ts
+++ b/packages/core/src/llm/llm.ts
@@ -59,6 +59,12 @@ export interface LLMUsage {
    *  `usage: { include: true }`. Accounts for prompt-cache discounts. Absent
    *  on Workers AI (`@cf/*`) calls, which aren't billed per-token here. */
   cost?: number;
+  /** Prompt-cache accounting, passed through by OpenRouter and OpenAI-compat
+   *  providers. `cached_tokens` is the portion of `prompt_tokens` (a subset,
+   *  not additional tokens) billed at the provider's cache-read rate instead
+   *  of the full input price. Absent when the routed endpoint doesn't support
+   *  prompt caching. */
+  prompt_tokens_details?: { cached_tokens?: number } | null;
 }
 
 export interface LLMCallOptions {
@@ -316,6 +322,10 @@ async function recordLLMCost(
       prompt_tokens: u?.prompt_tokens ?? input ?? null,
       completion_tokens: u?.completion_tokens ?? output ?? null,
       total_tokens: u?.total_tokens ?? null,
+      // Prompt-cache hits (subset of prompt_tokens billed at the cache-read
+      // rate). Null on endpoints without caching — distinguishes "no caching
+      // available" from a genuine zero-hit call.
+      cached_tokens: u?.prompt_tokens_details?.cached_tokens ?? null,
       // Structured attribution — null when the caller didn't supply it.
       kind: a?.kind ?? null,
       producer_id: a?.producerId ?? null,

--- a/packages/talmud/src/client/UsagePage.tsx
+++ b/packages/talmud/src/client/UsagePage.tsx
@@ -63,6 +63,9 @@ interface UsageBucket {
   calls: number;
   tokensIn: number;
   tokensOut: number;
+  /** Prompt-cache hits (subset of tokensIn); optional — absent on aggregates
+   *  computed before the field existed. */
+  tokensCached?: number;
   costUsd: number;
   costInUsd?: number;
   costOutUsd?: number;
@@ -305,6 +308,9 @@ interface LlmCostData {
   totalCostUsd: number;
   estInputCostUsd?: number;
   estOutputCostUsd?: number;
+  /** Prompt-cache hit volume over the 7-day ledger window (subset of prompt
+   *  tokens billed at cache-read rates); absent on pre-field cached reports. */
+  cachedTokens?: number;
   byDaf?: Record<string, DafLedgerBucket>;
   byKind?: Record<string, { calls: number; cost: number }>;
 }

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -5981,6 +5981,10 @@ interface LlmCostRec {
   prompt_tokens: number | null;
   completion_tokens: number | null;
   total_tokens: number | null;
+  /** Prompt-cache hits: subset of prompt_tokens billed at the cache-read rate.
+   *  Additive — null on entries written before it existed AND on endpoints
+   *  without prompt caching. */
+  cached_tokens?: number | null;
   // Attribution (additive; null on entries written before it existed).
   cost_in_est?: number | null;
   cost_out_est?: number | null;
@@ -6059,11 +6063,18 @@ app.get('/api/admin/llm-cost', async (c) => {
     let callsWithCost = 0;
     let promptTokens = 0;
     let completionTokens = 0;
+    let cachedTokens = 0;
     let minTs = Number.POSITIVE_INFINITY;
     let maxTs = 0;
     const byModel: Record<
       string,
-      { calls: number; cost: number; promptTokens: number; completionTokens: number }
+      {
+        calls: number;
+        cost: number;
+        promptTokens: number;
+        completionTokens: number;
+        cachedTokens: number;
+      }
     > = {};
     const byTag: Record<string, { calls: number; cost: number }> = {};
     const byKind: Record<string, { calls: number; cost: number }> = {};
@@ -6099,14 +6110,22 @@ app.get('/api/admin/llm-cost', async (c) => {
         if (typeof r.cost_out_est === 'number') totalCostOutEst += r.cost_out_est;
         if (typeof r.prompt_tokens === 'number') promptTokens += r.prompt_tokens;
         if (typeof r.completion_tokens === 'number') completionTokens += r.completion_tokens;
+        if (typeof r.cached_tokens === 'number') cachedTokens += r.cached_tokens;
         if (r.ts < minTs) minTs = r.ts;
         if (r.ts > maxTs) maxTs = r.ts;
-        const m = byModel[r.model] ?? { calls: 0, cost: 0, promptTokens: 0, completionTokens: 0 };
+        const m = byModel[r.model] ?? {
+          calls: 0,
+          cost: 0,
+          promptTokens: 0,
+          completionTokens: 0,
+          cachedTokens: 0,
+        };
         byModel[r.model] = m;
         m.calls++;
         m.cost += r.cost ?? 0;
         m.promptTokens += r.prompt_tokens ?? 0;
         m.completionTokens += r.completion_tokens ?? 0;
+        m.cachedTokens += r.cached_tokens ?? 0;
         const t = byTag[r.tag] ?? { calls: 0, cost: 0 };
         byTag[r.tag] = t;
         t.calls++;
@@ -6153,6 +6172,9 @@ app.get('/api/admin/llm-cost', async (c) => {
       callsWithCost,
       promptTokens,
       completionTokens,
+      // Prompt-cache hit volume (subset of promptTokens billed at cache-read
+      // rates). cachedTokens / promptTokens = the live cache hit rate.
+      cachedTokens,
       window: { from: calls ? minTs : null, to: calls ? maxTs : null },
       byModel,
       byTag,
@@ -6872,6 +6894,7 @@ function captureLlmUsage(
     model: args.result.model ?? null,
     tokensIn: input,
     tokensOut: output,
+    tokensCached: usage?.prompt_tokens_details?.cached_tokens ?? 0,
     costUsd: cost,
     costInUsd,
     costOutUsd,

--- a/packages/talmud/src/worker/usage-rollup.ts
+++ b/packages/talmud/src/worker/usage-rollup.ts
@@ -27,6 +27,9 @@ export interface UsageDelta {
   model: string | null;
   tokensIn: number;
   tokensOut: number;
+  /** Prompt-cache hits: the subset of tokensIn billed at the provider's
+   *  cache-read rate (~1-10% of list). 0/absent on endpoints without caching. */
+  tokensCached?: number;
   /** null when the model has no known list price (Workers AI etc.). */
   costUsd: number | null;
   /** List-price estimate split (input-side / output-side dollars) so the
@@ -42,6 +45,9 @@ export interface UsageBucket {
   calls: number;
   tokensIn: number;
   tokensOut: number;
+  /** Prompt-cache hits (subset of tokensIn). Additive field — reads as 0 on
+   *  rollup docs stored before it existed. tokensCached / tokensIn = hit rate. */
+  tokensCached: number;
   costUsd: number; // sum of priced calls only (billed-or-est total)
   costInUsd: number; // est input-side dollars
   costOutUsd: number; // est output-side dollars
@@ -63,6 +69,7 @@ function emptyBucket(): UsageBucket {
     calls: 0,
     tokensIn: 0,
     tokensOut: 0,
+    tokensCached: 0,
     costUsd: 0,
     costInUsd: 0,
     costOutUsd: 0,
@@ -75,6 +82,8 @@ function applyToBucket(b: UsageBucket, d: UsageDelta): void {
   b.calls += 1;
   b.tokensIn += d.tokensIn;
   b.tokensOut += d.tokensOut;
+  // `b` may be a bucket parsed from a pre-tokensCached rollup doc — coalesce.
+  b.tokensCached = (b.tokensCached ?? 0) + (d.tokensCached ?? 0);
   if (d.costUsd != null) {
     b.costUsd += d.costUsd;
     b.costInUsd += d.costInUsd ?? 0;
@@ -165,6 +174,7 @@ function mergeBucketInto(
     t.calls += b.calls;
     t.tokensIn += b.tokensIn;
     t.tokensOut += b.tokensOut;
+    t.tokensCached += b.tokensCached ?? 0;
     t.costUsd += b.costUsd;
     t.costInUsd += b.costInUsd ?? 0;
     t.costOutUsd += b.costOutUsd ?? 0;
@@ -205,10 +215,17 @@ export async function readUsageSummary(cache: KVNamespace, days = 120): Promise<
     } catch {
       continue;
     }
+    // Normalize docs stored before additive fields existed, so `series`
+    // entries actually satisfy the declared shape (consumers chart them raw).
+    r.tokensCached ??= 0;
+    for (const split of [r.byModel, r.byMark, r.byEnrichment]) {
+      for (const b of Object.values(split ?? {})) b.tokensCached ??= 0;
+    }
     series.push(r);
     totals.calls += r.calls;
     totals.tokensIn += r.tokensIn;
     totals.tokensOut += r.tokensOut;
+    totals.tokensCached += r.tokensCached ?? 0;
     totals.costUsd += r.costUsd;
     totals.costInUsd += r.costInUsd ?? 0;
     totals.costOutUsd += r.costOutUsd ?? 0;

--- a/packages/talmud/tests/usage-rollup.test.ts
+++ b/packages/talmud/tests/usage-rollup.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { readUsageSummary, recordUsage, type UsageDelta } from '../src/worker/usage-rollup';
+import {
+  readUsageSummary,
+  recordUsage,
+  todayUtc,
+  type UsageDelta,
+} from '../src/worker/usage-rollup';
 
 // Prefix-aware in-memory KV — usage-rollup lists `usage:daily:v1:*` and does a
 // read-modify-write per record, so the fake must support get/put + prefix list.
@@ -91,6 +96,103 @@ describe('usage-rollup with cost split', () => {
     expect(s.byModel['openrouter/deepseek/deepseek-v4-flash'].calls).toBe(2);
     expect(s.byMark.rabbi.calls).toBe(1);
     expect(s.byEnrichment['rabbi.synthesis'].calls).toBe(1);
+  });
+
+  it('accumulates prompt-cache hit tokens per bucket', async () => {
+    const { kv } = makeFakeKV();
+    const env = { CACHE: kv };
+    await record(env, [
+      priced({ markId: 'rabbi', tokensIn: 4000, tokensCached: 3712 }),
+      priced({ markId: 'rabbi', tokensIn: 4000 }), // endpoint without caching: field absent
+      priced({ enrichmentId: 'rabbi.synthesis', tokensIn: 2000, tokensCached: 1500 }),
+    ]);
+    const s = await readUsageSummary(kv);
+    expect(s.totals.tokensCached).toBe(5212);
+    expect(s.totals.tokensIn).toBe(10000);
+    expect(s.byMark.rabbi.tokensCached).toBe(3712);
+    expect(s.byEnrichment['rabbi.synthesis'].tokensCached).toBe(1500);
+    expect(s.byModel['openrouter/deepseek/deepseek-v4-flash'].tokensCached).toBe(5212);
+  });
+
+  it('coalesces tokensCached over rollup docs stored before the field existed', async () => {
+    const { kv, store } = makeFakeKV();
+    const env = { CACHE: kv };
+    // A pre-tokensCached daily doc, as it exists in KV today.
+    store.set(
+      `usage:daily:v1:${todayUtc()}`,
+      JSON.stringify({
+        date: todayUtc(),
+        errors: 0,
+        cacheHits: 0,
+        calls: 1,
+        tokensIn: 1000,
+        tokensOut: 100,
+        costUsd: 0.001,
+        costInUsd: 0.0007,
+        costOutUsd: 0.0003,
+        pricedCalls: 1,
+        unpricedCalls: 0,
+        byModel: {},
+        byMark: {
+          rabbi: {
+            calls: 1,
+            tokensIn: 1000,
+            tokensOut: 100,
+            costUsd: 0.001,
+            costInUsd: 0.0007,
+            costOutUsd: 0.0003,
+            pricedCalls: 1,
+            unpricedCalls: 0,
+          },
+        },
+        byEnrichment: {},
+      }),
+    );
+    await record(env, [priced({ markId: 'rabbi', tokensIn: 4000, tokensCached: 3000 })]);
+    const s = await readUsageSummary(kv);
+    expect(s.totals.calls).toBe(2);
+    expect(s.totals.tokensCached).toBe(3000);
+    expect(s.byMark.rabbi.tokensCached).toBe(3000);
+    expect(s.byMark.rabbi.tokensIn).toBe(5000);
+  });
+
+  it('normalizes tokensCached onto series entries read from old docs', async () => {
+    const { kv, store } = makeFakeKV();
+    // A historical (read-only) doc from before the field existed.
+    store.set(
+      'usage:daily:v1:2026-01-01',
+      JSON.stringify({
+        date: '2026-01-01',
+        errors: 0,
+        cacheHits: 0,
+        calls: 1,
+        tokensIn: 1000,
+        tokensOut: 100,
+        costUsd: 0.001,
+        costInUsd: 0.0007,
+        costOutUsd: 0.0003,
+        pricedCalls: 1,
+        unpricedCalls: 0,
+        byModel: {},
+        byMark: {
+          rabbi: {
+            calls: 1,
+            tokensIn: 1000,
+            tokensOut: 100,
+            costUsd: 0.001,
+            costInUsd: 0.0007,
+            costOutUsd: 0.0003,
+            pricedCalls: 1,
+            unpricedCalls: 0,
+          },
+        },
+        byEnrichment: {},
+      }),
+    );
+    const s = await readUsageSummary(kv);
+    expect(s.series[0].tokensCached).toBe(0);
+    expect(s.series[0].byMark.rabbi.tokensCached).toBe(0);
+    expect(s.totals.tokensCached).toBe(0);
   });
 
   it('counts unpriced calls without inflating cost, and tracks errors/cache hits', async () => {


### PR DESCRIPTION
First step of the prompt-cache cost program (target: input spend −70-90%; see Sandbox/2026-07-15-cost-analysis/cache-design.md on the analysis side). Measurement before optimization: this PR only records what providers already return.

## What
- `LLMUsage` gains `prompt_tokens_details.cached_tokens` — OpenRouter/OpenAI-compat providers return it today; the type boundary was dropping it.
- `llmcost:v1` per-call ledger records `cached_tokens` (null = routed endpoint has no caching, distinct from a genuine zero-hit call).
- `GET /api/admin/llm-cost` aggregates `cachedTokens` (totals + byModel) — `cachedTokens/promptTokens` is the live 7-day hit rate.
- Daily rollups (`usage:daily:v1:*`) carry `tokensCached` per bucket (totals/byModel/byMark/byEnrichment). Additive over previously stored docs; parsed docs are normalized on read so `series` entries satisfy the declared shape.
- Client type mirrors extended (no UI column yet — that comes with the measured-hit-rate report).

## What it does NOT change
Billed-cost accounting: `usage.cost` stays authoritative; cached tokens are separate telemetry, never subtracted from prompt tokens or folded into billed totals.

## Verification
- `pnpm typecheck` / `pnpm test` (2,726 passing incl. 3 new rollup tests: per-bucket accumulation, old-doc coalescing, read-only old-doc normalization) / `pnpm lint` clean.
- Live check against first-party DeepSeek via OpenRouter: two calls sharing a ~3.7k-token prefix report `cached_tokens: 3712` on the second, billed cost matching the $0.0036/M cache-read rate exactly.
- Codex read-only review: both findings (old-doc series normalization, client type drift) addressed.