### PR TITLE
Fix sage-page overflow for real: explicit width on the grid items

### DIFF
--- a/packages/talmud/src/client/SagesPage.tsx
+++ b/packages/talmud/src/client/SagesPage.tsx
@@ -1256,8 +1256,8 @@ const SAGES_CSS = `
 .sages-list-region { text-transform: uppercase; letter-spacing: 0.04em; }
 .sages-list-cap { font-size: 10.5px; color: #94a3b8; padding: 0.6rem; font-style: italic; text-align: center; }
 
-.sages-detail { padding: 1rem 1.25rem; min-height: 200px; min-width: 0; }
-.sages-list { min-width: 0; }
+.sages-detail { padding: 1rem 1.25rem; min-height: 200px; min-width: 0; width: 100%; max-width: 100%; }
+.sages-list { min-width: 0; width: 100%; max-width: 100%; }
 .sage-detail { display: flex; flex-direction: column; gap: 0.75rem; }
 .sage-head { display: flex; align-items: flex-start; gap: 0.5rem; padding-bottom: 0.5rem; border-bottom: 1px solid #e5e7eb; }
 .sage-head-titles { flex: 1; min-width: 0; }


### PR DESCRIPTION
Follow-up to #556, which didn't hold: `min-width: 0` was applied and the grid track computed 906px, yet Chrome sized the block-level grid item's auto width to its content max-width (the 1,448px arc SVG), pushing document scroll-width to 1,844 at a 1,280 viewport. Diagnosed and **verified headlessly against production** (Playwright fix-matrix): `justify-self: stretch` and `overflow-x: hidden` did nothing; `width: 100%; max-width: 100%` on the item pins it to the track — document scroll 1,844 → 1,280, bio wraps at pane width, inner scroll containers actually scroll. Applied to both grid children; re-verifying live post-deploy the same way.