### PR TITLE
Trunks colored by the dominant relation kind

### DIFF
--- a/packages/talmud/src/client/SageNetworkSection.tsx
+++ b/packages/talmud/src/client/SageNetworkSection.tsx
@@ -26,7 +26,7 @@ import {
   type JSX,
   Show,
 } from 'solid-js';
-import { KIND_COLOR, stmtRelKind } from './ArgumentFlowGraph';
+import { KIND_COLOR, KIND_DASH, stmtRelKind } from './ArgumentFlowGraph';
 import { type EgoRow, type EgoWire, groupEgoEdges, splitDafLabel } from './egoNetwork';
 import {
   colorForGeneration,
@@ -44,6 +44,9 @@ const REL_KINDS = ['opposes', 'responds-to', 'resolves', 'cites', 'supports'] as
 
 function relColor(kind: string): string {
   return kind === 'supports' ? SUPPORTS_COLOR : KIND_COLOR[stmtRelKind(kind)];
+}
+function relDash(kind: string): string | undefined {
+  return kind === 'supports' ? undefined : KIND_DASH[stmtRelKind(kind)];
 }
 
 function genLabel(generation: string | null): string {
@@ -220,6 +223,7 @@ export function SageNetworkSection(props: { slug: string }): JSX.Element {
                               fill="none"
                               stroke={a.rel ? relColor(a.rel) : colorForGeneration(a.gen)}
                               stroke-width={a.stroke}
+                              stroke-dasharray={a.rel ? relDash(a.rel) : undefined}
                               stroke-linecap="round"
                               opacity={
                                 (a.slug ? dimSlug(a.slug) : dimGen(a.gen))
@@ -229,7 +233,16 @@ export function SageNetworkSection(props: { slug: string }): JSX.Element {
                                     : 0.7
                               }
                             >
-                              <title>{`${genLabel(a.gen)}${a.rel ? ` — ${t(`dafvoices.rel.${a.rel}`)}` : ''} ×${a.weight}`}</title>
+                              <title>
+                                {a.kind === 'trunk' && a.rel
+                                  ? t('network.arc.trunkTitle', {
+                                      gen: genLabel(a.gen),
+                                      kind: t(`dafvoices.rel.${a.rel}`),
+                                      kindWeight: a.relWeight,
+                                      total: a.weight,
+                                    })
+                                  : `${genLabel(a.gen)}${a.rel ? ` — ${t(`dafvoices.rel.${a.rel}`)}` : ''} ×${a.weight}`}
+                              </title>
                             </path>
                           )}
                         </For>

--- a/packages/talmud/src/client/i18n.ts
+++ b/packages/talmud/src/client/i18n.ts
@@ -236,7 +236,11 @@ const CATALOG = {
   },
   'network.arc.expand': { en: 'Show the {n} sages of {gen}', he: 'הצגת {n} חכמי {gen}' },
   'network.arc.collapse': { en: 'Collapse {gen}', he: 'צמצום {gen}' },
-  'network.arc.kindLegend': { en: 'bars & chips:', he: 'פסים ותוויות:' },
+  'network.arc.kindLegend': { en: 'relations:', he: 'סוגי קשר:' },
+  'network.arc.trunkTitle': {
+    en: '{gen} — mostly {kind} ({kindWeight} of ×{total})',
+    he: '{gen} — בעיקר {kind} ({kindWeight} מתוך ×{total})',
+  },
   'network.arc.fanOverflow': {
     en: '+{n} weaker ties not drawn in the expanded generation (all listed below)',
     he: '+{n} קשרים חלשים שאינם מצוירים בדור הפתוח (כולם ברשימה למטה)',

--- a/packages/talmud/src/client/sageArcLayout.ts
+++ b/packages/talmud/src/client/sageArcLayout.ts
@@ -91,7 +91,13 @@ export interface ArcEdge {
   kind: 'trunk' | 'fan';
   gen: string | null; // target generation (hover keying at L1)
   slug: string | null; // partner slug (fan only)
-  rel: string | null; // relation kind (fan only): opposes | cites | ...
+  /** Relation kind: the fan line's kind, or the trunk's DOMINANT kind — the
+   *  arc palette says what the relationship with that generation mostly IS
+   *  (era is already encoded by position on the fixed timeline). */
+  rel: string | null;
+  /** Weight of `rel` specifically (= weight for fans; the dominant kind's
+   *  share for trunks — the tooltip says "mostly opposes ×30 of ×47"). */
+  relWeight: number;
   x1: number;
   x2: number;
   ry: number;
@@ -257,7 +263,8 @@ export function layoutSageArcs(
         kind: 'trunk',
         gen: g.gen,
         slug: null,
-        rel: null,
+        rel: g.byKind[0]?.kind ?? null,
+        relWeight: g.byKind[0]?.weight ?? 0,
         x1: centerX,
         x2: g.pill.x,
         ry: ryFor(Math.abs(g.pill.x - centerX)),
@@ -277,6 +284,7 @@ export function layoutSageArcs(
             gen: g.gen,
             slug: d.row.other.slug,
             rel,
+            relWeight: w,
             x1: centerX,
             x2: d.x,
             ry: ryFor(Math.abs(d.x - centerX)) + nest * KIND_NEST_STEP,

--- a/packages/talmud/tests/sage-arc-layout.test.ts
+++ b/packages/talmud/tests/sage-arc-layout.test.ts
@@ -57,7 +57,8 @@ describe('layoutSageArcs — L1 trunks', () => {
     const trunks = l.edges.filter((e) => e.kind === 'trunk' && e.gen === 'amora-bavel-3');
     expect(trunks).toHaveLength(1); // direction is row detail, not a diagram dimension
     expect(trunks[0].weight).toBe(36); // 6 partners x (4 opposes + 2 cites)
-    expect(trunks[0].rel).toBeNull();
+    expect(trunks[0].rel).toBe('opposes'); // the DOMINANT kind colors the trunk
+    expect(trunks[0].relWeight).toBe(24);
     const t2 = l.edges.filter((e) => e.kind === 'trunk' && e.gen === 'tanna-2');
     expect(t2).toHaveLength(1);
   });


### PR DESCRIPTION
Design feedback: color the network by dominant relationship type. Era color on trunks was redundant (position on the fixed timeline already encodes generation) — each trunk now wears its generation's **dominant relation kind** with the app's dash pattern as secondary encoding and a "mostly opposes (24 of ×36)" tooltip. The overview now says at a glance what the sage's relationship with each era mostly is, consistent with the kind-split lines on expansion. Pills keep era color (timeline identity). Layout carries `rel`/`relWeight` on trunks (test-locked: dominant = opposes at 24/36 in the fixture).