### PR TITLE
Arc diagram: fixed timeline, uniform heights, click-away reset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ Thumbs.db
 *.swp
 *.swo
 __pycache__/
+*.local.test.ts

--- a/packages/talmud/src/client/SageNetworkSection.tsx
+++ b/packages/talmud/src/client/SageNetworkSection.tsx
@@ -34,7 +34,7 @@ import {
   legibleTextColor,
 } from './generations';
 import { lang, t } from './i18n';
-import { arcPath, barSegments, layoutSageArcs, shortGenLabel } from './sageArcLayout';
+import { ARC_BAND, arcPath, barSegments, layoutSageArcs, shortGenLabel } from './sageArcLayout';
 
 const SUPPORTS_COLOR = '#0891b2';
 const AXIS_INK = '#c9c2b2';
@@ -129,9 +129,10 @@ export function SageNetworkSection(props: { slug: string }): JSX.Element {
               );
               const anyExpanded = () =>
                 layout().groups.some((g) => g.expanded && g.dots.length > 0);
-              const axisY = () => TOP_PAD + Math.max(layout().maxAbove, 26) + 12;
-              const labelsY = () =>
-                axisY() + layout().maxBelow + (anyExpanded() ? 22 + NAME_BAND : 28);
+              // Constant vertical envelope (ARC_BAND) — a 3-partner sage's
+              // diagram stands as tall as Rava's, so pages compare directly.
+              const axisY = () => TOP_PAD + ARC_BAND + 12;
+              const labelsY = () => axisY() + ARC_BAND + (anyExpanded() ? 22 + NAME_BAND : 28);
               const barsY = () => labelsY() + LABEL_H;
               const height = () => barsY() + BAR_H + BOTTOM_PAD;
               const maxGroupTotal = () => layout().groups.reduce((m, g) => Math.max(m, g.total), 1);
@@ -179,6 +180,19 @@ export function SageNetworkSection(props: { slug: string }): JSX.Element {
                         role="img"
                         aria-label={t('network.arc.aria', { name: wire.node.name })}
                       >
+                        {/* click-away resets the drill-down to the default view */}
+                        <Show when={expandedGen() && !layout().autoExpanded}>
+                          {/* biome-ignore lint/a11y/noStaticElementInteractions: pointer-only click-away dismiss; keyboard users collapse via the generation label/pill toggles or the Show-all button */}
+                          <rect
+                            x={0}
+                            y={0}
+                            width={layout().width}
+                            height={height()}
+                            fill="transparent"
+                            onClick={() => setExpandedGen(null)}
+                          />
+                        </Show>
+
                         {/* direction hints, centered on the diagram */}
                         <text
                           x={layout().width / 2}
@@ -191,7 +205,7 @@ export function SageNetworkSection(props: { slug: string }): JSX.Element {
                         </text>
                         <text
                           x={layout().width / 2}
-                          y={axisY() + layout().maxBelow + 11}
+                          y={axisY() + ARC_BAND + 11}
                           font-size="9"
                           fill="#a89e8a"
                           text-anchor="middle"
@@ -207,7 +221,7 @@ export function SageNetworkSection(props: { slug: string }): JSX.Element {
                                 x={g.x}
                                 y={TOP_PAD + 4}
                                 width={g.width}
-                                height={axisY() + layout().maxBelow - TOP_PAD + 4}
+                                height={axisY() + ARC_BAND - TOP_PAD + 4}
                                 rx={10}
                                 fill="#8a6d3b"
                                 opacity="0.06"
@@ -369,9 +383,9 @@ export function SageNetworkSection(props: { slug: string }): JSX.Element {
                                         style={{ cursor: 'pointer' }}
                                       />
                                       <text
-                                        transform={`rotate(40 ${d.x} ${axisY() + layout().maxBelow + 22})`}
+                                        transform={`rotate(40 ${d.x} ${axisY() + ARC_BAND + 22})`}
                                         x={d.x}
-                                        y={axisY() + layout().maxBelow + 22}
+                                        y={axisY() + ARC_BAND + 22}
                                         font-size="9"
                                         fill={dimSlug(d.row.other.slug) ? '#c8c2b4' : '#555'}
                                         text-anchor="start"

--- a/packages/talmud/src/client/sageArcLayout.ts
+++ b/packages/talmud/src/client/sageArcLayout.ts
@@ -20,7 +20,11 @@ import { GENERATION_IDS } from './generations';
 export const AUTO_EXPAND_MAX = 8;
 export const ARC_MAX_PARTNERS_PER_GEN = 14; // fan cap inside one expanded generation
 
-const DOT_GAP = 34; // px between partner dots inside an EXPANDED generation
+const DOT_GAP = 34; // px between partner dots inside a manually EXPANDED generation
+/** Auto-expanded (small-network) pages use compact spacing so dots sit WITHIN
+ *  the fixed slots — their default ruler matches every other page exactly
+ *  whenever a generation holds <= 2 partners. */
+const DOT_GAP_COMPACT = 22;
 const GROUP_PAD = 16;
 const COLLAPSED_W = 64; // fixed width of a trunked (collapsed) generation group
 const EDGE_PAD = 20;
@@ -33,12 +37,27 @@ const TRUNK_MIN = 2.5;
 const TRUNK_MAX = 13;
 const FAN_MIN = 1.5;
 const FAN_MAX = 5.5;
-const ARC_HEIGHT_RATIO = 0.32;
-const ARC_RY_MIN = 16;
-const ARC_RY_MAX = 120;
+// Flattened arc profile: height is loosely tied to span but tightly clamped,
+// so long arcs read as wide flat ribbons and short ones still rise visibly —
+// and every sage's diagram lands in the same vertical envelope (ARC_BAND).
+const ARC_HEIGHT_RATIO = 0.45;
+const ARC_RY_MIN = 26;
+const ARC_RY_MAX = 68;
+/** The constant vertical band reserved above and below the axis. */
+export const ARC_BAND = 74;
 
 const GEN_ORDER = new Map<string, number>(GENERATION_IDS.map((id, i) => [id, i]));
 const UNKNOWN_ORDER = GENERATION_IDS.length;
+
+// The FIXED axis: every talmudic generation (zugim..savora) always renders, in
+// the same order with the same slot width, so any two sages' diagrams are
+// directly comparable — a late Bavel sage's cluster visibly sits at the far
+// right of the same ruler an early tanna's sits at the left of. Post-talmudic
+// generations (geonim+) and the unknown '?' slot are appended only when a
+// partner actually lives there.
+const SAVORA_IDX = GENERATION_IDS.indexOf('savora' as (typeof GENERATION_IDS)[number]);
+const FIXED_TIMELINE: (string | null)[] =
+  SAVORA_IDX >= 0 ? GENERATION_IDS.slice(0, SAVORA_IDX + 1) : [...GENERATION_IDS];
 
 export function genOrder(gen: string | null | undefined): number {
   return gen ? (GEN_ORDER.get(gen) ?? UNKNOWN_ORDER) : UNKNOWN_ORDER;
@@ -116,7 +135,9 @@ export function layoutSageArcs(
     byGen.set(g, arr);
   }
   if (!byGen.has(centerGen ?? null)) byGen.set(centerGen ?? null, []);
-  const genKeys = [...byGen.keys()].sort((a, b) => genOrder(a) - genOrder(b));
+  const slotSet = new Set<string | null>(FIXED_TIMELINE);
+  for (const g of byGen.keys()) slotSet.add(g);
+  const genKeys = [...slotSet].sort((a, b) => genOrder(a) - genOrder(b));
   const centerOrder = genOrder(centerGen ?? null);
 
   const maxGenTotal = Math.max(
@@ -150,18 +171,32 @@ export function layoutSageArcs(
     }
 
     const slots = expanded ? drawn.length : drawn.length > 0 ? 1 : 0;
+    const gap = autoExpanded ? DOT_GAP_COMPACT : DOT_GAP;
+    // Uniform slot width when collapsed — empty or not, CENTER INCLUDED — so
+    // the ruler is byte-identical on every sage's page. Auto-expanded pages
+    // use compact spacing and the collapsed-style center so their DEFAULT view
+    // shares the exact ruler too; only a slot with 3+ partners (or a manual
+    // expansion) stretches.
+    const compactCenter = isCenterGroup && (!expanded || autoExpanded);
     const innerW = expanded
-      ? Math.max(0, slots - 1) * DOT_GAP
-      : slots > 0
-        ? Math.max(0, COLLAPSED_W - GROUP_PAD * 2)
-        : 0;
-    const width =
-      GROUP_PAD * 2 + innerW + (isCenterGroup ? CENTER_EXTRA + (slots > 0 ? DOT_GAP : 0) : 0);
+      ? Math.max(0, slots - 1) * gap + (compactCenter && slots > 0 ? 28 : 0)
+      : Math.max(0, COLLAPSED_W - GROUP_PAD * 2);
+    const width = Math.max(
+      COLLAPSED_W,
+      GROUP_PAD * 2 + innerW + (isCenterGroup && expanded && !autoExpanded ? CENTER_EXTRA + DOT_GAP : 0),
+    );
     const start = x;
     let slotX = start + GROUP_PAD;
     if (isCenterGroup) {
-      centerX = slotX;
-      slotX += DOT_GAP + CENTER_EXTRA;
+      if (expanded && !autoExpanded) {
+        centerX = slotX;
+        slotX += DOT_GAP + CENTER_EXTRA;
+      } else {
+        // Compact center: the sage's dot sits left in the uniform slot; any
+        // partner dots (auto-expanded) or the pill start to its right.
+        centerX = start + 18;
+        slotX = start + 46;
+      }
     }
 
     const total = members.reduce((s, r) => s + r.totalWeight, 0);
@@ -174,11 +209,11 @@ export function layoutSageArcs(
     if (expanded) {
       for (const row of drawn) {
         dots.push({ row, x: slotX, r: scaled(row.totalWeight, maxPartnerW, MIN_R, MAX_R) });
-        slotX += DOT_GAP;
+        slotX += gap;
       }
     } else if (drawn.length > 0) {
       pill = {
-        x: start + width / 2 + (isCenterGroup ? CENTER_EXTRA / 2 : 0),
+        x: isCenterGroup ? start + width - 18 : start + width / 2,
         r: scaled(members.length, maxPartnerCount, PILL_MIN_R, PILL_MAX_R),
         partnerCount: members.length,
       };

--- a/packages/talmud/src/client/sageArcLayout.ts
+++ b/packages/talmud/src/client/sageArcLayout.ts
@@ -183,7 +183,9 @@ export function layoutSageArcs(
       : Math.max(0, COLLAPSED_W - GROUP_PAD * 2);
     const width = Math.max(
       COLLAPSED_W,
-      GROUP_PAD * 2 + innerW + (isCenterGroup && expanded && !autoExpanded ? CENTER_EXTRA + DOT_GAP : 0),
+      GROUP_PAD * 2 +
+        innerW +
+        (isCenterGroup && expanded && !autoExpanded ? CENTER_EXTRA + DOT_GAP : 0),
     );
     const start = x;
     let slotX = start + GROUP_PAD;

--- a/packages/talmud/tests/sage-arc-layout.test.ts
+++ b/packages/talmud/tests/sage-arc-layout.test.ts
@@ -123,9 +123,37 @@ describe('layoutSageArcs — small networks', () => {
     expect(hx).toBeGreaterThan(lx);
   });
 
-  it('creates the center generation group even with no partners in it', () => {
+  it('always renders the full fixed timeline (zugim through savora)', () => {
     const l = layoutSageArcs('savora', [row('x', 'tanna-1', 1)]);
-    expect(l.groups.map((g) => g.gen)).toEqual(['tanna-1', 'savora']);
+    const gens = l.groups.map((g) => g.gen);
+    expect(gens[0]).toBe('zugim');
+    expect(gens[gens.length - 1]).toBe('savora');
+    expect(gens).toContain('amora-bavel-8');
+    expect(l.groups.length).toBeGreaterThanOrEqual(21);
+  });
+
+  it('the ruler is identical across sages in the default view', () => {
+    const a = layoutSageArcs('tanna-2', [row('p1', 'tanna-4', 3)], null);
+    const b = layoutSageArcs('amora-bavel-6', [row('p2', 'amora-ey-1', 5)], null);
+    // autoExpanded kicks in for tiny networks, so force-collapse comparison:
+    // both have <= AUTO_EXPAND_MAX rows, so compare group geometry only for
+    // larger synthetic sets.
+    const many = (gen: string) =>
+      Array.from({ length: 10 }, (_, i) => row(`m${i}`, 'amora-ey-2', i + 1));
+    const bigA = layoutSageArcs('tanna-2', many('a'), null);
+    const bigB = layoutSageArcs('amora-bavel-6', many('b'), null);
+    expect(bigA.groups.map((g) => [g.gen, g.x, g.width])).toEqual(
+      bigB.groups.map((g) => [g.gen, g.x, g.width]),
+    );
+    expect(bigA.width).toBe(bigB.width);
+    expect(a.groups.length).toBe(b.groups.length);
+    // …and an auto-expanded (small) page shares the exact same ruler as a
+    // trunked page whenever no generation holds 3+ partners.
+    const small = layoutSageArcs('amora-bavel-6', [row('s1', 'amora-bavel-4', 2)], null);
+    expect(small.autoExpanded).toBe(true);
+    expect(small.groups.map((g) => [g.gen, g.x, g.width])).toEqual(
+      bigA.groups.map((g) => [g.gen, g.x, g.width]),
+    );
   });
 });
 


### PR DESCRIPTION
Design-review refinements on #549:

1. **Fixed timeline** — all 21 talmudic generations always render at uniform slot widths, so every sage's page shares a byte-identical ruler (locked by a geometry test): where the cluster sits on the axis is where the sage sits in history. Small (auto-expanded) pages use compact in-slot spacing + a collapsed-style center so their default view matches exactly too.
2. **Uniform heights** — flattened arc profile (ry 26–68, constant vertical envelope): small sages' diagrams stand as tall as Rava's; long arcs are flat ribbons, not half-circles.
3. **Click-away** — clicking empty diagram space collapses the drill-down back to the default view.

Geometry verified numerically against live prod data (Rava vs a 3-partner sage: 0 shared-slot mismatches; ry ranges 26–68 and 68–68). Plus a `.gitignore` guard for scratch preview tests.