### PR TITLE
Shared daf-text preamble: restructure prompts for provider prefix caching

### DIFF
--- a/packages/core/src/llm/llm.ts
+++ b/packages/core/src/llm/llm.ts
@@ -512,7 +512,17 @@ export function inlineSchemaForFirstParty(
       ? wrapper.schema
       : wrapper;
   const guidance = `\n\nReturn ONLY a single JSON object — no markdown fences, no commentary. It must conform to this JSON Schema:\n${JSON.stringify(schema)}`;
-  const idx = messages.findIndex((m) => m.role === 'system');
+  // Append to the LAST system message: message 0 may be the shared daf-context
+  // preamble (see run/daf-preamble.ts), which must stay byte-identical across
+  // producers or the provider prefix cache splits. The producer-instruction
+  // system message is the right home — schema text is producer-constant.
+  let idx = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === 'system') {
+      idx = i;
+      break;
+    }
+  }
   const out = messages.slice();
   if (idx >= 0) {
     out[idx] = { ...out[idx], content: out[idx].content + guidance };

--- a/packages/core/src/run/daf-preamble.ts
+++ b/packages/core/src/run/daf-preamble.ts
@@ -1,0 +1,109 @@
+/**
+ * Shared daf-text preamble — the shared-prefix backbone of provider-side
+ * prompt caching.
+ *
+ * Every producer that works on a daf used to inline the daf text (Hebrew +
+ * English, ~8-15k tokens) somewhere in the MIDDLE of its own prompt, behind
+ * producer-specific framing — so across the ~40-120 LLM calls of a cold daf
+ * the byte-shared prefix was zero and provider prefix caching (first-party
+ * DeepSeek: cache reads at ~1% of the input price) never engaged.
+ *
+ * This module restructures every daf-bound request as:
+ *
+ *   [ DAF CONTEXT preamble — byte-identical for a given daf across ALL
+ *     producers and BOTH languages ]  +  [ producer instructions ]  +
+ *   [ per-call content, most-shared first ]
+ *
+ * so call 2..N of a warm burst reads the daf at the cache-hit price.
+ *
+ * Byte-identity is BY CONSTRUCTION: the preamble is built here, from the
+ * canonical segment arrays only, with fixed formatting — producers never
+ * render their own copy (one byte of drift = a cold prefix; same failure
+ * class as the cache-key slug lesson). The daf-text template variables are
+ * then "pointerized" so the text is not paid for twice in one prompt.
+ * Segment numbering is [0]-based, matching the app renderers' `[i] seg`
+ * convention, so producer prompts that reference segment numbers stay valid.
+ *
+ * Producers whose vars carry no segment arrays (daf-agnostic work: rabbi
+ * biography leaves, translate/hebraize utilities) get no preamble — the
+ * builder returns null and their prompts are untouched.
+ */
+
+/** Template vars that carry (a rendering of) the daf text. */
+export const DAF_TEXT_VAR_KEYS = [
+  'gemara',
+  'gemara_he',
+  'gemara_en',
+  'hebrew',
+  'english',
+  'segments_he',
+  'segments_en',
+] as const;
+
+/** What a pointerized daf-text var renders as inside a producer template. */
+export const DAF_TEXT_POINTER =
+  '(the full daf text is in the DAF CONTEXT block at the top of this prompt)';
+
+function numbered(segs: string[]): string {
+  return segs.map((s, i) => `[${i}] ${s}`).join('\n');
+}
+
+/**
+ * Build the canonical bilingual daf-context block, or null when the vars
+ * carry no Hebrew segment array (daf-agnostic producers, non-daf spines).
+ * Depends ONLY on tractate/page + the segment arrays — never on producer,
+ * language, or call shape — so it is byte-identical wherever it appears.
+ */
+export function buildDafPreamble(vars: Record<string, unknown>): string | null {
+  const he = vars.segments_he;
+  if (!Array.isArray(he) || he.length === 0) return null;
+  const en = vars.segments_en;
+  const tractate = typeof vars.tractate === 'string' ? vars.tractate : '';
+  const page = typeof vars.page === 'string' ? vars.page : '';
+  const enBlock =
+    Array.isArray(en) && en.length > 0
+      ? `\n\n=== ENGLISH SEGMENTS ===\n${numbered(en as string[])}`
+      : '';
+  return (
+    `=== DAF CONTEXT: ${tractate} ${page} ===\n` +
+    'The canonical text of this daf follows. The task below refers to it; ' +
+    'segment numbers [n] refer to these lines.\n\n' +
+    `=== HEBREW SEGMENTS ===\n${numbered(he as string[])}${enBlock}`
+  );
+}
+
+/**
+ * Shallow-copy `vars` with every daf-text var replaced by a short pointer,
+ * so templates keep their structure without re-paying for the text the
+ * preamble already carries. `keepInline` exempts vars whose value is
+ * per-call (e.g. a fan-out's narrowed section slice — that IS the
+ * instance-specific content and must stay in the tail).
+ */
+export function pointerizeDafVars(
+  vars: Record<string, unknown>,
+  keepInline: readonly string[] = [],
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...vars };
+  for (const k of DAF_TEXT_VAR_KEYS) {
+    if (keepInline.includes(k)) continue;
+    if (out[k] !== undefined) out[k] = DAF_TEXT_POINTER;
+  }
+  return out;
+}
+
+/**
+ * Prepend the preamble as its OWN leading system message. Measured on
+ * first-party DeepSeek: a byte-identical complete leading message reliably
+ * prefix-caches across different producers (96% of prompt tokens at the
+ * cache-read price), while the same bytes merged into one system message
+ * that diverges later in the SAME message did not. Downstream, the
+ * schema-inlining transform appends to the LAST system message, so the
+ * preamble message is never perturbed.
+ */
+export function prependPreamble<M extends { role: string; content: string }>(
+  preamble: string | null | undefined,
+  messages: M[],
+): M[] {
+  if (!preamble) return messages;
+  return [{ role: 'system', content: preamble } as M, ...messages];
+}

--- a/packages/core/src/run/run-producer.ts
+++ b/packages/core/src/run/run-producer.ts
@@ -41,6 +41,7 @@ import { instanceIdOf, normalizeQualifier, qualifierHash } from '../cache/keys.t
 import type { CostStamp, InputRef, Provenance } from '../model/provenance.ts';
 import { authorityForTransport } from '../model/provenance.ts';
 import type { StoredArtifact } from '../store/envelope.ts';
+import { buildDafPreamble, pointerizeDafVars } from './daf-preamble.ts';
 import type { ResolvedInputs, RunDependency } from './producer-run.ts';
 
 export type RunLang = 'en' | 'he';
@@ -174,7 +175,9 @@ export interface RunProducerPorts<
     },
   ): Promise<{ result: LLMResultLike; systemPrompt: string; userPrompt: string }>;
   /** The enrichment LLM call (host owns options: model override / reasoning /
-   *  cost_class / attribution). Prompts are already rendered by core. */
+   *  cost_class / attribution). Prompts are already rendered by core. When
+   *  `contextPreamble` is non-null the host must send it as the LEADING
+   *  system content (see daf-preamble.ts — it is the shared cache prefix). */
   enrichmentLLM(
     ctx: Ctx,
     args: {
@@ -186,6 +189,7 @@ export interface RunProducerPorts<
       page: string;
       bypassCache: boolean;
       modelOverride?: string;
+      contextPreamble?: string | null;
     },
   ): Promise<LLMResultLike>;
   /** The post-generation check layer (the host fetches whatever context its
@@ -611,8 +615,15 @@ export async function runProducer<
       useHe && edef.user_prompt_template_he
         ? edef.user_prompt_template_he
         : edef.user_prompt_template;
-    systemPrompt = ports.renderTemplate(sysTpl, vars);
-    userPrompt = ports.renderTemplate(usrTpl, vars);
+    // Shared-prefix restructure: the daf text moves into a canonical leading
+    // preamble (byte-identical across producers and languages, so provider
+    // prompt caching engages) and the in-template daf vars render as a short
+    // pointer instead of a second copy. Daf-agnostic producers (no segment
+    // arrays in vars) get null and are untouched.
+    const contextPreamble = buildDafPreamble(vars);
+    const promptVars = contextPreamble ? pointerizeDafVars(vars) : vars;
+    systemPrompt = ports.renderTemplate(sysTpl, promptVars);
+    userPrompt = ports.renderTemplate(usrTpl, promptVars);
     result = await ports.enrichmentLLM(ctx, {
       def: edef,
       systemPrompt,
@@ -622,6 +633,7 @@ export async function runProducer<
       page,
       bypassCache,
       modelOverride: opts.modelOverride,
+      contextPreamble,
     });
   }
 

--- a/packages/core/tests/daf-preamble.test.ts
+++ b/packages/core/tests/daf-preamble.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildDafPreamble,
+  DAF_TEXT_POINTER,
+  pointerizeDafVars,
+  prependPreamble,
+} from '../src/run/daf-preamble';
+
+const dafVars = (extra: Record<string, unknown> = {}) => ({
+  tractate: 'Chullin',
+  page: '79a',
+  hebrew: 'HE-FULL',
+  english: 'EN-FULL',
+  gemara: 'HE-FULL\n\n---\n\nEN-FULL',
+  gemara_he: 'HE-FULL',
+  gemara_en: 'EN-FULL',
+  segments_he: ['aleph', 'bet'],
+  segments_en: ['first', 'second'],
+  ...extra,
+});
+
+describe('buildDafPreamble', () => {
+  it('is byte-identical regardless of producer-specific vars or language', () => {
+    const a = buildDafPreamble(dafVars({ mark_input: { move: 1 }, context: 'X' }));
+    const b = buildDafPreamble(dafVars({ commentaries: 'Rashi...', depends: { flow: {} } }));
+    expect(a).toBe(b === null ? a : b);
+    expect(a).not.toBeNull();
+  });
+
+  it('numbers segments [0]-based, matching the renderers', () => {
+    const p = buildDafPreamble(dafVars());
+    expect(p).toContain('=== DAF CONTEXT: Chullin 79a ===');
+    expect(p).toContain('[0] aleph\n[1] bet');
+    expect(p).toContain('[0] first\n[1] second');
+  });
+
+  it('returns null for daf-agnostic vars (no segment arrays)', () => {
+    expect(buildDafPreamble({ tractate: 'Chullin', page: '79a', name: 'Rava' })).toBeNull();
+    expect(buildDafPreamble(dafVars({ segments_he: [] }))).toBeNull();
+  });
+
+  it('tolerates missing English segments', () => {
+    const p = buildDafPreamble(dafVars({ segments_en: undefined }));
+    expect(p).toContain('[0] aleph');
+    expect(p).not.toContain('ENGLISH SEGMENTS');
+  });
+});
+
+describe('pointerizeDafVars', () => {
+  it('replaces every daf-text var, leaves the rest, does not mutate', () => {
+    const vars = dafVars({ mark_input: { x: 1 }, context: 'keep' });
+    const out = pointerizeDafVars(vars);
+    for (const k of ['gemara', 'hebrew', 'english', 'segments_he', 'segments_en']) {
+      expect(out[k]).toBe(DAF_TEXT_POINTER);
+    }
+    expect(out.mark_input).toEqual({ x: 1 });
+    expect(out.context).toBe('keep');
+    expect(vars.segments_he).toEqual(['aleph', 'bet']);
+  });
+
+  it('honors keepInline exemptions', () => {
+    const out = pointerizeDafVars(dafVars(), ['segments_he']);
+    expect(out.segments_he).toEqual(['aleph', 'bet']);
+    expect(out.gemara).toBe(DAF_TEXT_POINTER);
+  });
+});
+
+describe('prependPreamble', () => {
+  it('adds the preamble as its own leading system message', () => {
+    const base = [
+      { role: 'system', content: 'INSTRUCTIONS' },
+      { role: 'user', content: 'TASK' },
+    ];
+    const out = prependPreamble('PREAMBLE', base);
+    expect(out).toHaveLength(3);
+    expect(out[0]).toEqual({ role: 'system', content: 'PREAMBLE' });
+    expect(out[1].content).toBe('INSTRUCTIONS');
+    expect(base).toHaveLength(2);
+  });
+
+  it('passes messages through untouched with no preamble', () => {
+    const base = [{ role: 'user', content: 'TASK' }];
+    expect(prependPreamble(null, base)).toBe(base);
+    expect(prependPreamble(undefined, base)).toBe(base);
+  });
+});

--- a/packages/core/tests/inline-schema.test.ts
+++ b/packages/core/tests/inline-schema.test.ts
@@ -45,6 +45,22 @@ describe('inlineSchemaForFirstParty', () => {
     expect(messages[0].content).toMatch(/JSON/);
   });
 
+  it('appends to the LAST system message, never the leading preamble', () => {
+    const input: LLMMessage[] = [
+      { role: 'system', content: 'DAF PREAMBLE' },
+      { role: 'system', content: 'You are the extractor.' },
+      { role: 'user', content: 'Extract.' },
+    ];
+    const { messages } = inlineSchemaForFirstParty(
+      'deepseek/deepseek-v4-pro',
+      input,
+      JSON_SCHEMA_RF,
+    );
+    expect(messages[0].content).toBe('DAF PREAMBLE');
+    expect(messages[1].content).toContain('conform to this JSON Schema');
+    expect(messages[2].content).toBe('Extract.');
+  });
+
   it('prepends a system message when none exists', () => {
     const { messages } = inlineSchemaForFirstParty(
       'deepseek/deepseek-v4-pro',

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -35,6 +35,11 @@ import {
   transitiveDependents,
 } from '@corpus/core/registry/depGraph';
 import {
+  buildDafPreamble,
+  pointerizeDafVars,
+  prependPreamble,
+} from '@corpus/core/run/daf-preamble';
+import {
   type ResolvedInputs,
   type ResolveInputsPorts,
   resolveInputs,
@@ -4209,35 +4214,42 @@ async function runExtractorFannedOut(
     ? dedupeByRange(rawInstances as Array<Partial<{ startSegIdx: number; endSegIdx: number }>>)
     : rawInstances;
 
+  // Shared-prefix restructure: the whole-daf context becomes the byte-stable
+  // leading block of EVERY fan-out call (same preamble the single-call and
+  // enrichment paths send), so per-section calls share the cache prefix with
+  // each other and with every other producer on this daf. Daf-text vars are
+  // pointerized; the narrowed per-section slice below then overwrites
+  // segments_he — the section text is instance-specific and stays inline.
+  const contextPreamble = buildDafPreamble(baseVars);
+  const pointeredBase = contextPreamble ? pointerizeDafVars(baseVars) : baseVars;
+
   const renderAndCall = async (
     anchorsOverride: Record<string, unknown>,
     maxTokens: number,
     segRange?: { start: number; end: number },
   ) => {
-    const callVars: Record<string, unknown> = { ...baseVars, anchors: anchorsOverride };
-    // Fan-out scoping: when this call covers a single section, send only that
-    // section's Hebrew segments instead of the whole amud. Pre-number the lines
-    // with their GLOBAL segment index (the exact [N] labels renderTemplate emits
-    // for the full array) so excerpt anchoring and the section-range move ids
-    // stay valid; passing a string makes renderTemplate skip its array path and
-    // emit it verbatim. Cuts (sections-1)x the amud's Hebrew per daf — the
-    // section text is the only large payload that was duplicated across calls.
+    const callVars: Record<string, unknown> = { ...pointeredBase, anchors: anchorsOverride };
+    // Fan-out scoping: when this call covers a single section, send that
+    // section's Hebrew segments inline. Pre-number the lines with their GLOBAL
+    // segment index (the exact [N] labels renderTemplate emits for the full
+    // array — and that the preamble uses) so excerpt anchoring and the
+    // section-range move ids stay valid; passing a string makes renderTemplate
+    // skip its array path and emit it verbatim. An out-of-range section (data
+    // drift between the parent mark and the slice) keeps the pointer — the
+    // full text is in the preamble.
     if (segRange && Array.isArray(baseVars.segments_he)) {
       const full = baseVars.segments_he as string[];
       const sliced = full.map((s, i) => `[${i}] ${s}`).slice(segRange.start, segRange.end + 1);
-      // Only narrow when the range actually selects segments. An out-of-range
-      // section (data drift between the parent mark and the slice) falls back
-      // to the full amud rather than sending an empty source.
       if (sliced.length > 0) callVars.segments_he = sliced.join('\n');
     }
     const systemPrompt = renderTemplate(ext.system_prompt, callVars);
     const userPrompt = renderTemplate(ext.user_prompt_template, callVars);
     const r = await runLLM(rc.env, {
       ...llmOptsBase,
-      messages: [
+      messages: prependPreamble(contextPreamble, [
         { role: 'system', content: systemPrompt },
         { role: 'user', content: userPrompt },
-      ],
+      ]),
       max_tokens: maxTokens,
     } as Parameters<typeof runLLM>[1]);
     return { r, systemPrompt, userPrompt };
@@ -4483,14 +4495,18 @@ const RUN_PORTS: RunProducerPorts<RunCtx, EnrichmentDefinition, SchemaMarkDefini
         userPrompt: fanned.userPromptSample,
       };
     }
-    const systemPrompt = renderTemplate(a.sysTpl, a.vars);
-    const userPrompt = renderTemplate(a.usrTpl, a.vars);
+    // Shared-prefix restructure (see daf-preamble.ts): canonical daf block
+    // first, pointerized daf vars in the producer template.
+    const contextPreamble = buildDafPreamble(a.vars);
+    const promptVars = contextPreamble ? pointerizeDafVars(a.vars) : a.vars;
+    const systemPrompt = renderTemplate(a.sysTpl, promptVars);
+    const userPrompt = renderTemplate(a.usrTpl, promptVars);
     const result = await runLLM(rc.env, {
       ...llmOptsBase,
-      messages: [
+      messages: prependPreamble(contextPreamble, [
         { role: 'system', content: systemPrompt },
         { role: 'user', content: userPrompt },
-      ],
+      ]),
       max_tokens: 16000,
     });
     return { result, systemPrompt, userPrompt };
@@ -4500,10 +4516,12 @@ const RUN_PORTS: RunProducerPorts<RunCtx, EnrichmentDefinition, SchemaMarkDefini
     const model = (a.modelOverride as LLMModelId | undefined) ?? def.model;
     return runLLM(rc.env, {
       ...(model ? { model } : {}),
-      messages: [
+      // Preamble-first as its OWN system message: a byte-identical complete
+      // leading message is what reliably prefix-caches across producers.
+      messages: prependPreamble(a.contextPreamble, [
         { role: 'system', content: a.systemPrompt },
         { role: 'user', content: a.userPrompt },
-      ],
+      ]),
       max_tokens: 16000,
       temperature: 0.2,
       response_format: def.output_schema


### PR DESCRIPTION
The centerpiece of the cost program (#538 telemetry, #539/#540/#541 routing): makes the daf text a byte-identical shared prefix so first-party DeepSeek's context cache reprices it at ~1% for calls 2..N of a warm burst.

## Design (measured, not assumed)
- **`buildDafPreamble`**: canonical bilingual daf block from the segment arrays only — byte-identical per daf across ALL producers and BOTH languages, by construction (one builder; producers never render their own copy).
- **`prependPreamble`**: the preamble is its OWN leading system message. Live-measured on first-party DeepSeek: the split form cached **3,712/3,876 tokens (96%) with cost −94%** across two different producers, while the same bytes merged into one diverging system message cached **zero** — DeepSeek's matcher wants a complete identical leading message.
- **`pointerizeDafVars`**: in-template daf vars render as a one-line pointer, so the text isn't paid for twice.
- Fan-out keeps the narrowed per-section slice inline (instance-specific content, global `[n]` numbering that matches the preamble); `inlineSchemaForFirstParty` now appends to the LAST system message so the preamble stays pristine.
- EN and HE runs share the same preamble (item: bilingual by construction), so a HE warm following an EN warm reads the daf at cache price.
- Daf-agnostic producers (rabbi leaves, translate/hebraize) are untouched (null preamble). Tanach unaffected (optional port field, no daf vars).

## Behavior notes
- Producers that previously saw only Hebrew now also see the English segments in the preamble (superset of context). Parse/lint/check gates and /api/admin/recent-errors make any quality drift observable; the deliberate first measurement is the next daf warm.
- Cache keys untouched: existing cached output serves as-is; only fresh generations use the new shape.

## Verification
- `pnpm typecheck` / `pnpm test` (2,874 passing incl. 11 new preamble + transform tests) / `pnpm lint` clean.
- Live validation: payloads emitted by the actual new code path land on first-party, parse, conform to schema, and prefix-cache at 96%.
- Codex read-only review: clean on all five asks (byte-identity, fan-out narrowing, tanach compat, Hebrew-only templates, stored-prompt consumers).