### PR TITLE
Fix API outage: run_worker_first must list the whole Worker surface

### DIFF
--- a/packages/talmud/tests/worker-routing-guard.test.ts
+++ b/packages/talmud/tests/worker-routing-guard.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+// Routing guard — locks the run_worker_first list in wrangler.toml to the
+// Worker's live surface.
+//
+// run_worker_first as a pattern list is EXCLUSIVE: only matching paths invoke
+// the Worker; every other non-asset path is served the SPA index.html by the
+// asset layer, the Worker never running. When the list was narrowed to just
+// ["/"] (PR #563), every /api/* and /mcp request on every hostname returned
+// the HTML shell and both apps' data layers went down (2026-07-17). The config
+// is invisible at code-review time; this suite makes it fail CI instead.
+
+const stripComments = (toml: string): string =>
+  toml
+    .split('\n')
+    .map((line) => line.replace(/#.*$/, ''))
+    .join('\n');
+
+const readRunWorkerFirst = (tomlPath: URL): string[] => {
+  const toml = stripComments(readFileSync(tomlPath, 'utf8'));
+  const m = toml.match(/run_worker_first\s*=\s*\[([^\]]*)\]/);
+  expect(m, 'run_worker_first list').toBeTruthy();
+  return [...(m as RegExpMatchArray)[1].matchAll(/["']([^"']+)["']/g)].map((x) => x[1]);
+};
+
+describe('routing guard: run_worker_first covers the Worker surface', () => {
+  const patterns = readRunWorkerFirst(new URL('../wrangler.toml', import.meta.url));
+
+  it('routes /api/* through the Worker (otherwise every API call serves the SPA shell)', () => {
+    expect(patterns).toContain('/api/*');
+  });
+
+  it('routes /mcp through the Worker (the code-mode MCP server)', () => {
+    expect(patterns).toContain('/mcp');
+  });
+
+  it('routes "/" through the Worker (the legacy-host redirect must see the bare domain)', () => {
+    expect(patterns).toContain('/');
+  });
+});

--- a/packages/talmud/wrangler.toml
+++ b/packages/talmud/wrangler.toml
@@ -23,12 +23,16 @@ routes = [
 directory = "./dist/client"
 binding = "ASSETS"
 not_found_handling = "single-page-application"
-# The bare domain (and /?query, the SPA's real entry) maps to the index.html
-# asset, which Cloudflare would serve WITHOUT invoking the Worker — so the
-# legacy-host redirect in the Worker would never see it. Route just "/" through
-# the Worker first; hashed /assets/* stay on the CDN fast path untouched. The
-# `app.get('/')` route serves index.html for "/" on the canonical host.
-run_worker_first = ["/"]
+# run_worker_first as a PATTERN LIST is exclusive: ONLY matching paths invoke
+# the Worker — everything else is served from assets, with non-asset paths
+# falling back to index.html (SPA), the Worker never running. So the list must
+# name the Worker's entire live surface, not just the paths that need
+# worker-FIRST ordering: when it was just ["/"], every /api/* and /mcp request
+# returned the SPA shell and both apps' data layers went down (2026-07-17).
+# "/" is here so the legacy-host redirect fires on the bare domain (the
+# `app.get('/')` route hands it back to assets on the canonical host); hashed
+# /assets/* stay on the CDN fast path by not matching.
+run_worker_first = ["/", "/api/*", "/mcp"]
 
 # Raise the CPU ceiling well above the 30s default. Queue jobs that parse a
 # large LLM streaming response (argument-move on a long daf emits a big

--- a/packages/tanach/tests/worker-routing-guard.test.ts
+++ b/packages/tanach/tests/worker-routing-guard.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+// Routing guard — locks the run_worker_first list in wrangler.toml to the
+// Worker's live surface.
+//
+// run_worker_first as a pattern list is EXCLUSIVE: only matching paths invoke
+// the Worker; every other non-asset path is served the SPA index.html by the
+// asset layer, the Worker never running. When the list was narrowed to just
+// ["/"] (PR #563), every /api/* request on every hostname returned the HTML
+// shell and the app's data layer went down (2026-07-17). The config is
+// invisible at code-review time; this suite makes it fail CI instead.
+
+const stripComments = (toml: string): string =>
+  toml
+    .split('\n')
+    .map((line) => line.replace(/#.*$/, ''))
+    .join('\n');
+
+const readRunWorkerFirst = (tomlPath: URL): string[] => {
+  const toml = stripComments(readFileSync(tomlPath, 'utf8'));
+  const m = toml.match(/run_worker_first\s*=\s*\[([^\]]*)\]/);
+  expect(m, 'run_worker_first list').toBeTruthy();
+  return [...(m as RegExpMatchArray)[1].matchAll(/["']([^"']+)["']/g)].map((x) => x[1]);
+};
+
+describe('routing guard: run_worker_first covers the Worker surface', () => {
+  const patterns = readRunWorkerFirst(new URL('../wrangler.toml', import.meta.url));
+
+  it('routes /api/* through the Worker (otherwise every API call serves the SPA shell)', () => {
+    expect(patterns).toContain('/api/*');
+  });
+
+  it('routes "/" through the Worker (the legacy-host redirect must see the bare domain)', () => {
+    expect(patterns).toContain('/');
+  });
+});

--- a/packages/tanach/wrangler.toml
+++ b/packages/tanach/wrangler.toml
@@ -19,12 +19,16 @@ routes = [
 directory = "./dist/client"
 binding = "ASSETS"
 not_found_handling = "single-page-application"
-# The bare domain (and /?query, the SPA's real entry) maps to the index.html
-# asset, which Cloudflare would serve WITHOUT invoking the Worker — so the
-# legacy-host redirect in the Worker would never see it. Route just "/" through
-# the Worker first; hashed /assets/* stay on the CDN fast path untouched. The
-# catch-all `app.get('*')` serves index.html for "/" on the canonical host.
-run_worker_first = ["/"]
+# run_worker_first as a PATTERN LIST is exclusive: ONLY matching paths invoke
+# the Worker — everything else is served from assets, with non-asset paths
+# falling back to index.html (SPA), the Worker never running. So the list must
+# name the Worker's entire live surface, not just the paths that need
+# worker-FIRST ordering: when it was just ["/"], every /api/* request returned
+# the SPA shell and the app's data layer went down (2026-07-17). "/" is here so
+# the legacy-host redirect fires on the bare domain (the catch-all `app.get('*')`
+# hands it back to assets on the canonical host); hashed /assets/* stay on the
+# CDN fast path by not matching.
+run_worker_first = ["/", "/api/*"]
 
 [observability]
 enabled = true


### PR DESCRIPTION
Both apps went down after #563: every `/api/*` (and `/mcp`) request on every hostname started returning the SPA index.html instead of JSON. The shell loaded, then every data fetch got HTML — the reader just spins.

**Root cause:** `run_worker_first` as a pattern array is exclusive. Only matching paths invoke the Worker; every other non-asset path is served the SPA fallback directly by the asset layer, the Worker never running. Cloudflare's docs put it plainly for the non-matching case: requests "either serve an asset that matches or serve the index.html fallback, without ever hitting this code." So `run_worker_first = [\"/\"]` routed exactly one path through the Worker and cut off the entire API surface.

**Fix:** enumerate the Worker's live surface —
- talmud: `[\"/\", \"/api/*\", \"/mcp\"]`
- tanach: `[\"/\", \"/api/*\"]`

This keeps what #562/#563 wanted (legacy-host 301 fires on the bare domain; hashed `/assets/*` stay on the CDN fast path) while restoring the API on all hostnames.

**Guard:** a `worker-routing-guard.test.ts` per app parses `wrangler.toml` and fails CI if the list is ever narrowed below the Worker's surface again — the config is invisible at code-review time, same rationale as the memory-budget guard.

Verified locally: typecheck, lint, full unit suites (2720 talmud + 69 tanach) green.