### PR TITLE
Cache-tier the argument-move prompt ordering: daf-constant blocks before the instance

### DIFF
--- a/packages/talmud/src/worker/code-marks.ts
+++ b/packages/talmud/src/worker/code-marks.ts
@@ -3769,16 +3769,20 @@ Rules:
 
 ${HEBREW_GLOSS_STYLE}`;
 
+// Prompt ordering rule (cache tiering): everything constant for the DAF
+// (gemara pointer, the rishonim block) comes BEFORE the per-move instance, so
+// the ~15-30 per-move calls of one daf share a byte-identical prefix through
+// the big commentaries block and read it at the provider cache-hit price.
 const ARGUMENT_MOVE_COMMENTARIES_USER_TEMPLATE = `Tractate: {{tractate}}, page {{page}}.
-
-THIS move:
-{{mark_input}}
 
 Hebrew source for the daf:
 {{gemara_he}}
 
 Rashi + Tosafot + other rishonim:
 {{commentaries}}
+
+THIS move:
+{{mark_input}}
 
 Produce the commentary digest for THIS move per the schema.`;
 
@@ -3801,10 +3805,10 @@ HARD RULES:
 
 ${HEBREW_GLOSS_STYLE}`;
 
+// Same cache-tiering order as the commentaries template: daf-constant blocks
+// (move list, gemara pointer, rabbi list) first, THIS move + its per-move
+// digest last.
 const ARGUMENT_MOVE_SYNTHESIS_USER_TEMPLATE = `Tractate: {{tractate}}, page {{page}}.
-
-THIS move:
-{{mark_input}}
 
 All moves on this daf (use to identify what THIS move responds to / supports / objects to):
 {{anchors.argument-move}}
@@ -3812,11 +3816,14 @@ All moves on this daf (use to identify what THIS move responds to / supports / o
 Hebrew source for the daf:
 {{gemara_he}}
 
-Commentary digest for THIS move (use to weave a single brief commentary clause if it sharpens the synthesis; do NOT enumerate):
-{{depends.argument-move.commentaries}}
-
 Rabbis identified on the daf:
 {{anchors.rabbi}}
+
+THIS move:
+{{mark_input}}
+
+Commentary digest for THIS move (use to weave a single brief commentary clause if it sharpens the synthesis; do NOT enumerate):
+{{depends.argument-move.commentaries}}
 
 Compose ONE tight paragraph about THIS move per the schema.`;
 
@@ -3964,14 +3971,14 @@ ${HEBREW_NATIVE_STYLE}`;
 
 const ARGUMENT_MOVE_COMMENTARIES_USER_TEMPLATE_HE = `מסכת: {{tractate}}, דף {{page}}.
 
-ה-move הזה:
-{{mark_input}}
-
 מקור עברי לדף:
 {{gemara_he}}
 
 רש"י + תוספות + ראשונים נוספים:
 {{commentaries}}
+
+ה-move הזה:
+{{mark_input}}
 
 הפק את תקציר הפירוש עבור ה-move הזה לפי הסכימה.`;
 
@@ -3994,20 +4001,20 @@ ${HEBREW_NATIVE_STYLE}`;
 
 const ARGUMENT_MOVE_SYNTHESIS_USER_TEMPLATE_HE = `מסכת: {{tractate}}, דף {{page}}.
 
-ה-move הזה:
-{{mark_input}}
-
 כל ה-moves בדף זה (השתמש כדי לזהות על מה ה-move הזה מגיב / תומך / מקשה):
 {{anchors.argument-move}}
 
 מקור עברי לדף:
 {{gemara_he}}
 
-תקציר פירוש ל-move הזה (השתמש כדי לשזור פסוקית פירוש קצרה אחת אם היא מחדדת את ה-synthesis; אל תמנה):
-{{depends.argument-move.commentaries}}
-
 חכמים שזוהו בדף:
 {{anchors.rabbi}}
+
+ה-move הזה:
+{{mark_input}}
+
+תקציר פירוש ל-move הזה (השתמש כדי לשזור פסוקית פירוש קצרה אחת אם היא מחדדת את ה-synthesis; אל תמנה):
+{{depends.argument-move.commentaries}}
 
 חבר פסקה הדוקה אחת על ה-move הזה לפי הסכימה.`;
 


### PR DESCRIPTION
Follow-up to #542 (shared daf preamble): the second cache tier. `argument-move.commentaries` re-sends the full daf's rishonim block on every one of ~15-30 per-move calls (455M input tokens / 50 days, 266:1 input:output, ~48k tokens per call) — positioned after the per-move `mark_input`, where it can never prefix-share.

## What
Reorders the user templates (EN + HE) for `argument-move.commentaries` and `argument-move.synthesis` so daf-constant blocks (rishonim text, full move list, rabbi list, gemara pointer) precede the per-move instance. Combined with the leading preamble message, the family's calls share a byte-identical prefix through the big blocks: move 1 pays, moves 2..N read at the ~1% cache-hit price.

Content unchanged — same blocks, same labels, same task; only order moved. Cache keys/versions untouched (existing output serves as-is; recipe-hash staleness will correctly flag old entries as stale-recipe).

## Verification
`pnpm typecheck` / talmud tests (2,663) / `pnpm lint` clean. The cache mechanics this relies on (complete-leading-message + mid-final-message prefix hits on first-party DeepSeek) were live-measured in #542 and #540.