### PR TITLE
Network trunks split by valence: debate above, support below

### DIFF
--- a/packages/talmud/src/client/SageNetworkSection.tsx
+++ b/packages/talmud/src/client/SageNetworkSection.tsx
@@ -36,7 +36,14 @@ import {
   legibleTextColor,
 } from './generations';
 import { lang, t } from './i18n';
-import { ARC_BAND, arcPath, barSegments, layoutSageArcs, shortGenLabel } from './sageArcLayout';
+import {
+  ARC_BAND,
+  arcPath,
+  barSegments,
+  layoutSageArcs,
+  shortGenLabel,
+  type Valence,
+} from './sageArcLayout';
 
 const SUPPORTS_COLOR = '#0891b2';
 const AXIS_INK = '#c9c2b2';
@@ -48,6 +55,13 @@ function relColor(kind: string): string {
 function relDash(kind: string): string | undefined {
   return kind === 'supports' ? undefined : KIND_DASH[stmtRelKind(kind)];
 }
+/** Valence colors: debate in the opposition red, support in the evidential
+ *  teal — the strongest hue pair in the app palette. Side reinforces color:
+ *  debate arcs rise above the axis, support arcs hang below. */
+const VALENCE_COLOR: Record<Valence, string> = {
+  debate: KIND_COLOR.contrasts,
+  support: SUPPORTS_COLOR,
+};
 
 function genLabel(generation: string | null): string {
   if (!generation) return '?';
@@ -137,7 +151,7 @@ export function SageNetworkSection(props: { slug: string }): JSX.Element {
               // Constant vertical envelope (ARC_BAND) — a 3-partner sage's
               // diagram stands as tall as Rava's, so pages compare directly.
               const axisY = () => TOP_PAD + ARC_BAND + 12;
-              const labelsY = () => axisY() + (anyExpanded() ? 16 + NAME_BAND : 26);
+              const labelsY = () => axisY() + ARC_BAND + (anyExpanded() ? 16 + NAME_BAND : 26);
               const barsY = () => labelsY() + LABEL_H;
               const height = () => barsY() + BAR_H + BOTTOM_PAD;
               const maxGroupTotal = () => layout().groups.reduce((m, g) => Math.max(m, g.total), 1);
@@ -206,7 +220,7 @@ export function SageNetworkSection(props: { slug: string }): JSX.Element {
                                 x={g.x}
                                 y={TOP_PAD + 4}
                                 width={g.width}
-                                height={axisY() - TOP_PAD + (anyExpanded() ? 14 : 4)}
+                                height={axisY() + ARC_BAND - TOP_PAD + (anyExpanded() ? 14 : 4)}
                                 rx={10}
                                 fill="#8a6d3b"
                                 opacity="0.06"
@@ -215,13 +229,20 @@ export function SageNetworkSection(props: { slug: string }): JSX.Element {
                           )}
                         </For>
 
-                        {/* arcs: era-colored trunks + fans; direction = side */}
+                        {/* arcs — debate above the axis, support below;
+                            trunks in valence colors, fans in kind colors */}
                         <For each={layout().edges}>
                           {(a) => (
                             <path
                               d={arcPath(a, axisY())}
                               fill="none"
-                              stroke={a.rel ? relColor(a.rel) : colorForGeneration(a.gen)}
+                              stroke={
+                                a.valence
+                                  ? VALENCE_COLOR[a.valence]
+                                  : a.rel
+                                    ? relColor(a.rel)
+                                    : colorForGeneration(a.gen)
+                              }
                               stroke-width={a.stroke}
                               stroke-dasharray={a.rel ? relDash(a.rel) : undefined}
                               stroke-linecap="round"
@@ -234,18 +255,37 @@ export function SageNetworkSection(props: { slug: string }): JSX.Element {
                               }
                             >
                               <title>
-                                {a.kind === 'trunk' && a.rel
-                                  ? t('network.arc.trunkTitle', {
-                                      gen: genLabel(a.gen),
-                                      kind: t(`dafvoices.rel.${a.rel}`),
-                                      kindWeight: a.relWeight,
-                                      total: a.weight,
-                                    })
+                                {a.valence
+                                  ? `${genLabel(a.gen)} — ${t(`network.arc.val.${a.valence}`)} ×${a.weight}: ${(
+                                      a.parts ?? []
+                                    )
+                                      .map((pt) => `${t(`dafvoices.rel.${pt.kind}`)} ×${pt.weight}`)
+                                      .join(', ')}`
                                   : `${genLabel(a.gen)}${a.rel ? ` — ${t(`dafvoices.rel.${a.rel}`)}` : ''} ×${a.weight}`}
                               </title>
                             </path>
                           )}
                         </For>
+
+                        {/* valence hints, centered */}
+                        <text
+                          x={layout().width / 2}
+                          y={TOP_PAD}
+                          font-size="9"
+                          fill={VALENCE_COLOR.debate}
+                          text-anchor="middle"
+                        >
+                          ↑ {t('network.arc.val.debate')}
+                        </text>
+                        <text
+                          x={layout().width / 2}
+                          y={axisY() + ARC_BAND + 10}
+                          font-size="9"
+                          fill={VALENCE_COLOR.support}
+                          text-anchor="middle"
+                        >
+                          ↓ {t('network.arc.val.support')}
+                        </text>
 
                         {/* axis */}
                         <line
@@ -378,9 +418,9 @@ export function SageNetworkSection(props: { slug: string }): JSX.Element {
                                         style={{ cursor: 'pointer' }}
                                       />
                                       <text
-                                        transform={`rotate(40 ${d.x} ${axisY() + 16})`}
+                                        transform={`rotate(40 ${d.x} ${axisY() + ARC_BAND + 16})`}
                                         x={d.x}
-                                        y={axisY() + 16}
+                                        y={axisY() + ARC_BAND + 16}
                                         font-size="9"
                                         fill={dimSlug(d.row.other.slug) ? '#c8c2b4' : '#555'}
                                         text-anchor="start"
@@ -475,7 +515,36 @@ export function SageNetworkSection(props: { slug: string }): JSX.Element {
                         'align-items': 'center',
                       }}
                     >
-                      <span style={{ color: '#a89e8a' }}>{t('network.arc.kindLegend')}</span>
+                      <For each={['debate', 'support'] as Valence[]}>
+                        {(v) => (
+                          <span
+                            style={{
+                              display: 'inline-flex',
+                              'align-items': 'center',
+                              gap: '0.3rem',
+                              'font-weight': 600,
+                              color: VALENCE_COLOR[v],
+                            }}
+                          >
+                            <svg width="20" height="8" aria-hidden="true">
+                              <line
+                                x1="1"
+                                y1="4"
+                                x2="19"
+                                y2="4"
+                                stroke={VALENCE_COLOR[v]}
+                                stroke-width="4"
+                                stroke-linecap="round"
+                              />
+                            </svg>
+                            {v === 'debate' ? '↑ ' : '↓ '}
+                            {t(`network.arc.val.${v}`)}
+                          </span>
+                        )}
+                      </For>
+                      <span style={{ color: '#a89e8a', 'margin-inline-start': '0.5rem' }}>
+                        {t('network.arc.kindLegend')}
+                      </span>
                       <For each={[...REL_KINDS]}>
                         {(k) => (
                           <span

--- a/packages/talmud/src/client/i18n.ts
+++ b/packages/talmud/src/client/i18n.ts
@@ -236,11 +236,12 @@ const CATALOG = {
   },
   'network.arc.expand': { en: 'Show the {n} sages of {gen}', he: 'הצגת {n} חכמי {gen}' },
   'network.arc.collapse': { en: 'Collapse {gen}', he: 'צמצום {gen}' },
-  'network.arc.kindLegend': { en: 'relations:', he: 'סוגי קשר:' },
-  'network.arc.trunkTitle': {
-    en: '{gen} — mostly {kind} ({kindWeight} of ×{total})',
-    he: '{gen} — בעיקר {kind} ({kindWeight} מתוך ×{total})',
+  'network.arc.val.debate': { en: 'debate (opposes, responds)', he: 'עימות (חולק, משיב)' },
+  'network.arc.val.support': {
+    en: 'support (cites, supports, resolves)',
+    he: 'הסתמכות (מצטט, תומך, מיישב)',
   },
+  'network.arc.kindLegend': { en: 'details:', he: 'פירוט:' },
   'network.arc.fanOverflow': {
     en: '+{n} weaker ties not drawn in the expanded generation (all listed below)',
     he: '+{n} קשרים חלשים שאינם מצוירים בדור הפתוח (כולם ברשימה למטה)',

--- a/packages/talmud/src/client/sageArcLayout.ts
+++ b/packages/talmud/src/client/sageArcLayout.ts
@@ -47,6 +47,19 @@ const ARC_RY_MAX = 68;
 /** The constant vertical band reserved above and below the axis. */
 export const ARC_BAND = 74;
 
+/** The two trunk VALENCES: every relation kind is either dialectic
+ *  confrontation or constructive reliance. Each generation gets up to one
+ *  trunk per valence, so the overview reads "how much debate vs how much
+ *  support" per era; the full 5-kind mix stays in the stacked bars. */
+export type Valence = 'debate' | 'support';
+export const KIND_VALENCE: Record<string, Valence> = {
+  opposes: 'debate',
+  'responds-to': 'debate',
+  cites: 'support',
+  supports: 'support',
+  resolves: 'support',
+};
+
 const GEN_ORDER = new Map<string, number>(GENERATION_IDS.map((id, i) => [id, i]));
 const UNKNOWN_ORDER = GENERATION_IDS.length;
 
@@ -91,13 +104,17 @@ export interface ArcEdge {
   kind: 'trunk' | 'fan';
   gen: string | null; // target generation (hover keying at L1)
   slug: string | null; // partner slug (fan only)
-  /** Relation kind: the fan line's kind, or the trunk's DOMINANT kind — the
-   *  arc palette says what the relationship with that generation mostly IS
-   *  (era is already encoded by position on the fixed timeline). */
+  /** The fan line's relation kind (fans only). */
   rel: string | null;
-  /** Weight of `rel` specifically (= weight for fans; the dominant kind's
-   *  share for trunks — the tooltip says "mostly opposes ×30 of ×47"). */
+  /** The trunk's valence (trunks only): debate | support. */
+  valence: Valence | null;
+  /** Kind breakdown behind a trunk (weight-desc) — feeds the tooltip. */
+  parts: { kind: string; weight: number }[] | null;
+  /** Weight of `rel` for fans (= this kind's sightings with that partner). */
   relWeight: number;
+  /** Valence decides the side: debate arcs rise ABOVE the axis, support arcs
+   *  hang BELOW — position and color reinforce the same reading. */
+  above: boolean;
   x1: number;
   x2: number;
   ry: number;
@@ -259,39 +276,54 @@ export function layoutSageArcs(
   for (const g of groups) {
     if (!g.expanded && g.pill) {
       if (g.total <= 0) continue;
-      push({
-        kind: 'trunk',
-        gen: g.gen,
-        slug: null,
-        rel: g.byKind[0]?.kind ?? null,
-        relWeight: g.byKind[0]?.weight ?? 0,
-        x1: centerX,
-        x2: g.pill.x,
-        ry: ryFor(Math.abs(g.pill.x - centerX)),
-        stroke: scaled(g.total, maxGenTotal, TRUNK_MIN, TRUNK_MAX),
-        weight: g.total,
-      });
+      // Up to two trunks: the generation's DEBATE volume and its SUPPORT
+      // volume, nested so both stay readable.
+      for (const valence of ['debate', 'support'] as const) {
+        const parts = g.byKind.filter((k) => (KIND_VALENCE[k.kind] ?? 'support') === valence);
+        const w = parts.reduce((sum, k) => sum + k.weight, 0);
+        if (w <= 0) continue;
+        push({
+          kind: 'trunk',
+          gen: g.gen,
+          slug: null,
+          rel: null,
+          valence,
+          parts,
+          relWeight: w,
+          x1: centerX,
+          x2: g.pill.x,
+          ry: ryFor(Math.abs(g.pill.x - centerX)),
+          stroke: scaled(w, maxGenTotal, TRUNK_MIN, TRUNK_MAX),
+          weight: w,
+          above: valence === 'debate',
+        });
+      }
     } else if (g.expanded) {
       for (const d of g.dots) {
         // Merge the partner's chips by relation kind (directions summed —
         // the rows below keep the ←/→ split).
         const byRel = new Map<string, number>();
         for (const c of d.row.chips) byRel.set(c.kind, (byRel.get(c.kind) ?? 0) + c.weight);
-        let nest = 0;
+        let aboveN = 0;
+        let belowN = 0;
         for (const [rel, w] of [...byRel.entries()].sort((a, b) => b[1] - a[1])) {
+          const above = (KIND_VALENCE[rel] ?? 'support') === 'debate';
+          const nest = above ? aboveN++ : belowN++;
           push({
             kind: 'fan',
             gen: g.gen,
             slug: d.row.other.slug,
             rel,
+            valence: null,
+            parts: null,
             relWeight: w,
             x1: centerX,
             x2: d.x,
             ry: ryFor(Math.abs(d.x - centerX)) + nest * KIND_NEST_STEP,
             stroke: scaled(w, maxPartnerW, FAN_MIN, FAN_MAX),
             weight: w,
+            above,
           });
-          nest++;
         }
       }
     }
@@ -329,9 +361,10 @@ export function barSegments(
   return out;
 }
 
-/** SVG path for one arc: half-ellipse from (x1, axisY) to (x2, axisY). */
-export function arcPath(a: Pick<ArcEdge, 'x1' | 'x2' | 'ry'>, axisY: number): string {
-  const sweep = a.x2 > a.x1 ? 1 : 0;
+/** SVG path for one arc: half-ellipse from (x1) to (x2) — above the axis for
+ *  debate, below for support. */
+export function arcPath(a: Pick<ArcEdge, 'x1' | 'x2' | 'ry' | 'above'>, axisY: number): string {
+  const sweep = a.above ? (a.x2 > a.x1 ? 1 : 0) : a.x2 > a.x1 ? 0 : 1;
   const rx = Math.abs(a.x2 - a.x1) / 2;
   return `M ${a.x1} ${axisY} A ${rx} ${a.ry} 0 0 ${sweep} ${a.x2} ${axisY}`;
 }

--- a/packages/talmud/tests/sage-arc-layout.test.ts
+++ b/packages/talmud/tests/sage-arc-layout.test.ts
@@ -55,12 +55,20 @@ describe('layoutSageArcs — L1 trunks', () => {
     expect(bavel3?.pill?.partnerCount).toBe(6);
     expect(bavel3?.dots).toHaveLength(0);
     const trunks = l.edges.filter((e) => e.kind === 'trunk' && e.gen === 'amora-bavel-3');
-    expect(trunks).toHaveLength(1); // direction is row detail, not a diagram dimension
-    expect(trunks[0].weight).toBe(36); // 6 partners x (4 opposes + 2 cites)
-    expect(trunks[0].rel).toBe('opposes'); // the DOMINANT kind colors the trunk
-    expect(trunks[0].relWeight).toBe(24);
+    // one trunk per VALENCE: debate (opposes x24) + support (cites x12)
+    expect(trunks.map((e) => [e.valence, e.weight]).sort()).toEqual([
+      ['debate', 24],
+      ['support', 12],
+    ]);
+    expect(trunks.find((e) => e.valence === 'debate')?.parts).toEqual([
+      { kind: 'opposes', weight: 24 },
+    ]);
+    // side encodes valence: debate above the axis, support below
+    expect(trunks.find((e) => e.valence === 'debate')?.above).toBe(true);
+    expect(trunks.find((e) => e.valence === 'support')?.above).toBe(false);
     const t2 = l.edges.filter((e) => e.kind === 'trunk' && e.gen === 'tanna-2');
-    expect(t2).toHaveLength(1);
+    expect(t2).toHaveLength(1); // opposes-only fixture => debate trunk only
+    expect(t2[0].valence).toBe('debate');
   });
 
   it('expanding one generation fans it while others stay trunked', () => {
@@ -180,10 +188,13 @@ describe('barSegments', () => {
 });
 
 describe('arcPath', () => {
-  it('always bulges above the axis, mirrored for leftward partners', () => {
+  it('debate bulges above the axis, support below, mirrored for leftward partners', () => {
     const base = { x1: 10, x2: 110, ry: 40 };
-    expect(arcPath(base, 100)).toBe('M 10 100 A 50 40 0 0 1 110 100');
-    expect(arcPath({ ...base, x1: 110, x2: 10 }, 100)).toBe('M 110 100 A 50 40 0 0 0 10 100');
+    expect(arcPath({ ...base, above: true }, 100)).toBe('M 10 100 A 50 40 0 0 1 110 100');
+    expect(arcPath({ ...base, above: false }, 100)).toBe('M 10 100 A 50 40 0 0 0 110 100');
+    expect(arcPath({ ...base, above: true, x1: 110, x2: 10 }, 100)).toBe(
+      'M 110 100 A 50 40 0 0 0 10 100',
+    );
   });
 });
 


### PR DESCRIPTION
Design feedback: two lines per generation — confrontation vs support — **with the axis side defined by it**. Each generation now shows a **debate** trunk (opposes + responds-to, opposition red, above the axis) and a **support** trunk (cites + supports + resolves, evidential teal, below). Position and color reinforce one reading: top-heavy = combative relationship with that era, bottom-heavy = reliance. Expanded fans follow the same sides with per-kind colors; trunk tooltips carry the exact breakdown ("debate ×30: opposes ×24, responds to ×6"); centered ↑/↓ hints + legend entries name the encoding. Layout test-locked (valence weights, sides, arcPath sweep).