### PR TITLE
Tanach: serve tanach.dev + www.tanach.dev alongside tanach.shaunregenbaum.com

### DIFF
--- a/packages/tanach/wrangler.toml
+++ b/packages/tanach/wrangler.toml
@@ -3,10 +3,15 @@ main = "src/worker/index.ts"
 compatibility_date = "2025-04-01"
 compatibility_flags = ["nodejs_compat"]
 
-# Custom production domain. The shaunregenbaum.com zone is on the same account
-# as the Talmud app; wrangler provisions the DNS record + cert on deploy.
+# Custom production domains. The shaunregenbaum.com and tanach.dev zones are
+# both on the same account as this worker; wrangler provisions the DNS record +
+# cert on deploy. Same shape as talmud: one deployment, all hostnames identical.
 # (Top-level key — must precede any [table] header or TOML folds it into it.)
-routes = [{ pattern = "tanach.shaunregenbaum.com", custom_domain = true }]
+routes = [
+  { pattern = "tanach.shaunregenbaum.com", custom_domain = true },
+  { pattern = "tanach.dev", custom_domain = true },
+  { pattern = "www.tanach.dev", custom_domain = true }
+]
 
 # The Solid client is built into ./dist/client and served by the Worker via the
 # ASSETS binding; unmatched routes fall through to index.html (SPA).


### PR DESCRIPTION
Adds the freshly registered tanach.dev zone (plus www) as custom domains on the tanach worker, mirroring the talmud setup: one deployment, identical backend on every hostname. Wrangler provisions DNS + certs on deploy; both zones live on the same Cloudflare account as the worker.