### PR TITLE
Prefer first-party DeepSeek routing; deny data collection on QA calls

### DIFF
--- a/packages/core/src/llm/llm.ts
+++ b/packages/core/src/llm/llm.ts
@@ -77,17 +77,27 @@ export interface LLMCallOptions {
   stream?: boolean;
   /**
    * OpenRouter provider routing. When unset, `openrouter/deepseek/*` models
-   * default to `{ sort: 'price', allow_fallbacks: true, require_parameters: true }`
-   * — cheapest qualifying endpoint first (see the routing block in
-   * callOpenRouterGateway). Pass an explicit object to override, or `null` to
-   * opt out and take OpenRouter's default load-balancer. Ignored for `@cf/*`.
+   * default to defaultDeepseekProviderPrefs (first-party-preferred for
+   * non-flash slugs, price-sorted otherwise). Pass an explicit object to
+   * override, or `null` to opt out and take OpenRouter's default
+   * load-balancer. Ignored for `@cf/*`.
    */
   provider?: {
     order?: string[];
     allow_fallbacks?: boolean;
     sort?: 'price' | 'throughput' | 'latency';
     require_parameters?: boolean;
+    data_collection?: 'deny' | 'allow';
   } | null;
+  /**
+   * Per-request data-policy restriction, merged into the provider routing
+   * block (explicit or default). 'deny' keeps the request off providers that
+   * may retain or train on inputs — REQUIRED on any call whose prompt carries
+   * user-typed content (custom Q&A), since the account-level OpenRouter
+   * privacy setting allows training providers for the public-domain
+   * enrichment traffic. Ignored for `@cf/*`.
+   */
+  data_collection?: 'deny' | 'allow';
   /**
    * Skip the Cloudflare AI Gateway's prompt cache for this request. Sends
    * `cf-aig-skip-cache: true` on the OpenRouter Universal Endpoint call. Use
@@ -411,6 +421,46 @@ async function callWorkersAI(
 // Transport: OpenRouter via CF AI Gateway Universal Endpoint
 // ---------------------------------------------------------------------------
 
+/**
+ * Default OpenRouter routing for DeepSeek slugs (undefined for everything
+ * else — non-DeepSeek models take OpenRouter's load-balancer).
+ *
+ * First-party DeepSeek is the list-cheapest host for every deepseek model
+ * EXCEPT v4-flash (third parties undercut its $0.14/M by ~35%), and it is the
+ * ONLY host with working prompt caching (`supports_implicit_caching` is false
+ * on all 16 third-party endpoints; first-party cache reads are $0.0036/M pro /
+ * $0.0028/M flash — ~99% off). So:
+ *
+ *   - non-flash: `order: ['deepseek']` puts first-party first DETERMINISTICALLY.
+ *     Price-sorting alone would usually pick it too (it's cheapest), but
+ *     price-sort flaps between hosts as quotes move, and every flap fragments
+ *     the prefix cache — stable routing is worth more than an occasional
+ *     cheaper quote once shared-prefix prompts land.
+ *   - flash: keep price-sorting (cheaper third parties win today). Flips to
+ *     first-party-preferred together with the shared-prefix prompt work, when
+ *     cache reads make first-party the effective cheapest.
+ *
+ * `require_parameters` keeps structured-output calls on endpoints that honor
+ * response_format/json_schema (first-party lacks `structured_outputs`, so
+ * json_schema calls fall past it to the cheapest qualifying host — the
+ * json_object migration that moves them onto first-party ships separately,
+ * eval-gated). `allow_fallbacks` preserves availability when first-party is
+ * congested or filtered.
+ */
+export function defaultDeepseekProviderPrefs(orSlug: string):
+  | {
+      order?: string[];
+      allow_fallbacks: boolean;
+      sort: 'price';
+      require_parameters: boolean;
+    }
+  | undefined {
+  if (!orSlug.startsWith('deepseek/')) return undefined;
+  const base = { sort: 'price' as const, allow_fallbacks: true, require_parameters: true };
+  if (orSlug.includes('flash')) return base;
+  return { order: ['deepseek'], ...base };
+}
+
 function openRouterGatewayUrl(env: LLMEnv): string {
   const account = env.CLOUDFLARE_ACCOUNT_ID;
   const gateway = env.AI_GATEWAY_ID;
@@ -466,24 +516,24 @@ async function callOpenRouterGateway(
     body.stream_options = { include_usage: true };
   }
   // Provider routing. An explicit opts.provider always wins; pass `null` to
-  // opt out and take OpenRouter's default load-balancer. Otherwise, for any
-  // DeepSeek slug we route cheapest-endpoint-first:
-  //   - V4 Pro: DeepSeek's own endpoint is the cheapest ($0.435/$0.87), so
-  //     price-sorting keeps Pro on first-party.
-  //   - V4 Flash: third-party providers (Baidu / DeepInfra / Cloudflare,
-  //     ~$0.10/$0.20) undercut DeepSeek's own Flash ($0.14/$0.28) by ~30-40%,
-  //     so price-sorting moves Flash to the cheaper endpoint.
-  // `require_parameters` keeps routing to providers that honor everything we
-  // send (response_format / json_schema / reasoning) so structured-output
-  // marks never land on an endpoint that silently drops the schema — if no
-  // cheaper provider qualifies it just falls back to DeepSeek, costing nothing.
-  // `allow_fallbacks` preserves availability under congestion (the reason
-  // hard-pinning was originally removed).
+  // opt out and take OpenRouter's default load-balancer. Otherwise DeepSeek
+  // slugs take defaultDeepseekProviderPrefs (first-party-preferred for
+  // non-flash, price-sorted for flash — rationale on the helper).
   const explicitProvider = (opts as { provider?: unknown }).provider;
   if (explicitProvider !== undefined) {
     if (explicitProvider !== null) body.provider = explicitProvider;
-  } else if (orSlug.startsWith('deepseek/')) {
-    body.provider = { sort: 'price', allow_fallbacks: true, require_parameters: true };
+  } else {
+    const prefs = defaultDeepseekProviderPrefs(orSlug);
+    if (prefs) body.provider = prefs;
+  }
+  // Per-request data-policy restriction composes with whatever routing block
+  // resulted above (including none), so a QA call keeps its protection even
+  // when a caller passed explicit routing prefs.
+  if (opts.data_collection) {
+    body.provider = {
+      ...((body.provider as Record<string, unknown> | undefined) ?? {}),
+      data_collection: opts.data_collection,
+    };
   }
 
   const url = openRouterGatewayUrl(env);

--- a/packages/core/tests/provider-prefs.test.ts
+++ b/packages/core/tests/provider-prefs.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { defaultDeepseekProviderPrefs } from '../src/llm/llm';
+
+describe('defaultDeepseekProviderPrefs', () => {
+  it('prefers first-party deterministically for v4-pro', () => {
+    const p = defaultDeepseekProviderPrefs('deepseek/deepseek-v4-pro');
+    expect(p).toEqual({
+      order: ['deepseek'],
+      sort: 'price',
+      allow_fallbacks: true,
+      require_parameters: true,
+    });
+  });
+
+  it('keeps flash on plain price-sorting (third parties undercut first-party)', () => {
+    const p = defaultDeepseekProviderPrefs('deepseek/deepseek-v4-flash');
+    expect(p).toEqual({ sort: 'price', allow_fallbacks: true, require_parameters: true });
+    expect(p?.order).toBeUndefined();
+  });
+
+  it('covers other deepseek slugs with the first-party preference', () => {
+    expect(defaultDeepseekProviderPrefs('deepseek/deepseek-v3.2-exp')?.order).toEqual(['deepseek']);
+  });
+
+  it('returns undefined for non-deepseek slugs', () => {
+    expect(defaultDeepseekProviderPrefs('anthropic/claude-sonnet-4.5')).toBeUndefined();
+    expect(defaultDeepseekProviderPrefs('openai/gpt-5.5')).toBeUndefined();
+    expect(defaultDeepseekProviderPrefs('z-ai/glm-4.6')).toBeUndefined();
+  });
+});

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -4524,6 +4524,11 @@ const RUN_PORTS: RunProducerPorts<RunCtx, EnrichmentDefinition, SchemaMarkDefini
       // Custom Q&A enrichments (<mark>.qa) count against the hourly custom-question
       // budget; everything else only against the daily total. See ./budget.
       cost_class: def.id.endsWith('.qa') ? 'custom-question' : undefined,
+      // .qa prompts carry the reader's typed question — the one producer path
+      // with user content. Keep those requests off providers that may retain
+      // or train on inputs (the account-level OpenRouter privacy setting
+      // allows training providers for the public-domain enrichment traffic).
+      data_collection: def.id.endsWith('.qa') ? ('deny' as const) : undefined,
     });
   },
   // Post-generation processing via the standardized check layer


### PR DESCRIPTION
Second step of the prompt-cache cost program (design: Sandbox/2026-07-15-cost-analysis/cache-design.md on the analysis side; telemetry in #538).

## Context
The OpenRouter account setting that blocked training providers excluded first-party DeepSeek entirely — the root cause of v4-pro billing at 1.7–4x list on third-party hosts ($325 of the last 30 days' $424). The account now allows it (owner decision: enrichment prompts are public-domain Talmud text). First-party is both the list-cheapest v4-pro host **and the only host with working prompt caching** — `supports_implicit_caching: false` on all 16 third-party endpoints; first-party cache reads are $0.0036/M (pro) / $0.0028/M (flash).

## What
- **`defaultDeepseekProviderPrefs`** (exported + unit-tested): `order: ['deepseek']` + price-sort + fallbacks for non-flash DeepSeek slugs. Deterministic first-party routing rather than price-sort alone: price-sorting flaps hosts, and every flap fragments the prefix cache once shared-prefix prompts land. Flash keeps plain price-sorting (third parties undercut first-party's $0.14/M by ~35%); it flips together with the shared-prefix PR when cache reads make first-party effectively cheapest.
- **`require_parameters` unchanged**: `json_schema` calls keep landing on structured-outputs hosts (first-party lacks the param), so schema enforcement is untouched. The json_object migration that moves those calls onto first-party ships separately, eval-gated.
- **Per-request `data_collection` option**, merged into the provider block last (survives explicit routing prefs). Set to `'deny'` on `.qa` enrichments — the one producer path carrying user-typed content — so those requests never route to training/retaining providers regardless of the account-level setting.

## Verification
- `pnpm typecheck` / `pnpm test` (2,855 passing incl. 4 new) / `pnpm lint` clean.
- Live-tested the exact provider blocks this code sends against OpenRouter: json_object and format-less calls land `provider: DeepSeek`, json_schema falls to a schema-capable host, and the deny block routes off first-party (StreamLake).
- Codex read-only review: clean (provider:null opt-out preserved; deny merge cannot be clobbered).