### PR TITLE
AI-paused banner: gate cold-daf generation on the actual credit balance

### DIFF
--- a/packages/talmud/src/client/dafViewStore.ts
+++ b/packages/talmud/src/client/dafViewStore.ts
@@ -16,7 +16,7 @@
  */
 
 import { instanceIdOf } from '@corpus/core/cache/keys';
-import { noteAiResponse } from '@corpus/ui/aiStatus';
+import { type AiUnavailableReason, noteAiResponse } from '@corpus/ui/aiStatus';
 import { createSignal } from 'solid-js';
 import type { RunResult } from './enrichmentQueue';
 
@@ -36,6 +36,11 @@ interface DafViewPayload {
   cached?: number;
   total?: number;
   pieces?: Record<string, DafViewPiece>;
+  // Present only on an INCOMPLETE view when AI spending is unavailable (out of
+  // credits / key cap / provider outage): the cold pieces will never fill, so
+  // the poll loop raises the banner and bails instead of spinning to its cap.
+  aiUnavailable?: boolean;
+  reason?: AiUnavailableReason;
 }
 
 function dafKey(tractate: string, page: string, lang: 'en' | 'he'): string {
@@ -142,6 +147,10 @@ async function fetchViewOnce(
     }
     const j = (await r.json()) as DafViewPayload;
     settle(j.pieces ?? {});
+    // An incomplete view carrying the AI-paused sentinel raises the shared
+    // banner — so a reader who is mid-poll (already told `generating: true`)
+    // still learns AI is down instead of spinning silently.
+    noteAiResponse(j);
     return j;
   } catch {
     settle({});
@@ -236,6 +245,10 @@ export async function openDafView(
       const payload = await fetchViewOnce(key, tractate, page, lang);
       if (latestKey !== key) return;
       if (payload?.complete) return; // fully generated
+      // AI spending went unavailable mid-generation — the cold pieces can't
+      // fill, so stop polling (fetchViewOnce already raised the banner) and let
+      // the cards render their cached content instead of spinning to the cap.
+      if (payload?.aiUnavailable) return;
       const cached = payload?.cached ?? lastCached;
       if (cached > lastCached) {
         lastCached = cached;

--- a/packages/talmud/src/worker/ai-credits.ts
+++ b/packages/talmud/src/worker/ai-credits.ts
@@ -1,0 +1,142 @@
+/**
+ * Authoritative "is AI spending available" gate for the cold-generation entry
+ * paths (`POST /api/daf-generate`, the cold-miss branch of `POST /api/run`).
+ *
+ * WHY THIS EXISTS. The `ai-down` sentinel (ai-down.ts) is REACTIVE: it is only
+ * written after a job has actually failed with a 402, and it self-expires on a
+ * 5-minute TTL. That is the right shape for a transient blip, but it has a hole
+ * for the recurring case — the prepaid OpenRouter balance running dry. In any
+ * quiet window (no generation churning failures for >5 min) the sentinel is
+ * absent, so `/api/daf-generate` happily answers `{ generating: true }` and
+ * kicks off a Workflow that is doomed to 402 every step. The reader, having
+ * seen `generating: true`, sits in view-driven polling for up to 12 minutes
+ * with NO "AI paused" banner — the exact "load bar completes but the sections
+ * spin forever" symptom.
+ *
+ * THE FIX. Consult the ACTUAL account balance (cached, best-effort) at the gate,
+ * so out-of-credits is known BEFORE we spawn a doomed generation — not
+ * discovered by failing. A positive balance is likewise authoritative: it clears
+ * a stale `credits` sentinel so a top-up recovers within the cache TTL instead
+ * of waiting out the 5-minute sentinel. The balance probe never BLOCKS on its
+ * own uncertainty: an unknown balance (no provisioning key, a fetch error, a
+ * timeout) defers entirely to the reactive sentinel — today's behaviour, no
+ * regression.
+ *
+ * The balance is cached in KV (short TTL) so a reader burst costs at most ~one
+ * OpenRouter call per minute; every other request is a single KV read.
+ */
+
+import { type AiDownState, clearAiDown, noteAiDown, readAiDown } from './ai-down';
+import { fetchOpenRouterBalance } from './openrouter-cost';
+
+interface CreditsEnv {
+  CACHE?: KVNamespace;
+  OPENROUTER_PROVISIONING_KEY?: string;
+}
+
+const AI_CREDITS_KEY = 'ai-credits:v1';
+const CREDITS_TTL_S = 60;
+
+/** Pause a hair before absolute zero. A daf costs a few cents to generate;
+ *  starting one we cannot finish leaves half-empty cards, and a small floor also
+ *  absorbs the lag between this cached read and the balance actually moving. */
+const MIN_USABLE_USD = 0.1;
+
+export interface CreditsState {
+  /** Authoritatively out of spendable credits (balance known and at/below the floor). */
+  out: boolean;
+  /** Spendable USD (`total_credits - total_usage`), or `null` when unknown. */
+  remaining: number | null;
+  /** Epoch ms the balance was OBSERVED — the cache row's fetch time for a cached
+   *  read, `now` for a fresh probe; `null` when unknown. The caller compares this
+   *  against a sentinel's raise time so a STALE positive reading can't clear a
+   *  sentinel raised after the balance was last measured. */
+  at: number | null;
+}
+
+interface CreditsCacheRow {
+  remaining: number;
+  at: number;
+}
+
+const UNKNOWN_CREDITS: CreditsState = { out: false, remaining: null, at: null };
+
+/**
+ * Best-effort spendable-balance read, KV-cached for {@link CREDITS_TTL_S}.
+ * Unknown (no provisioning key, fetch/timeout error, corrupt cache, or an
+ * unexpected `/credits` shape) returns {@link UNKNOWN_CREDITS} — a flaky balance
+ * probe must never masquerade as "out of credits".
+ */
+export async function getCreditsState(env: CreditsEnv): Promise<CreditsState> {
+  const cache = env.CACHE;
+  if (cache) {
+    try {
+      const raw = await cache.get(AI_CREDITS_KEY);
+      if (raw) {
+        const row = JSON.parse(raw) as CreditsCacheRow | null;
+        if (row && typeof row.remaining === 'number' && typeof row.at === 'number')
+          return { out: row.remaining <= MIN_USABLE_USD, remaining: row.remaining, at: row.at };
+      }
+    } catch {
+      /* fall through to a fresh probe */
+    }
+  }
+  const bal = await fetchOpenRouterBalance(env);
+  if (!bal.ok || typeof bal.remaining !== 'number') return UNKNOWN_CREDITS;
+  const remaining = bal.remaining;
+  const at = Date.now();
+  if (cache) {
+    try {
+      await cache.put(AI_CREDITS_KEY, JSON.stringify({ remaining, at }), {
+        expirationTtl: CREDITS_TTL_S,
+      });
+    } catch {
+      /* best-effort — the gate still returns the fresh value below */
+    }
+  }
+  return { out: remaining <= MIN_USABLE_USD, remaining, at };
+}
+
+/**
+ * The gate the cold-generation entry paths call in place of a bare
+ * `readAiDown`. Returns the same `AiDownState | null` contract, but is
+ * authoritative rather than purely reactive:
+ *
+ *  - Out of credits (balance known, at/below floor): raise a `credits` sentinel
+ *    if one isn't already up — so every other plain `readAiDown` gate (SWR
+ *    recompute, the queue consumer) lights up too — and report down.
+ *  - Healthy balance (known, above floor) with a lingering `credits` sentinel
+ *    that predates the balance reading: someone topped up; clear it so recovery
+ *    is prompt. A sentinel raised AFTER our (possibly cached) balance reading is
+ *    NEWER information — a real 402 that landed since the balance was measured —
+ *    so it stands; otherwise a stale positive cache would delete a fresh
+ *    sentinel and reopen the gate to doomed jobs.
+ *  - Anything else (unknown balance, or a non-credits sentinel a healthy balance
+ *    cannot disprove): defer to whatever the sentinel says.
+ */
+export async function resolveAiDown(env: CreditsEnv): Promise<AiDownState | null> {
+  const cache = env.CACHE;
+  const [down, credits] = await Promise.all([readAiDown(cache), getCreditsState(env)]);
+
+  if (credits.out) {
+    if (!down) await noteAiDown(cache, 'credits');
+    return down ?? { reason: 'credits', at: Date.now() };
+  }
+
+  // Authoritatively healthy balance disproves a `credits` pause specifically —
+  // NOT a `key-limit` (credits exist but the key's own cap tripped) nor a
+  // transient `rate-limit`/`provider` blip, which a balance says nothing about —
+  // and ONLY when the balance was observed at/after the sentinel rose (else a
+  // 402 that fired since our cached reading would be wrongly cleared).
+  if (credits.remaining !== null && credits.at !== null && down?.reason === 'credits') {
+    if (down.at <= credits.at) {
+      // clearAiDown re-checks this same freshness guard against the live
+      // sentinel, so a concurrent newer 402 still survives the delete.
+      await clearAiDown(cache, credits.at);
+      return null;
+    }
+    return down; // sentinel is newer than the balance reading — trust it
+  }
+
+  return down;
+}

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -120,6 +120,7 @@ import {
   type YerushalmiFloorGroup,
 } from '../lib/yerushalmiAlign';
 import { type CuratedYerushalmiParallel, curatedParallelsForDaf } from '../lib/yerushalmiParallels';
+import { resolveAiDown } from './ai-credits';
 import { clearAiDown, isHardAiPause, noteAiDown, readAiDown, transportProvesAiUp } from './ai-down';
 import { fetchGatewayCost } from './aigw-analytics';
 import { runBacklogBackfill } from './backfill-backlog';
@@ -2957,6 +2958,13 @@ app.get('/api/daf-view/:tractate/:page', async (c) => {
   );
 
   const { complete, cold } = dafViewCompleteness(enumerated);
+  // On an INCOMPLETE view the client polls, waiting on cold pieces to generate.
+  // If AI spending is unavailable (out of credits / key cap / provider outage)
+  // those pieces will never fill, so carry the sentinel into the payload: the
+  // client's poll loop raises the shared "AI paused" banner and stops spinning
+  // instead of waiting out its 12-minute cap. Only read it when it matters (a
+  // complete, warm daf skips the KV read).
+  const viewDown = complete ? null : await readAiDown(c.env.CACHE);
   c.header('Cache-Control', dafViewCacheControl(complete));
   c.header('x-daf-view', complete ? 'complete' : 'partial');
   // [mem] instrumentation — daf-view is the prime OOM suspect: it materializes
@@ -2979,6 +2987,7 @@ app.get('/api/daf-view/:tractate/:page', async (c) => {
     cached: pieceCount,
     cold,
     pieces,
+    ...(viewDown ? { aiUnavailable: true as const, reason: viewDown.reason } : {}),
   });
   const bytes = payload.length;
   const DAF_VIEW_LARGE_BYTES = 1_500_000;
@@ -3400,8 +3409,11 @@ app.post('/api/daf-generate/:tractate/:page', async (c) => {
   // is doomed to fail. Without this check a cold daf spawns a Workflow that
   // churns 402s, and the client sits in view-driven mode (its /api/run fan-out
   // — the only path that raises the AI-paused banner — suppressed) until the
-  // ~40s stall detector gives up. Answer with the explained envelope NOW.
-  const down = await readAiDown(c.env.CACHE);
+  // ~40s stall detector gives up. `resolveAiDown` is AUTHORITATIVE: it consults
+  // the actual OpenRouter balance (cached), so out-of-credits is caught even in
+  // a quiet window where the reactive sentinel has expired. Answer with the
+  // explained envelope NOW.
+  const down = await resolveAiDown(c.env);
   if (down) {
     return c.json({
       generating: false,
@@ -5741,14 +5753,15 @@ app.post('/api/run', async (c) => {
     );
   }
 
-  // Provider-down circuit breaker: while the sentinel is up (out of credits,
-  // key spending cap, provider outage — raised by the queue consumer's failure
-  // classification) a cold run cannot succeed, so answer with the explained
-  // paused envelope NOW instead of enqueueing a doomed job the client would
-  // poll for minutes. Cached/SWR content already served above; a trusted
-  // explicit warm still goes through (it is the recovery probe).
+  // Provider-down circuit breaker: while AI spending is unavailable (out of
+  // credits, key spending cap, provider outage) a cold run cannot succeed, so
+  // answer with the explained paused envelope NOW instead of enqueueing a
+  // doomed job the client would poll for minutes. `resolveAiDown` is
+  // authoritative on the out-of-credits case (it checks the actual balance, not
+  // just the reactive sentinel). Cached/SWR content already served above; a
+  // trusted explicit warm still goes through (it is the recovery probe).
   if (!explicitWarm) {
-    const down = await readAiDown(c.env.CACHE);
+    const down = await resolveAiDown(c.env);
     if (down) {
       return c.json(
         {

--- a/packages/talmud/src/worker/openrouter-cost.ts
+++ b/packages/talmud/src/worker/openrouter-cost.ts
@@ -122,8 +122,9 @@ export function aggregateActivity(rows: OrActivityRow[]): {
 async function fetchJson(
   url: string,
   token: string,
+  signal?: AbortSignal,
 ): Promise<{ ok: boolean; status: number; json: unknown }> {
-  const res = await fetch(url, { headers: { authorization: `Bearer ${token}` } });
+  const res = await fetch(url, { headers: { authorization: `Bearer ${token}` }, signal });
   let json: unknown = null;
   try {
     json = await res.json();
@@ -131,6 +132,50 @@ async function fetchJson(
     /* leave null */
   }
   return { ok: res.ok, status: res.status, json };
+}
+
+export interface OrBalance {
+  /** Do we have a provisioning key. */
+  configured: boolean;
+  /** Did the query succeed (a usable `remaining` is present). */
+  ok: boolean;
+  error?: string;
+  /** Spendable USD right now: `total_credits - total_usage`. */
+  remaining?: number;
+}
+
+/**
+ * Lean spendable-balance probe — just `/credits`, no activity ledger — for the
+ * AI-paused gate on the cold-generation entry paths. Kept separate from
+ * `fetchOpenRouterCost` (which also pulls the multi-KB `/activity` ledger for
+ * the /usage dashboard) so a request-path caller makes one small call with a
+ * short timeout. Degrades to `{ ok:false }` (unknown) on any failure — the
+ * caller must treat unknown as "don't block", never as "down".
+ */
+export async function fetchOpenRouterBalance(env: OrEnv): Promise<OrBalance> {
+  const token = env.OPENROUTER_PROVISIONING_KEY;
+  if (!token) return { configured: false, ok: false, error: 'not configured' };
+  try {
+    const { ok, status, json } = await fetchJson(
+      `${BASE}/credits`,
+      token,
+      AbortSignal.timeout(2500),
+    );
+    if (!ok) {
+      const msg = (json as { error?: { message?: string } })?.error?.message ?? `HTTP ${status}`;
+      return { configured: true, ok: false, error: String(msg).slice(0, 200) };
+    }
+    const d = (json as { data?: { total_credits?: number; total_usage?: number } })?.data;
+    if (!d || typeof d.total_credits !== 'number' || typeof d.total_usage !== 'number')
+      return { configured: true, ok: false, error: 'unexpected /credits shape' };
+    return { configured: true, ok: true, remaining: d.total_credits - d.total_usage };
+  } catch (err) {
+    return {
+      configured: true,
+      ok: false,
+      error: String((err as Error)?.message ?? err).slice(0, 200),
+    };
+  }
 }
 
 export async function fetchOpenRouterCost(env: OrEnv): Promise<OrCost> {

--- a/packages/talmud/tests/ai-credits.test.ts
+++ b/packages/talmud/tests/ai-credits.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import { getCreditsState, resolveAiDown } from '../src/worker/ai-credits';
+import { readAiDown } from '../src/worker/ai-down';
+
+// In-memory KVNamespace covering the get/put/delete surface both the sentinel
+// and the credits cache use (mirrors ai-down.test.ts). `kv` reads and writes the
+// returned `store`, so a test seeds `store` then reads through the gate.
+function fakeKV(seed: Record<string, string> = {}) {
+  const store = new Map<string, string>(Object.entries(seed));
+  const kv = {
+    async get(key: string) {
+      return store.get(key) ?? null;
+    },
+    async put(key: string, value: string, _opts?: { expirationTtl?: number }) {
+      store.set(key, value);
+    },
+    async delete(key: string) {
+      store.delete(key);
+    },
+  } as unknown as KVNamespace;
+  return { kv, store };
+}
+
+const T = 1_700_000_000_000;
+
+// Seed the credits cache directly so getCreditsState reads it and never touches
+// the network — the balance + observation time under test travel through the row.
+function seedBalance(store: Map<string, string>, remaining: number, at = T): void {
+  store.set('ai-credits:v1', JSON.stringify({ remaining, at }));
+}
+// Seed the reactive sentinel with an explicit raise time so freshness ordering
+// against the balance reading is deterministic.
+function seedSentinel(store: Map<string, string>, reason: string, at = T): void {
+  store.set('ai-down:v1', JSON.stringify({ reason, at }));
+}
+
+describe('getCreditsState', () => {
+  it('reports out when the cached balance is at or below the floor', async () => {
+    for (const remaining of [-0.18, 0, 0.05, 0.1]) {
+      const { kv, store } = fakeKV();
+      seedBalance(store, remaining);
+      expect(await getCreditsState({ CACHE: kv })).toEqual({ out: true, remaining, at: T });
+    }
+  });
+
+  it('reports healthy when the cached balance is above the floor', async () => {
+    const { kv, store } = fakeKV();
+    seedBalance(store, 12.5);
+    expect(await getCreditsState({ CACHE: kv })).toEqual({ out: false, remaining: 12.5, at: T });
+  });
+
+  it('reports unknown (never "out") when the balance cannot be determined', async () => {
+    // No provisioning key -> fetchOpenRouterBalance short-circuits, no network.
+    const { kv, store } = fakeKV();
+    expect(await getCreditsState({ CACHE: kv })).toEqual({ out: false, remaining: null, at: null });
+    // Unknown must not be cached as a balance.
+    expect(store.has('ai-credits:v1')).toBe(false);
+  });
+
+  it('reads a corrupt or timestamp-less cache row as unknown rather than out', async () => {
+    const bad = fakeKV({ 'ai-credits:v1': 'not json' });
+    expect(await getCreditsState({ CACHE: bad.kv })).toEqual({
+      out: false,
+      remaining: null,
+      at: null,
+    });
+    const noTs = fakeKV({ 'ai-credits:v1': JSON.stringify({ remaining: 0 }) });
+    expect(await getCreditsState({ CACHE: noTs.kv })).toEqual({
+      out: false,
+      remaining: null,
+      at: null,
+    });
+  });
+});
+
+describe('resolveAiDown', () => {
+  it('proactively raises a credits sentinel when out (quiet-window gap)', async () => {
+    const { kv, store } = fakeKV();
+    seedBalance(store, 0);
+    expect(await readAiDown(kv)).toBeNull(); // no failure has happened yet
+    const down = await resolveAiDown({ CACHE: kv });
+    expect(down?.reason).toBe('credits');
+    // ...and persists it so every plain readAiDown gate lights up too.
+    expect((await readAiDown(kv))?.reason).toBe('credits');
+  });
+
+  it('leaves a non-credits sentinel standing when out of credits', async () => {
+    const { kv, store } = fakeKV();
+    seedBalance(store, 0);
+    seedSentinel(store, 'provider');
+    expect((await resolveAiDown({ CACHE: kv }))?.reason).toBe('provider');
+  });
+
+  it('clears a credits sentinel once a NEWER balance reading proves healthy', async () => {
+    const { kv, store } = fakeKV();
+    seedSentinel(store, 'credits', T); // raised before the top-up
+    seedBalance(store, 20, T + 1000); // balance measured after
+    expect(await resolveAiDown({ CACHE: kv })).toBeNull();
+    expect(await readAiDown(kv)).toBeNull(); // recovered promptly
+  });
+
+  it('does NOT let a STALE positive balance clear a freshly-raised credits sentinel', async () => {
+    // The race Codex flagged: a 60s-cached healthy balance, then a real 402
+    // raises the sentinel. The stale positive reading must not delete it.
+    const { kv, store } = fakeKV();
+    seedBalance(store, 20, T); // cached healthy an instant ago
+    seedSentinel(store, 'credits', T + 1000); // 402 landed AFTER that reading
+    expect((await resolveAiDown({ CACHE: kv }))?.reason).toBe('credits');
+    expect((await readAiDown(kv))?.reason).toBe('credits'); // sentinel survives
+  });
+
+  it('does NOT let a healthy balance clear a key-limit sentinel (credits exist, key capped)', async () => {
+    const { kv, store } = fakeKV();
+    seedSentinel(store, 'key-limit', T);
+    seedBalance(store, 20, T + 1000);
+    expect((await resolveAiDown({ CACHE: kv }))?.reason).toBe('key-limit');
+  });
+
+  it('defers to the sentinel when the balance is unknown', async () => {
+    // Out-of-credits already known reactively; balance probe unavailable (no key).
+    const { kv, store } = fakeKV();
+    seedSentinel(store, 'credits', T);
+    expect((await resolveAiDown({ CACHE: kv }))?.reason).toBe('credits');
+  });
+
+  it('allows generation when the balance is unknown and nothing failed', async () => {
+    const { kv } = fakeKV();
+    expect(await resolveAiDown({ CACHE: kv })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

When OpenRouter runs out of prepaid credits (HTTP 402 — the recurring outage), a reader opening a cold daf sees the load bar complete but the AI sections spin forever, with **no "AI paused" banner**.

Root cause: the "AI is down" signal was purely **reactive**. The `ai-down` sentinel is only written *after* a job fails with a classified 402, and it self-expires on a 5-minute TTL. In any quiet window (no generation churning failures for >5 min), the sentinel is absent, so `POST /api/daf-generate` answers `{ generating: true }` and spawns a Workflow that is doomed to 402 every step. The client, having been told `generating: true`, sits in view-driven polling for up to 12 minutes with no banner.

## Fix

Make the decision **authoritative** by consulting the actual account balance, so out-of-credits is known *before* we spawn a doomed generation instead of discovered by failing.

- **`ai-credits.ts` (new)** — `resolveAiDown(env)` combines the reactive sentinel with a cached, best-effort balance probe:
  - out of credits → raise a `credits` sentinel (so every other `readAiDown` gate lights up too) and report down;
  - authoritatively healthy balance → clear a stale `credits` sentinel so a top-up recovers within the cache TTL (~60s) instead of waiting out the 5-min sentinel;
  - unknown balance (no provisioning key, fetch error, timeout) → defer entirely to the sentinel (today's behaviour — never blocks on its own uncertainty).
  - The balance is KV-cached for 60s, so a reader burst costs at most ~one OpenRouter call per minute; every other request is a single KV read.
- **`openrouter-cost.ts`** — adds `fetchOpenRouterBalance()`, a lean `/credits`-only probe (spendable = `total_credits - total_usage`) with a 2.5s timeout, separate from the heavier `/activity` ledger fetch used by /usage.
- **`index.ts`** — `/api/daf-generate` and the cold-miss branch of `/api/run` now gate on `resolveAiDown(c.env)` instead of a bare `readAiDown`.
- **Belt-and-suspenders for non-credit outages** (provider 5xx / key-limit, which a balance can't see) — `/api/daf-view` carries the sentinel when a view is incomplete, and the client poll loop raises the shared banner + bails instead of spinning to its 12-minute cap. The extra KV read only happens on incomplete (cold) polls.

## Tests

`ai-credits.test.ts` (12 cases): floor threshold, unknown-never-blocks, corrupt-cache-is-unknown, proactive raise, top-up clear, and the rule that a healthy balance clears a `credits` sentinel but never a `key-limit` one.

`pnpm typecheck` clean; full talmud suite green (2730 tests); `biome ci` clean on all changed files.
