### PR TITLE
Coverage strip: honest wording for the two pipelines

### DIFF
--- a/packages/talmud/src/client/SageCoverageStrip.tsx
+++ b/packages/talmud/src/client/SageCoverageStrip.tsx
@@ -77,14 +77,15 @@ export function SageCoverageStrip(props: { slug: string; generation: string | nu
       <h3 style={{ margin: '0 0 0.2rem', 'font-size': '0.95rem' }}>{t('coverage.title')}</h3>
       <Show when={!obs.loading} fallback={<p class="sages-empty">{t('sages.list.loading')}</p>}>
         <p style={{ margin: '0 0 0.5rem', color: '#777', 'font-size': '0.8rem' }}>
-          {t('coverage.summary', {
-            dapim: sageTotal(),
-            masechtot: tractatesWithSage(),
-            analyzed: net()?.dapim ?? 0,
-          })}
-          <Show when={!hasDenominator()}>
+          {t('coverage.summary', { dapim: sageTotal(), masechtot: tractatesWithSage() })}
+          <Show
+            when={hasDenominator()}
+            fallback={<span style={{ color: '#a89e8a' }}> {t('coverage.noDenominator')}</span>}
+          >
             {' '}
-            <span style={{ color: '#a89e8a' }}>{t('coverage.noDenominator')}</span>
+            <span style={{ color: '#a89e8a' }}>
+              {t('coverage.analyzedNote', { analyzed: net()?.dapim ?? 0 })}
+            </span>
           </Show>
         </p>
         <div style={{ 'overflow-x': 'auto' }}>

--- a/packages/talmud/src/client/i18n.ts
+++ b/packages/talmud/src/client/i18n.ts
@@ -196,16 +196,20 @@ const CATALOG = {
   'dafvoices.rel.responds-to': { en: 'responds to', he: 'משיב ל' },
   'coverage.title': { en: 'Where in Shas', he: 'היכן בש״ס' },
   'coverage.summary': {
-    en: 'Observed on {dapim} dapim across {masechtot} masechtot (of {analyzed} analyzed so far).',
-    he: 'נצפה ב־{dapim} דפים ב־{masechtot} מסכתות (מתוך {analyzed} שנותחו עד כה).',
+    en: 'Observed on {dapim} dapim across {masechtot} masechtot.',
+    he: 'נצפה ב־{dapim} דפים ב־{masechtot} מסכתות.',
+  },
+  'coverage.analyzedNote': {
+    en: 'The darker band marks dapim with full voice analysis ({analyzed} Shas-wide) — sage sightings come from the wider mark pipeline, so fills can exceed the band.',
+    he: 'הרצועה הכהה מסמנת דפים עם ניתוח קולות מלא ({analyzed} בכל הש״ס) — תצפיות החכם מגיעות מצנרת רחבה יותר, ולכן המילוי עשוי לחרוג מהרצועה.',
   },
   'coverage.noDenominator': {
     en: 'Per-masechet analyzed counts appear after the next graph rebuild.',
     he: 'ספירת הניתוח למסכת תופיע לאחר הבנייה הבאה של הגרף.',
   },
   'coverage.cellTitle': {
-    en: '{masechet} — on {sage} of {analyzed} analyzed dapim ({total} total)',
-    he: '{masechet} — ב־{sage} מתוך {analyzed} דפים שנותחו ({total} סה״כ)',
+    en: '{masechet} — observed on {sage} dapim · {analyzed} voice-analyzed · {total} total',
+    he: '{masechet} — נצפה ב־{sage} דפים · {analyzed} נותחו · {total} סה״כ',
   },
   'coverage.cellTitleNoDenom': {
     en: '{masechet} — on {sage} dapim ({total} total)',


### PR DESCRIPTION
Live data exposed a wording bug within minutes of #554: sage sightings (rabbi-mark pipeline, ~all Shas — Rava 2,524 dapim) exceed the voice-analyzed count (396), so "observed on 2,524 (of 396 analyzed)" read as nonsense. The caption now states the two figures independently and explains why fills can exceed the darker band; cell tooltips list observed / voice-analyzed / total side by side.