### PR TITLE
Route schema-shaped DeepSeek calls onto first-party via json_object + inlined schema

### DIFF
--- a/packages/core/src/llm/llm.ts
+++ b/packages/core/src/llm/llm.ts
@@ -471,6 +471,56 @@ export function defaultDeepseekProviderPrefs(orSlug: string):
   return { order: ['deepseek'], ...base };
 }
 
+/**
+ * First-party DeepSeek — the only host with working prompt caching, and the
+ * list-cheapest non-flash endpoint ($0.435/M vs $0.71-1.74 on third parties)
+ * — does not support `structured_outputs`. A `json_schema` response_format +
+ * `require_parameters` therefore routes every schema-shaped call past it,
+ * which in practice was most of the v4-pro traffic (effective rate ~$1.20/M).
+ *
+ * For slugs whose default routing prefers first-party (non-flash DeepSeek),
+ * convert the request into what first-party CAN honor:
+ *   - `json_object` mode — syntactically valid JSON guaranteed, supported by
+ *     first-party and by every fallback host. (DeepSeek's json_object also
+ *     requires the prompt to mention JSON — the injected text satisfies it.)
+ *   - the schema inlined at the END of the system message, so the model
+ *     still sees the exact expected shape. The injected block is byte-stable
+ *     per producer (schema JSON is deterministic), which keeps the system
+ *     message a stable prefix for provider-side prompt caching.
+ *
+ * Structural conformance shifts from provider-side grammar to the model plus
+ * the existing parse/checks gate — a parse failure blocks the cache write and
+ * is counted/observable, so a regression here is visible, not silent.
+ * Flash and non-DeepSeek slugs are untouched (their hosts support
+ * json_schema and are already cheap).
+ */
+export function inlineSchemaForFirstParty(
+  orSlug: string,
+  messages: LLMMessage[],
+  response_format: LLMCallOptions['response_format'],
+): { messages: LLMMessage[]; response_format: LLMCallOptions['response_format'] } {
+  const prefersFirstParty = orSlug.startsWith('deepseek/') && !orSlug.includes('flash');
+  if (!prefersFirstParty || response_format?.type !== 'json_schema') {
+    return { messages, response_format };
+  }
+  // output_schema values are OpenAI-style wrappers ({ name, strict, schema });
+  // inline the inner JSON Schema. Tolerate a raw schema passed directly.
+  const wrapper = response_format.json_schema as { schema?: unknown } | null | undefined;
+  const schema =
+    wrapper && typeof wrapper === 'object' && wrapper.schema !== undefined
+      ? wrapper.schema
+      : wrapper;
+  const guidance = `\n\nReturn ONLY a single JSON object — no markdown fences, no commentary. It must conform to this JSON Schema:\n${JSON.stringify(schema)}`;
+  const idx = messages.findIndex((m) => m.role === 'system');
+  const out = messages.slice();
+  if (idx >= 0) {
+    out[idx] = { ...out[idx], content: out[idx].content + guidance };
+  } else {
+    out.unshift({ role: 'system', content: guidance.trimStart() });
+  }
+  return { messages: out, response_format: { type: 'json_object' } };
+}
+
 function openRouterGatewayUrl(env: LLMEnv): string {
   const account = env.CLOUDFLARE_ACCOUNT_ID;
   const gateway = env.AI_GATEWAY_ID;
@@ -497,17 +547,25 @@ async function callOpenRouterGateway(
 ): Promise<Omit<LLMResult, 'attempts'>> {
   if (!env.OPENROUTER_API_KEY)
     throw new LLMError(503, 'OPENROUTER_API_KEY not set', { cls: NEITHER });
-  const promptChars = opts.messages.reduce((s, m) => s + m.content.length, 0);
   const t0 = Date.now();
   const orSlug = model.replace(/^openrouter\//, '');
+  // json_schema -> json_object + inlined schema for first-party-preferred
+  // DeepSeek slugs (no-op for everything else). Must run before the body is
+  // assembled so promptChars and the sent messages agree.
+  const { messages, response_format } = inlineSchemaForFirstParty(
+    orSlug,
+    opts.messages,
+    opts.response_format,
+  );
+  const promptChars = messages.reduce((s, m) => s + m.content.length, 0);
 
   const body: Record<string, unknown> = {
     model: orSlug,
-    messages: opts.messages,
+    messages,
     max_tokens: opts.max_tokens,
     temperature: opts.temperature ?? DEFAULT_TEMPERATURE,
   };
-  if (opts.response_format) body.response_format = opts.response_format;
+  if (response_format) body.response_format = response_format;
   // Ask OpenRouter to return billed cost (USD, net of prompt-cache discounts)
   // in the response `usage` object. Drives the cost ledger / /api/admin/llm-cost.
   body.usage = { include: true };

--- a/packages/core/tests/inline-schema.test.ts
+++ b/packages/core/tests/inline-schema.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { inlineSchemaForFirstParty, type LLMMessage } from '../src/llm/llm';
+
+const SCHEMA_WRAPPER = {
+  name: 'test_shape',
+  strict: true,
+  schema: {
+    type: 'object',
+    required: ['ok'],
+    properties: { ok: { type: 'boolean' } },
+  },
+};
+const JSON_SCHEMA_RF = { type: 'json_schema' as const, json_schema: SCHEMA_WRAPPER };
+
+const msgs = (): LLMMessage[] => [
+  { role: 'system', content: 'You are the extractor.' },
+  { role: 'user', content: 'Extract from this daf.' },
+];
+
+describe('inlineSchemaForFirstParty', () => {
+  it('converts json_schema to json_object and inlines the inner schema for v4-pro', () => {
+    const input = msgs();
+    const { messages, response_format } = inlineSchemaForFirstParty(
+      'deepseek/deepseek-v4-pro',
+      input,
+      JSON_SCHEMA_RF,
+    );
+    expect(response_format).toEqual({ type: 'json_object' });
+    expect(messages[0].content).toContain('You are the extractor.');
+    expect(messages[0].content).toContain('conform to this JSON Schema');
+    expect(messages[0].content).toContain(JSON.stringify(SCHEMA_WRAPPER.schema));
+    // the wrapper's name/strict metadata is not injected, only the schema
+    expect(messages[0].content).not.toContain('test_shape');
+    // user message untouched; original array not mutated
+    expect(messages[1]).toEqual(input[1]);
+    expect(input[0].content).toBe('You are the extractor.');
+  });
+
+  it('mentions JSON in the injected text (DeepSeek json_object requirement)', () => {
+    const { messages } = inlineSchemaForFirstParty(
+      'deepseek/deepseek-v4-pro',
+      msgs(),
+      JSON_SCHEMA_RF,
+    );
+    expect(messages[0].content).toMatch(/JSON/);
+  });
+
+  it('prepends a system message when none exists', () => {
+    const { messages } = inlineSchemaForFirstParty(
+      'deepseek/deepseek-v4-pro',
+      [{ role: 'user', content: 'Extract.' }],
+      JSON_SCHEMA_RF,
+    );
+    expect(messages[0].role).toBe('system');
+    expect(messages[0].content).toContain('conform to this JSON Schema');
+    expect(messages[1].content).toBe('Extract.');
+  });
+
+  it('tolerates a raw schema without the OpenAI wrapper', () => {
+    const raw = { type: 'object', properties: { x: { type: 'string' } } };
+    const { messages } = inlineSchemaForFirstParty('deepseek/deepseek-v4-pro', msgs(), {
+      type: 'json_schema',
+      json_schema: raw,
+    });
+    expect(messages[0].content).toContain(JSON.stringify(raw));
+  });
+
+  it('leaves flash untouched (hosts support json_schema and are already cheap)', () => {
+    const input = msgs();
+    const out = inlineSchemaForFirstParty('deepseek/deepseek-v4-flash', input, JSON_SCHEMA_RF);
+    expect(out.response_format).toBe(JSON_SCHEMA_RF);
+    expect(out.messages).toBe(input);
+  });
+
+  it('leaves non-deepseek slugs untouched', () => {
+    const input = msgs();
+    const out = inlineSchemaForFirstParty('anthropic/claude-sonnet-4.5', input, JSON_SCHEMA_RF);
+    expect(out.response_format).toBe(JSON_SCHEMA_RF);
+    expect(out.messages).toBe(input);
+  });
+
+  it('leaves json_object and absent response_format untouched', () => {
+    const input = msgs();
+    const a = inlineSchemaForFirstParty('deepseek/deepseek-v4-pro', input, {
+      type: 'json_object',
+    });
+    expect(a.response_format).toEqual({ type: 'json_object' });
+    expect(a.messages).toBe(input);
+    const b = inlineSchemaForFirstParty('deepseek/deepseek-v4-pro', input, undefined);
+    expect(b.response_format).toBeUndefined();
+    expect(b.messages).toBe(input);
+  });
+});


### PR DESCRIPTION
Third step of the prompt-cache cost program (#538 telemetry, #539 routing preference). Pulls the json_object migration forward: the live warm measurement showed v4-pro still billing ~$1.20/M because json_schema + require_parameters excludes first-party DeepSeek ($0.435/M, and the only host with working prompt caching) — schema-shaped calls were most of the pro traffic.

## What
`inlineSchemaForFirstParty` (exported, unit-tested): for **non-flash deepseek/* slugs** with `response_format: json_schema`, send `json_object` instead and append the inner JSON Schema to the system message. First-party honors json_object (syntactic validity guaranteed) and the injected text satisfies DeepSeek's prompt-must-mention-JSON requirement. The injected block is byte-stable per producer — the system message stays a stable prefix for provider-side prompt caching. Flash + non-DeepSeek slugs untouched; a pro→flash fallback re-sends the original json_schema (verified: opts are reused per attempt).

## Tradeoff, stated plainly
Structural conformance shifts from provider-side grammar to the model + the existing JSON.parse/checks gate. Parse failures block the cache write and are counted — visible on /usage (errors, lint failures) and /api/admin/recent-errors. If parse/lint rates rise, revert is this single commit.

## Verification
- `pnpm typecheck` / `pnpm test` (2,865 passing incl. 7 new transform tests) / `pnpm lint` clean.
- Live-validated the exact emitted request shape (real daf text + a real producer schema, first-party-preferred provider block): lands `provider: DeepSeek`, output parses, required keys present, no extra keys, enum respected.
- Codex read-only review: clean on all five asks (mutation, promptChars/body consistency, Workers-AI/streaming paths, fallback re-sends original json_schema, edge cases).