### PR TITLE
#network ego view: one sage's learned circle

### DIFF
--- a/packages/talmud/src/client/App.tsx
+++ b/packages/talmud/src/client/App.tsx
@@ -4,6 +4,7 @@ import { AlignPage } from './AlignPage';
 import { AttributionsPage } from './AttributionsPage';
 import Compare from './Compare';
 import DafViewer from './DafViewer';
+import { EgoNetworkPage } from './EgoNetworkPage';
 import { HowItWorksPage } from './HowItWorksPage';
 import { McpPage } from './McpPage';
 import PretextSpike from './PretextSpike';
@@ -93,7 +94,17 @@ export default function App() {
                                                       route() === 'voices' ||
                                                       route().startsWith('voices/')
                                                     }
-                                                    fallback={<DafViewer />}
+                                                    fallback={
+                                                      <Show
+                                                        when={
+                                                          route() === 'network' ||
+                                                          route().startsWith('network/')
+                                                        }
+                                                        fallback={<DafViewer />}
+                                                      >
+                                                        <EgoNetworkPage />
+                                                      </Show>
+                                                    }
                                                   >
                                                     <VoicesPage />
                                                   </Show>

--- a/packages/talmud/src/client/EgoNetworkPage.tsx
+++ b/packages/talmud/src/client/EgoNetworkPage.tsx
@@ -1,0 +1,387 @@
+/**
+ * #network/<slug> — one sage's LEARNED circle: who they demonstrably argue
+ * with, cite, answer, and support across every analyzed daf, from the
+ * Shas-wide voice graph (GET /api/rabbi-network/:slug). One row per
+ * neighboring sage (strongest tie first), with per-relation chips and the
+ * daf citations as receipts; click a neighbor to re-center on them.
+ *
+ * Same visual language as the #voices graph: generation-striped node boxes,
+ * the flow palette for relation kinds. Rows instead of lanes because every
+ * edge here shares the center endpoint — a column of neighbors IS the graph.
+ */
+import {
+  createEffect,
+  createMemo,
+  createResource,
+  createSignal,
+  For,
+  type JSX,
+  onCleanup,
+  Show,
+} from 'solid-js';
+import { KIND_COLOR, stmtRelKind } from './ArgumentFlowGraph';
+import { type EgoRow, type EgoWire, groupEgoEdges, splitDafLabel } from './egoNetwork';
+import {
+  colorForGeneration,
+  GENERATION_BY_ID,
+  type GenerationInfo,
+  generationLabelHe,
+} from './generations';
+import { lang, t } from './i18n';
+import { type IndexRow, searchSages } from './sageSearch';
+
+const SUPPORTS_COLOR = '#0891b2';
+function relColor(kind: string): string {
+  return kind === 'supports' ? SUPPORTS_COLOR : KIND_COLOR[stmtRelKind(kind)];
+}
+
+function slugFromHash(): string | null {
+  const raw = window.location.hash.replace(/^#/, '');
+  if (!raw.startsWith('network/')) return null;
+  const slug = raw.slice('network/'.length).trim();
+  return slug || null;
+}
+
+function genLabel(generation: string | null): string {
+  if (!generation) return '';
+  const info = (GENERATION_BY_ID as Record<string, GenerationInfo | undefined>)[generation];
+  if (!info) return generation;
+  return lang() === 'he' ? generationLabelHe(info) : info.label;
+}
+
+function dafHref(label: string): string | null {
+  const d = splitDafLabel(label);
+  if (!d) return null;
+  return `?tractate=${encodeURIComponent(d.tractate)}&page=${encodeURIComponent(d.page)}#daf`;
+}
+
+interface NetworkSummary {
+  dapim?: number;
+  nodes?: number;
+  edges?: number;
+  newlyConnected?: number;
+}
+
+export function EgoNetworkPage(): JSX.Element {
+  const [slug, setSlug] = createSignal<string | null>(slugFromHash());
+  const sync = () => setSlug(slugFromHash());
+  window.addEventListener('hashchange', sync);
+  window.addEventListener('popstate', sync);
+  onCleanup(() => {
+    window.removeEventListener('hashchange', sync);
+    window.removeEventListener('popstate', sync);
+  });
+
+  const [index] = createResource(async () => {
+    const r = await fetch('/api/sages-index');
+    if (!r.ok) return [] as IndexRow[];
+    return ((await r.json()) as { rows: IndexRow[] }).rows;
+  });
+
+  const [summary] = createResource(async () => {
+    const r = await fetch('/api/rabbi-network');
+    if (!r.ok) return null;
+    return (await r.json()) as NetworkSummary;
+  });
+
+  const [ego] = createResource(
+    () => slug(),
+    async (s) => {
+      const r = await fetch(`/api/rabbi-network/${encodeURIComponent(s)}`);
+      if (r.status === 404) {
+        const body = (await r.json().catch(() => ({}))) as { error?: string };
+        return { miss: body.error?.includes('not compiled') ? 'building' : 'absent' } as const;
+      }
+      if (!r.ok) return { miss: 'error' } as const;
+      return { wire: (await r.json()) as EgoWire } as const;
+    },
+  );
+
+  const rows = createMemo<EgoRow[]>(() => {
+    const e = ego();
+    return e && 'wire' in e && e.wire ? groupEgoEdges(e.wire.edges) : [];
+  });
+
+  const [query, setQuery] = createSignal('');
+  const hits = createMemo(() => searchSages(index() ?? [], query(), 8));
+  const go = (s: string) => {
+    setQuery('');
+    window.location.hash = `network/${s}`;
+  };
+
+  const [openRow, setOpenRow] = createSignal<string | null>(null);
+  createEffect(() => {
+    slug(); // re-centering collapses any expanded neighbor row
+    setOpenRow(null);
+  });
+
+  return (
+    <main class="page-shell" style={{ '--page-max': '880px', color: '#222' }}>
+      <header style={{ 'margin-bottom': '1rem' }}>
+        <h1 style={{ margin: 0, 'font-size': '1.45rem' }}>{t('network.page.title')}</h1>
+        <p
+          style={{ margin: '0.3rem 0 0', color: '#666', 'font-size': '0.9rem', 'line-height': 1.5 }}
+        >
+          {t('network.page.blurb')}
+          <Show when={summary()?.dapim}>
+            {' '}
+            {t('network.page.coverage', {
+              dapim: summary()?.dapim ?? 0,
+              edges: summary()?.edges ?? 0,
+            })}
+          </Show>
+        </p>
+      </header>
+
+      {/* search */}
+      <div style={{ position: 'relative', 'margin-bottom': '1.2rem', 'max-width': '420px' }}>
+        <input
+          type="search"
+          value={query()}
+          onInput={(e) => setQuery(e.currentTarget.value)}
+          placeholder={t('network.page.search')}
+          style={{
+            width: '100%',
+            padding: '0.5rem 0.7rem',
+            border: '1px solid #d8d2c4',
+            'border-radius': '8px',
+            'font-size': '0.95rem',
+          }}
+        />
+        <Show when={hits().length > 0}>
+          <div
+            style={{
+              position: 'absolute',
+              top: '100%',
+              left: 0,
+              right: 0,
+              'z-index': 10,
+              background: '#fff',
+              border: '1px solid #d8d2c4',
+              'border-radius': '8px',
+              'box-shadow': '0 4px 14px rgba(0,0,0,0.08)',
+              overflow: 'hidden',
+            }}
+          >
+            <For each={hits()}>
+              {(r) => (
+                <button
+                  type="button"
+                  onClick={() => go(r.slug)}
+                  style={{
+                    display: 'flex',
+                    width: '100%',
+                    gap: '0.5rem',
+                    'align-items': 'baseline',
+                    padding: '0.45rem 0.7rem',
+                    border: 'none',
+                    background: 'transparent',
+                    cursor: 'pointer',
+                    'text-align': 'start',
+                    'font-size': '0.9rem',
+                  }}
+                >
+                  <span
+                    style={{
+                      width: '8px',
+                      height: '8px',
+                      'border-radius': '50%',
+                      background: colorForGeneration(r.generation),
+                      'flex-shrink': 0,
+                      'align-self': 'center',
+                    }}
+                  />
+                  <span>{lang() === 'he' ? (r.canonicalHe ?? r.canonical) : r.canonical}</span>
+                  <span style={{ color: '#999', 'font-size': '0.8rem' }}>
+                    {genLabel(r.generation)}
+                  </span>
+                </button>
+              )}
+            </For>
+          </div>
+        </Show>
+      </div>
+
+      <Show when={slug()} fallback={<p style={{ color: '#666' }}>{t('network.page.pickOne')}</p>}>
+        <Show when={ego()} keyed>
+          {(e) => (
+            <Show
+              when={'wire' in e ? e.wire : null}
+              keyed
+              fallback={
+                <p style={{ color: '#8a6d3b' }}>
+                  {'miss' in e && e.miss === 'building'
+                    ? t('network.page.building')
+                    : t('network.page.notInGraph')}
+                </p>
+              }
+            >
+              {(wire) => (
+                <section>
+                  {/* center sage header */}
+                  <div
+                    style={{
+                      display: 'flex',
+                      'align-items': 'center',
+                      gap: '0.7rem',
+                      padding: '0.7rem 0.9rem',
+                      border: '1px solid #d8d2c4',
+                      'border-inline-start': `6px solid ${colorForGeneration(wire.node.generation)}`,
+                      'border-radius': '10px',
+                      background: '#fffdf8',
+                      'margin-bottom': '0.9rem',
+                    }}
+                  >
+                    <div style={{ flex: 1 }}>
+                      <div style={{ 'font-weight': 600, 'font-size': '1.1rem' }}>
+                        {wire.node.name}
+                      </div>
+                      <div style={{ color: '#777', 'font-size': '0.82rem' }}>
+                        {genLabel(wire.node.generation)}
+                        {' · '}
+                        {t('network.page.meta', {
+                          sections: wire.node.sections,
+                          partners: rows().length,
+                        })}
+                        <Show when={(wire.node.curatedEdges ?? 0) === 0 && rows().length > 0}>
+                          {' · '}
+                          <span style={{ color: '#0a7a4b', 'font-weight': 600 }}>
+                            {t('network.page.newlyConnected')}
+                          </span>
+                        </Show>
+                      </div>
+                    </div>
+                    <a
+                      href={`#sages/${wire.id}`}
+                      style={{
+                        'font-size': '0.82rem',
+                        color: '#8a2a2b',
+                        'text-decoration': 'none',
+                      }}
+                    >
+                      {t('network.page.sagePage')} →
+                    </a>
+                  </div>
+
+                  <Show
+                    when={rows().length > 0}
+                    fallback={<p style={{ color: '#666' }}>{t('network.page.noEdges')}</p>}
+                  >
+                    <ol style={{ 'list-style': 'none', margin: 0, padding: 0 }}>
+                      <For each={rows()}>
+                        {(row) => (
+                          <li
+                            style={{
+                              border: '1px solid #e4ded1',
+                              'border-inline-start': `6px solid ${colorForGeneration(row.other.generation)}`,
+                              'border-radius': '10px',
+                              padding: '0.55rem 0.8rem',
+                              'margin-bottom': '0.5rem',
+                              background: '#fff',
+                            }}
+                          >
+                            <div
+                              style={{
+                                display: 'flex',
+                                'flex-wrap': 'wrap',
+                                gap: '0.45rem',
+                                'align-items': 'center',
+                              }}
+                            >
+                              <a
+                                href={`#network/${row.other.slug}`}
+                                style={{
+                                  'font-weight': 600,
+                                  color: '#222',
+                                  'text-decoration': 'none',
+                                }}
+                              >
+                                {row.other.name}
+                              </a>
+                              <span style={{ color: '#999', 'font-size': '0.78rem' }}>
+                                {genLabel(row.other.generation)}
+                              </span>
+                              <For each={row.chips}>
+                                {(c) => (
+                                  <span
+                                    style={{
+                                      border: `1px solid ${relColor(c.kind)}`,
+                                      color: relColor(c.kind),
+                                      'border-radius': '999px',
+                                      padding: '0.05rem 0.5rem',
+                                      'font-size': '0.75rem',
+                                      'white-space': 'nowrap',
+                                    }}
+                                    title={t('network.page.chipTitle', {
+                                      strict: c.strict,
+                                      weight: c.weight,
+                                    })}
+                                  >
+                                    {c.direction === 'out' ? '→ ' : '← '}
+                                    {t(`dafvoices.rel.${c.kind}`)}
+                                    {c.weight > 1 ? ` ×${c.weight}` : ''}
+                                  </span>
+                                )}
+                              </For>
+                              <button
+                                type="button"
+                                onClick={() =>
+                                  setOpenRow((o) => (o === row.other.slug ? null : row.other.slug))
+                                }
+                                style={{
+                                  'margin-inline-start': 'auto',
+                                  border: 'none',
+                                  background: 'transparent',
+                                  color: '#8a6d3b',
+                                  cursor: 'pointer',
+                                  'font-size': '0.78rem',
+                                }}
+                              >
+                                {openRow() === row.other.slug
+                                  ? t('network.page.hideDafs')
+                                  : t('network.page.showDafs', { n: row.dafs.length })}
+                              </button>
+                            </div>
+                            <Show when={openRow() === row.other.slug}>
+                              <div
+                                style={{
+                                  display: 'flex',
+                                  'flex-wrap': 'wrap',
+                                  gap: '0.35rem',
+                                  'margin-top': '0.45rem',
+                                }}
+                              >
+                                <For each={row.dafs}>
+                                  {(d) => (
+                                    <a
+                                      href={dafHref(d) ?? '#'}
+                                      style={{
+                                        border: '1px solid #d8d2c4',
+                                        'border-radius': '6px',
+                                        padding: '0.05rem 0.45rem',
+                                        'font-size': '0.75rem',
+                                        color: '#555',
+                                        'text-decoration': 'none',
+                                        background: '#faf8f2',
+                                      }}
+                                    >
+                                      {d}
+                                    </a>
+                                  )}
+                                </For>
+                              </div>
+                            </Show>
+                          </li>
+                        )}
+                      </For>
+                    </ol>
+                  </Show>
+                </section>
+              )}
+            </Show>
+          )}
+        </Show>
+      </Show>
+    </main>
+  );
+}

--- a/packages/talmud/src/client/SagesPage.tsx
+++ b/packages/talmud/src/client/SagesPage.tsx
@@ -7,15 +7,7 @@
  */
 import { createMemo, createResource, createSignal, For, type JSX, Show } from 'solid-js';
 import { t } from './i18n';
-
-interface IndexRow {
-  slug: string;
-  canonical: string;
-  canonicalHe: string | null;
-  aliases: string[];
-  generation: string | null;
-  region: 'israel' | 'bavel' | null;
-}
+import { type IndexRow, isHebrewQuery, normalize, scoreRow } from './sageSearch';
 
 interface IndexResp {
   rows: IndexRow[];
@@ -131,63 +123,6 @@ async function getJSON<T>(url: string): Promise<T | null> {
   if (!res.ok) return null;
   return res.json() as Promise<T>;
 }
-
-/* -------- fuzzy search -------- */
-
-// Lowercases ASCII and strips common punctuation. Hebrew is preserved as-is.
-const normalize = (s: string): string =>
-  s
-    .toLowerCase()
-    .replace(/[.,;:'"`()[\]{}]/g, '')
-    .replace(/\s+/g, ' ')
-    .trim();
-
-// Returns true if `q` chars appear in order anywhere in `s` (subsequence).
-const subseq = (q: string, s: string): boolean => {
-  let i = 0;
-  for (const ch of s) {
-    if (ch === q[i]) i += 1;
-    if (i === q.length) return true;
-  }
-  return i === q.length;
-};
-
-const scoreField = (q: string, field: string): number => {
-  if (!field) return 0;
-  const f = normalize(field);
-  if (!f) return 0;
-  if (f === q) return 1000;
-  if (f.startsWith(q)) return 600 - Math.min(100, f.length - q.length);
-  const idx = f.indexOf(q);
-  if (idx >= 0) return 350 - Math.min(100, idx);
-  if (q.length >= 3 && subseq(q, f)) return 80;
-  return 0;
-};
-
-// Hebrew shortcut — no lowercase, just substring/subseq.
-const scoreHebrew = (q: string, field: string | null): number => {
-  if (!field) return 0;
-  if (field === q) return 1000;
-  if (field.startsWith(q)) return 600;
-  if (field.includes(q)) return 350;
-  if (q.length >= 2 && subseq(q, field)) return 80;
-  return 0;
-};
-
-const isHebrewQuery = (q: string): boolean => /[֐-׿]/.test(q);
-
-const scoreRow = (qNorm: string, qHe: string | null, row: IndexRow): number => {
-  let best = 0;
-  // Hebrew query → only score against canonicalHe.
-  if (qHe) {
-    best = Math.max(best, scoreHebrew(qHe, row.canonicalHe));
-    return best;
-  }
-  best = Math.max(best, scoreField(qNorm, row.slug.replace(/-/g, ' ')));
-  best = Math.max(best, scoreField(qNorm, row.canonical));
-  for (const a of row.aliases) best = Math.max(best, scoreField(qNorm, a) - 30); // slight penalty vs canonical
-  return best;
-};
 
 /* -------- page -------- */
 
@@ -560,6 +495,12 @@ function SageDetail(props: {
     <article class="sage-detail">
       <header class="sage-head">
         <div class="sage-head-titles">
+          <a
+            href={`#network/${props.slug}`}
+            style={{ float: 'inline-end', 'font-size': '0.8rem', color: '#8a2a2b' }}
+          >
+            {t('network.page.title')} →
+          </a>
           <Show when={unified()?.canonical.en} fallback={<h2 class="sage-name">{props.slug}</h2>}>
             <h2 class="sage-name">
               {unified()!.canonical.en}

--- a/packages/talmud/src/client/egoNetwork.ts
+++ b/packages/talmud/src/client/egoNetwork.ts
@@ -1,0 +1,80 @@
+/**
+ * Pure shaping for the #network ego view: group the wire edges from
+ * GET /api/rabbi-network/:slug (one per (from,to,kind)) into one row per
+ * neighboring sage, with per-(kind,direction) chips and a merged daf sample.
+ * DOM-free — unit-tested in tests/ego-network.test.ts.
+ */
+
+export interface EgoWireEdge {
+  from: string;
+  to: string;
+  kind: string;
+  weight: number;
+  strict: number;
+  dafs: string[];
+  direction: 'out' | 'in';
+  other: { slug: string; name: string; generation: string | null };
+}
+
+export interface EgoWire {
+  type: 'rabbi';
+  id: string;
+  builtAt: number;
+  dapim: number;
+  node: {
+    name: string;
+    generation: string | null;
+    sections: number;
+    dafs: string[];
+    curatedEdges?: number;
+  };
+  edges: EgoWireEdge[];
+}
+
+export interface EgoChip {
+  kind: string;
+  direction: 'out' | 'in';
+  weight: number;
+  strict: number;
+}
+
+export interface EgoRow {
+  other: { slug: string; name: string; generation: string | null };
+  chips: EgoChip[];
+  totalWeight: number;
+  totalStrict: number;
+  dafs: string[];
+}
+
+const ROW_DAF_CAP = 18;
+
+/** One row per neighbor, strongest first; chips sorted by weight within. */
+export function groupEgoEdges(edges: readonly EgoWireEdge[]): EgoRow[] {
+  const rows = new Map<string, EgoRow>();
+  for (const e of edges) {
+    if (!e?.other?.slug) continue;
+    let row = rows.get(e.other.slug);
+    if (!row) {
+      row = { other: e.other, chips: [], totalWeight: 0, totalStrict: 0, dafs: [] };
+      rows.set(e.other.slug, row);
+    }
+    row.chips.push({ kind: e.kind, direction: e.direction, weight: e.weight, strict: e.strict });
+    row.totalWeight += e.weight;
+    row.totalStrict += e.strict;
+    for (const d of e.dafs) {
+      if (row.dafs.length >= ROW_DAF_CAP) break;
+      if (!row.dafs.includes(d)) row.dafs.push(d);
+    }
+  }
+  const out = [...rows.values()];
+  for (const r of out) r.chips.sort((a, b) => b.weight - a.weight);
+  out.sort((a, b) => b.totalWeight - a.totalWeight || b.totalStrict - a.totalStrict);
+  return out;
+}
+
+/** "Berakhot 2a" -> { tractate: "Berakhot", page: "2a" } (last space splits). */
+export function splitDafLabel(label: string): { tractate: string; page: string } | null {
+  const i = label.lastIndexOf(' ');
+  if (i <= 0 || i === label.length - 1) return null;
+  return { tractate: label.slice(0, i), page: label.slice(i + 1) };
+}

--- a/packages/talmud/src/client/i18n.ts
+++ b/packages/talmud/src/client/i18n.ts
@@ -170,6 +170,47 @@ const CATALOG = {
   'dafvoices.rel.opposes': { en: 'opposes', he: 'חולק על' },
   'dafvoices.rel.supports': { en: 'supports', he: 'תומך ב' },
   'dafvoices.rel.responds-to': { en: 'responds to', he: 'משיב ל' },
+  'network.page.title': { en: 'Sage network', he: 'רשת החכמים' },
+  'network.page.blurb': {
+    en: 'Who a sage argues with, cites, answers, and supports — learned from the voice graphs of every analyzed daf, with the dapim as receipts.',
+    he: 'עם מי החכם חולק, את מי הוא מצטט ולמי הוא משיב — מתוך גרפי הקולות של כל דף שנותח, עם הדפים כאסמכתאות.',
+  },
+  'network.page.coverage': {
+    en: 'Built from {dapim} dapim ({edges} connections so far).',
+    he: 'נבנה מ־{dapim} דפים ({edges} קשרים עד כה).',
+  },
+  'network.page.search': { en: 'Search a sage…', he: 'חיפוש חכם…' },
+  'network.page.pickOne': {
+    en: 'Search for a sage to see their circle.',
+    he: 'חפשו חכם כדי לראות את מעגל הקשרים שלו.',
+  },
+  'network.page.building': {
+    en: 'The Shas-wide network is still being built — check back soon.',
+    he: 'רשת הש״ס עדיין נבנית — נסו שוב בקרוב.',
+  },
+  'network.page.notInGraph': {
+    en: 'No voice-graph sightings for this sage yet (coverage grows as more dapim are analyzed).',
+    he: 'אין עדיין תצפיות לחכם זה (הכיסוי גדל ככל שמנותחים עוד דפים).',
+  },
+  'network.page.meta': {
+    en: 'speaks in {sections} sections · {partners} partners',
+    he: 'מדבר ב־{sections} קטעים · {partners} בני שיח',
+  },
+  'network.page.newlyConnected': {
+    en: 'first relationships for this sage',
+    he: 'קשרים ראשונים לחכם זה',
+  },
+  'network.page.sagePage': { en: 'Sage page', he: 'דף החכם' },
+  'network.page.noEdges': {
+    en: 'Appears on analyzed dapim, but no confident partner edges yet.',
+    he: 'מופיע בדפים שנותחו, אך עדיין ללא קשרים ודאיים.',
+  },
+  'network.page.chipTitle': {
+    en: '{weight} sightings ({strict} strict)',
+    he: '{weight} תצפיות ({strict} ודאיות)',
+  },
+  'network.page.showDafs': { en: 'dapim ({n})', he: 'דפים ({n})' },
+  'network.page.hideDafs': { en: 'hide', he: 'הסתרה' },
   'dafvoices.rel.cites': { en: 'cites', he: 'מצטט את' },
   'dafvoices.rel.resolves': { en: 'resolves', he: 'מיישב את' },
   // Voice roles (argument taxonomy)

--- a/packages/talmud/src/client/sageSearch.ts
+++ b/packages/talmud/src/client/sageSearch.ts
@@ -1,0 +1,83 @@
+/**
+ * Fuzzy sage search over the /api/sages-index rows — shared by SagesPage and
+ * the #network ego view. Scores slug + canonical EN/HE + aliases; a Hebrew
+ * query scores only against canonicalHe.
+ */
+
+export interface IndexRow {
+  slug: string;
+  canonical: string;
+  canonicalHe: string | null;
+  aliases: string[];
+  generation: string | null;
+  region: 'israel' | 'bavel' | null;
+}
+
+// Lowercases ASCII and strips common punctuation. Hebrew is preserved as-is.
+export const normalize = (s: string): string =>
+  s
+    .toLowerCase()
+    .replace(/[.,;:'"`()[\]{}]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+// Returns true if `q` chars appear in order anywhere in `s` (subsequence).
+const subseq = (q: string, s: string): boolean => {
+  let i = 0;
+  for (const ch of s) {
+    if (ch === q[i]) i += 1;
+    if (i === q.length) return true;
+  }
+  return i === q.length;
+};
+
+const scoreField = (q: string, field: string): number => {
+  if (!field) return 0;
+  const f = normalize(field);
+  if (!f) return 0;
+  if (f === q) return 1000;
+  if (f.startsWith(q)) return 600 - Math.min(100, f.length - q.length);
+  const idx = f.indexOf(q);
+  if (idx >= 0) return 350 - Math.min(100, idx);
+  if (q.length >= 3 && subseq(q, f)) return 80;
+  return 0;
+};
+
+// Hebrew shortcut — no lowercase, just substring/subseq.
+const scoreHebrew = (q: string, field: string | null): number => {
+  if (!field) return 0;
+  if (field === q) return 1000;
+  if (field.startsWith(q)) return 600;
+  if (field.includes(q)) return 350;
+  if (q.length >= 2 && subseq(q, field)) return 80;
+  return 0;
+};
+
+export const isHebrewQuery = (q: string): boolean => /[֐-׿]/.test(q);
+
+export const scoreRow = (qNorm: string, qHe: string | null, row: IndexRow): number => {
+  let best = 0;
+  // Hebrew query → only score against canonicalHe.
+  if (qHe) {
+    best = Math.max(best, scoreHebrew(qHe, row.canonicalHe));
+    return best;
+  }
+  best = Math.max(best, scoreField(qNorm, row.slug.replace(/-/g, ' ')));
+  best = Math.max(best, scoreField(qNorm, row.canonical));
+  for (const a of row.aliases) best = Math.max(best, scoreField(qNorm, a) - 30); // slight penalty vs canonical
+  return best;
+};
+
+/** Top-N rows for a raw query, strongest first. */
+export function searchSages(rows: readonly IndexRow[], query: string, limit = 12): IndexRow[] {
+  const q = query.trim();
+  if (!q) return [];
+  const qHe = isHebrewQuery(q) ? q : null;
+  const qNorm = normalize(q);
+  return rows
+    .map((row) => ({ row, score: scoreRow(qNorm, qHe, row) }))
+    .filter((x) => x.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+    .map((x) => x.row);
+}

--- a/packages/talmud/tests/ego-network.test.ts
+++ b/packages/talmud/tests/ego-network.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { type EgoWireEdge, groupEgoEdges, splitDafLabel } from '../src/client/egoNetwork';
+
+const edge = (over: Partial<EgoWireEdge>): EgoWireEdge => ({
+  from: 'rava',
+  to: 'abaye',
+  kind: 'opposes',
+  weight: 1,
+  strict: 0,
+  dafs: [],
+  direction: 'out',
+  other: { slug: 'abaye', name: 'Abaye', generation: 'amora-bavel-4' },
+  ...over,
+});
+
+describe('groupEgoEdges', () => {
+  it('groups by neighbor, merges dafs, sorts by total weight', () => {
+    const rows = groupEgoEdges([
+      edge({ kind: 'opposes', weight: 3, strict: 2, dafs: ['Berakhot 2a', 'Shabbat 21b'] }),
+      edge({ kind: 'cites', direction: 'in', weight: 1, dafs: ['Berakhot 2a'] }),
+      edge({
+        kind: 'supports',
+        weight: 9,
+        dafs: ['Chullin 3a'],
+        other: { slug: 'rav-papa', name: 'Rav Papa', generation: 'amora-bavel-5' },
+      }),
+    ]);
+    expect(rows.map((r) => r.other.slug)).toEqual(['rav-papa', 'abaye']);
+    const abaye = rows[1];
+    expect(abaye.chips.map((c) => c.kind)).toEqual(['opposes', 'cites']); // weight-sorted
+    expect(abaye.totalWeight).toBe(4);
+    expect(abaye.totalStrict).toBe(2);
+    expect(abaye.dafs).toEqual(['Berakhot 2a', 'Shabbat 21b']); // deduped union
+  });
+
+  it('drops rows without an other slug', () => {
+    const bad = edge({});
+    // @ts-expect-error simulating a corrupt wire row
+    bad.other = null;
+    expect(groupEgoEdges([bad])).toEqual([]);
+  });
+});
+
+describe('splitDafLabel', () => {
+  it('splits at the LAST space (multi-word tractates)', () => {
+    expect(splitDafLabel('Bava Metzia 59a')).toEqual({ tractate: 'Bava Metzia', page: '59a' });
+    expect(splitDafLabel('Berakhot 2a')).toEqual({ tractate: 'Berakhot', page: '2a' });
+  });
+  it('rejects labels without a page', () => {
+    expect(splitDafLabel('Berakhot')).toBeNull();
+    expect(splitDafLabel('Berakhot ')).toBeNull();
+  });
+});


### PR DESCRIPTION
The reader-facing surface for the learned voice graph (#544/#545): `#network/<slug>` shows one sage's demonstrated circle — who they argue with, cite, answer, and support across every analyzed daf — with the daf citations as receipts.

- Fuzzy sage search (the SagesPage scorer, extracted to `sageSearch.ts` and shared — behavior-preserving refactor).
- One row per neighbor, strongest tie first: generation stripes + the flow relation palette (same visual language as #voices); per-(kind, direction) chips with weights; expandable dapim chips deep-linking into the reader; click a neighbor to re-center.
- Sages with zero curated relationships get a "first relationships" badge (40 such sages already, at 16% Shas coverage).
- States: graph-still-building, sage-not-sighted-yet, sage-with-no-confident-edges. EN/HE, RTL-safe logical borders.
- `egoNetwork.ts` pure grouping helpers unit-tested; SagesPage detail pane links across.

Codex-reviewed; findings (listener cleanup on route churn, He/RTL localization, stale expanded row on re-center) fixed in this diff. The prod blob is live (seeded from the offline build; the cron's authoritative walk overwrites it on completion), so the page has real data on deploy.