### PR TITLE
Redirect legacy hostnames to talmud.dev / tanach.dev

### DIFF
--- a/packages/talmud/src/lib/context/linkTarget.ts
+++ b/packages/talmud/src/lib/context/linkTarget.ts
@@ -41,8 +41,10 @@ export interface LinkTarget {
  *  "<chapter>:<verse|halacha>", so the page shape disambiguates them. */
 const BAVLI_PAGE = /^\d+[ab]$/;
 
-/** The sister Tanach reader — a pasuk link opens the containing chapter there. */
-const TANACH_APP = 'https://tanach.shaunregenbaum.com';
+/** The sister Tanach reader — a pasuk link opens the containing chapter there.
+ *  Its canonical name: tanach.shaunregenbaum.com still resolves but redirects
+ *  here, so linking straight to tanach.dev saves readers the extra hop. */
+const TANACH_APP = 'https://tanach.dev';
 
 export function linkCorpus(c: AnchorCoord): LinkCorpus {
   // An external corpus spine the daf links INTO: a pasuk ('tanach') or a

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -567,6 +567,30 @@ interface DafSkeleton {
 
 const app = new Hono<{ Bindings: Bindings }>();
 
+/** The public name. Every other hostname on this worker is an alias for it. */
+const CANONICAL_HOST = 'talmud.dev';
+/** Aliases that redirect to CANONICAL_HOST. www.talmud.dev is deliberately
+ *  absent — it is served as-is, same as it was before. */
+const LEGACY_HOSTS = new Set(['talmud.shaunregenbaum.com']);
+
+/**
+ * Send browsers on a legacy hostname to the canonical one, path and query
+ * intact, so the app has a single public name.
+ *
+ * The machine surfaces are exempt and keep answering on every hostname: /mcp
+ * is POST-based (a redirect asks the client to re-issue the POST, which not
+ * every MCP client does) and /api/* has callers — the OpenAPI spec still
+ * advertises the legacy host as its server. Redirecting those would break
+ * live clients to buy nothing; only the browsing surface needs one name.
+ */
+app.use('*', async (c, next) => {
+  const url = new URL(c.req.url);
+  if (!LEGACY_HOSTS.has(url.hostname)) return next();
+  if (url.pathname === '/mcp' || url.pathname.startsWith('/api/')) return next();
+  url.hostname = CANONICAL_HOST;
+  return c.redirect(url.toString(), 301);
+});
+
 app.get('/api/health', (c) => c.json({ ok: true }));
 
 /**

--- a/packages/talmud/tests/canonical-host.test.ts
+++ b/packages/talmud/tests/canonical-host.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import worker from '../src/worker/index';
+import type { Bindings } from '../src/worker/types';
+
+// The worker answers on three hostnames. talmud.dev is the public name;
+// talmud.shaunregenbaum.com is the legacy alias and redirects to it. The
+// machine surfaces (/mcp, /api/*) are exempt so live clients keep working —
+// that exemption is the part worth locking down, since silently redirecting a
+// POST /mcp would break MCP clients that don't re-issue the body.
+const ctx = {
+  waitUntil() {},
+  passThroughOnException() {},
+} as unknown as ExecutionContext;
+
+function fetchAs(url: string, init?: RequestInit) {
+  return worker.fetch(new Request(url, init), {} as Bindings, ctx);
+}
+
+describe('canonical host (talmud.dev)', () => {
+  it('redirects the legacy host, keeping path and query', async () => {
+    const res = await fetchAs('https://talmud.shaunregenbaum.com/Berakhot/2a?lang=he');
+    expect(res.status).toBe(301);
+    expect(res.headers.get('location')).toBe('https://talmud.dev/Berakhot/2a?lang=he');
+  });
+
+  it('redirects the legacy root', async () => {
+    const res = await fetchAs('https://talmud.shaunregenbaum.com/');
+    expect(res.status).toBe(301);
+    expect(res.headers.get('location')).toBe('https://talmud.dev/');
+  });
+
+  it('serves the canonical host without redirecting', async () => {
+    const res = await fetchAs('https://talmud.dev/api/health');
+    expect(res.status).toBe(200);
+  });
+
+  it('does not redirect /api/* on the legacy host', async () => {
+    const res = await fetchAs('https://talmud.shaunregenbaum.com/api/health');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it('does not redirect POST /mcp on the legacy host', async () => {
+    const res = await fetchAs('https://talmud.shaunregenbaum.com/mcp', { method: 'POST' });
+    expect(res.status).not.toBe(301);
+  });
+});

--- a/packages/talmud/tests/link-target.test.ts
+++ b/packages/talmud/tests/link-target.test.ts
@@ -65,7 +65,7 @@ describe('linkTarget', () => {
       label: 'Genesis 19:5',
       corpus: 'tanach',
       navigable: true,
-      href: 'https://tanach.shaunregenbaum.com/?book=Genesis&chapter=19',
+      href: 'https://tanach.dev/?book=Genesis&chapter=19',
       external: true,
     });
   });

--- a/packages/tanach/src/worker/index.ts
+++ b/packages/tanach/src/worker/index.ts
@@ -36,6 +36,26 @@ interface Env extends TanachEnv {
 
 const app = new Hono<{ Bindings: Env }>();
 
+/** The public name. Every other hostname on this worker is an alias for it. */
+const CANONICAL_HOST = 'tanach.dev';
+/** Aliases that redirect to CANONICAL_HOST. www.tanach.dev is deliberately
+ *  absent — it is served as-is, same as it was before. */
+const LEGACY_HOSTS = new Set(['tanach.shaunregenbaum.com']);
+
+/**
+ * Send browsers on a legacy hostname to the canonical one, path and query
+ * intact, so the app has a single public name. /api/* is exempt and keeps
+ * answering on every hostname — it has callers (the Talmud app links here),
+ * and redirecting them would break live clients to buy nothing.
+ */
+app.use('*', async (c, next) => {
+  const url = new URL(c.req.url);
+  if (!LEGACY_HOSTS.has(url.hostname)) return next();
+  if (url.pathname.startsWith('/api/')) return next();
+  url.hostname = CANONICAL_HOST;
+  return c.redirect(url.toString(), 301);
+});
+
 /** Map a producer-run failure to the legacy route responses: a source error
  *  keeps its specific status + body (404 ref-not-found / not-enough-material,
  *  502 upstream fetch failures with their original messages); anything else is

--- a/packages/tanach/tests/canonical-host.test.ts
+++ b/packages/tanach/tests/canonical-host.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import worker from '../src/worker/index';
+
+// tanach.dev is the public name; tanach.shaunregenbaum.com is the legacy alias
+// and redirects to it. /api/* is exempt so existing callers (the Talmud app
+// links into this reader) keep working untouched.
+const ctx = {
+  waitUntil() {},
+  passThroughOnException() {},
+} as unknown as ExecutionContext;
+
+// biome-ignore lint/suspicious/noExplicitAny: the redirect runs before any
+// binding is touched, so an empty env is enough to exercise it.
+function fetchAs(url: string, init?: RequestInit) {
+  return worker.fetch(new Request(url, init), {} as any, ctx);
+}
+
+describe('canonical host (tanach.dev)', () => {
+  it('redirects the legacy host, keeping path and query', async () => {
+    const res = await fetchAs('https://tanach.shaunregenbaum.com/?book=Genesis&chapter=19');
+    expect(res.status).toBe(301);
+    expect(res.headers.get('location')).toBe('https://tanach.dev/?book=Genesis&chapter=19');
+  });
+
+  it('redirects the legacy root', async () => {
+    const res = await fetchAs('https://tanach.shaunregenbaum.com/');
+    expect(res.status).toBe(301);
+    expect(res.headers.get('location')).toBe('https://tanach.dev/');
+  });
+
+  it('does not redirect /api/* on the legacy host', async () => {
+    const res = await fetchAs('https://tanach.shaunregenbaum.com/api/chapter/Genesis/19');
+    expect(res.status).not.toBe(301);
+  });
+});


### PR DESCRIPTION
Makes the `.dev` names canonical. A browser on the legacy `*.shaunregenbaum.com` hostname gets a `301` to the same path/query on the `.dev` name.

## What redirects
- `talmud.shaunregenbaum.com/*` → `talmud.dev/*`
- `tanach.shaunregenbaum.com/*` → `tanach.dev/*`

## What deliberately does NOT redirect
- `/api/*` on both workers, and `/mcp` on talmud. These have live callers — the OpenAPI spec advertises the legacy host as its server, and an MCP client is configured against `talmud.shaunregenbaum.com/mcp`. Redirecting a POST asks the client to re-issue the body, which not all do. They keep answering on every hostname.
- `www.talmud.dev` / `www.tanach.dev` — served as-is, unchanged.

Also repoints the Talmud app's Tanach pasuk links straight at `tanach.dev` to skip a redirect hop.

## Tests
- New `canonical-host.test.ts` in each package: legacy host 301s with path+query preserved; canonical host and `/api/*` (and `/mcp`) are not redirected.
- Full suite green: talmud 2716, tanach 67, core 147. typecheck + biome clean.