### PR TITLE
Sages hygiene: exclude non-sage topics; surface the missing-rabbis worklist

### DIFF
--- a/packages/talmud/src/client/SagesPage.tsx
+++ b/packages/talmud/src/client/SagesPage.tsx
@@ -125,6 +125,86 @@ async function getJSON<T>(url: string): Promise<T | null> {
   return res.json() as Promise<T>;
 }
 
+/* -------- missing-from-registry panel -------- */
+
+interface BacklogRabbi {
+  name: string;
+  nameHe?: string;
+  generation?: string;
+  count: number;
+  dafs: string[];
+}
+interface BacklogResp {
+  rabbis?: { total: number; scanned?: number; sample: BacklogRabbi[] };
+}
+
+/** Names the AI reliably reads as a distinct sage on real dapim but that match
+ *  NO registry entry — the "who needs a bio next" worklist. Data: the live
+ *  unknown-rabbi backlog (sampled; see the caption). */
+function MissingSagesPanel(): JSX.Element {
+  const [open, setOpen] = createSignal(false);
+  const [backlog] = createResource(open, async (o) => {
+    if (!o) return null;
+    const r = await fetch('/api/usage/backlog');
+    if (!r.ok) return { rabbis: undefined } satisfies BacklogResp; // unavailable, not loading
+    return (await r.json()) as BacklogResp;
+  });
+  const dafHref = (label: string) => {
+    const i = label.lastIndexOf(' ');
+    if (i <= 0) return '#';
+    return `?tractate=${encodeURIComponent(label.slice(0, i))}&page=${encodeURIComponent(label.slice(i + 1))}#daf`;
+  };
+  return (
+    <div class="sages-missing">
+      <button
+        type="button"
+        class="sages-missing-toggle"
+        aria-expanded={open()}
+        onClick={() => setOpen((o) => !o)}
+      >
+        {open() ? '▾' : '▸'} {t('sages.missing.title')}
+      </button>
+      <Show when={open()}>
+        <Show when={backlog()} fallback={<div class="sages-empty">{t('sages.list.loading')}</div>}>
+          {(b) => (
+            <>
+              <Show when={!b().rabbis}>
+                <p class="sages-missing-note">{t('sages.missing.unavailable')}</p>
+              </Show>
+              <p class="sages-missing-note">
+                {t('sages.missing.note', {
+                  total: b().rabbis?.total ?? 0,
+                  scanned: b().rabbis?.scanned ?? 0,
+                })}
+              </p>
+              <For each={b().rabbis?.sample ?? []}>
+                {(r) => (
+                  <div class="sages-missing-row">
+                    <span class="sages-list-name">{r.name}</span>
+                    <Show when={r.nameHe}>
+                      <span class="sages-list-name-he">{r.nameHe}</span>
+                    </Show>
+                    <span class="sages-missing-count">×{r.count}</span>
+                    <span class="sages-missing-dafs">
+                      <For each={r.dafs.slice(0, 3)}>
+                        {(d) => (
+                          <a href={dafHref(d)} class="sages-missing-daf">
+                            {d}
+                          </a>
+                        )}
+                      </For>
+                    </span>
+                  </div>
+                )}
+              </For>
+            </>
+          )}
+        </Show>
+      </Show>
+    </div>
+  );
+}
+
 /* -------- page -------- */
 
 export function SagesPage(): JSX.Element {
@@ -383,6 +463,7 @@ export function SagesPage(): JSX.Element {
               {t('sages.list.cap', { count: ranked().length - 300 })}
             </div>
           </Show>
+          <MissingSagesPanel />
         </aside>
 
         <main class="sages-detail panel">
@@ -1140,6 +1221,13 @@ const SAGES_CSS = `
 
 .sages-list { padding: 0.5rem; max-height: 78vh; overflow-y: auto; }
 .sages-empty { color: #94a3b8; font-style: italic; font-size: 12.5px; padding: 1rem; text-align: center; }
+.sages-missing { border-top: 1px solid #e2e8f0; margin-top: 0.6rem; padding: 0.4rem 0.2rem; }
+.sages-missing-toggle { border: none; background: transparent; cursor: pointer; font-size: 12.5px; font-weight: 600; color: #8a6d3b; padding: 0.3rem 0.5rem; width: 100%; text-align: start; }
+.sages-missing-note { color: #94a3b8; font-size: 11.5px; margin: 0.2rem 0.5rem 0.5rem; line-height: 1.4; }
+.sages-missing-row { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.35rem; padding: 0.25rem 0.5rem; font-size: 12.5px; border-bottom: 1px dashed #eef2f7; }
+.sages-missing-count { color: #8a6d3b; font-weight: 600; font-size: 11.5px; }
+.sages-missing-dafs { display: inline-flex; flex-wrap: wrap; gap: 0.3rem; }
+.sages-missing-daf { color: #64748b; font-size: 11px; text-decoration: none; border: 1px solid #e2e8f0; border-radius: 5px; padding: 0 0.3rem; }
 .sages-empty-large { padding: 3rem 1rem; font-size: 14px; }
 .sages-list-item { display: flex; flex-direction: column; gap: 0.15rem; align-items: flex-start; text-align: left; padding: 0.4rem 0.55rem; border: none; border-radius: 4px; background: transparent; cursor: pointer; width: 100%; box-sizing: border-box; }
 .sages-list-item:hover { background: #f1f5f9; }

--- a/packages/talmud/src/client/i18n.ts
+++ b/packages/talmud/src/client/i18n.ts
@@ -170,6 +170,15 @@ const CATALOG = {
   'dafvoices.rel.opposes': { en: 'opposes', he: 'חולק על' },
   'dafvoices.rel.supports': { en: 'supports', he: 'תומך ב' },
   'dafvoices.rel.responds-to': { en: 'responds to', he: 'משיב ל' },
+  'sages.missing.title': { en: 'Missing from the registry', he: 'חסרים במאגר' },
+  'sages.missing.unavailable': {
+    en: 'Backlog unavailable right now.',
+    he: 'הרשימה אינה זמינה כרגע.',
+  },
+  'sages.missing.note': {
+    en: '{total} distinct names were sighted on analyzed dapim but match no registry entry — the "needs a bio" worklist. Counts sampled from the first {scanned} records.',
+    he: '{total} שמות נצפו בדפים שנותחו אך אינם במאגר — רשימת העבודה של \u201cחסרה ביוגרפיה\u201d. הספירה מדגימה את {scanned} הרשומות הראשונות.',
+  },
   'network.page.title': { en: 'Sage network', he: 'רשת החכמים' },
   'network.page.coverageShort': {
     en: 'from {dapim} analyzed dapim',

--- a/packages/talmud/src/lib/nonSageTopics.ts
+++ b/packages/talmud/src/lib/nonSageTopics.ts
@@ -1,0 +1,23 @@
+/**
+ * Non-sage "person" topics that ride along in the Sefaria-derived registry —
+ * kabbalistic concepts (Partzuf, Sefira, …), liturgical texts (Hallel), and
+ * biblical figures whose bare Hebrew collides with a sage's name (Mordechai;
+ * Hallel's הלל collides with Hillel in the standalone-name allowlist, which is
+ * how a liturgical text ended up in the #sages browser AND made bare "Hillel"
+ * a fake homonym for the resolver).
+ *
+ * One predicate, used by BOTH the sages index (what the browser shows) and the
+ * resolver's candidate index (who a daf name can denote).
+ */
+
+const NON_SAGE_SLUGS = new Set([
+  'hallel',
+  'mordekhai',
+  'mordechai1',
+  'blessings',
+  'blessings-(halakhah)',
+]);
+
+export function isNonSageTopic(slug: string, canonicalHe?: string | null): boolean {
+  return NON_SAGE_SLUGS.has(slug) || (canonicalHe ?? '').includes('קבלה');
+}

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -68,6 +68,7 @@ import { dafSpine } from '../lib/context/spine';
 import { spineLinks } from '../lib/context/spineLinks';
 import { buildGeoModel, type GeoEnrichment, type RabbiGeoSource } from '../lib/geographyModel';
 import { buildCodificationChain, buildDerivation } from '../lib/halacha/codifiers';
+import { isNonSageTopic } from '../lib/nonSageTopics';
 import {
   buildRabbiEnrichUserMessage,
   type LocalRabbiInput,
@@ -8901,7 +8902,7 @@ function isRabbinicEntry(r: RabbiPlacesEntry): boolean {
 
 app.get('/api/admin/rabbi-slugs', (c) => {
   const slugs = Object.entries(RABBI_PLACES.rabbis)
-    .filter(([, r]) => isRabbinicEntry(r))
+    .filter(([slug, r]) => !isNonSageTopic(slug, r.canonicalHe) && isRabbinicEntry(r))
     .map(([slug]) => slug);
   return c.json({ slugs, count: slugs.length });
 });
@@ -8911,7 +8912,7 @@ app.get('/api/admin/rabbi-slugs', (c) => {
 // Reads straight from the bundled rabbi-places.json — no cache lookup.
 app.get('/api/sages-index', (c) => {
   const rows = Object.entries(RABBI_PLACES.rabbis)
-    .filter(([, r]) => isRabbinicEntry(r))
+    .filter(([slug, r]) => !isNonSageTopic(slug, r.canonicalHe) && isRabbinicEntry(r))
     .map(([slug, r]) => ({
       slug,
       canonical: r.canonical,

--- a/packages/talmud/src/worker/rabbi-graph.ts
+++ b/packages/talmud/src/worker/rabbi-graph.ts
@@ -23,6 +23,7 @@
  */
 
 import hierarchyData from '../lib/data/rabbi-hierarchy.json';
+import { isNonSageTopic } from '../lib/nonSageTopics';
 
 interface HierarchyNode {
   canonical: string;
@@ -201,6 +202,10 @@ function buildIndex(): IndexBuilt {
   const slugToCanonical = new Map<string, string>();
   for (const [slug, node] of Object.entries(DATA.nodes)) {
     slugToCanonical.set(slug, node.canonical);
+    // Non-sage topics (kabbalah concepts, liturgy — e.g. Hallel, whose Hebrew
+    // collides with Hillel) never enter the NAME indices: a daf name must not
+    // resolve to them, nor become a fake homonym because of them.
+    if (isNonSageTopic(slug, node.canonicalHe)) continue;
     const normCanonical = normalizeName(node.canonical);
     if (!nameToSlug.has(normCanonical)) nameToSlug.set(normCanonical, slug);
     // Also index the slug itself as a normalized name (slug → name form).
@@ -247,6 +252,7 @@ function findSlug(name: string, nameHe?: string, generation?: string): string | 
   //    safer fallthrough to LLM disambiguation).
   if (!slug && generation) {
     for (const [s, node] of Object.entries(DATA.nodes)) {
+      if (isNonSageTopic(s, node.canonicalHe)) continue;
       if (node.generation !== generation) continue;
       const nodeNorm = normalizeName(node.canonical);
       if (nodeNorm === norm || nodeNorm.startsWith(`${norm} `)) {
@@ -272,9 +278,9 @@ export function generationOf(slug: string): string | null {
 // Every (normalizedCanonical, slug) pair, built once — for enumerating ALL
 // registry nodes a name could refer to (homonym candidate set), not just the
 // first match findSlug returns.
-const NORM_INDEX: { norm: string; slug: string }[] = Object.entries(DATA.nodes).map(
-  ([slug, n]) => ({ norm: normalizeName(n.canonical), slug }),
-);
+const NORM_INDEX: { norm: string; slug: string }[] = Object.entries(DATA.nodes)
+  .filter(([slug, n]) => !isNonSageTopic(slug, n.canonicalHe))
+  .map(([slug, n]) => ({ norm: normalizeName(n.canonical), slug }));
 
 /** ALL registry nodes a name could denote. For a homonym like "Rav Kahana"
  *  this returns every Kahana node (Rav Kahana (II), Rav Kahana of Pum Nahara,

--- a/packages/talmud/tests/non-sage-topics.test.ts
+++ b/packages/talmud/tests/non-sage-topics.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { isNonSageTopic } from '../src/lib/nonSageTopics';
+import { rabbiCandidates, resolveRabbiSlug } from '../src/worker/rabbi-graph';
+
+describe('isNonSageTopic', () => {
+  it('flags liturgy, kabbalah concepts, and biblical name-colliders', () => {
+    expect(isNonSageTopic('hallel', 'הַלֵּל')).toBe(true);
+    expect(isNonSageTopic('partzuf', 'פַּרְצוּף (קבלה)')).toBe(true);
+    expect(isNonSageTopic('mordekhai', 'מרדכי')).toBe(true);
+    expect(isNonSageTopic('hillel', 'הלל')).toBe(false);
+    expect(isNonSageTopic('rava', 'רבא')).toBe(false);
+  });
+});
+
+describe('resolver excludes non-sage topics', () => {
+  it('bare Hillel is UNIQUE again — the liturgical Hallel no longer makes it a fake homonym', () => {
+    const cands = rabbiCandidates('Hillel', 'הלל');
+    expect(cands).toEqual(['hillel']);
+    expect(resolveRabbiSlug('Hillel', 'הלל')).toEqual({ slug: 'hillel', basis: 'unique' });
+  });
+
+  it('a non-sage topic never resolves from a daf name', () => {
+    // DELIBERATE: names reach the resolver only after the AI asserted them as
+    // a PERSON, and a person written הלל is Hillel — the transliteration
+    // "Hallel" identifies with the sage, not with the (excluded) liturgy topic.
+    expect(rabbiCandidates('Hallel', 'הַלֵּל')).toEqual(['hillel']);
+    expect(rabbiCandidates('Partzuf')).toEqual([]);
+  });
+});


### PR DESCRIPTION
Two data-quality items from review:

1. **Non-sage topics out of the sage surfaces.** The Sefaria-derived registry includes kabbalah concepts, liturgy, and biblical figures as "person" topics. A shared predicate (`lib/nonSageTopics.ts`) excludes them from the #sages index **and** the resolver's name indices. Side win: the liturgical **Hallel**'s Hebrew (הלל) was colliding with **Hillel** in the standalone-name allowlist — bare Hillel now resolves `unique` again instead of being a fake homonym (locked by test; `rabbi-resolve-bench` floors hold). Deep links to excluded slugs keep working.
2. **The missing-rabbis worklist, where you'd look for it.** The #sages list pane gains a collapsible **Missing from the registry** panel — names sighted as distinct sages on analyzed dapim that match no registry entry (the live unknown-rabbi backlog), with counts + daf receipts and an honest sampled-counts caption. This is the live twin of the Sefaria missing-bios deliverable.

Codex-reviewed; its findings (findSlug bypass, panel error state, test-intent documentation) addressed in this diff.