### PR TITLE
Fix cold-daf warm crash: dedupe per-instance DAG nodes by instance id

### DIFF
--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -318,6 +318,7 @@ import {
   createDagPool,
   type DafWarmParams,
   dafGenSentinelKey,
+  dedupeInstancesByIid,
   expandInlineDeps,
   perInstanceEnrichments,
   topoTiers,
@@ -11943,8 +11944,10 @@ export class DafWarmWorkflow extends WorkflowEntrypoint<Bindings, DafWarmParams>
       const eids = perInstByMark.get(mid);
       if (!eids || eids.length === 0) return;
       const insts = await readMarkInstances(wrapped, mid, tractate, page);
-      const withIds: { inst: unknown; iid: string }[] = [];
-      for (const inst of insts) withIds.push({ inst, iid: await instanceIdOf(inst) });
+      // Dedupe by instance id: the same iid can surface from two sections (a
+      // pasuk cited twice), and fanning out a second `<eid>::<iid>` node would
+      // throw `dag: duplicate node` and abort the whole daf's warm.
+      const withIds = await dedupeInstancesByIid(insts, (inst) => instanceIdOf(inst));
       for (const tier of topoTiers(eids, enrichDepsOf)) {
         for (const eid of tier) {
           const def = await loadEnrichmentDef(wrapped, eid);

--- a/packages/talmud/src/worker/workflow-warm.ts
+++ b/packages/talmud/src/worker/workflow-warm.ts
@@ -200,6 +200,34 @@ interface DagNode {
   status: 'declared' | 'pending' | 'running' | 'done';
 }
 
+/**
+ * Collapse a mark's instances to one entry per instance id (the value
+ * `instanceIdOf` derives, which IS the per-instance cache key). The SAME
+ * instance id legitimately surfaces more than once on a daf — e.g. a pasuk cited
+ * by two different sections yields two `pesukim` instances that both resolve to
+ * `leviticus_22_27`. They map to one cache key / one artifact, so the warm DAG
+ * must fan out ONE node for them: a second `pool.add("<eid>::<iid>")` throws
+ * `dag: duplicate node` and aborts the entire daf's generation (observed live on
+ * Chullin 81, where every warm errored at DAG build before any AI ran).
+ *
+ * First-wins: the deduped instance drives the single node, matching the existing
+ * cache-key semantics (both would have written the same key regardless).
+ */
+export async function dedupeInstancesByIid<T>(
+  insts: readonly T[],
+  iidOf: (inst: T) => Promise<string>,
+): Promise<{ inst: T; iid: string }[]> {
+  const out: { inst: T; iid: string }[] = [];
+  const seen = new Set<string>();
+  for (const inst of insts) {
+    const iid = await iidOf(inst);
+    if (seen.has(iid)) continue;
+    seen.add(iid);
+    out.push({ inst, iid });
+  }
+  return out;
+}
+
 export function createDagPool(limit: number): DagPool {
   const nodes = new Map<string, DagNode>();
   let inFlight = 0;

--- a/packages/talmud/tests/workflow-warm.test.ts
+++ b/packages/talmud/tests/workflow-warm.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   createDagPool,
   dafGenSentinelKey,
+  dedupeInstancesByIid,
   expandInlineDeps,
   perInstanceEnrichments,
   topoTiers,
@@ -456,5 +457,51 @@ describe('createDagPool', () => {
 
   it('an empty pool drains immediately', async () => {
     await expect(createDagPool(2).drain()).resolves.toBeUndefined();
+  });
+
+  // Regression: the whole-daf warm crashed on Chullin 81 with
+  // `dag: duplicate node pesukim.why-here::leviticus_22_27` — a pasuk cited by
+  // two sections yielded two instances with the same id, so the per-instance
+  // fan-out called pool.add() twice for the same uid and aborted the daf.
+  it('adding the same node id twice throws (the invariant behind the crash)', () => {
+    const pool = createDagPool(2);
+    pool.add('pesukim.why-here::leviticus_22_27', [], async () => {});
+    expect(() => pool.add('pesukim.why-here::leviticus_22_27', [], async () => {})).toThrow(
+      /duplicate node pesukim\.why-here::leviticus_22_27/,
+    );
+  });
+});
+
+describe('dedupeInstancesByIid', () => {
+  it('collapses instances that share an instance id (the daf-warm fix)', async () => {
+    // Two sections cite Lev 22:27; both instances resolve to the same iid.
+    const insts = [
+      { seg: 3, pasuk: 'leviticus_22_27' },
+      { seg: 9, pasuk: 'leviticus_22_28' },
+      { seg: 14, pasuk: 'leviticus_22_27' }, // duplicate iid from another section
+    ];
+    const out = await dedupeInstancesByIid(insts, async (i) => i.pasuk);
+    expect(out.map((o) => o.iid)).toEqual(['leviticus_22_27', 'leviticus_22_28']);
+    // First-wins: the surviving node carries the first instance's payload.
+    expect(out[0].inst).toEqual({ seg: 3, pasuk: 'leviticus_22_27' });
+  });
+
+  it('feeding deduped instances into the pool no longer throws', async () => {
+    const insts = [{ pasuk: 'leviticus_22_27' }, { pasuk: 'leviticus_22_27' }];
+    const withIds = await dedupeInstancesByIid(insts, async (i) => i.pasuk);
+    const pool = createDagPool(2);
+    // Exactly one node per unique iid — the fan-out the warm actually does.
+    for (const { iid } of withIds) pool.add(`pesukim.why-here::${iid}`, [], async () => {});
+    await expect(pool.drain()).resolves.toBeUndefined();
+  });
+
+  it('preserves order and passes instance ids through unchanged when all unique', async () => {
+    const insts = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+    const out = await dedupeInstancesByIid(insts, async (i) => i.id);
+    expect(out).toEqual([
+      { inst: { id: 'a' }, iid: 'a' },
+      { inst: { id: 'b' }, iid: 'b' },
+      { inst: { id: 'c' }, iid: 'c' },
+    ]);
   });
 });


### PR DESCRIPTION
## Problem

Today's daf (Chullin 81) would not generate — the load bar completed but every AI section spun forever, **with credits present and no error surfaced to the reader**. Every `DafWarmWorkflow` instance errored at DAG-build within ~1s:

```
Error: dag: duplicate node pesukim.why-here::leviticus_22_27
Last Successful Step: mark:places-1
```

The warm workflow fans out one DAG node per mark instance, keyed `<enrichId>::<instanceId>`. On Chullin 81 the verse Leviticus 22:27 is cited by **two different sections**, so the `pesukim` mark yields two instances that both resolve to the instance id `leviticus_22_27`. The fan-out called `pool.add("pesukim.why-here::leviticus_22_27")` twice; `createDagPool.add` throws on a duplicate id, aborting the **entire daf's** generation before any AI step ran.

## Fix

The two instances map to one cache key / one artifact, so they must produce **one** node. New `dedupeInstancesByIid` (`workflow-warm.ts`) collapses a mark's instances to one entry per instance id (first-wins, matching existing cache-key semantics); the per-instance fan-out uses it.

## Tests (regression)

`workflow-warm.test.ts`:
- the duplicate-node throw invariant (documents the exact crash),
- `dedupeInstancesByIid`: collapse-by-iid, order preservation, first-wins payload,
- deduped instances drain the pool without throwing.

`pnpm typecheck` clean; full talmud suite green (2739); `biome ci` clean on changed files.