### PR TITLE
Fix detail-pane overflow; coverage strip becomes a skyline

### DIFF
--- a/packages/talmud/src/client/SageCoverageStrip.tsx
+++ b/packages/talmud/src/client/SageCoverageStrip.tsx
@@ -1,16 +1,16 @@
 /**
- * Where in Shas does this sage speak? One cell per masechet in seder order,
- * cell width ∝ the masechet's size. Three nested layers per cell:
- *   base   — the whole masechet (what exists)
- *   middle — dapim we have AI-analyzed so far (the voice-graph denominator)
- *   fill   — dapim where THIS sage is observed (era-colored)
- * So "not yet analyzed" is always visible as the unfilled remainder — absence
- * of the sage in an unanalyzed masechet is honestly not evidence of absence.
+ * Where in Shas does this sage speak? A SKYLINE: one column per masechet in
+ * seder order (width ∝ the masechet's size), bar HEIGHT = how often the sage
+ * is observed there, normalized to their busiest masechet, in their era
+ * color. A masechet where they never appear stays a flat baseline. Once the
+ * voice-graph blob carries dapimByTractate, a darker underline per column
+ * shows how much of that masechet has been analyzed — so absence in a barely
+ * analyzed masechet is honestly not evidence of absence.
  *
  * Numerator: /api/rabbi-observations/:slug?summary=1 byTractate (10-min cached
- * fold of the per-daf observation slices). Denominator: dapimByTractate from
- * the Shas-wide voice-graph blob (appears after its next rebuild; the strip
- * degrades to sage-vs-total shading until then).
+ * fold of the per-daf observation slices, near-all-Shas coverage). Denominator:
+ * dapimByTractate from the Shas-wide voice-graph blob (appears after its next
+ * rebuild).
  */
 import { createMemo, createResource, For, type JSX, Show } from 'solid-js';
 import { iterAmudim } from '../lib/sefref/amudim';
@@ -31,9 +31,10 @@ interface NetworkSummary {
   dapimByTractate?: Record<string, number>;
 }
 
-const CELL_H = 26;
+const BAR_AREA = 44; // skyline height
+const BASELINE_H = 2;
 const PX_PER_AMUD = 0.24;
-const CELL_MIN_W = 10;
+const CELL_MIN_W = 12;
 
 export function SageCoverageStrip(props: { slug: string; generation: string | null }): JSX.Element {
   const [obs] = createResource(
@@ -68,6 +69,7 @@ export function SageCoverageStrip(props: { slug: string; generation: string | nu
     });
   });
 
+  const maxSage = () => Math.max(1, ...cells().map((c) => c.sage));
   const sageTotal = () => obs()?.dafCount ?? 0;
   const tractatesWithSage = () => cells().filter((c) => c.sage > 0).length;
   const hasDenominator = () => net()?.dapimByTractate != null;
@@ -100,9 +102,10 @@ export function SageCoverageStrip(props: { slug: string; generation: string | nu
           >
             <For each={cells()}>
               {(c) => {
+                const h = () =>
+                  c.sage > 0 ? 4 + (BAR_AREA - 8) * (c.sage / maxSage()) : BASELINE_H;
                 const analyzedFrac = () =>
-                  c.analyzed != null && c.total > 0 ? Math.min(1, c.analyzed / c.total) : 1;
-                const sageFrac = () => (c.total > 0 ? Math.min(1, c.sage / c.total) : 0);
+                  c.analyzed != null && c.total > 0 ? Math.min(1, c.analyzed / c.total) : 0;
                 const title = () =>
                   c.analyzed != null
                     ? t('coverage.cellTitle', {
@@ -118,54 +121,62 @@ export function SageCoverageStrip(props: { slug: string; generation: string | nu
                       });
                 return (
                   <div
-                    style={{ position: 'relative', width: `${c.w}px`, height: `${CELL_H}px` }}
+                    style={{ position: 'relative', width: `${c.w}px`, height: `${BAR_AREA}px` }}
                     title={title()}
                   >
-                    {/* whole masechet */}
-                    <div
-                      style={{
-                        position: 'absolute',
-                        inset: 0,
-                        background: '#efeadf',
-                        'border-radius': '3px',
-                      }}
-                    />
-                    {/* analyzed-so-far band */}
+                    {/* the skyline bar: height = sage's presence */}
                     <div
                       style={{
                         position: 'absolute',
                         left: 0,
+                        right: 0,
                         bottom: 0,
-                        top: 0,
-                        width: `${analyzedFrac() * 100}%`,
-                        background: '#d9d2c0',
-                        'border-radius': '3px',
+                        height: `${h()}px`,
+                        background: c.sage > 0 ? colorForGeneration(props.generation) : '#e4ddcc',
+                        'border-radius': '3px 3px 0 0',
                       }}
                     />
-                    {/* the sage */}
-                    <Show when={c.sage > 0}>
+                    {/* analyzed-so-far underline (denominator context) */}
+                    <Show when={analyzedFrac() > 0}>
                       <div
                         style={{
                           position: 'absolute',
                           left: 0,
-                          bottom: 0,
-                          top: 0,
-                          width: `${Math.max(6, sageFrac() * 100)}%`,
-                          background: colorForGeneration(props.generation),
-                          'border-radius': '3px',
+                          bottom: '-4px',
+                          height: '2.5px',
+                          width: `${analyzedFrac() * 100}%`,
+                          background: '#8a6d3b',
+                          'border-radius': '2px',
+                          opacity: 0.65,
                         }}
                       />
+                    </Show>
+                    {/* count on top of meaningful bars */}
+                    <Show when={c.sage > 0 && c.sage / maxSage() > 0.35}>
+                      <span
+                        style={{
+                          position: 'absolute',
+                          bottom: `${h() + 1}px`,
+                          left: '50%',
+                          transform: 'translateX(-50%)',
+                          'font-size': '8px',
+                          color: '#8a8271',
+                        }}
+                      >
+                        {c.sage}
+                      </span>
                     </Show>
                     <span
                       style={{
                         position: 'absolute',
-                        top: `${CELL_H + 4}px`,
+                        top: `${BAR_AREA + 6}px`,
                         left: '2px',
                         'font-size': '8.5px',
                         color: c.sage > 0 ? '#555' : '#b6ae9c',
                         'white-space': 'nowrap',
                         transform: 'rotate(40deg)',
                         'transform-origin': 'top left',
+                        'text-shadow': '0 0 3px #fff, 0 0 3px #fff',
                       }}
                     >
                       {c.label}

--- a/packages/talmud/src/client/SagesPage.tsx
+++ b/packages/talmud/src/client/SagesPage.tsx
@@ -477,6 +477,7 @@ export function SagesPage(): JSX.Element {
             {(slug) => (
               <SageDetail
                 slug={slug()}
+                generationId={index()?.rows.find((r) => r.slug === slug())?.generation ?? null}
                 cohort={cohort()}
                 places={places()}
                 academy={academy()}
@@ -496,6 +497,7 @@ export function SagesPage(): JSX.Element {
 
 function SageDetail(props: {
   slug: string;
+  generationId: string | null;
   cohort: CohortBlob | null | undefined;
   places: PlacesBlob | null | undefined;
   academy: AcademyRosterBlob | null | undefined;
@@ -842,7 +844,7 @@ function SageDetail(props: {
         )}
       </Show>
 
-      <SageCoverageStrip slug={props.slug} generation={unified()?.generation ?? null} />
+      <SageCoverageStrip slug={props.slug} generation={props.generationId} />
 
       <SageNetworkSection slug={props.slug} />
 
@@ -1254,7 +1256,8 @@ const SAGES_CSS = `
 .sages-list-region { text-transform: uppercase; letter-spacing: 0.04em; }
 .sages-list-cap { font-size: 10.5px; color: #94a3b8; padding: 0.6rem; font-style: italic; text-align: center; }
 
-.sages-detail { padding: 1rem 1.25rem; min-height: 200px; }
+.sages-detail { padding: 1rem 1.25rem; min-height: 200px; min-width: 0; }
+.sages-list { min-width: 0; }
 .sage-detail { display: flex; flex-direction: column; gap: 0.75rem; }
 .sage-head { display: flex; align-items: flex-start; gap: 0.5rem; padding-bottom: 0.5rem; border-bottom: 1px solid #e5e7eb; }
 .sage-head-titles { flex: 1; min-width: 0; }

--- a/packages/talmud/src/client/i18n.ts
+++ b/packages/talmud/src/client/i18n.ts
@@ -196,8 +196,8 @@ const CATALOG = {
   'dafvoices.rel.responds-to': { en: 'responds to', he: 'משיב ל' },
   'coverage.title': { en: 'Where in Shas', he: 'היכן בש״ס' },
   'coverage.summary': {
-    en: 'Observed on {dapim} dapim across {masechtot} masechtot.',
-    he: 'נצפה ב־{dapim} דפים ב־{masechtot} מסכתות.',
+    en: 'Observed on {dapim} dapim across {masechtot} masechtot — taller bars = appears more often.',
+    he: 'נצפה ב־{dapim} דפים ב־{masechtot} מסכתות — עמודה גבוהה יותר = מופיע לעיתים קרובות יותר.',
   },
   'coverage.analyzedNote': {
     en: 'The darker band marks dapim with full voice analysis ({analyzed} Shas-wide) — sage sightings come from the wider mark pipeline, so fills can exceed the band.',


### PR DESCRIPTION
Two immediate follow-ups on #554 from live review:

1. **Horizontal overflow**: the `.sages-grid` detail column lacked `min-width: 0`, so the strip's `max-content` row and the arc SVG blew the column past the viewport (bio + chips clipped at screen edge) instead of scrolling inside their own `overflow-x` containers.
2. **"Where in Shas" was unreadable**: sage presence rendered as a ~2px width-sliver, and the era color silently failed (unified's short gen codes ≠ GenerationIds — the real id now threads from the sages index). Redesigned as a **skyline**: bar height = presence (normalized to the sage's busiest masechet, era-colored, counts on tall bars), width still = masechet size, flat baseline where absent, analyzed-coverage as a darker underline once the blob rebuild lands, white-halo labels, one-line encoding explanation in the caption.