### PR TITLE
Coverage strip: density-normalized heights; detail pane scrolls vertically

### DIFF
--- a/packages/talmud/src/client/SageCoverageStrip.tsx
+++ b/packages/talmud/src/client/SageCoverageStrip.tsx
@@ -69,7 +69,6 @@ export function SageCoverageStrip(props: { slug: string; generation: string | nu
     });
   });
 
-  const maxSage = () => Math.max(1, ...cells().map((c) => c.sage));
   const sageTotal = () => obs()?.dafCount ?? 0;
   const tractatesWithSage = () => cells().filter((c) => c.sage > 0).length;
   const hasDenominator = () => net()?.dapimByTractate != null;
@@ -102,8 +101,15 @@ export function SageCoverageStrip(props: { slug: string; generation: string | nu
           >
             <For each={cells()}>
               {(c) => {
+                // Height = DENSITY: the share of this masechet's dapim where the
+                // sage appears. Width is already the masechet's size, so bar
+                // AREA tracks the absolute count while height answers "how
+                // present is he HERE" — a small masechet he saturates stands
+                // as tall as a big one he dominates.
                 const h = () =>
-                  c.sage > 0 ? 4 + (BAR_AREA - 8) * (c.sage / maxSage()) : BASELINE_H;
+                  c.sage > 0 && c.total > 0
+                    ? 4 + (BAR_AREA - 8) * Math.min(1, c.sage / c.total)
+                    : BASELINE_H;
                 const analyzedFrac = () =>
                   c.analyzed != null && c.total > 0 ? Math.min(1, c.analyzed / c.total) : 0;
                 const title = () =>
@@ -152,7 +158,7 @@ export function SageCoverageStrip(props: { slug: string; generation: string | nu
                       />
                     </Show>
                     {/* count on top of meaningful bars */}
-                    <Show when={c.sage > 0 && c.sage / maxSage() > 0.35}>
+                    <Show when={c.sage > 0 && c.total > 0 && c.sage / c.total > 0.3}>
                       <span
                         style={{
                           position: 'absolute',

--- a/packages/talmud/src/client/SagesPage.tsx
+++ b/packages/talmud/src/client/SagesPage.tsx
@@ -1256,7 +1256,7 @@ const SAGES_CSS = `
 .sages-list-region { text-transform: uppercase; letter-spacing: 0.04em; }
 .sages-list-cap { font-size: 10.5px; color: #94a3b8; padding: 0.6rem; font-style: italic; text-align: center; }
 
-.sages-detail { padding: 1rem 1.25rem; min-height: 200px; min-width: 0; width: 100%; max-width: 100%; }
+.sages-detail { padding: 1rem 1.25rem; min-height: 200px; min-width: 0; width: 100%; max-width: 100%; max-height: 82vh; overflow-y: auto; }
 .sages-list { min-width: 0; width: 100%; max-width: 100%; }
 .sage-detail { display: flex; flex-direction: column; gap: 0.75rem; }
 .sage-head { display: flex; align-items: flex-start; gap: 0.5rem; padding-bottom: 0.5rem; border-bottom: 1px solid #e5e7eb; }

--- a/packages/talmud/src/client/i18n.ts
+++ b/packages/talmud/src/client/i18n.ts
@@ -196,8 +196,8 @@ const CATALOG = {
   'dafvoices.rel.responds-to': { en: 'responds to', he: 'משיב ל' },
   'coverage.title': { en: 'Where in Shas', he: 'היכן בש״ס' },
   'coverage.summary': {
-    en: 'Observed on {dapim} dapim across {masechtot} masechtot — taller bars = appears more often.',
-    he: 'נצפה ב־{dapim} דפים ב־{masechtot} מסכתות — עמודה גבוהה יותר = מופיע לעיתים קרובות יותר.',
+    en: 'Observed on {dapim} dapim across {masechtot} masechtot — bar height = share of that masechet\u2019s dapim.',
+    he: 'נצפה ב־{dapim} דפים ב־{masechtot} מסכתות — גובה העמודה = חלקו מדפי אותה מסכת.',
   },
   'coverage.analyzedNote': {
     en: 'The darker band marks dapim with full voice analysis ({analyzed} Shas-wide) — sage sightings come from the wider mark pipeline, so fills can exceed the band.',


### PR DESCRIPTION
Design feedback on the strip: (1) **normalize to the masechet's length** — bar height is now the sage's share of that masechet's dapim (width already encodes masechet size, so bar *area* still tracks the absolute count); (2) the **detail pane fits the viewport** with its own vertical scroll (max-height 82vh, matching the list pane).