### PR TITLE
Learned voice-graph adjacency in rabbi homonym resolution

### DIFF
--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -228,6 +228,7 @@ import {
   type RabbiCandidateSummary,
   type RelationshipsData,
   rabbiCandidateSummaries,
+  setLearnedAdjacency,
 } from './rabbi-graph';
 import {
   buildObservationSlices,
@@ -295,7 +296,7 @@ import {
   recordUnknownRabbi,
 } from './unknown-registry';
 import { readUsageSummary, recordUsage } from './usage-rollup';
-import { egoSlice, type VoiceGraphBlob } from './voice-graph';
+import { buildLearnedAdjacency, egoSlice, type VoiceGraphBlob } from './voice-graph';
 import {
   getWarmTotal,
   halachaWarmProgressProcessed,
@@ -1366,11 +1367,61 @@ interface SectionRabbi {
   slug: string;
   name: string;
 }
+// ---------------------------------------------------------------------------
+// Learned adjacency for the rabbi resolver. Gated by LEARNED_ADJACENCY='1';
+// loads rabbi-voice-graph:v1 at most once per TTL per isolate (negative
+// results cached too — a missing blob costs one KV read per TTL, not per
+// grounding). The resolver falls back to curated-only behaviour whenever the
+// adjacency isn't loaded.
+let learnedAdjacencyCheckedAt = 0;
+let learnedAdjacencyLoad: Promise<void> | null = null;
+const LEARNED_ADJACENCY_TTL_MS = 10 * 60 * 1000;
+
+async function ensureLearnedAdjacency(env: Bindings): Promise<void> {
+  if (env.LEARNED_ADJACENCY !== '1' || !env.CACHE) {
+    // Gate off (or no KV): resolution must be curated-only, even in a reused
+    // isolate that loaded an adjacency before a rollback.
+    setLearnedAdjacency(null);
+    return;
+  }
+  const now = Date.now();
+  if (now - learnedAdjacencyCheckedAt < LEARNED_ADJACENCY_TTL_MS) return;
+  // Single-flight: concurrent cold requests await the SAME load instead of
+  // racing past a pre-stamped timestamp with no adjacency installed.
+  if (!learnedAdjacencyLoad) {
+    const cache = env.CACHE;
+    learnedAdjacencyLoad = (async () => {
+      try {
+        const raw = await cache.get(keyForRabbiVoiceGraph());
+        if (!raw) {
+          setLearnedAdjacency(null); // blob deleted => back to curated-only
+          return;
+        }
+        const blob = JSON.parse(raw) as VoiceGraphBlob;
+        if (!blob || typeof blob.edges !== 'object') {
+          console.warn('[learned-adjacency] malformed rabbi-voice-graph blob; keeping last-good');
+          return;
+        }
+        const adj = buildLearnedAdjacency(blob.edges);
+        setLearnedAdjacency(adj);
+        console.log(`[learned-adjacency] loaded: ${adj.size} rabbis (builtAt=${blob.builtAt})`);
+      } catch (e) {
+        console.warn('[learned-adjacency] load failed; keeping last-good:', e);
+      } finally {
+        learnedAdjacencyCheckedAt = Date.now();
+        learnedAdjacencyLoad = null;
+      }
+    })();
+  }
+  await learnedAdjacencyLoad;
+}
+
 async function readSectionRabbis(
   env: Bindings,
   tractate: string,
   page: string,
 ): Promise<{ start: number; title: string; rabbis: SectionRabbi[] }[]> {
+  await ensureLearnedAdjacency(env);
   const insts = await readMarkInstances(env, 'argument', tractate, page).catch(() => []);
   const voicesDef = findCodeEnrichment('argument.voices');
   // The daf's full rabbi cast (from the rabbi mark): names supply the relational
@@ -4656,6 +4707,7 @@ const RUN_PORTS: RunProducerPorts<RunCtx, EnrichmentDefinition, SchemaMarkDefini
     markPostParse: async (rc, a) => {
       let parsed = a.parsed;
       if (parsed && a.def.id === 'rabbi') {
+        await ensureLearnedAdjacency(rc.env);
         parsed = postProcessRabbi(parsed, stripHtmlServer(String(a.vars.hebrew ?? '')));
         // Ground each rabbi's generation through the registry (relational homonym
         // disambiguation off the daf's cast): authoritative era when identified,

--- a/packages/talmud/src/worker/rabbi-graph.ts
+++ b/packages/talmud/src/worker/rabbi-graph.ts
@@ -352,6 +352,33 @@ export interface ResolvedRabbi {
   basis: ResolveBasis;
 }
 
+/** Learned adjacency from the Shas-wide voice graph (rabbi-voice-graph:v1):
+ *  slug -> the slugs it demonstrably interacts with on real dapim. Built from
+ *  STRICT-tier voice edges only (both endpoints resolved 'unique'), so this
+ *  evidence cannot itself contain homonym guesses — using it to pin homonyms
+ *  cannot self-reinforce an earlier wrong pin. Injected at runtime by
+ *  index.ts (ensureLearnedAdjacency); null = not loaded / feature off, and
+ *  resolution behaves exactly as before. */
+let LEARNED_ADJ: ReadonlyMap<string, ReadonlySet<string>> | null = null;
+
+export function setLearnedAdjacency(adj: ReadonlyMap<string, ReadonlySet<string>> | null): void {
+  LEARNED_ADJ = adj;
+}
+
+/** Run `fn` with the learned adjacency forced OFF, restoring it after. The
+ *  voice-graph fold uses this so the SOURCE graph is a deterministic function
+ *  of its inputs (curated-only grounding), never of whatever adjacency a
+ *  reused isolate happened to have loaded. `fn` must be synchronous. */
+export function withoutLearnedAdjacency<T>(fn: () => T): T {
+  const prev = LEARNED_ADJ;
+  LEARNED_ADJ = null;
+  try {
+    return fn();
+  } finally {
+    LEARNED_ADJ = prev;
+  }
+}
+
 /** A relational win must beat the runner-up by this many shared edges. A
  *  1-edge "win" is exactly what incidental co-presence produces (e.g. Rav
  *  appearing in another sugya on the daf handed Rav Kahana to the early
@@ -365,7 +392,9 @@ const RELATIONAL_MARGIN = 2;
  *  - 1 candidate          → it ('unique').
  *  - >1 (a homonym)       → disambiguate by DAF EVIDENCE: score each candidate
  *    by how many of the co-occurring rabbis on the daf sit in its registry
- *    teacher/student/colleague edges. A candidate wins 'relational' only when
+ *    teacher/student/colleague edges — or, when the learned voice-graph
+ *    adjacency is loaded (setLearnedAdjacency), in its strict-tier learned
+ *    interaction set. A candidate wins 'relational' only when
  *    its score clears the runner-up by RELATIONAL_MARGIN — a single shared
  *    edge is routinely incidental co-presence on a multi-sugya daf, not
  *    identification. On a candidate set that itself SPANS generations (the
@@ -400,17 +429,17 @@ export function resolveRabbiSlug(
   const scoreOf = new Map<string, number>();
   for (const slug of cands) {
     const node = DATA.nodes[slug];
-    if (!node) {
-      scoreOf.set(slug, 0);
-      continue;
-    }
     const nbrs = new Set<string>([
-      ...(node.teachers ?? []),
-      ...(node.students ?? []),
-      ...(node.colleagues ?? []),
+      ...(node?.teachers ?? []),
+      ...(node?.students ?? []),
+      ...(node?.colleagues ?? []),
     ]);
+    // Learned voice-graph neighbors extend the curated ones; a co-rabbi
+    // counts once whether curated, learned, or both — the margin + veto
+    // semantics below are unchanged.
+    const learned = LEARNED_ADJ?.get(slug);
     let score = 0;
-    for (const cs of coSlugs) if (nbrs.has(cs)) score++;
+    for (const cs of coSlugs) if (nbrs.has(cs) || learned?.has(cs)) score++;
     scoreOf.set(slug, score);
   }
   const ranked = [...scoreOf.entries()].sort((a, b) => b[1] - a[1]);

--- a/packages/talmud/src/worker/types.ts
+++ b/packages/talmud/src/worker/types.ts
@@ -80,6 +80,9 @@ export interface Bindings {
   OBSERVATIONS_WARM_SHAS?: string;
   /** '1' enables the incremental Shas-wide voice-graph fold (warm-cron). */
   VOICE_GRAPH_WARM_SHAS?: string;
+  /** '1' feeds the learned voice-graph adjacency into the rabbi resolver's
+   *  relational homonym scoring (benchmark-gated; see rabbi-resolve-bench). */
+  LEARNED_ADJACENCY?: string;
   // When '1', the warm-cron incrementally builds the per-tractate spine-view
   // snapshot shelf (a window of warmed dapim per tick). OFF by default.
   SPINE_VIEW_WARM_SHAS?: string;

--- a/packages/talmud/src/worker/voice-graph.ts
+++ b/packages/talmud/src/worker/voice-graph.ts
@@ -220,6 +220,32 @@ export function finalizeVoiceGraph(staging: VoiceGraphStaging, builtAt: number):
   return { ...rest, builtAt, dapim: Object.keys(dafsSeen).length, newlyConnected };
 }
 
+/** Build the resolver's learned adjacency from a voice-graph blob: symmetric
+ *  slug -> neighbor-set over STRICT-tier edges only (both endpoints resolved
+ *  'unique'), thresholded at minStrict distinct section sightings. Weight
+ *  (which includes relational/generation-grounded sightings) is deliberately
+ *  NOT used — see the module header on circularity. */
+export function buildLearnedAdjacency(
+  edges: Record<string, Pick<VoiceEdgeAgg, 'from' | 'to' | 'strict'>>,
+  minStrict = 2,
+): Map<string, Set<string>> {
+  const adj = new Map<string, Set<string>>();
+  const add = (a: string, b: string) => {
+    let set = adj.get(a);
+    if (!set) {
+      set = new Set();
+      adj.set(a, set);
+    }
+    set.add(b);
+  };
+  for (const e of Object.values(edges)) {
+    if (!e || e.strict < minStrict) continue;
+    add(e.from, e.to);
+    add(e.to, e.from);
+  }
+  return adj;
+}
+
 export interface EgoEdge extends VoiceEdgeAgg {
   /** The other endpoint, with display info resolved from the blob nodes. */
   other: { slug: string; name: string; generation: string | null };

--- a/packages/talmud/src/worker/warm-cron.ts
+++ b/packages/talmud/src/worker/warm-cron.ts
@@ -25,6 +25,7 @@ import {
 } from './cache-keys';
 import { computeCacheStats, writeCachedCacheStats } from './cache-stats';
 import { CODE_ENRICHMENTS, CODE_MARKS } from './code-marks';
+import { withoutLearnedAdjacency } from './rabbi-graph';
 import {
   getDafyomiContentCached,
   getHalachaRefsCached,
@@ -377,7 +378,12 @@ export async function runVoiceGraphBackfill(
       }
       if (!parsed || typeof parsed !== 'object') continue;
       const voices = (parsed as { voices?: unknown }).voices;
-      const grounded = groundVoices(Array.isArray(voices) ? voices : [], cast);
+      // Curated-only grounding: the source graph must be a deterministic
+      // function of its inputs, never of whatever learned adjacency a reused
+      // isolate happened to have loaded (see withoutLearnedAdjacency).
+      const grounded = withoutLearnedAdjacency(() =>
+        groundVoices(Array.isArray(voices) ? voices : [], cast),
+      );
       foldSection(staging, parsed, grounded, label);
     }
   }

--- a/packages/talmud/tests/learned-adjacency.test.ts
+++ b/packages/talmud/tests/learned-adjacency.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { rabbiCandidates, resolveRabbiSlug, setLearnedAdjacency } from '../src/worker/rabbi-graph';
+import { buildLearnedAdjacency } from '../src/worker/voice-graph';
+
+// "Ravin" is a real permanently-ambiguous case: two registry bearers
+// (ravin-b-rav-ada / ravin-b-rav-nachman), SAME generation (amora-bavel-3),
+// and — like ~940 registry nodes — ZERO curated edges on either. Curated
+// relational scoring can never separate them; the learned voice graph is the
+// only evidence that can. That makes it the exact seam this feature exists
+// for, and a stable fixture (the assertions below verify the precondition).
+const NAME = 'Ravin';
+const HE = 'רבין';
+const A = 'ravin-b-rav-ada';
+const B = 'ravin-b-rav-nachman';
+
+afterEach(() => setLearnedAdjacency(null));
+
+describe('resolveRabbiSlug with learned adjacency', () => {
+  it('precondition: the fixture name is a curated-edge-less homonym', () => {
+    expect(rabbiCandidates(NAME, HE).sort()).toEqual([A, B]);
+    expect(resolveRabbiSlug(NAME, HE, { coRabbis: ['Rava', 'Abaye'] })).toEqual({
+      slug: null,
+      basis: 'ambiguous',
+    });
+  });
+
+  it('a margin-clearing learned win resolves relationally', () => {
+    // Two co-rabbis sit in A's learned interaction set, none in B's.
+    setLearnedAdjacency(
+      new Map([
+        [A, new Set(['rava', 'abaye'])],
+        ['rava', new Set([A])],
+        ['abaye', new Set([A])],
+      ]),
+    );
+    expect(resolveRabbiSlug(NAME, HE, { coRabbis: ['Rava', 'Abaye'] })).toEqual({
+      slug: A,
+      basis: 'relational',
+    });
+  });
+
+  it('a one-edge learned "win" stays below the margin — still ambiguous', () => {
+    setLearnedAdjacency(new Map([[A, new Set(['rava'])]]));
+    expect(resolveRabbiSlug(NAME, HE, { coRabbis: ['Rava', 'Abaye'] })).toEqual({
+      slug: null,
+      basis: 'ambiguous',
+    });
+  });
+
+  it('split learned evidence (one co-rabbi each) is a tie — still ambiguous', () => {
+    setLearnedAdjacency(
+      new Map([
+        [A, new Set(['rava'])],
+        [B, new Set(['abaye'])],
+      ]),
+    );
+    expect(resolveRabbiSlug(NAME, HE, { coRabbis: ['Rava', 'Abaye'] })).toEqual({
+      slug: null,
+      basis: 'ambiguous',
+    });
+  });
+
+  it('clearing the adjacency restores curated-only behaviour', () => {
+    setLearnedAdjacency(new Map([[A, new Set(['rava', 'abaye'])]]));
+    setLearnedAdjacency(null);
+    expect(resolveRabbiSlug(NAME, HE, { coRabbis: ['Rava', 'Abaye'] }).basis).toBe('ambiguous');
+  });
+});
+
+describe('buildLearnedAdjacency', () => {
+  it('is symmetric, strict-thresholded, and ignores weight', () => {
+    const adj = buildLearnedAdjacency({
+      'a|b|opposes': { from: 'a', to: 'b', strict: 3 },
+      'b|c|cites': { from: 'b', to: 'c', strict: 1 }, // below default threshold
+      'c|d|supports': { from: 'c', to: 'd', strict: 0 }, // weight-only edge: excluded
+    });
+    expect(adj.get('a')?.has('b')).toBe(true);
+    expect(adj.get('b')?.has('a')).toBe(true);
+    expect(adj.get('b')?.has('c') ?? false).toBe(false);
+    expect(adj.get('c')).toBeUndefined();
+  });
+
+  it('minStrict=1 admits single strict sightings', () => {
+    const adj = buildLearnedAdjacency({ 'b|c|cites': { from: 'b', to: 'c', strict: 1 } }, 1);
+    expect(adj.get('c')?.has('b')).toBe(true);
+  });
+});

--- a/packages/talmud/wrangler.generator.toml
+++ b/packages/talmud/wrangler.generator.toml
@@ -49,6 +49,8 @@ OPENROUTER_GATEWAY_PROVIDER = "openrouter"
 OBSERVATIONS_WARM_SHAS = "1"
 # Incremental Shas-wide voice-graph fold (warm-cron); consulted on the generator only.
 VOICE_GRAPH_WARM_SHAS = "1"
+# Learned voice-graph adjacency in the rabbi resolver (benchmark-gated: bench held, 0 flips, +2 resolutions).
+LEARNED_ADJACENCY = "1"
 DAFYOMI_WARM_SHAS = "1"
 SPINE_VIEW_WARM_SHAS = "1"
 # Spend budget — enforced at the runLLM chokepoint, which now lives here.

--- a/packages/talmud/wrangler.toml
+++ b/packages/talmud/wrangler.toml
@@ -70,6 +70,8 @@ OPENROUTER_GATEWAY_PROVIDER = "openrouter"
 OBSERVATIONS_WARM_SHAS = "1"
 # Incremental Shas-wide voice-graph fold (warm-cron); consulted on the generator only.
 VOICE_GRAPH_WARM_SHAS = "1"
+# Learned voice-graph adjacency in the rabbi resolver (benchmark-gated: bench held, 0 flips, +2 resolutions).
+LEARNED_ADJACENCY = "1"
 # Gradual dafyomi.co.il (Kollel Iyun HaDaf) ingestion. When "1", the warm cron
 # walks all of Shas a couple dapim per 5-min tick (hub-driven live fetch, then
 # KV-cached forever — gentle, ~4-5 days for a full pass), then latches done and


### PR DESCRIPTION
Follow-up to #544: the learned Shas-wide voice graph now feeds `resolveRabbiSlug`'s relational homonym scoring — a co-occurring rabbi counts as evidence when it sits in the candidate's curated edges **or** its learned strict-tier interaction set. Margin + era-veto unchanged.

## Benchmark gate (real prod data)

Built the actual blob from 400 dapim / 3,551 cached voice sections and ran the `rabbi-resolve-bench` fixture with and without adjacency:

- **0 already-resolved slugs changed** (the never-silently-different invariant)
- ambiguous 18 → 16; both new resolutions are bare **"Rabbi Yehoshua" → `rabbi-yehoshua-b-hananiah`** (the correct conventional identification, via generation-corroboration)
- the result **holds with Berakhot excluded** from the graph build — the evidence generalizes across dapim
- blob stats: 278 nodes, 1,123 learned edges (251 strict≥2), **40 rabbis newly connected** (zero curated edges before)

## Design

- **Circularity discipline**: only strict-tier edges (both endpoints resolved `'unique'`) build the adjacency — the evidence base for pinning homonyms cannot itself contain homonym guesses. `weight` is deliberately unused.
- **Determinism**: the voice-graph fold grounds curated-only (`withoutLearnedAdjacency`), so the source graph is a function of its inputs, not of isolate history.
- **Loader**: single-flight + TTL; gate-off / deleted blob clears back to curated-only; corrupt blob keeps last-good with a warning.
- Gated by `LEARNED_ADJACENCY='1'` (on in both configs). Affects future mark generations; cached marks are untouched (no cache bump, no re-warm cost).
- Codex-reviewed; its findings (concurrent cold-start race, stale adjacency on rollback, isolate-history-dependent rebuilds, silent loader failures) are addressed in this diff.