### PR TITLE
Learned rabbi voice graph: Shas-wide fold of argument.voices

### DIFF
--- a/packages/talmud/src/worker/cache-keys.ts
+++ b/packages/talmud/src/worker/cache-keys.ts
@@ -254,6 +254,11 @@ export function keyForRabbiBioOnDaf(
 export function keyForRabbiGraph(): string {
   return 'rabbi-graph:v1';
 }
+/** The learned Shas-wide rabbi voice graph (voice-graph.ts / warm-cron fold).
+ *  Distinct from rabbi-graph:v1 (the compiled curated teacher/student blob). */
+export function keyForRabbiVoiceGraph(): string {
+  return 'rabbi-voice-graph:v1';
+}
 export function keyForRabbiCohort(): string {
   return 'rabbi-cohort:v1';
 }

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -145,6 +145,7 @@ import {
   keyForRabbiObs,
   keyForRabbiObsDirty,
   keyForRabbiPlacesIndex,
+  keyForRabbiVoiceGraph,
   keyForRabbiWikiBio,
   keyForRabbiWikidata,
   keyForReferences,
@@ -294,14 +295,17 @@ import {
   recordUnknownRabbi,
 } from './unknown-registry';
 import { readUsageSummary, recordUsage } from './usage-rollup';
+import { egoSlice, type VoiceGraphBlob } from './voice-graph';
 import {
   getWarmTotal,
   halachaWarmProgressProcessed,
   readHalachaWarmCursor,
   readSefariaWarmCursor,
   readWarmCursor,
+  runVoiceGraphBackfill,
   runWarmCron,
   sefariaWarmProgressProcessed,
+  VOICE_GRAPH_STATE_KEY,
   warmProgressProcessed,
 } from './warm-cron';
 import { checkWholeDafLeakAndAlert } from './whole-daf-leak-watch';
@@ -10268,6 +10272,84 @@ app.get('/api/admin/rabbi-cohort', async (c) => {
   const hit = await c.env.CACHE.get(keyForRabbiCohort());
   if (!hit) return c.json({ error: 'not compiled' }, 404);
   return c.json(JSON.parse(hit));
+});
+
+// ---------------------------------------------------------------------------
+// Learned rabbi voice graph — the Shas-wide fold of every cached
+// argument.voices section (voice-graph.ts + warm-cron incremental walk).
+// Public reads; the step/rebuild mutations are studio-gated.
+
+app.get('/api/rabbi-network', async (c) => {
+  if (!c.env.CACHE) return c.json({ error: 'CACHE unavailable' }, 503);
+  const hit = await c.env.CACHE.get(keyForRabbiVoiceGraph());
+  if (!hit) return c.json({ error: 'not compiled' }, 404);
+  const blob = JSON.parse(hit) as VoiceGraphBlob;
+  const { nodes, edges, ...meta } = blob;
+  return c.json({ ...meta, nodes: Object.keys(nodes).length, edges: Object.keys(edges).length });
+});
+
+app.get('/api/rabbi-network/:slug', async (c) => {
+  if (!c.env.CACHE) return c.json({ error: 'CACHE unavailable' }, 503);
+  const hit = await c.env.CACHE.get(keyForRabbiVoiceGraph());
+  if (!hit) return c.json({ error: 'not compiled' }, 404);
+  const blob = JSON.parse(hit) as VoiceGraphBlob;
+  const slug = c.req.param('slug');
+  const ego = egoSlice(blob, slug);
+  if (!ego) return c.json({ error: 'not in the voice graph yet', dapim: blob.dapim }, 404);
+  return c.json({ type: 'rabbi', id: slug, builtAt: blob.builtAt, dapim: blob.dapim, ...ego });
+});
+
+app.get('/api/admin/voice-graph/status', async (c) => {
+  if (!c.env.CACHE) return c.json({ error: 'CACHE unavailable' }, 503);
+  const [state, blob] = await Promise.all([
+    c.env.CACHE.get(VOICE_GRAPH_STATE_KEY),
+    c.env.CACHE.get(keyForRabbiVoiceGraph()),
+  ]);
+  // Collapse the heavy graph payloads to counts — status is a meta view.
+  const meta = (raw: string | null) => {
+    if (!raw) return null;
+    try {
+      const b = JSON.parse(raw) as Record<string, unknown> & {
+        nodes?: object;
+        edges?: object;
+        dafsSeen?: object;
+        staging?: { nodes?: object; edges?: object; dafsSeen?: object } & Record<string, unknown>;
+      };
+      const shrink = (o: Record<string, unknown>) => {
+        const { nodes, edges, dafsSeen, ...rest } = o as {
+          nodes?: object;
+          edges?: object;
+          dafsSeen?: object;
+        } & Record<string, unknown>;
+        return {
+          ...rest,
+          ...(nodes ? { nodes: Object.keys(nodes).length } : {}),
+          ...(edges ? { edges: Object.keys(edges).length } : {}),
+          ...(dafsSeen ? { dapimSeen: Object.keys(dafsSeen).length } : {}),
+        };
+      };
+      return b.staging ? { ...shrink(b), staging: shrink(b.staging) } : shrink(b);
+    } catch {
+      return null;
+    }
+  };
+  return c.json({ state: meta(state), blob: meta(blob) });
+});
+
+app.post('/api/admin/voice-graph/step', async (c) => {
+  if (!isTrustedRequest(c)) return c.json({ error: 'studio auth required' }, 403);
+  const result = await runVoiceGraphBackfill(c.env, { force: true });
+  return c.json({ result });
+});
+
+app.post('/api/admin/voice-graph/rebuild', async (c) => {
+  if (!isTrustedRequest(c)) return c.json({ error: 'studio auth required' }, 403);
+  if (!c.env.CACHE) return c.json({ error: 'CACHE unavailable' }, 503);
+  await c.env.CACHE.delete(VOICE_GRAPH_STATE_KEY);
+  return c.json({
+    ok: true,
+    note: 'state cleared; next warm ticks (or /step) rebuild from scratch',
+  });
 });
 
 app.get('/api/admin/rabbi-places-index', async (c) => {

--- a/packages/talmud/src/worker/rabbi-graph.ts
+++ b/packages/talmud/src/worker/rabbi-graph.ts
@@ -701,6 +701,15 @@ export function lookupRelationshipsBySlug(slug: string, displayName?: string): L
   };
 }
 
+/** Curated hierarchy edge count for a slug (teachers+students+colleagues).
+ *  0 for unknown slugs and for the ~940 registry nodes without curated edges —
+ *  the population the learned voice graph exists to connect. */
+export function curatedEdgeCount(slug: string): number {
+  const n = DATA.nodes[slug];
+  if (!n) return 0;
+  return (n.teachers?.length ?? 0) + (n.students?.length ?? 0) + (n.colleagues?.length ?? 0);
+}
+
 /** Diagnostic — coverage stats for the loaded graph. */
 export function graphStats(): {
   totalNodes: number;

--- a/packages/talmud/src/worker/types.ts
+++ b/packages/talmud/src/worker/types.ts
@@ -78,6 +78,8 @@ export interface Bindings {
   // When '1', the background Sefaria Shas walk also enqueues rabbi.observations
   // per amud (full reverse-index backfill). OFF by default — see WarmEnv.
   OBSERVATIONS_WARM_SHAS?: string;
+  /** '1' enables the incremental Shas-wide voice-graph fold (warm-cron). */
+  VOICE_GRAPH_WARM_SHAS?: string;
   // When '1', the warm-cron incrementally builds the per-tractate spine-view
   // snapshot shelf (a window of warmed dapim per tick). OFF by default.
   SPINE_VIEW_WARM_SHAS?: string;

--- a/packages/talmud/src/worker/voice-graph.ts
+++ b/packages/talmud/src/worker/voice-graph.ts
@@ -1,0 +1,254 @@
+/**
+ * Shas-wide rabbi voice graph — the aggregation of every cached per-section
+ * argument.voices graph into one learned rabbi-to-rabbi network.
+ *
+ * Each cached argument.voices result is a section-local dispute graph whose
+ * speakers are RAW LLM names. This module grounds those names to registry
+ * slugs (groundRabbiNames — the same resolver the reader uses) and folds the
+ * section edges into a single accumulated graph:
+ *
+ *   node  = a registry rabbi (slug), with how often / where they speak
+ *   edge  = (from, to, kind) with weight = distinct section sightings and a
+ *           capped sample of dafs as provenance
+ *
+ * Precision discipline: an edge is kept only when BOTH endpoints ground to a
+ * slug; sightings where both endpoints resolved with basis 'unique' (name
+ * unambiguous in the registry) are additionally counted in `strict`. The
+ * strict tier is the evidence base later used to disambiguate homonyms — it
+ * must not itself depend on homonym guesses, or errors would self-reinforce.
+ *
+ * The fold is pure (no env, no KV): the incremental walk that feeds it lives
+ * in warm-cron.ts, the read endpoints in index.ts.
+ */
+
+import { resolveVoiceGroup } from '../client/voiceGroups';
+import { type ArgumentVoicesData, deriveVoiceEdges } from '../lib/typing/voices';
+import { curatedEdgeCount, type GroundedRabbi, groundRabbiNames } from './rabbi-graph';
+
+/** The finite voice-edge relation set (ArgumentEdge['kind']). Anything else in
+ *  a cached value is treated as corrupt and skipped. */
+const VALID_KINDS = new Set(['opposes', 'supports', 'responds-to', 'cites', 'resolves']);
+
+/** Max sample dafs kept per edge / per node — provenance, not exhaustive. */
+const EDGE_DAF_CAP = 12;
+const NODE_DAF_CAP = 25;
+
+export interface VoiceEdgeAgg {
+  from: string; // slug
+  to: string; // slug
+  kind: string; // opposes | supports | responds-to | cites | resolves
+  /** Distinct section sightings (each cached section counted once per pass). */
+  weight: number;
+  /** Sightings where both endpoints resolved with basis 'unique'. */
+  strict: number;
+  dafs: string[]; // sample, capped at EDGE_DAF_CAP, "Tractate Page"
+}
+
+export interface VoiceNodeAgg {
+  name: string; // registry canonical
+  generation: string | null;
+  /** Distinct section sightings where this rabbi speaks. */
+  sections: number;
+  dafs: string[]; // sample, capped at NODE_DAF_CAP
+  /** Stamped at finalize: curated hierarchy edge count (teachers+students+
+   *  colleagues). 0 = this node was edge-less before the voice graph. */
+  curatedEdges?: number;
+}
+
+export interface VoiceGraphStaging {
+  version: 1;
+  startedAt: number;
+  scannedKeys: number;
+  sections: number;
+  voicesSeen: number;
+  voicesResolved: number;
+  edgesSeen: number;
+  edgesKept: number;
+  dafsSeen: Record<string, 1>;
+  nodes: Record<string, VoiceNodeAgg>;
+  edges: Record<string, VoiceEdgeAgg>;
+}
+
+export interface VoiceGraphBlob extends Omit<VoiceGraphStaging, 'dafsSeen'> {
+  builtAt: number;
+  dapim: number;
+  /** Nodes that gained voice edges while having ZERO curated hierarchy edges —
+   *  the "filled blanks". */
+  newlyConnected: number;
+}
+
+export function emptyVoiceGraphStaging(startedAt: number): VoiceGraphStaging {
+  return {
+    version: 1,
+    startedAt,
+    scannedKeys: 0,
+    sections: 0,
+    voicesSeen: 0,
+    voicesResolved: 0,
+    edgesSeen: 0,
+    edgesKept: 0,
+    dafsSeen: {},
+    nodes: {},
+    edges: {},
+  };
+}
+
+/** A daf's rabbi-mark cast, as grounding context. */
+export interface CastItem {
+  name: string;
+  nameHe?: string;
+  generation?: string;
+}
+
+/**
+ * Ground a section's voices against the daf cast. Collectives (Stam, the
+ * Sages, Beit Hillel…) are institutional voices, not people — skipped. The
+ * daf cast supplies both the relational context and, by exact-name match,
+ * the generation hint (mirroring how the #voices page colors nodes).
+ * Returns a map keyed by the RAW voice name.
+ */
+export function groundVoices(
+  voices: readonly { name?: unknown; nameHe?: unknown }[],
+  cast: readonly CastItem[],
+): Map<string, GroundedRabbi> {
+  const genByName = new Map<string, string>();
+  for (const c of cast) if (c.generation) genByName.set(c.name.trim().toLowerCase(), c.generation);
+  const items: { name: string; nameHe?: string; generation?: string }[] = [];
+  for (const v of voices) {
+    const name = typeof v.name === 'string' ? v.name.trim() : '';
+    if (!name || resolveVoiceGroup(name)) continue;
+    items.push({
+      name,
+      nameHe: typeof v.nameHe === 'string' && v.nameHe ? v.nameHe : undefined,
+      generation: genByName.get(name.toLowerCase()),
+    });
+  }
+  const grounded = groundRabbiNames(
+    items,
+    cast.map((c) => c.name),
+  );
+  const out = new Map<string, GroundedRabbi>();
+  grounded.forEach((g, i) => {
+    out.set(items[i].name, g);
+  });
+  return out;
+}
+
+function pushCapped(arr: string[], v: string, cap: number): void {
+  if (arr.length < cap && !arr.includes(v)) arr.push(v);
+}
+
+/**
+ * Fold one cached section's voices into the staging graph. `parsed` is the
+ * RunResult.parsed of an argument.voices entry; `grounded` comes from
+ * groundVoices; `dafLabel` is the display form "Tractate Page".
+ */
+export function foldSection(
+  g: VoiceGraphStaging,
+  parsed: unknown,
+  grounded: Map<string, GroundedRabbi>,
+  dafLabel: string,
+): void {
+  const data = deriveVoiceEdges(parsed) as Partial<ArgumentVoicesData> | null;
+  const voices = Array.isArray(data?.voices) ? data.voices : [];
+  const edges = Array.isArray(data?.edges) ? data.edges : [];
+  g.sections++;
+  g.dafsSeen[dafLabel] = 1;
+
+  // Per-section dedup: a duplicated voice row / duplicated (from,to,kind) row
+  // inside ONE cached section must not inflate counts — "weight" means
+  // distinct section sightings.
+  const seenSlugs = new Set<string>();
+  const seenEdges = new Set<string>();
+
+  for (const v of voices) {
+    const name = typeof v?.name === 'string' ? v.name.trim() : '';
+    if (!name || resolveVoiceGroup(name)) continue;
+    g.voicesSeen++;
+    const gr = grounded.get(name);
+    if (!gr?.slug || !gr.canonical) continue;
+    if (seenSlugs.has(gr.slug)) continue;
+    seenSlugs.add(gr.slug);
+    g.voicesResolved++;
+    let node = g.nodes[gr.slug];
+    if (!node) {
+      node = { name: gr.canonical, generation: gr.generation ?? null, sections: 0, dafs: [] };
+      g.nodes[gr.slug] = node;
+    }
+    node.sections++;
+    pushCapped(node.dafs, dafLabel, NODE_DAF_CAP);
+  }
+
+  for (const e of edges) {
+    const from = typeof e?.from === 'string' ? e.from.trim() : '';
+    const to = typeof e?.to === 'string' ? e.to.trim() : '';
+    const kind = typeof e?.kind === 'string' ? e.kind : '';
+    if (!from || !to || !VALID_KINDS.has(kind)) continue;
+    g.edgesSeen++;
+    const gf = grounded.get(from);
+    const gt = grounded.get(to);
+    if (!gf?.slug || !gt?.slug || gf.slug === gt.slug) continue;
+    const key = `${gf.slug}|${gt.slug}|${kind}`;
+    if (seenEdges.has(key)) continue;
+    seenEdges.add(key);
+    g.edgesKept++;
+    let agg = g.edges[key];
+    if (!agg) {
+      agg = { from: gf.slug, to: gt.slug, kind, weight: 0, strict: 0, dafs: [] };
+      g.edges[key] = agg;
+    }
+    agg.weight++;
+    if (gf.genSource === 'unique' && gt.genSource === 'unique') agg.strict++;
+    pushCapped(agg.dafs, dafLabel, EDGE_DAF_CAP);
+  }
+}
+
+/** Promote a completed staging accumulation to the served blob: stamp curated
+ *  edge counts + the newly-connected count, collapse dafsSeen to a number. */
+export function finalizeVoiceGraph(staging: VoiceGraphStaging, builtAt: number): VoiceGraphBlob {
+  const { dafsSeen, ...rest } = staging;
+  const connected = new Set<string>();
+  for (const e of Object.values(staging.edges)) {
+    connected.add(e.from);
+    connected.add(e.to);
+  }
+  let newlyConnected = 0;
+  for (const [slug, node] of Object.entries(staging.nodes)) {
+    node.curatedEdges = curatedEdgeCount(slug);
+    if (node.curatedEdges === 0 && connected.has(slug)) newlyConnected++;
+  }
+  return { ...rest, builtAt, dapim: Object.keys(dafsSeen).length, newlyConnected };
+}
+
+export interface EgoEdge extends VoiceEdgeAgg {
+  /** The other endpoint, with display info resolved from the blob nodes. */
+  other: { slug: string; name: string; generation: string | null };
+  direction: 'out' | 'in';
+}
+
+/** One rabbi's slice of the learned graph, edges sorted by weight desc. */
+export function egoSlice(
+  blob: VoiceGraphBlob,
+  slug: string,
+): { node: VoiceNodeAgg; edges: EgoEdge[] } | null {
+  const node = blob.nodes[slug];
+  if (!node) return null;
+  const edges: EgoEdge[] = [];
+  for (const e of Object.values(blob.edges)) {
+    if (e.from !== slug && e.to !== slug) continue;
+    const direction: 'out' | 'in' = e.from === slug ? 'out' : 'in';
+    const otherSlug = direction === 'out' ? e.to : e.from;
+    const other = blob.nodes[otherSlug];
+    edges.push({
+      ...e,
+      direction,
+      other: {
+        slug: otherSlug,
+        name: other?.name ?? otherSlug,
+        generation: other?.generation ?? null,
+      },
+    });
+  }
+  edges.sort((a, b) => b.weight - a.weight || b.strict - a.strict);
+  return { node, edges };
+}

--- a/packages/talmud/src/worker/warm-cron.ts
+++ b/packages/talmud/src/worker/warm-cron.ts
@@ -12,15 +12,19 @@
 import { iterAmudim } from '../lib/sefref/amudim';
 import { listDafyomiMasechtos } from '../lib/sefref/dafyomi/masechtos';
 import { TRACTATE_IDS } from '../lib/sefref/hebrewbooks/client';
+import { dafFromCacheKey } from './backfill-backlog';
 import {
   keyForDafyomi,
   keyForHalachaRefs,
   keyForHebrewBooks,
+  keyForRabbiVoiceGraph,
   keyForSefariaBundle,
   keyForSefariaSegments,
   keyForTalmudParallels,
+  slugDaf,
 } from './cache-keys';
 import { computeCacheStats, writeCachedCacheStats } from './cache-stats';
+import { CODE_ENRICHMENTS, CODE_MARKS } from './code-marks';
 import {
   getDafyomiContentCached,
   getHalachaRefsCached,
@@ -31,6 +35,14 @@ import {
   getYerushalmiCached,
 } from './source-cache';
 import type { JobMessage } from './types';
+import {
+  type CastItem,
+  emptyVoiceGraphStaging,
+  finalizeVoiceGraph,
+  foldSection,
+  groundVoices,
+  type VoiceGraphStaging,
+} from './voice-graph';
 
 const CURSOR_KEY = 'warm-cursor:v1';
 const SEFARIA_CURSOR_KEY = 'warm-cursor-sefaria:v1';
@@ -80,6 +92,13 @@ export interface WarmEnv {
    *  fan-out + pesukim) to extract across the whole shas. Set via wrangler.toml
    *  [vars] once you're ready to pay for the backfill. */
   OBSERVATIONS_WARM_SHAS?: string;
+  /** When '1', an incremental phase folds every cached argument.voices
+   *  section across Shas into the learned rabbi voice graph
+   *  (rabbi-voice-graph:v1) — one KV list page per warm tick, cursor-resumable,
+   *  self-latching when the full prefix has been walked. Coverage grows as more
+   *  dapim get warmed; to rebuild against newer coverage, delete the
+   *  voice-graph-cursor:v1 + staging keys (or POST /api/admin/voice-graph/rebuild). */
+  VOICE_GRAPH_WARM_SHAS?: string;
   /** When '1', a small independent phase walks all of Shas filling the
    *  halacha-refs source cache (Sefaria codifier links + their text) — the
    *  source behind the halacha card + GET /api/halacha-text. Sefaria-only, no
@@ -215,6 +234,190 @@ async function runObservationsBackfill(env: WarmEnv): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
+// Shas-wide rabbi voice graph — incremental, cursor-resumable, self-refreshing.
+//
+// Gated by VOICE_GRAPH_WARM_SHAS='1'. Walks the cached argument.voices prefix
+// one KV list page per warm tick, grounds each section's speakers against the
+// daf's rabbi-mark cast (groundRabbiNames — the reader's resolver), and folds
+// the section dispute edges into an accumulating state; when the list
+// completes, the graph is finalized into rabbi-voice-graph:v1 and the state
+// latches done — until the latch EXPIRES (VOICE_GRAPH_REBUILD_AFTER_MS), at
+// which point a fresh walk starts so the graph tracks growing daf coverage.
+//
+// Failure safety: ALL walk state (accumulated staging + list cursor + input
+// producer versions) lives in ONE KV key written exactly once per folded page,
+// so "page folded" and "cursor advanced" commit atomically — a failed tick
+// replays at most the current page into a state that does NOT yet include it.
+// The final tick writes the blob BEFORE the done-state; if the done-state
+// write fails, the last page replays and re-finalizes to identical content.
+// A producer cache_version bump (argument.voices or the rabbi mark) resets the
+// walk rather than mixing input versions in one accumulation.
+//
+// Subrequest budget per tick: one list page (VOICE_GRAPH_LIST_LIMIT value
+// reads) + one rabbi-mark read per distinct daf on the page + one state write
+// — worst case ~2×limit + a handful, comfortably under the cap alongside the
+// other warm phases. Pure fold logic lives in voice-graph.ts.
+// ---------------------------------------------------------------------------
+export const VOICE_GRAPH_STATE_KEY = 'voice-graph-state:v1';
+const VOICE_GRAPH_LIST_LIMIT = 120;
+/** A completed graph is rebuilt from scratch after this long, folding in
+ *  whatever new dapim were warmed since. */
+const VOICE_GRAPH_REBUILD_AFTER_MS = 7 * 24 * 60 * 60 * 1000;
+
+interface VoiceGraphState {
+  /** Input producer versions this walk reads — a bump resets the walk. */
+  inputs: { voices: string; rabbi: string };
+  staging?: VoiceGraphStaging;
+  cursor?: string;
+  done?: boolean;
+  builtAt?: number;
+  scanned?: number;
+}
+
+function voiceGraphInputs(): { voices: string; rabbi: string } {
+  return {
+    voices: CODE_ENRICHMENTS.find((e) => e.id === 'argument.voices')?.cache_version ?? '',
+    rabbi: CODE_MARKS.find((m) => m.id === 'rabbi')?.cache_version ?? '',
+  };
+}
+
+function rabbiMarkKey(rabbiVersion: string, tractate: string, page: string): string {
+  return `mark:rabbi:${rabbiVersion}:${slugDaf(tractate, page)}`;
+}
+
+/** The daf's grounded rabbi cast (names + generations) as resolution context. */
+async function readRabbiCast(
+  cache: KVNamespace,
+  rabbiVersion: string,
+  tractate: string,
+  page: string,
+): Promise<CastItem[]> {
+  const raw = await cache.get(rabbiMarkKey(rabbiVersion, tractate, page));
+  if (!raw) return [];
+  try {
+    const parsed = (JSON.parse(raw) as { parsed?: { instances?: unknown } }).parsed;
+    const insts = Array.isArray(parsed?.instances) ? parsed.instances : [];
+    const out: CastItem[] = [];
+    for (const inst of insts) {
+      const f = (inst as { fields?: Record<string, unknown> })?.fields;
+      const name = typeof f?.name === 'string' ? f.name.trim() : '';
+      if (!name) continue;
+      out.push({
+        name,
+        nameHe: typeof f?.nameHe === 'string' ? f.nameHe : undefined,
+        generation: typeof f?.generation === 'string' ? f.generation : undefined,
+      });
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+/** One page of the walk. Exported for the admin /step route (force) and called
+ *  every warm tick when gated on. Returns null when gated off / no CACHE. */
+export async function runVoiceGraphBackfill(
+  env: WarmEnv,
+  opts?: { force?: boolean },
+): Promise<{ done: boolean; scanned: number } | null> {
+  if (!opts?.force && env.VOICE_GRAPH_WARM_SHAS !== '1') return null;
+  const cache = env.CACHE;
+  if (!cache) return null;
+
+  const inputs = voiceGraphInputs();
+  let state: VoiceGraphState | null = null;
+  const rawState = await cache.get(VOICE_GRAPH_STATE_KEY);
+  if (rawState) {
+    try {
+      state = JSON.parse(rawState) as VoiceGraphState;
+    } catch {
+      /* reset */
+    }
+  }
+  // Reset when the input producer versions changed (never mix versions in one
+  // accumulation) or when a completed build has aged out.
+  if (state && (state.inputs?.voices !== inputs.voices || state.inputs?.rabbi !== inputs.rabbi)) {
+    state = null;
+  }
+  if (state?.done) {
+    const age = Date.now() - (state.builtAt ?? 0);
+    if (age < VOICE_GRAPH_REBUILD_AFTER_MS) return { done: true, scanned: state.scanned ?? 0 };
+    state = null; // latch expired — start a fresh walk over the grown coverage
+  }
+  const staging: VoiceGraphStaging = state?.staging ?? emptyVoiceGraphStaging(Date.now());
+
+  const res = await cache.list({
+    prefix: `enrich:argument.voices:${inputs.voices}:`,
+    cursor: state?.cursor,
+    limit: VOICE_GRAPH_LIST_LIMIT,
+  });
+  // Group this page's EN keys by daf so each daf's cast is read once.
+  // dafFromCacheKey skips the :he: namespace (EN is canonical — counting both
+  // langs would double every sighting).
+  const byDaf = new Map<string, { tractate: string; page: string; keys: string[] }>();
+  for (const k of res.keys) {
+    const daf = dafFromCacheKey(k.name);
+    if (!daf) continue;
+    const label = `${daf.tractate} ${daf.page}`;
+    const group = byDaf.get(label) ?? { ...daf, keys: [] };
+    group.keys.push(k.name);
+    byDaf.set(label, group);
+  }
+  for (const [label, group] of byDaf) {
+    const cast = await readRabbiCast(cache, inputs.rabbi, group.tractate, group.page);
+    for (const key of group.keys) {
+      const raw = await cache.get(key);
+      staging.scannedKeys++;
+      if (!raw) continue;
+      let parsed: unknown = null;
+      try {
+        parsed = (JSON.parse(raw) as { parsed?: unknown }).parsed ?? null;
+      } catch {
+        /* skip corrupt */
+      }
+      if (!parsed || typeof parsed !== 'object') continue;
+      const voices = (parsed as { voices?: unknown }).voices;
+      const grounded = groundVoices(Array.isArray(voices) ? voices : [], cast);
+      foldSection(staging, parsed, grounded, label);
+    }
+  }
+
+  if (res.list_complete) {
+    // Blob first, done-state second: if the state write fails, the last page
+    // replays into a staging that does not include it and re-finalizes to the
+    // same blob — idempotent.
+    const blob = finalizeVoiceGraph(staging, Date.now());
+    await cache.put(keyForRabbiVoiceGraph(), JSON.stringify({ ...blob, inputs }));
+    await cache.put(
+      VOICE_GRAPH_STATE_KEY,
+      JSON.stringify({
+        inputs,
+        done: true,
+        builtAt: blob.builtAt,
+        scanned: staging.scannedKeys,
+      } satisfies VoiceGraphState),
+    );
+    console.log(
+      `[warm-cron] voice graph COMPLETE — ${blob.dapim} dapim, ` +
+        `${Object.keys(blob.nodes).length} rabbis, ${Object.keys(blob.edges).length} edges, ` +
+        `${blob.newlyConnected} newly connected`,
+    );
+    return { done: true, scanned: staging.scannedKeys };
+  }
+
+  // The ONE commit point per page: accumulated staging + advanced cursor
+  // together, atomically.
+  await cache.put(
+    VOICE_GRAPH_STATE_KEY,
+    JSON.stringify({ inputs, staging, cursor: res.cursor } satisfies VoiceGraphState),
+  );
+  console.log(
+    `[warm-cron] voice graph progress: scanned=${staging.scannedKeys} sections=${staging.sections}`,
+  );
+  return { done: false, scanned: staging.scannedKeys };
+}
+
+// ---------------------------------------------------------------------------
 // Dafyomi.co.il (Kollel Iyun HaDaf) gradual ingestion — gated, self-latching.
 //
 // Gated by DAFYOMI_WARM_SHAS='1'. Walks all dafyomi-mapped masechtos (Chullin +
@@ -321,6 +524,9 @@ export async function runWarmCron(env: WarmEnv): Promise<void> {
 
   // Gradual dafyomi.co.il ingestion (gated, self-latching). Independent phase.
   await runDafyomiBackfill(env);
+
+  // Incremental rabbi voice-graph fold (gated, cursor-resumable, self-latching).
+  await runVoiceGraphBackfill(env);
 
   // Gradual halacha-refs source fill (gated). Independent + small-batch because
   // each amud bursts many Sefaria getText calls. Runs every tick regardless of

--- a/packages/talmud/tests/source-cache-keys.test.ts
+++ b/packages/talmud/tests/source-cache-keys.test.ts
@@ -21,6 +21,7 @@ import {
   keyForRabbiObs,
   keyForRabbiObsDirty,
   keyForRabbiPlacesIndex,
+  keyForRabbiVoiceGraph,
   keyForRabbiWikiBio,
   keyForRabbiWikidata,
   keyForReferences,
@@ -123,6 +124,7 @@ describe('content + rabbi caches — byte-exact contract', () => {
   it('rabbi aggregate blobs: fixed keys, no params', () => {
     expect(keyForRabbiGraph()).toBe('rabbi-graph:v1');
     expect(keyForRabbiCohort()).toBe('rabbi-cohort:v1');
+    expect(keyForRabbiVoiceGraph()).toBe('rabbi-voice-graph:v1');
     expect(keyForRabbiPlacesIndex()).toBe('rabbi-places-index:v1');
     expect(keyForRabbiAcademyRoster()).toBe('rabbi-academy-roster:v1');
   });

--- a/packages/talmud/tests/source-coverage-dashboard.test.ts
+++ b/packages/talmud/tests/source-coverage-dashboard.test.ts
@@ -113,6 +113,7 @@ const CLASSIFICATION: Record<string, Classification> = {
   keyForRabbiBioBySlug: { role: 'not-source', note: 'per-rabbi global bio enrichment' },
   keyForRabbiBioOnDaf: { role: 'not-source', note: 'per-rabbi per-daf bio synthesis' },
   keyForRabbiGraph: { role: 'not-source', note: 'rabbi aggregate blob' },
+  keyForRabbiVoiceGraph: { role: 'not-source', note: 'learned voice-graph aggregate blob' },
   keyForRabbiCohort: { role: 'not-source', note: 'rabbi aggregate blob' },
   keyForRabbiPlacesIndex: { role: 'not-source', note: 'rabbi aggregate blob' },
   keyForRabbiAcademyRoster: { role: 'not-source', note: 'rabbi aggregate blob' },

--- a/packages/talmud/tests/voice-graph-backfill.test.ts
+++ b/packages/talmud/tests/voice-graph-backfill.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+import { keyForRabbiVoiceGraph, slugDaf } from '../src/worker/cache-keys';
+import { CODE_ENRICHMENTS, CODE_MARKS } from '../src/worker/code-marks';
+import type { VoiceGraphBlob } from '../src/worker/voice-graph';
+import { runVoiceGraphBackfill, VOICE_GRAPH_STATE_KEY } from '../src/worker/warm-cron';
+
+const VOICES_VER = CODE_ENRICHMENTS.find((e) => e.id === 'argument.voices')?.cache_version ?? '';
+const RABBI_VER = CODE_MARKS.find((m) => m.id === 'rabbi')?.cache_version ?? '';
+
+/** Minimal in-memory KV with its OWN page size — the walker follows
+ *  list_complete/cursor, so a tiny fake page size exercises multi-tick
+ *  cursor resume without needing hundreds of keys. */
+function fakeKV(pageSize: number) {
+  const store = new Map<string, string>();
+  const kv = {
+    async get(key: string): Promise<string | null> {
+      return store.get(key) ?? null;
+    },
+    async put(key: string, value: string): Promise<void> {
+      store.set(key, value);
+    },
+    async delete(key: string): Promise<void> {
+      store.delete(key);
+    },
+    async list(opts: { prefix?: string; cursor?: string; limit?: number }) {
+      const all = [...store.keys()].filter((k) => !opts.prefix || k.startsWith(opts.prefix)).sort();
+      const start = opts.cursor ? Number(opts.cursor) : 0;
+      const page = all.slice(start, start + pageSize);
+      const complete = start + pageSize >= all.length;
+      return {
+        keys: page.map((name) => ({ name })),
+        list_complete: complete,
+        ...(complete ? {} : { cursor: String(start + pageSize) }),
+      };
+    },
+  };
+  return { kv: kv as unknown as KVNamespace, store };
+}
+
+function voicesKey(section: string, tractate: string, page: string): string {
+  return `enrich:argument.voices:${VOICES_VER}:${section}:${slugDaf(tractate, page)}`;
+}
+
+function seed(store: Map<string, string>, tractate: string, page: string, section: string) {
+  store.set(
+    voicesKey(section, tractate, page),
+    JSON.stringify({
+      parsed: {
+        voices: [
+          { name: 'Rava', nameHe: 'רבא', role: 'originator', side: 'A', stance: '' },
+          { name: 'Abaye', nameHe: 'אביי', role: 'objector', side: 'B', stance: '' },
+        ],
+        edges: [{ from: 'Abaye', to: 'Rava', kind: 'opposes' }],
+      },
+    }),
+  );
+  store.set(
+    `mark:rabbi:${RABBI_VER}:${slugDaf(tractate, page)}`,
+    JSON.stringify({
+      parsed: {
+        instances: [
+          { fields: { name: 'Rava', nameHe: 'רבא', generation: 'amora-bavel-4' } },
+          { fields: { name: 'Abaye', nameHe: 'אביי', generation: 'amora-bavel-4' } },
+        ],
+      },
+    }),
+  );
+}
+
+describe('runVoiceGraphBackfill', () => {
+  it('is a no-op unless gated on (or forced)', async () => {
+    const { kv, store } = fakeKV(10);
+    seed(store, 'Berakhot', '2a', 'sec1');
+    expect(await runVoiceGraphBackfill({ CACHE: kv })).toBeNull();
+    expect(store.has(keyForRabbiVoiceGraph())).toBe(false);
+  });
+
+  it('walks the prefix across ticks, skips :he:, finalizes and latches', async () => {
+    const { kv, store } = fakeKV(2); // tiny pages => several ticks
+    seed(store, 'Berakhot', '2a', 'sec1');
+    seed(store, 'Berakhot', '2a', 'sec2');
+    seed(store, 'Shabbat', '21b', 'sec1');
+    // Hebrew twin must be skipped, not double-counted.
+    store.set(
+      `enrich:argument.voices:${VOICES_VER}:he:sec1:${slugDaf('Berakhot', '2a')}`,
+      store.get(voicesKey('sec1', 'Berakhot', '2a')) ?? '',
+    );
+
+    const env = { CACHE: kv, VOICE_GRAPH_WARM_SHAS: '1' };
+    let done = false;
+    for (let i = 0; i < 10 && !done; i++) {
+      const r = await runVoiceGraphBackfill(env);
+      expect(r).not.toBeNull();
+      done = r?.done ?? false;
+    }
+    expect(done).toBe(true);
+
+    const blob = JSON.parse(store.get(keyForRabbiVoiceGraph()) ?? 'null') as VoiceGraphBlob;
+    expect(blob).not.toBeNull();
+    expect(blob.dapim).toBe(2);
+    expect(blob.sections).toBe(3); // 3 EN sections; the :he: twin skipped
+    const edge = Object.values(blob.edges).find((e) => e.kind === 'opposes');
+    expect(edge?.weight).toBe(3);
+    expect(edge?.dafs.sort()).toEqual(['Berakhot 2a', 'Shabbat 21b']);
+    expect(blob.nodes.rava?.sections).toBe(3);
+    // state latched done, staging dropped from it
+    const st = JSON.parse(store.get(VOICE_GRAPH_STATE_KEY) ?? '{}') as {
+      done?: boolean;
+      staging?: unknown;
+    };
+    expect(st.done).toBe(true);
+    expect(st.staging).toBeUndefined();
+
+    // Latched: another tick is a no-op that reports done.
+    const again = await runVoiceGraphBackfill(env);
+    expect(again).toEqual({ done: true, scanned: expect.any(Number) });
+  });
+
+  it('resets the walk when input producer versions change', async () => {
+    const { kv, store } = fakeKV(10);
+    seed(store, 'Berakhot', '2a', 'sec1');
+    // A stale in-flight state written by an older producer version.
+    store.set(
+      VOICE_GRAPH_STATE_KEY,
+      JSON.stringify({
+        inputs: { voices: 'OLD', rabbi: 'OLD' },
+        staging: { version: 1, startedAt: 1, scannedKeys: 999 },
+        cursor: '1',
+      }),
+    );
+    const r = await runVoiceGraphBackfill({ CACHE: kv, VOICE_GRAPH_WARM_SHAS: '1' });
+    // Fresh walk: the poisoned staging was discarded, the single page completed.
+    expect(r?.done).toBe(true);
+    const blob = JSON.parse(store.get(keyForRabbiVoiceGraph()) ?? 'null') as VoiceGraphBlob;
+    expect(blob.scannedKeys).toBe(1);
+  });
+
+  it('force runs even when ungated (the admin /step path)', async () => {
+    const { kv, store } = fakeKV(10);
+    seed(store, 'Berakhot', '2a', 'sec1');
+    const r = await runVoiceGraphBackfill({ CACHE: kv }, { force: true });
+    expect(r?.done).toBe(true);
+    expect(store.has(keyForRabbiVoiceGraph())).toBe(true);
+  });
+});

--- a/packages/talmud/tests/voice-graph.test.ts
+++ b/packages/talmud/tests/voice-graph.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { curatedEdgeCount } from '../src/worker/rabbi-graph';
+import {
+  egoSlice,
+  emptyVoiceGraphStaging,
+  finalizeVoiceGraph,
+  foldSection,
+  groundVoices,
+} from '../src/worker/voice-graph';
+
+// Real registry names with unambiguous canonical forms: Rava and Abaye resolve
+// 'unique'; "Rav Kahana" is the classic homonym (multiple registry bearers).
+const SECTION = {
+  voices: [
+    { name: 'Rava', nameHe: 'רבא', role: 'originator', side: 'A', stance: '' },
+    { name: 'Abaye', nameHe: 'אביי', role: 'objector', side: 'B', stance: '' },
+    { name: 'Stam', nameHe: '', role: 'transmitter', side: 'stam', stance: '' },
+  ],
+  edges: [
+    { from: 'Abaye', to: 'Rava', kind: 'opposes' },
+    { from: 'Stam', to: 'Rava', kind: 'cites' },
+  ],
+};
+
+function groundedFor(section: typeof SECTION) {
+  return groundVoices(section.voices, [
+    { name: 'Rava', nameHe: 'רבא', generation: 'amora-bavel-4' },
+    { name: 'Abaye', nameHe: 'אביי', generation: 'amora-bavel-4' },
+  ]);
+}
+
+describe('groundVoices', () => {
+  it('grounds real names, skips collectives', () => {
+    const g = groundedFor(SECTION);
+    expect(g.get('Rava')?.slug).toBe('rava');
+    expect(g.get('Rava')?.genSource).toBe('unique');
+    expect(g.get('Abaye')?.slug).toBeTruthy();
+    expect(g.has('Stam')).toBe(false); // collective — never a person node
+  });
+});
+
+describe('foldSection', () => {
+  it('accumulates nodes + edges, drops collective endpoints, counts strict tier', () => {
+    const st = emptyVoiceGraphStaging(1000);
+    foldSection(st, SECTION, groundedFor(SECTION), 'Berakhot 2a');
+    expect(st.sections).toBe(1);
+    expect(Object.keys(st.nodes)).toContain('rava');
+    expect(st.nodes.rava.sections).toBe(1);
+    expect(st.nodes.rava.dafs).toEqual(['Berakhot 2a']);
+    // Stam→Rava edge dropped (collective endpoint); Abaye→Rava kept.
+    expect(st.edgesSeen).toBe(2);
+    expect(st.edgesKept).toBe(1);
+    const kept = Object.values(st.edges);
+    expect(kept).toHaveLength(1);
+    expect(kept[0].to).toBe('rava');
+    expect(kept[0].kind).toBe('opposes');
+    expect(kept[0].weight).toBe(1);
+    expect(kept[0].strict).toBe(1); // both endpoints resolved 'unique'
+  });
+
+  it('is additive across sections and dedupes daf samples', () => {
+    const st = emptyVoiceGraphStaging(1000);
+    foldSection(st, SECTION, groundedFor(SECTION), 'Berakhot 2a');
+    foldSection(st, SECTION, groundedFor(SECTION), 'Berakhot 2a');
+    foldSection(st, SECTION, groundedFor(SECTION), 'Shabbat 21b');
+    const edge = Object.values(st.edges)[0];
+    expect(edge.weight).toBe(3);
+    expect(edge.dafs).toEqual(['Berakhot 2a', 'Shabbat 21b']);
+    expect(st.nodes.rava.sections).toBe(3);
+    expect(Object.keys(st.dafsSeen)).toHaveLength(2);
+  });
+
+  it('never emits an edge for an unresolved (homonym) endpoint', () => {
+    const st = emptyVoiceGraphStaging(1000);
+    const section = {
+      voices: [
+        { name: 'Rava', nameHe: 'רבא' },
+        { name: 'Rav Kahana', nameHe: 'רב כהנא' },
+      ],
+      edges: [{ from: 'Rav Kahana', to: 'Rava', kind: 'cites' }],
+    };
+    const grounded = groundVoices(section.voices, []);
+    // The bare homonym must not have resolved to a slug with no evidence.
+    expect(grounded.get('Rav Kahana')?.slug ?? null).toBeNull();
+    foldSection(st, section, grounded, 'Bava Batra 3a');
+    expect(st.edgesKept).toBe(0);
+    expect(Object.keys(st.edges)).toHaveLength(0);
+  });
+});
+
+describe('finalizeVoiceGraph + egoSlice', () => {
+  it('stamps curated edge counts, counts newly connected, slices egos', () => {
+    const st = emptyVoiceGraphStaging(1000);
+    foldSection(st, SECTION, groundedFor(SECTION), 'Berakhot 2a');
+    const blob = finalizeVoiceGraph(st, 2000);
+    expect(blob.builtAt).toBe(2000);
+    expect(blob.dapim).toBe(1);
+    expect(blob.nodes.rava.curatedEdges).toBe(curatedEdgeCount('rava'));
+    // Rava has curated edges in the registry, so he is not "newly connected".
+    expect(curatedEdgeCount('rava')).toBeGreaterThan(0);
+
+    const ego = egoSlice(blob, 'rava');
+    expect(ego).not.toBeNull();
+    expect(ego?.edges).toHaveLength(1);
+    expect(ego?.edges[0].direction).toBe('in');
+    expect(ego?.edges[0].other.slug).toBeTruthy();
+    expect(egoSlice(blob, 'no-such-rabbi')).toBeNull();
+  });
+});

--- a/packages/talmud/wrangler.generator.toml
+++ b/packages/talmud/wrangler.generator.toml
@@ -47,6 +47,8 @@ OPENROUTER_GATEWAY_PROVIDER = "openrouter"
 # Background full-Shas backfills run from the GENERATOR's cron (PR-1b moves the
 # crons here). Same values as the reader carried.
 OBSERVATIONS_WARM_SHAS = "1"
+# Incremental Shas-wide voice-graph fold (warm-cron); consulted on the generator only.
+VOICE_GRAPH_WARM_SHAS = "1"
 DAFYOMI_WARM_SHAS = "1"
 SPINE_VIEW_WARM_SHAS = "1"
 # Spend budget — enforced at the runLLM chokepoint, which now lives here.

--- a/packages/talmud/wrangler.toml
+++ b/packages/talmud/wrangler.toml
@@ -68,6 +68,8 @@ OPENROUTER_GATEWAY_PROVIDER = "openrouter"
 # ~$70 (entity marks only). Safe to leave at "1" — it's a no-op once latched.
 # To re-run a pass, delete the obs-backfill-cursor:v1 KV key.
 OBSERVATIONS_WARM_SHAS = "1"
+# Incremental Shas-wide voice-graph fold (warm-cron); consulted on the generator only.
+VOICE_GRAPH_WARM_SHAS = "1"
 # Gradual dafyomi.co.il (Kollel Iyun HaDaf) ingestion. When "1", the warm cron
 # walks all of Shas a couple dapim per 5-min tick (hub-driven live fetch, then
 # KV-cached forever — gentle, ~4-5 days for a full pass), then latches done and


### PR DESCRIPTION
Aggregates every cached per-section `argument.voices` dispute graph into one learned Shas-wide rabbi network (`rabbi-voice-graph:v1`) — the data layer for (a) evidence-backed relationships for the ~940 registry rabbis with zero curated edges, and (b) a bigger relational evidence base for homonym disambiguation (follow-up PR).

## What

- **`voice-graph.ts`** — pure fold: speakers ground via `groundRabbiNames` (the reader's resolver) with the daf's rabbi-mark cast as relational context; collectives skipped; edges kept only when **both** endpoints resolve; sightings where both endpoints resolved `'unique'` counted separately as the **strict tier** (the disambiguation evidence base must not contain homonym guesses, or errors would self-reinforce). Per-section dedup, finite edge-kind filter, capped daf samples as provenance.
- **`warm-cron.ts`** — `runVoiceGraphBackfill`: one KV list page per warm tick over `enrich:argument.voices:<v>:` (`:he:` skipped via `dafFromCacheKey`). **All walk state lives in one key written once per folded page**, so page-folded ⟺ cursor-advanced commits atomically; the blob is written before the done-state, making every failure mode an idempotent replay. Input producer version bumps reset the walk; the done latch expires after 7 days so the graph refreshes as coverage grows. Gated by `VOICE_GRAPH_WARM_SHAS` (on in both wrangler configs; only the generator's scheduler reaches it).
- **Routes** — public `GET /api/rabbi-network` (summary incl. `newlyConnected`) and `GET /api/rabbi-network/:slug` (ego view: learned edges with weights, kinds, sample dafs); `GET /api/admin/voice-graph/status`; studio-gated `POST /api/admin/voice-graph/step` + `/rebuild`.
- **Tests** — pure fold suite (grounding, dedup, strict tier, homonym endpoints dropped, finalize/ego) + fake-KV multi-tick walk (cursor resume, `:he:` skip, latch, version-bump reset, force path). Cache key locked in `source-cache-keys.test.ts` + classified in the coverage-dashboard drift guard.

## Notes

- Reviewed with Codex mid-flight; its findings (two-key checkpoint race, permanent latch vs growing coverage, intra-section double-count, version drift, subrequest budget) are all addressed in this diff.
- Consumers of homonym evidence must use `strict`, not `weight` — documented in the module header; the resolver integration lands separately, gated on the `rabbi-resolve-bench` floors.