### PR TITLE
Rabbi page redesign: simpler arcs, Shas coverage strip, reader-first layout

### DIFF
--- a/packages/talmud/src/client/SageCoverageStrip.tsx
+++ b/packages/talmud/src/client/SageCoverageStrip.tsx
@@ -1,0 +1,181 @@
+/**
+ * Where in Shas does this sage speak? One cell per masechet in seder order,
+ * cell width ∝ the masechet's size. Three nested layers per cell:
+ *   base   — the whole masechet (what exists)
+ *   middle — dapim we have AI-analyzed so far (the voice-graph denominator)
+ *   fill   — dapim where THIS sage is observed (era-colored)
+ * So "not yet analyzed" is always visible as the unfilled remainder — absence
+ * of the sage in an unanalyzed masechet is honestly not evidence of absence.
+ *
+ * Numerator: /api/rabbi-observations/:slug?summary=1 byTractate (10-min cached
+ * fold of the per-daf observation slices). Denominator: dapimByTractate from
+ * the Shas-wide voice-graph blob (appears after its next rebuild; the strip
+ * degrades to sage-vs-total shading until then).
+ */
+import { createMemo, createResource, For, type JSX, Show } from 'solid-js';
+import { iterAmudim } from '../lib/sefref/amudim';
+import { TRACTATE_OPTIONS } from '../lib/sefref/tractates';
+import { colorForGeneration } from './generations';
+import { lang, t } from './i18n';
+
+const AMUDIM_TOTAL = new Map<string, number>(
+  TRACTATE_OPTIONS.map((o) => [o.value, [...iterAmudim(o.value)].length]),
+);
+
+interface ObsSummary {
+  dafCount?: number;
+  byTractate?: Record<string, number>;
+}
+interface NetworkSummary {
+  dapim?: number;
+  dapimByTractate?: Record<string, number>;
+}
+
+const CELL_H = 26;
+const PX_PER_AMUD = 0.24;
+const CELL_MIN_W = 10;
+
+export function SageCoverageStrip(props: { slug: string; generation: string | null }): JSX.Element {
+  const [obs] = createResource(
+    () => props.slug,
+    async (slug) => {
+      const r = await fetch(
+        `/api/rabbi-observations/${encodeURIComponent(slug)}?summary=1&min=9999`,
+      );
+      if (!r.ok) return null;
+      return (await r.json()) as ObsSummary;
+    },
+  );
+  const [net] = createResource(async () => {
+    const r = await fetch('/api/rabbi-network');
+    if (!r.ok) return null;
+    return (await r.json()) as NetworkSummary;
+  });
+
+  const cells = createMemo(() => {
+    const by = obs()?.byTractate ?? {};
+    const analyzed = net()?.dapimByTractate ?? null;
+    return TRACTATE_OPTIONS.map((o) => {
+      const total = AMUDIM_TOTAL.get(o.value) ?? 0;
+      return {
+        value: o.value,
+        label: lang() === 'he' ? o.label : o.value,
+        total,
+        analyzed: analyzed ? (analyzed[o.value] ?? 0) : null,
+        sage: by[o.value] ?? 0,
+        w: Math.max(CELL_MIN_W, total * PX_PER_AMUD),
+      };
+    });
+  });
+
+  const sageTotal = () => obs()?.dafCount ?? 0;
+  const tractatesWithSage = () => cells().filter((c) => c.sage > 0).length;
+  const hasDenominator = () => net()?.dapimByTractate != null;
+
+  return (
+    <section class="sage-coverage" style={{ margin: '0.9rem 0' }}>
+      <h3 style={{ margin: '0 0 0.2rem', 'font-size': '0.95rem' }}>{t('coverage.title')}</h3>
+      <Show when={!obs.loading} fallback={<p class="sages-empty">{t('sages.list.loading')}</p>}>
+        <p style={{ margin: '0 0 0.5rem', color: '#777', 'font-size': '0.8rem' }}>
+          {t('coverage.summary', {
+            dapim: sageTotal(),
+            masechtot: tractatesWithSage(),
+            analyzed: net()?.dapim ?? 0,
+          })}
+          <Show when={!hasDenominator()}>
+            {' '}
+            <span style={{ color: '#a89e8a' }}>{t('coverage.noDenominator')}</span>
+          </Show>
+        </p>
+        <div style={{ 'overflow-x': 'auto' }}>
+          <div
+            style={{
+              display: 'flex',
+              'align-items': 'flex-end',
+              gap: '2px',
+              'padding-bottom': '2.6rem',
+              width: 'max-content',
+            }}
+          >
+            <For each={cells()}>
+              {(c) => {
+                const analyzedFrac = () =>
+                  c.analyzed != null && c.total > 0 ? Math.min(1, c.analyzed / c.total) : 1;
+                const sageFrac = () => (c.total > 0 ? Math.min(1, c.sage / c.total) : 0);
+                const title = () =>
+                  c.analyzed != null
+                    ? t('coverage.cellTitle', {
+                        masechet: c.value,
+                        sage: c.sage,
+                        analyzed: c.analyzed,
+                        total: c.total,
+                      })
+                    : t('coverage.cellTitleNoDenom', {
+                        masechet: c.value,
+                        sage: c.sage,
+                        total: c.total,
+                      });
+                return (
+                  <div
+                    style={{ position: 'relative', width: `${c.w}px`, height: `${CELL_H}px` }}
+                    title={title()}
+                  >
+                    {/* whole masechet */}
+                    <div
+                      style={{
+                        position: 'absolute',
+                        inset: 0,
+                        background: '#efeadf',
+                        'border-radius': '3px',
+                      }}
+                    />
+                    {/* analyzed-so-far band */}
+                    <div
+                      style={{
+                        position: 'absolute',
+                        left: 0,
+                        bottom: 0,
+                        top: 0,
+                        width: `${analyzedFrac() * 100}%`,
+                        background: '#d9d2c0',
+                        'border-radius': '3px',
+                      }}
+                    />
+                    {/* the sage */}
+                    <Show when={c.sage > 0}>
+                      <div
+                        style={{
+                          position: 'absolute',
+                          left: 0,
+                          bottom: 0,
+                          top: 0,
+                          width: `${Math.max(6, sageFrac() * 100)}%`,
+                          background: colorForGeneration(props.generation),
+                          'border-radius': '3px',
+                        }}
+                      />
+                    </Show>
+                    <span
+                      style={{
+                        position: 'absolute',
+                        top: `${CELL_H + 4}px`,
+                        left: '2px',
+                        'font-size': '8.5px',
+                        color: c.sage > 0 ? '#555' : '#b6ae9c',
+                        'white-space': 'nowrap',
+                        transform: 'rotate(40deg)',
+                        'transform-origin': 'top left',
+                      }}
+                    >
+                      {c.label}
+                    </span>
+                  </div>
+                );
+              }}
+            </For>
+          </div>
+        </div>
+      </Show>
+    </section>
+  );
+}

--- a/packages/talmud/src/client/SageNetworkSection.tsx
+++ b/packages/talmud/src/client/SageNetworkSection.tsx
@@ -11,9 +11,11 @@
  *   L3  a partner's rows expand into daf receipts; dots and names link to the
  *       partner's sage page.
  *
- * Relation kinds are encoded in the stacked bars + row chips (with a legend);
- * arcs carry era + direction + volume only — that separation is what keeps a
- * 60-partner sage readable.
+ * At the overview, arcs carry era + volume only (relation kinds live in the
+ * stacked bars + row chips); when a generation is opened, its trunk splits
+ * into kind-colored category lines — the palette appears exactly when it is
+ * examinable. Direction (who acts on whom) is row-chip detail (→/←), not a
+ * diagram dimension.
  */
 import {
   createEffect,
@@ -132,7 +134,7 @@ export function SageNetworkSection(props: { slug: string }): JSX.Element {
               // Constant vertical envelope (ARC_BAND) — a 3-partner sage's
               // diagram stands as tall as Rava's, so pages compare directly.
               const axisY = () => TOP_PAD + ARC_BAND + 12;
-              const labelsY = () => axisY() + ARC_BAND + (anyExpanded() ? 22 + NAME_BAND : 28);
+              const labelsY = () => axisY() + (anyExpanded() ? 16 + NAME_BAND : 26);
               const barsY = () => labelsY() + LABEL_H;
               const height = () => barsY() + BAR_H + BOTTOM_PAD;
               const maxGroupTotal = () => layout().groups.reduce((m, g) => Math.max(m, g.total), 1);
@@ -193,26 +195,6 @@ export function SageNetworkSection(props: { slug: string }): JSX.Element {
                           />
                         </Show>
 
-                        {/* direction hints, centered on the diagram */}
-                        <text
-                          x={layout().width / 2}
-                          y={TOP_PAD}
-                          font-size="9"
-                          fill="#a89e8a"
-                          text-anchor="middle"
-                        >
-                          {t('network.arc.outgoing', { name: wire.node.name })}
-                        </text>
-                        <text
-                          x={layout().width / 2}
-                          y={axisY() + ARC_BAND + 11}
-                          font-size="9"
-                          fill="#a89e8a"
-                          text-anchor="middle"
-                        >
-                          {t('network.arc.incoming', { name: wire.node.name })}
-                        </text>
-
                         {/* expanded-group background band */}
                         <For each={layout().groups}>
                           {(g) => (
@@ -221,7 +203,7 @@ export function SageNetworkSection(props: { slug: string }): JSX.Element {
                                 x={g.x}
                                 y={TOP_PAD + 4}
                                 width={g.width}
-                                height={axisY() + ARC_BAND - TOP_PAD + 4}
+                                height={axisY() - TOP_PAD + (anyExpanded() ? 14 : 4)}
                                 rx={10}
                                 fill="#8a6d3b"
                                 opacity="0.06"
@@ -236,7 +218,7 @@ export function SageNetworkSection(props: { slug: string }): JSX.Element {
                             <path
                               d={arcPath(a, axisY())}
                               fill="none"
-                              stroke={colorForGeneration(a.gen)}
+                              stroke={a.rel ? relColor(a.rel) : colorForGeneration(a.gen)}
                               stroke-width={a.stroke}
                               stroke-linecap="round"
                               opacity={
@@ -244,10 +226,10 @@ export function SageNetworkSection(props: { slug: string }): JSX.Element {
                                   ? 0.12
                                   : a.kind === 'trunk'
                                     ? 0.75
-                                    : 0.55
+                                    : 0.7
                               }
                             >
-                              <title>{`${genLabel(a.gen)} — ${a.above ? t('network.arc.outWord') : t('network.arc.inWord')} ×${a.weight}`}</title>
+                              <title>{`${genLabel(a.gen)}${a.rel ? ` — ${t(`dafvoices.rel.${a.rel}`)}` : ''} ×${a.weight}`}</title>
                             </path>
                           )}
                         </For>
@@ -383,9 +365,9 @@ export function SageNetworkSection(props: { slug: string }): JSX.Element {
                                         style={{ cursor: 'pointer' }}
                                       />
                                       <text
-                                        transform={`rotate(40 ${d.x} ${axisY() + ARC_BAND + 22})`}
+                                        transform={`rotate(40 ${d.x} ${axisY() + 16})`}
                                         x={d.x}
-                                        y={axisY() + ARC_BAND + 22}
+                                        y={axisY() + 16}
                                         font-size="9"
                                         fill={dimSlug(d.row.other.slug) ? '#c8c2b4' : '#555'}
                                         text-anchor="start"

--- a/packages/talmud/src/client/SagesPage.tsx
+++ b/packages/talmud/src/client/SagesPage.tsx
@@ -7,6 +7,7 @@
  */
 import { createMemo, createResource, createSignal, For, type JSX, Show } from 'solid-js';
 import { t } from './i18n';
+import { SageCoverageStrip } from './SageCoverageStrip';
 import { SageNetworkSection } from './SageNetworkSection';
 import { type IndexRow, isHebrewQuery, normalize, scoreRow } from './sageSearch';
 
@@ -597,8 +598,6 @@ function SageDetail(props: {
         </button>
       </header>
 
-      <SageNetworkSection slug={props.slug} />
-
       <Show when={unified.loading && !unified()}>
         <div class="sage-loading">{t('sages.detail.loadingSage')}</div>
       </Show>
@@ -843,94 +842,9 @@ function SageDetail(props: {
         )}
       </Show>
 
-      {/* Wikipedia. Always renders so Run/Refresh stays reachable. */}
-      <Section
-        label={t('sages.section.wikipedia')}
-        actions={
-          <StageActions
-            stage="wiki-bio"
-            cached={!!wikiBio()}
-            running={!!stageRunning()['wiki-bio']}
-            error={stageError()['wiki-bio']}
-            onRun={runStage}
-          />
-        }
-      >
-        <Show
-          when={wikiBio()}
-          fallback={<p class="sage-empty-inline">{t('sages.wiki.noExtract')}</p>}
-        >
-          {(w) => (
-            <Show
-              when={w().enWiki || w().heWiki}
-              fallback={<p class="sage-empty-inline">{t('sages.wiki.noPage')}</p>}
-            >
-              <Show when={w().enWiki}>
-                {(p) => (
-                  <div class="wiki-block">
-                    <a class="wiki-link" href={p().url} target="_blank" rel="noopener noreferrer">
-                      {t('sages.wiki.enPrefix')} {p().title}
-                    </a>
-                    <p class="wiki-extract">{p().extract}</p>
-                  </div>
-                )}
-              </Show>
-              <Show when={w().heWiki}>
-                {(p) => (
-                  <div class="wiki-block">
-                    <a class="wiki-link" href={p().url} target="_blank" rel="noopener noreferrer">
-                      {t('sages.wiki.hePrefix')} {p().title}
-                    </a>
-                    <p class="wiki-extract" dir="rtl" lang="he">
-                      {p().extract}
-                    </p>
-                  </div>
-                )}
-              </Show>
-            </Show>
-          )}
-        </Show>
-      </Section>
+      <SageCoverageStrip slug={props.slug} generation={unified()?.generation ?? null} />
 
-      {/* Wikidata. Always renders so Run/Refresh stays reachable. */}
-      <Section
-        label={t('sages.section.wikidata')}
-        actions={
-          <StageActions
-            stage="wikidata"
-            cached={!!wikidata()}
-            running={!!stageRunning().wikidata}
-            error={stageError().wikidata}
-            onRun={runStage}
-          />
-        }
-      >
-        <Show
-          when={wikidata()}
-          fallback={<p class="sage-empty-inline">{t('sages.wikidata.noRecord')}</p>}
-        >
-          {(w) => (
-            <>
-              <div class="wd-head">
-                <a
-                  class="wd-qid"
-                  href={`https://www.wikidata.org/wiki/${w().qid}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {w().qid}
-                </a>
-                <Show when={w().birthYear || w().deathYear}>
-                  <span class="wd-years">
-                    {w().birthYear ?? '?'}–{w().deathYear ?? '?'}
-                  </span>
-                </Show>
-              </div>
-              <WikidataEdges rec={w()} />
-            </>
-          )}
-        </Show>
-      </Section>
+      <SageNetworkSection slug={props.slug} />
 
       {/* External refs. */}
       <Show when={hasAnyRefs(refs())}>
@@ -970,18 +884,113 @@ function SageDetail(props: {
         </Section>
       </Show>
 
-      <Show when={unified()}>
-        {(u) => (
-          <footer class="sage-foot">
-            <span>{t('sages.foot.enriched', { date: fmtDate(u().enrichedAt) })}</span>
-            <Show when={u().sources.length > 0}>
-              <span class="sage-foot-sources">
-                {t('sages.foot.sources', { sources: u().sources.join(', ') })}
-              </span>
-            </Show>
-          </footer>
-        )}
-      </Show>
+      {/* Operator tools — enrichment stages + provenance, tucked away so the
+          page reads as a rabbi profile first. */}
+      <details class="sage-ops">
+        <summary>{t('sages.ops.title')}</summary>
+
+        {/* Wikipedia. Always renders so Run/Refresh stays reachable. */}
+        <Section
+          label={t('sages.section.wikipedia')}
+          actions={
+            <StageActions
+              stage="wiki-bio"
+              cached={!!wikiBio()}
+              running={!!stageRunning()['wiki-bio']}
+              error={stageError()['wiki-bio']}
+              onRun={runStage}
+            />
+          }
+        >
+          <Show
+            when={wikiBio()}
+            fallback={<p class="sage-empty-inline">{t('sages.wiki.noExtract')}</p>}
+          >
+            {(w) => (
+              <Show
+                when={w().enWiki || w().heWiki}
+                fallback={<p class="sage-empty-inline">{t('sages.wiki.noPage')}</p>}
+              >
+                <Show when={w().enWiki}>
+                  {(p) => (
+                    <div class="wiki-block">
+                      <a class="wiki-link" href={p().url} target="_blank" rel="noopener noreferrer">
+                        {t('sages.wiki.enPrefix')} {p().title}
+                      </a>
+                      <p class="wiki-extract">{p().extract}</p>
+                    </div>
+                  )}
+                </Show>
+                <Show when={w().heWiki}>
+                  {(p) => (
+                    <div class="wiki-block">
+                      <a class="wiki-link" href={p().url} target="_blank" rel="noopener noreferrer">
+                        {t('sages.wiki.hePrefix')} {p().title}
+                      </a>
+                      <p class="wiki-extract" dir="rtl" lang="he">
+                        {p().extract}
+                      </p>
+                    </div>
+                  )}
+                </Show>
+              </Show>
+            )}
+          </Show>
+        </Section>
+
+        {/* Wikidata. Always renders so Run/Refresh stays reachable. */}
+        <Section
+          label={t('sages.section.wikidata')}
+          actions={
+            <StageActions
+              stage="wikidata"
+              cached={!!wikidata()}
+              running={!!stageRunning().wikidata}
+              error={stageError().wikidata}
+              onRun={runStage}
+            />
+          }
+        >
+          <Show
+            when={wikidata()}
+            fallback={<p class="sage-empty-inline">{t('sages.wikidata.noRecord')}</p>}
+          >
+            {(w) => (
+              <>
+                <div class="wd-head">
+                  <a
+                    class="wd-qid"
+                    href={`https://www.wikidata.org/wiki/${w().qid}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {w().qid}
+                  </a>
+                  <Show when={w().birthYear || w().deathYear}>
+                    <span class="wd-years">
+                      {w().birthYear ?? '?'}–{w().deathYear ?? '?'}
+                    </span>
+                  </Show>
+                </div>
+                <WikidataEdges rec={w()} />
+              </>
+            )}
+          </Show>
+        </Section>
+
+        <Show when={unified()}>
+          {(u) => (
+            <footer class="sage-foot">
+              <span>{t('sages.foot.enriched', { date: fmtDate(u().enrichedAt) })}</span>
+              <Show when={u().sources.length > 0}>
+                <span class="sage-foot-sources">
+                  {t('sages.foot.sources', { sources: u().sources.join(', ') })}
+                </span>
+              </Show>
+            </footer>
+          )}
+        </Show>
+      </details>
     </article>
   );
 }
@@ -1221,6 +1230,8 @@ const SAGES_CSS = `
 
 .sages-list { padding: 0.5rem; max-height: 78vh; overflow-y: auto; }
 .sages-empty { color: #94a3b8; font-style: italic; font-size: 12.5px; padding: 1rem; text-align: center; }
+.sage-ops { border-top: 1px dashed #e2e8f0; margin-top: 1.2rem; padding-top: 0.6rem; }
+.sage-ops > summary { cursor: pointer; color: #94a3b8; font-size: 12px; font-weight: 600; }
 .sages-missing { border-top: 1px solid #e2e8f0; margin-top: 0.6rem; padding: 0.4rem 0.2rem; }
 .sages-missing-toggle { border: none; background: transparent; cursor: pointer; font-size: 12.5px; font-weight: 600; color: #8a6d3b; padding: 0.3rem 0.5rem; width: 100%; text-align: start; }
 .sages-missing-note { color: #94a3b8; font-size: 11.5px; margin: 0.2rem 0.5rem 0.5rem; line-height: 1.4; }

--- a/packages/talmud/src/client/i18n.ts
+++ b/packages/talmud/src/client/i18n.ts
@@ -170,6 +170,24 @@ const CATALOG = {
   'dafvoices.rel.opposes': { en: 'opposes', he: 'חולק על' },
   'dafvoices.rel.supports': { en: 'supports', he: 'תומך ב' },
   'dafvoices.rel.responds-to': { en: 'responds to', he: 'משיב ל' },
+  'coverage.title': { en: 'Where in Shas', he: 'היכן בש״ס' },
+  'coverage.summary': {
+    en: 'Observed on {dapim} dapim across {masechtot} masechtot (of {analyzed} analyzed so far).',
+    he: 'נצפה ב־{dapim} דפים ב־{masechtot} מסכתות (מתוך {analyzed} שנותחו עד כה).',
+  },
+  'coverage.noDenominator': {
+    en: 'Per-masechet analyzed counts appear after the next graph rebuild.',
+    he: 'ספירת הניתוח למסכת תופיע לאחר הבנייה הבאה של הגרף.',
+  },
+  'coverage.cellTitle': {
+    en: '{masechet} — on {sage} of {analyzed} analyzed dapim ({total} total)',
+    he: '{masechet} — ב־{sage} מתוך {analyzed} דפים שנותחו ({total} סה״כ)',
+  },
+  'coverage.cellTitleNoDenom': {
+    en: '{masechet} — on {sage} dapim ({total} total)',
+    he: '{masechet} — ב־{sage} דפים ({total} סה״כ)',
+  },
+  'sages.ops.title': { en: 'Enrichment tools & sources', he: 'כלי העשרה ומקורות' },
   'sages.missing.title': { en: 'Missing from the registry', he: 'חסרים במאגר' },
   'sages.missing.unavailable': {
     en: 'Backlog unavailable right now.',
@@ -190,8 +208,6 @@ const CATALOG = {
   },
   'network.arc.expand': { en: 'Show the {n} sages of {gen}', he: 'הצגת {n} חכמי {gen}' },
   'network.arc.collapse': { en: 'Collapse {gen}', he: 'צמצום {gen}' },
-  'network.arc.outWord': { en: 'outgoing', he: 'יוצא' },
-  'network.arc.inWord': { en: 'incoming', he: 'נכנס' },
   'network.arc.kindLegend': { en: 'bars & chips:', he: 'פסים ותוויות:' },
   'network.arc.fanOverflow': {
     en: '+{n} weaker ties not drawn in the expanded generation (all listed below)',
@@ -203,8 +219,6 @@ const CATALOG = {
     en: 'Arc diagram of {name}\u2019s interactions by generation',
     he: 'תרשים קשתות של קשרי {name} לפי דורות',
   },
-  'network.arc.outgoing': { en: '↑ {name} → others', he: '↑ {name} ← אחרים' },
-  'network.arc.incoming': { en: '↓ others → {name}', he: '↓ אחרים ← {name}' },
   'network.page.building': {
     en: 'The Shas-wide network is still being built — check back soon.',
     he: 'רשת הש״ס עדיין נבנית — נסו שוב בקרוב.',

--- a/packages/talmud/src/client/sageArcLayout.ts
+++ b/packages/talmud/src/client/sageArcLayout.ts
@@ -37,6 +37,7 @@ const TRUNK_MIN = 2.5;
 const TRUNK_MAX = 13;
 const FAN_MIN = 1.5;
 const FAN_MAX = 5.5;
+const KIND_NEST_STEP = 6; // extra ry per additional relation kind on the same pair
 // Flattened arc profile: height is loosely tied to span but tightly clamped,
 // so long arcs read as wide flat ribbons and short ones still rise visibly —
 // and every sage's diagram lands in the same vertical envelope (ARC_BAND).
@@ -90,11 +91,11 @@ export interface ArcEdge {
   kind: 'trunk' | 'fan';
   gen: string | null; // target generation (hover keying at L1)
   slug: string | null; // partner slug (fan only)
+  rel: string | null; // relation kind (fan only): opposes | cites | ...
   x1: number;
   x2: number;
   ry: number;
   stroke: number;
-  above: boolean; // out = above, in = below
   weight: number;
 }
 
@@ -104,7 +105,6 @@ export interface ArcLayoutResult {
   groups: ArcGroup[];
   edges: ArcEdge[];
   maxAbove: number;
-  maxBelow: number;
   autoExpanded: boolean;
   /** Partners not drawn inside an expanded generation (fan cap). */
   fanOverflow: number;
@@ -239,60 +239,51 @@ export function layoutSageArcs(
   }
   const width = x + EDGE_PAD;
 
-  // Edges. Collapsed group => up to two TRUNKS (out above / in below) to its
-  // pill. Expanded group => one FAN line per partner per direction present,
-  // thickness from that partner's directional weight.
+  // Edges. Collapsed group => ONE trunk to its pill (total volume; direction
+  // is row-level detail, not a diagram dimension). Expanded group => the trunk
+  // splits into CATEGORY lines: one kind-colored arc per (partner, relation
+  // kind), nested per partner, thickness from that kind's weight.
   const edges: ArcEdge[] = [];
   let maxAbove = 0;
-  let maxBelow = 0;
   const push = (e: ArcEdge) => {
     edges.push(e);
-    if (e.above) maxAbove = Math.max(maxAbove, e.ry);
-    else maxBelow = Math.max(maxBelow, e.ry);
+    maxAbove = Math.max(maxAbove, e.ry);
   };
 
   for (const g of groups) {
     if (!g.expanded && g.pill) {
-      const members = byGen.get(g.gen) ?? [];
-      for (const above of [true, false]) {
-        const w = members.reduce(
-          (s, r) =>
-            s +
-            r.chips.reduce((cs, c) => cs + ((c.direction === 'out') === above ? c.weight : 0), 0),
-          0,
-        );
-        if (w <= 0) continue;
-        push({
-          kind: 'trunk',
-          gen: g.gen,
-          slug: null,
-          x1: centerX,
-          x2: g.pill.x,
-          ry: ryFor(Math.abs(g.pill.x - centerX)),
-          stroke: scaled(w, maxGenTotal, TRUNK_MIN, TRUNK_MAX),
-          above,
-          weight: w,
-        });
-      }
+      if (g.total <= 0) continue;
+      push({
+        kind: 'trunk',
+        gen: g.gen,
+        slug: null,
+        rel: null,
+        x1: centerX,
+        x2: g.pill.x,
+        ry: ryFor(Math.abs(g.pill.x - centerX)),
+        stroke: scaled(g.total, maxGenTotal, TRUNK_MIN, TRUNK_MAX),
+        weight: g.total,
+      });
     } else if (g.expanded) {
       for (const d of g.dots) {
-        for (const above of [true, false]) {
-          const w = d.row.chips.reduce(
-            (cs, c) => cs + ((c.direction === 'out') === above ? c.weight : 0),
-            0,
-          );
-          if (w <= 0) continue;
+        // Merge the partner's chips by relation kind (directions summed —
+        // the rows below keep the ←/→ split).
+        const byRel = new Map<string, number>();
+        for (const c of d.row.chips) byRel.set(c.kind, (byRel.get(c.kind) ?? 0) + c.weight);
+        let nest = 0;
+        for (const [rel, w] of [...byRel.entries()].sort((a, b) => b[1] - a[1])) {
           push({
             kind: 'fan',
             gen: g.gen,
             slug: d.row.other.slug,
+            rel,
             x1: centerX,
             x2: d.x,
-            ry: ryFor(Math.abs(d.x - centerX)),
+            ry: ryFor(Math.abs(d.x - centerX)) + nest * KIND_NEST_STEP,
             stroke: scaled(w, maxPartnerW, FAN_MIN, FAN_MAX),
-            above,
             weight: w,
           });
+          nest++;
         }
       }
     }
@@ -304,7 +295,6 @@ export function layoutSageArcs(
     groups,
     edges,
     maxAbove,
-    maxBelow,
     autoExpanded,
     fanOverflow,
   };
@@ -332,8 +322,8 @@ export function barSegments(
 }
 
 /** SVG path for one arc: half-ellipse from (x1, axisY) to (x2, axisY). */
-export function arcPath(a: Pick<ArcEdge, 'x1' | 'x2' | 'ry' | 'above'>, axisY: number): string {
-  const sweep = a.above ? (a.x2 > a.x1 ? 1 : 0) : a.x2 > a.x1 ? 0 : 1;
+export function arcPath(a: Pick<ArcEdge, 'x1' | 'x2' | 'ry'>, axisY: number): string {
+  const sweep = a.x2 > a.x1 ? 1 : 0;
   const rx = Math.abs(a.x2 - a.x1) / 2;
   return `M ${a.x1} ${axisY} A ${rx} ${a.ry} 0 0 ${sweep} ${a.x2} ${axisY}`;
 }

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -5973,6 +5973,8 @@ app.get('/api/rabbi-observations/:slug', async (c) => {
   const RANK: Record<string, number> = { high: 3, medium: 2, low: 1 };
 
   const byType: Record<string, number> = {};
+  // Distinct dapim per tractate — feeds the sage-page coverage strip.
+  const byTractate: Record<string, number> = {};
   // Frequency across dafs, keyed by observation hash (same place/move/verse on
   // N dafs => dafs:N) — the signal a future "notable places" ranking needs.
   const freq = new Map<
@@ -6002,6 +6004,7 @@ app.get('/api/rabbi-observations/:slug', async (c) => {
         continue; // skip corrupt slice
       }
       dafCount++;
+      byTractate[s.tractate] = (byTractate[s.tractate] ?? 0) + 1;
       if (!name && s.name) name = s.name;
       if (!nameHe && s.nameHe) nameHe = s.nameHe;
       for (const o of s.observations) {
@@ -6030,6 +6033,7 @@ app.get('/api/rabbi-observations/:slug', async (c) => {
     nameHe,
     dafCount,
     byType,
+    byTractate,
     aggregated,
     observations,
   };

--- a/packages/talmud/src/worker/voice-graph.ts
+++ b/packages/talmud/src/worker/voice-graph.ts
@@ -72,6 +72,10 @@ export interface VoiceGraphStaging {
 export interface VoiceGraphBlob extends Omit<VoiceGraphStaging, 'dafsSeen'> {
   builtAt: number;
   dapim: number;
+  /** Analyzed dapim per tractate (display-name keys) — the denominator for
+   *  the sage-page coverage strip. Present from the first rebuild after this
+   *  field shipped; consumers must tolerate absence. */
+  dapimByTractate?: Record<string, number>;
   /** Nodes that gained voice edges while having ZERO curated hierarchy edges —
    *  the "filled blanks". */
   newlyConnected: number;
@@ -217,7 +221,20 @@ export function finalizeVoiceGraph(staging: VoiceGraphStaging, builtAt: number):
     node.curatedEdges = curatedEdgeCount(slug);
     if (node.curatedEdges === 0 && connected.has(slug)) newlyConnected++;
   }
-  return { ...rest, builtAt, dapim: Object.keys(dafsSeen).length, newlyConnected };
+  const dapimByTractate: Record<string, number> = {};
+  for (const label of Object.keys(dafsSeen)) {
+    const i = label.lastIndexOf(' ');
+    if (i <= 0) continue;
+    const tractate = label.slice(0, i);
+    dapimByTractate[tractate] = (dapimByTractate[tractate] ?? 0) + 1;
+  }
+  return {
+    ...rest,
+    builtAt,
+    dapim: Object.keys(dafsSeen).length,
+    dapimByTractate,
+    newlyConnected,
+  };
 }
 
 /** Build the resolver's learned adjacency from a voice-graph blob: symmetric

--- a/packages/talmud/tests/sage-arc-layout.test.ts
+++ b/packages/talmud/tests/sage-arc-layout.test.ts
@@ -40,7 +40,7 @@ describe('layoutSageArcs — L1 trunks', () => {
   // 10 partners across two generations => above the auto-expand threshold.
   const many = [
     ...Array.from({ length: 6 }, (_, i) =>
-      row(`b${i}`, 'amora-bavel-3', 6 - i, [
+      row(`b${i}`, 'amora-bavel-3', 6, [
         { kind: 'opposes', direction: 'out', weight: 4 },
         { kind: 'cites', direction: 'in', weight: 2 },
       ]),
@@ -48,21 +48,18 @@ describe('layoutSageArcs — L1 trunks', () => {
     ...Array.from({ length: 4 }, (_, i) => row(`t${i}`, 'tanna-2', 2)),
   ];
 
-  it('collapses generations into pills with directional trunks', () => {
+  it('collapses generations into pills with ONE total-volume trunk each', () => {
     const l = layoutSageArcs('amora-bavel-4', many, null);
     expect(l.autoExpanded).toBe(false);
     const bavel3 = l.groups.find((g) => g.gen === 'amora-bavel-3');
     expect(bavel3?.pill?.partnerCount).toBe(6);
     expect(bavel3?.dots).toHaveLength(0);
     const trunks = l.edges.filter((e) => e.kind === 'trunk' && e.gen === 'amora-bavel-3');
-    // bavel-3 has both out (opposes) and in (cites) volume => two trunks
-    expect(trunks.map((e) => e.above).sort()).toEqual([false, true]);
-    const out = trunks.find((e) => e.above);
-    expect(out?.weight).toBe(24); // 6 partners x out 4
-    // tanna-2 is out-only => a single above trunk
+    expect(trunks).toHaveLength(1); // direction is row detail, not a diagram dimension
+    expect(trunks[0].weight).toBe(36); // 6 partners x (4 opposes + 2 cites)
+    expect(trunks[0].rel).toBeNull();
     const t2 = l.edges.filter((e) => e.kind === 'trunk' && e.gen === 'tanna-2');
     expect(t2).toHaveLength(1);
-    expect(t2[0].above).toBe(true);
   });
 
   it('expanding one generation fans it while others stay trunked', () => {
@@ -70,7 +67,10 @@ describe('layoutSageArcs — L1 trunks', () => {
     const bavel3 = l.groups.find((g) => g.gen === 'amora-bavel-3');
     expect(bavel3?.expanded).toBe(true);
     expect(bavel3?.dots).toHaveLength(6);
-    expect(l.edges.filter((e) => e.kind === 'fan')).toHaveLength(12); // 6 partners x 2 directions
+    // the trunk splits into CATEGORY lines: 6 partners x 2 relation kinds
+    const fans = l.edges.filter((e) => e.kind === 'fan');
+    expect(fans).toHaveLength(12);
+    expect(new Set(fans.map((f) => f.rel))).toEqual(new Set(['opposes', 'cites']));
     const t2 = l.groups.find((g) => g.gen === 'tanna-2');
     expect(t2?.pill?.partnerCount).toBe(4);
   });
@@ -179,13 +179,10 @@ describe('barSegments', () => {
 });
 
 describe('arcPath', () => {
-  it('bulges up for above-axis arcs and down for below', () => {
+  it('always bulges above the axis, mirrored for leftward partners', () => {
     const base = { x1: 10, x2: 110, ry: 40 };
-    expect(arcPath({ ...base, above: true }, 100)).toBe('M 10 100 A 50 40 0 0 1 110 100');
-    expect(arcPath({ ...base, above: false }, 100)).toBe('M 10 100 A 50 40 0 0 0 110 100');
-    expect(arcPath({ ...base, above: true, x1: 110, x2: 10 }, 100)).toBe(
-      'M 110 100 A 50 40 0 0 0 10 100',
-    );
+    expect(arcPath(base, 100)).toBe('M 10 100 A 50 40 0 0 1 110 100');
+    expect(arcPath({ ...base, x1: 110, x2: 10 }, 100)).toBe('M 110 100 A 50 40 0 0 0 10 100');
   });
 });
 


### PR DESCRIPTION
Design-review round 3:

1. **Above/below is gone.** Direction as a diagram dimension read as noise — one trunk per generation now; →/← stays on the row chips where it's legible. Diagram loses its whole lower band.
2. **Click → category lines.** Opening a generation splits its trunk into **relation-colored lines** (opposes/cites/supports…) to the named partners — the kind palette appears exactly when it's examinable.
3. **"Where in Shas" strip** — per-masechet cells in seder order (width ∝ masechet size) with three layers: whole masechet / analyzed-so-far / this sage (era-colored). Un-analyzed Shas is always visible, so absence is never mistaken for evidence of absence. Numerator: `byTractate` folded into the observations summary (same pass, zero extra KV reads). Denominator: `dapimByTractate` stamped into the voice-graph blob at finalize — appears after the next rebuild; the strip degrades gracefully until then.
4. **Reader-first page**: identity + bio → coverage → network → refs; the operator surface (stage runners, Wikipedia/Wikidata dumps, provenance footer) collapses into an "Enrichment tools & sources" disclosure.

2,703 tests green; layout changes covered by the updated pure-layout suite.