### PR TITLE
Usage page: shared sortable DataTable + more visualizations

### DIFF
--- a/packages/talmud/src/client/DataTable.tsx
+++ b/packages/talmud/src/client/DataTable.tsx
@@ -1,0 +1,377 @@
+/**
+ * Usage-page table + chart kit. One ordered, sortable table component behind
+ * every tabular view (latency, cache, cost, errors, lint), plus small inline
+ * cells (a meter bar, a heat chip) and a ranked horizontal-bar chart. The point
+ * is consistency: click a header to sort, numerics right-align and use tabular
+ * figures, and long lists collapse behind a "show all". Styling is inline (the
+ * usage page's convention) but funneled through these primitives.
+ */
+
+import { createMemo, createSignal, For, type JSX, Show } from 'solid-js';
+import { t } from './i18n';
+
+export type Align = 'left' | 'right' | 'center';
+
+export interface Column<T> {
+  key: string;
+  header: string;
+  align?: Align;
+  /** Provide to make the column sortable; returns the sort key for a row. */
+  sortValue?: (row: T) => number | string;
+  /** Cell content. */
+  cell: (row: T) => JSX.Element | string;
+  width?: string;
+  mono?: boolean;
+  /** Muted (grey) cell text — for secondary columns. */
+  muted?: boolean;
+}
+
+const HEAD: JSX.CSSProperties = {
+  padding: '0.4rem 0.5rem',
+  'font-weight': 600,
+  'font-size': '0.72rem',
+  'text-transform': 'uppercase',
+  'letter-spacing': '0.03em',
+  color: '#8a857c',
+  'border-bottom': '1px solid var(--line, #e5e3dc)',
+  'white-space': 'nowrap',
+  'user-select': 'none',
+};
+
+export function DataTable<T>(props: {
+  columns: Column<T>[];
+  rows: T[];
+  initialSort?: { key: string; dir: 'asc' | 'desc' };
+  /** Collapse to N rows behind a "show all N" toggle. */
+  maxRows?: number;
+  emptyText?: string;
+  onRowClick?: (row: T) => void;
+}): JSX.Element {
+  const [sort, setSort] = createSignal<{ key: string; dir: 'asc' | 'desc' } | null>(
+    props.initialSort ?? null,
+  );
+  const [expanded, setExpanded] = createSignal(false);
+
+  const sorted = createMemo(() => {
+    const s = sort();
+    const rows = props.rows.slice();
+    if (!s) return rows;
+    const col = props.columns.find((c) => c.key === s.key);
+    if (!col?.sortValue) return rows;
+    const val = col.sortValue;
+    rows.sort((a, b) => {
+      const av = val(a);
+      const bv = val(b);
+      const cmp =
+        typeof av === 'number' && typeof bv === 'number'
+          ? av - bv
+          : String(av).localeCompare(String(bv));
+      return s.dir === 'asc' ? cmp : -cmp;
+    });
+    return rows;
+  });
+  const visible = () => {
+    const rows = sorted();
+    return props.maxRows && !expanded() ? rows.slice(0, props.maxRows) : rows;
+  };
+  const hiddenCount = () =>
+    Math.max(0, sorted().length - (props.maxRows ?? Number.POSITIVE_INFINITY));
+
+  const toggleSort = (col: Column<T>) => {
+    if (!col.sortValue) return;
+    setSort((s) =>
+      s?.key !== col.key
+        ? { key: col.key, dir: 'desc' }
+        : { key: col.key, dir: s.dir === 'desc' ? 'asc' : 'desc' },
+    );
+  };
+
+  return (
+    <>
+      <table style={{ width: '100%', 'border-collapse': 'collapse', 'font-size': '0.83rem' }}>
+        <thead>
+          <tr>
+            <For each={props.columns}>
+              {(col) => (
+                <th
+                  style={{
+                    ...HEAD,
+                    'text-align': col.align ?? 'left',
+                    width: col.width,
+                    cursor: col.sortValue ? 'pointer' : 'default',
+                  }}
+                  onClick={() => toggleSort(col)}
+                >
+                  {col.header}
+                  <Show when={col.sortValue}>
+                    <span style={{ color: sort()?.key === col.key ? 'var(--accent)' : '#ccc' }}>
+                      {sort()?.key === col.key ? (sort()?.dir === 'asc' ? ' ▲' : ' ▼') : ' ⇅'}
+                    </span>
+                  </Show>
+                </th>
+              )}
+            </For>
+          </tr>
+        </thead>
+        <tbody>
+          <Show
+            when={visible().length > 0}
+            fallback={
+              <tr>
+                <td
+                  colspan={props.columns.length}
+                  style={{ padding: '0.6rem 0.5rem', color: '#aaa', 'font-size': '0.82rem' }}
+                >
+                  {props.emptyText ?? t('usage.table.empty')}
+                </td>
+              </tr>
+            }
+          >
+            <For each={visible()}>
+              {(row) => (
+                <tr
+                  style={{
+                    'border-bottom': '1px solid #f2f0ea',
+                    cursor: props.onRowClick ? 'pointer' : undefined,
+                  }}
+                  onClick={() => props.onRowClick?.(row)}
+                >
+                  <For each={props.columns}>
+                    {(col) => (
+                      <td
+                        style={{
+                          padding: '0.35rem 0.5rem',
+                          'text-align': col.align ?? 'left',
+                          'font-variant-numeric':
+                            col.align === 'right' ? 'tabular-nums' : undefined,
+                          'font-family': col.mono ? 'monospace' : undefined,
+                          'font-size': col.mono ? '0.78rem' : undefined,
+                          color: col.muted ? '#8a857c' : undefined,
+                          'vertical-align': 'top',
+                        }}
+                      >
+                        {col.cell(row)}
+                      </td>
+                    )}
+                  </For>
+                </tr>
+              )}
+            </For>
+          </Show>
+        </tbody>
+      </table>
+      <Show when={props.maxRows && hiddenCount() > 0}>
+        <button
+          type="button"
+          onClick={() => setExpanded((e) => !e)}
+          style={{
+            'margin-top': '0.4rem',
+            border: 'none',
+            background: 'none',
+            color: 'var(--accent)',
+            cursor: 'pointer',
+            'font-size': '0.78rem',
+            padding: '0.2rem 0',
+          }}
+        >
+          {expanded()
+            ? t('usage.table.showLess')
+            : t('usage.table.showMore', { count: String(hiddenCount()) })}
+        </button>
+      </Show>
+    </>
+  );
+}
+
+/** Inline meter: a track + accent fill sized by value/max, with trailing text.
+ *  Used for latency, cost, and hit-rate cells so magnitudes read at a glance. */
+export function Meter(props: {
+  value: number;
+  max: number;
+  text: string;
+  color?: string;
+  width?: string;
+}): JSX.Element {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        'align-items': 'center',
+        gap: '0.5rem',
+        'justify-content': 'flex-end',
+      }}
+    >
+      <div
+        style={{
+          flex: props.width ? undefined : 1,
+          width: props.width,
+          'min-width': '2.5rem',
+          height: '7px',
+          background: '#f0ede6',
+          'border-radius': '3px',
+          overflow: 'hidden',
+        }}
+      >
+        <div
+          style={{
+            width: `${props.max > 0 ? Math.min(100, (props.value / props.max) * 100) : 0}%`,
+            height: '100%',
+            background: props.color ?? 'var(--accent)',
+          }}
+        />
+      </div>
+      <span
+        style={{
+          'font-variant-numeric': 'tabular-nums',
+          'min-width': '3.2rem',
+          'text-align': 'right',
+        }}
+      >
+        {props.text}
+      </span>
+    </div>
+  );
+}
+
+/** Warm heat colour for a 0..1 rate (red → amber → green). For cache-hit chips. */
+export function heatColor(rate: number): { fg: string; bg: string } {
+  if (rate >= 0.8) return { fg: '#3f6f43', bg: '#e6efe3' };
+  if (rate >= 0.5) return { fg: '#8a6d00', bg: '#f7efd6' };
+  if (rate >= 0.2) return { fg: '#a05a1e', bg: '#f6e6d6' };
+  return { fg: '#9a3b30', bg: '#f5e0dc' };
+}
+
+/** A cache-hit% chip coloured by the heat scale. */
+export function HitChip(props: { rate: number }): JSX.Element {
+  const c = () => heatColor(props.rate);
+  return (
+    <span
+      style={{
+        display: 'inline-block',
+        padding: '0.05rem 0.4rem',
+        'border-radius': '999px',
+        'font-size': '0.74rem',
+        'font-variant-numeric': 'tabular-nums',
+        color: c().fg,
+        background: c().bg,
+      }}
+    >
+      {Math.round(props.rate * 100)}%
+    </span>
+  );
+}
+
+export interface RankedItem {
+  label: string;
+  value: number;
+  sub?: string;
+  color?: string;
+  /** Optional inner tick (e.g. p50 within a p95 bar), same units as value. */
+  tick?: number;
+}
+
+/** A ranked horizontal-bar chart: one row per item, bar width ∝ value, an
+ *  optional inner tick, and a right-aligned formatted value + sub. Used for
+ *  "slowest producers", lint-failure counts, error-reason tallies, etc. */
+export function RankedBars(props: {
+  items: RankedItem[];
+  fmt: (n: number) => string;
+  top?: number;
+  labelWidth?: string;
+}): JSX.Element {
+  const items = createMemo(() => {
+    const sorted = props.items.slice().sort((a, b) => b.value - a.value);
+    return props.top ? sorted.slice(0, props.top) : sorted;
+  });
+  const max = () => Math.max(1, ...items().map((i) => i.value));
+  const lw = () => props.labelWidth ?? '11rem';
+  return (
+    <div style={{ display: 'flex', 'flex-direction': 'column', gap: '0.28rem' }}>
+      <For each={items()}>
+        {(it) => (
+          <div
+            style={{
+              display: 'flex',
+              'align-items': 'center',
+              gap: '0.55rem',
+              'font-size': '0.8rem',
+            }}
+          >
+            <span
+              style={{
+                width: lw(),
+                'flex-shrink': 0,
+                'font-family': 'monospace',
+                'font-size': '0.75rem',
+                overflow: 'hidden',
+                'text-overflow': 'ellipsis',
+                'white-space': 'nowrap',
+              }}
+              title={it.label}
+            >
+              {it.label}
+            </span>
+            <div
+              style={{
+                flex: 1,
+                height: '14px',
+                background: '#f1efe9',
+                'border-radius': '3px',
+                position: 'relative',
+                overflow: 'hidden',
+              }}
+            >
+              <div
+                style={{
+                  position: 'absolute',
+                  left: 0,
+                  top: 0,
+                  bottom: 0,
+                  width: `${(it.value / max()) * 100}%`,
+                  background: it.color ?? 'var(--accent)',
+                  'border-radius': '3px',
+                }}
+              />
+              <Show when={it.tick != null}>
+                <div
+                  style={{
+                    position: 'absolute',
+                    top: 0,
+                    bottom: 0,
+                    left: `${Math.min(100, ((it.tick ?? 0) / max()) * 100)}%`,
+                    width: '2px',
+                    background: 'rgba(0,0,0,0.32)',
+                  }}
+                />
+              </Show>
+            </div>
+            <span
+              style={{
+                width: '4rem',
+                'text-align': 'right',
+                'font-variant-numeric': 'tabular-nums',
+                color: '#555',
+                'flex-shrink': 0,
+              }}
+            >
+              {props.fmt(it.value)}
+            </span>
+            <Show when={it.sub}>
+              <span
+                style={{
+                  width: '6rem',
+                  'text-align': 'right',
+                  color: '#aaa',
+                  'font-size': '0.72rem',
+                  'flex-shrink': 0,
+                }}
+              >
+                {it.sub}
+              </span>
+            </Show>
+          </div>
+        )}
+      </For>
+    </div>
+  );
+}

--- a/packages/talmud/src/client/UsagePage.tsx
+++ b/packages/talmud/src/client/UsagePage.tsx
@@ -1,6 +1,7 @@
 import { WorldBubbleMap } from '@corpus/ui/WorldBubbleMap';
 import { createMemo, createResource, createSignal, For, type JSX, onCleanup, Show } from 'solid-js';
 import { estimateShasCost, type ProducerCost } from '../lib/shasCost';
+import { type Column, DataTable, HitChip, Meter, RankedBars, type RankedItem } from './DataTable';
 import { lang, t } from './i18n';
 
 interface PerEndpoint {
@@ -1789,69 +1790,57 @@ function ByProducerSection(props: {
           </For>
         </div>
         {/* Full attributed table */}
-        <table style={tableStyle}>
-          <thead>
-            <tr style={{ 'text-align': 'left', 'border-bottom': '1px solid #eee', color: '#666' }}>
-              <th style={thStyle}>{t('usage.shas.col.producer')}</th>
-              <th style={{ ...thStyle, 'text-align': 'right' }}>{t('usage.col.calls')}</th>
-              <th style={{ ...thStyle, 'text-align': 'right' }}>{t('usage.col.tokens')}</th>
-              <th style={{ ...thStyle, 'text-align': 'right' }}>{t('usage.col.cost')}</th>
-            </tr>
-          </thead>
-          <tbody>
-            <For each={rows()}>
-              {([id, b]) => (
-                <tr style={{ 'border-bottom': '1px solid #f4f4f4' }}>
-                  <td
-                    style={{
-                      padding: '0.3rem 0.5rem',
-                      'font-family': 'monospace',
-                      'font-size': '0.8rem',
-                    }}
-                  >
-                    {id}
-                  </td>
-                  <td
-                    style={{
-                      padding: '0.3rem 0.5rem',
-                      'text-align': 'right',
-                      'font-variant-numeric': 'tabular-nums',
-                      color: '#888',
-                    }}
-                  >
-                    {fmtInt(b.calls)}
-                  </td>
-                  <td
-                    style={{
-                      padding: '0.3rem 0.5rem',
-                      'text-align': 'right',
-                      'font-variant-numeric': 'tabular-nums',
-                      color: '#888',
-                    }}
-                  >
-                    {fmtTokens(b.tokensIn + b.tokensOut)}
-                  </td>
-                  <td
-                    style={{
-                      padding: '0.3rem 0.5rem',
-                      'text-align': 'right',
-                      'font-variant-numeric': 'tabular-nums',
-                    }}
-                  >
-                    {b.pricedCalls ? (
-                      fmtUsd(b.costUsd)
-                    ) : (
-                      <span style={{ color: '#bbb' }}>{t('usage.unpriced')}</span>
-                    )}
-                  </td>
-                </tr>
-              )}
-            </For>
-          </tbody>
-        </table>
+        <DataTable
+          columns={producerCols(() => Math.max(...rows().map(([, b]) => b.costUsd), 1e-9))}
+          rows={rows()}
+          initialSort={{ key: 'cost', dir: 'desc' }}
+          maxRows={20}
+        />
       </Show>
     </Collapsible>
   );
+}
+
+// Columns for the per-producer cost table (shared shape: [id, UsageBucket]).
+function producerCols(maxCost: () => number): Column<[string, UsageBucket]>[] {
+  return [
+    {
+      key: 'id',
+      header: t('usage.shas.col.producer'),
+      mono: true,
+      sortValue: ([id]) => id,
+      cell: ([id]) => id,
+    },
+    {
+      key: 'calls',
+      header: t('usage.col.calls'),
+      align: 'right',
+      muted: true,
+      sortValue: ([, b]) => b.calls,
+      cell: ([, b]) => fmtInt(b.calls),
+    },
+    {
+      key: 'tokens',
+      header: t('usage.col.tokens'),
+      align: 'right',
+      muted: true,
+      sortValue: ([, b]) => b.tokensIn + b.tokensOut,
+      cell: ([, b]) => fmtTokens(b.tokensIn + b.tokensOut),
+    },
+    {
+      key: 'cost',
+      header: t('usage.col.cost'),
+      align: 'right',
+      width: '11rem',
+      sortValue: ([, b]) => b.costUsd,
+      cell: ([, b]) =>
+        b.pricedCalls ? (
+          <Meter value={b.costUsd} max={maxCost()} text={fmtUsd(b.costUsd)} />
+        ) : (
+          <span style={{ color: '#bbb' }}>{t('usage.unpriced')}</span>
+        ),
+    },
+  ];
 }
 
 // The redesigned Cost tab: one authoritative total + a remaining-to-finish
@@ -1987,52 +1976,49 @@ function CostSection(props: { cost: CostSectionData; stats: CacheStats | undefin
 
 /** Per-model cost table shared by the OpenRouter (billed) and AI Gateway
  *  (gateway-estimated) breakdowns — both carry the same row shape. */
-function ModelCostTable(props: {
-  rows: Array<{
-    model: string;
-    requests: number;
-    tokensIn: number;
-    tokensOut: number;
-    costUsd: number;
-  }>;
-}): JSX.Element {
-  const cellNum = {
-    padding: '0.4rem 0.5rem',
-    'text-align': 'right',
-    'font-variant-numeric': 'tabular-nums',
-  } as const;
-  return (
-    <table style={tableStyle}>
-      <thead>
-        <tr style={{ 'text-align': 'left', 'border-bottom': '1px solid #eee', color: '#666' }}>
-          <th style={thStyle}>{t('usage.col.model')}</th>
-          <th style={{ ...thStyle, 'text-align': 'right' }}>{t('usage.col.requests')}</th>
-          <th style={{ ...thStyle, 'text-align': 'right' }}>{t('usage.col.tokens')}</th>
-          <th style={{ ...thStyle, 'text-align': 'right' }}>{t('usage.col.cost')}</th>
-        </tr>
-      </thead>
-      <tbody>
-        <For each={props.rows}>
-          {(m) => (
-            <tr style={{ 'border-bottom': '1px solid #f4f4f4' }}>
-              <td
-                style={{
-                  padding: '0.4rem 0.5rem',
-                  'font-family': 'monospace',
-                  'font-size': '0.8rem',
-                }}
-              >
-                {m.model}
-              </td>
-              <td style={cellNum}>{fmtInt(m.requests)}</td>
-              <td style={cellNum}>{fmtTokens(m.tokensIn + m.tokensOut)}</td>
-              <td style={cellNum}>{fmtUsd(m.costUsd)}</td>
-            </tr>
-          )}
-        </For>
-      </tbody>
-    </table>
-  );
+type ModelRow = {
+  model: string;
+  requests: number;
+  tokensIn: number;
+  tokensOut: number;
+  costUsd: number;
+};
+function ModelCostTable(props: { rows: ModelRow[] }): JSX.Element {
+  const maxCost = () => Math.max(...props.rows.map((m) => m.costUsd), 1e-9);
+  const cols: Column<ModelRow>[] = [
+    {
+      key: 'model',
+      header: t('usage.col.model'),
+      mono: true,
+      sortValue: (m) => m.model,
+      cell: (m) => m.model,
+    },
+    {
+      key: 'requests',
+      header: t('usage.col.requests'),
+      align: 'right',
+      muted: true,
+      sortValue: (m) => m.requests,
+      cell: (m) => fmtInt(m.requests),
+    },
+    {
+      key: 'tokens',
+      header: t('usage.col.tokens'),
+      align: 'right',
+      muted: true,
+      sortValue: (m) => m.tokensIn + m.tokensOut,
+      cell: (m) => fmtTokens(m.tokensIn + m.tokensOut),
+    },
+    {
+      key: 'cost',
+      header: t('usage.col.cost'),
+      align: 'right',
+      width: '11rem',
+      sortValue: (m) => m.costUsd,
+      cell: (m) => <Meter value={m.costUsd} max={maxCost()} text={fmtUsd(m.costUsd)} />,
+    },
+  ];
+  return <DataTable columns={cols} rows={props.rows} initialSort={{ key: 'cost', dir: 'desc' }} />;
 }
 
 // The full billing detail — provider-billed vs gateway-estimated vs our own
@@ -2456,65 +2442,77 @@ function ShasEstimate(props: { est: ReturnType<typeof estimateShasCost> }): JSX.
 }
 
 // ---- Latency -------------------------------------------------------------
+type LatRow = { name: string; r: PerEndpoint };
 function LatencyTable(props: {
   title: string;
   hint?: string;
   rows: Array<[string, PerEndpoint]>;
 }): JSX.Element {
+  const rows = () => props.rows.filter(([, r]) => r.count > 0).map(([name, r]) => ({ name, r }));
+  const maxP95 = () => Math.max(1, ...rows().map((x) => x.r.p95Ms));
+  const cols: Column<LatRow>[] = [
+    {
+      key: 'name',
+      header: t('usage.col.name'),
+      mono: true,
+      sortValue: (x) => x.name,
+      cell: (x) => x.name,
+    },
+    {
+      key: 'calls',
+      header: t('usage.col.calls'),
+      align: 'right',
+      muted: true,
+      sortValue: (x) => x.r.count,
+      cell: (x) => fmtInt(x.r.count),
+    },
+    {
+      key: 'hit',
+      header: t('usage.col.cacheHit'),
+      align: 'right',
+      sortValue: (x) => x.r.cacheHitRate,
+      cell: (x) => <HitChip rate={x.r.cacheHitRate} />,
+    },
+    {
+      key: 'p50',
+      header: 'p50',
+      align: 'right',
+      muted: true,
+      sortValue: (x) => x.r.p50Ms,
+      cell: (x) => fmtMs(x.r.p50Ms),
+    },
+    {
+      key: 'p95',
+      header: 'p95',
+      align: 'right',
+      width: '12rem',
+      sortValue: (x) => x.r.p95Ms,
+      cell: (x) => (
+        <Meter
+          value={x.r.p95Ms}
+          max={maxP95()}
+          text={fmtMs(x.r.p95Ms)}
+          color={latColor(x.r.p95Ms)}
+        />
+      ),
+    },
+    {
+      key: 'err',
+      header: t('usage.col.errors'),
+      align: 'right',
+      sortValue: (x) => x.r.errorCount,
+      cell: (x) =>
+        x.r.errorCount ? (
+          <span style={{ color: '#9a3b30' }}>{x.r.errorCount}</span>
+        ) : (
+          <span style={{ color: '#ccc' }}>0</span>
+        ),
+    },
+  ];
   return (
-    <section style={{ 'margin-bottom': '1.6rem' }}>
+    <section style={{ 'margin-bottom': '1.4rem' }}>
       <SectionHeading title={props.title} hint={props.hint} />
-      <Show
-        when={props.rows.length > 0}
-        fallback={<p style={{ color: '#888' }}>{t('usage.noDataYet')}</p>}
-      >
-        <table style={tableStyle}>
-          <thead>
-            <tr style={{ 'text-align': 'left', 'border-bottom': '1px solid #eee', color: '#666' }}>
-              <th style={thStyle}>{t('usage.col.name')}</th>
-              <th style={{ ...thStyle, 'text-align': 'right' }}>{t('usage.col.calls')}</th>
-              <th style={{ ...thStyle, 'text-align': 'right' }}>{t('usage.col.cacheHit')}</th>
-              <th style={{ ...thStyle, 'text-align': 'right' }}>p50</th>
-              <th style={{ ...thStyle, 'text-align': 'right' }}>p95</th>
-              <th style={{ ...thStyle, 'text-align': 'right' }}>{t('usage.col.errors')}</th>
-              <th style={thStyle}>{t('usage.col.kinds')}</th>
-            </tr>
-          </thead>
-          <tbody>
-            <For each={props.rows}>
-              {([name, row]) => (
-                <tr style={{ 'border-bottom': '1px solid #f4f4f4' }}>
-                  <td style={{ padding: '0.4rem 0.5rem', 'font-family': 'monospace' }}>{name}</td>
-                  <td style={{ padding: '0.4rem 0.5rem', 'text-align': 'right' }}>{row.count}</td>
-                  <td style={{ padding: '0.4rem 0.5rem', 'text-align': 'right' }}>
-                    {row.count ? `${Math.round(row.cacheHitRate * 100)}%` : '—'}
-                  </td>
-                  <td style={{ padding: '0.4rem 0.5rem', 'text-align': 'right' }}>
-                    {row.count ? fmtMs(row.p50Ms) : '—'}
-                  </td>
-                  <td style={{ padding: '0.4rem 0.5rem', 'text-align': 'right' }}>
-                    {row.count ? fmtMs(row.p95Ms) : '—'}
-                  </td>
-                  <td
-                    style={{
-                      padding: '0.4rem 0.5rem',
-                      'text-align': 'right',
-                      color: row.errorCount ? '#c33' : '#888',
-                    }}
-                  >
-                    {row.errorCount}
-                  </td>
-                  <td style={{ padding: '0.4rem 0.5rem', 'font-size': '0.75rem', color: '#888' }}>
-                    {Object.entries(row.errorsByKind)
-                      .map(([k, n]) => `${k}:${n}`)
-                      .join(', ')}
-                  </td>
-                </tr>
-              )}
-            </For>
-          </tbody>
-        </table>
-      </Show>
+      <DataTable columns={cols} rows={rows()} initialSort={{ key: 'p95', dir: 'desc' }} />
     </section>
   );
 }
@@ -2807,115 +2805,6 @@ function latColor(p95Ms: number): string {
   return '#a04030';
 }
 
-// A horizontal p95-latency bar per producer, slowest first, coloured by
-// severity, with the p50 shown as a tick and hit% / calls trailing. A quick
-// "what's slow" read the detail tables below back up.
-function LatencyBars(props: {
-  title: string;
-  rows: Array<[string, PerEndpoint]>;
-  top?: number;
-}): JSX.Element {
-  const rows = createMemo(() =>
-    props.rows
-      .filter(([, r]) => r.count > 0)
-      .sort(([, a], [, b]) => b.p95Ms - a.p95Ms)
-      .slice(0, props.top ?? 15),
-  );
-  const max = () => Math.max(1, ...rows().map(([, r]) => r.p95Ms));
-  return (
-    <Show when={rows().length > 0}>
-      <div style={{ 'margin-bottom': '1.1rem' }}>
-        <SectionHeading title={props.title} hint={t('usage.latency.barsHint')} />
-        <div style={{ display: 'flex', 'flex-direction': 'column', gap: '0.28rem' }}>
-          <For each={rows()}>
-            {([name, r]) => (
-              <div
-                style={{
-                  display: 'flex',
-                  'align-items': 'center',
-                  gap: '0.55rem',
-                  'font-size': '0.8rem',
-                }}
-              >
-                <span
-                  style={{
-                    width: '11rem',
-                    'flex-shrink': 0,
-                    'font-family': 'monospace',
-                    'font-size': '0.75rem',
-                    overflow: 'hidden',
-                    'text-overflow': 'ellipsis',
-                    'white-space': 'nowrap',
-                  }}
-                  title={name}
-                >
-                  {name}
-                </span>
-                <div
-                  style={{
-                    flex: 1,
-                    height: '14px',
-                    background: '#f1efe9',
-                    'border-radius': '3px',
-                    position: 'relative',
-                    overflow: 'hidden',
-                  }}
-                >
-                  <div
-                    style={{
-                      position: 'absolute',
-                      left: 0,
-                      top: 0,
-                      bottom: 0,
-                      width: `${(r.p95Ms / max()) * 100}%`,
-                      background: latColor(r.p95Ms),
-                      'border-radius': '3px',
-                    }}
-                  />
-                  {/* p50 tick within the p95 span */}
-                  <div
-                    style={{
-                      position: 'absolute',
-                      top: 0,
-                      bottom: 0,
-                      left: `${Math.min(100, (r.p50Ms / max()) * 100)}%`,
-                      width: '2px',
-                      background: 'rgba(0,0,0,0.32)',
-                    }}
-                    title={`p50 ${fmtMs(r.p50Ms)}`}
-                  />
-                </div>
-                <span
-                  style={{
-                    width: '4rem',
-                    'text-align': 'right',
-                    'font-variant-numeric': 'tabular-nums',
-                    color: '#555',
-                    'flex-shrink': 0,
-                  }}
-                >
-                  {fmtMs(r.p95Ms)}
-                </span>
-                <span
-                  style={{
-                    width: '6rem',
-                    'text-align': 'right',
-                    color: '#aaa',
-                    'font-size': '0.72rem',
-                    'flex-shrink': 0,
-                  }}
-                >
-                  {Math.round(r.cacheHitRate * 100)}% · {fmtInt(r.count)}
-                </span>
-              </div>
-            )}
-          </For>
-        </div>
-      </div>
-    </Show>
-  );
-}
-
 function SpeedSection(props: { telemetry: TelemetrySection }): JSX.Element {
   const d = () => props.telemetry;
   const endpointRows = () =>
@@ -2923,9 +2812,23 @@ function SpeedSection(props: { telemetry: TelemetrySection }): JSX.Element {
       .map(([k, v]) => [displayEndpoint(k), v] as [string, PerEndpoint])
       .sort(([a], [b]) => a.localeCompare(b));
   const producerRows = () => [...Object.entries(d().perMark), ...Object.entries(d().perEnrichment)];
+  // Slowest producers as a ranked p95 bar chart (p50 tick, hit%·calls sub).
+  const latencyItems = (): RankedItem[] =>
+    producerRows()
+      .filter(([, r]) => r.count > 0)
+      .map(([name, r]) => ({
+        label: name,
+        value: r.p95Ms,
+        tick: r.p50Ms,
+        color: latColor(r.p95Ms),
+        sub: `${Math.round(r.cacheHitRate * 100)}% · ${fmtInt(r.count)}`,
+      }));
   return (
     <Collapsible id="health.speed" title={t('usage.health.speed')} defaultOpen>
-      <LatencyBars title={t('usage.latency.slowest')} rows={producerRows()} />
+      <section style={{ 'margin-bottom': '1.1rem' }}>
+        <SectionHeading title={t('usage.latency.slowest')} hint={t('usage.latency.barsHint')} />
+        <RankedBars items={latencyItems()} fmt={fmtMs} top={15} />
+      </section>
       <LatencyTable
         title={t('usage.latency.byEndpoint', { count: d().totalCount })}
         rows={endpointRows()}
@@ -2998,117 +2901,203 @@ function CacheSection(props: {
         </Show>
       </div>
       <Show when={producerRows().length > 0}>
-        <table style={tableStyle}>
-          <thead>
-            <tr style={{ 'text-align': 'left', 'border-bottom': '1px solid #eee', color: '#666' }}>
-              <th style={thStyle}>{t('usage.col.name')}</th>
-              <th style={{ ...thStyle, 'text-align': 'right' }}>{t('usage.col.calls')}</th>
-              <th style={{ ...thStyle, 'text-align': 'right' }}>{t('usage.col.cacheHit')}</th>
-            </tr>
-          </thead>
-          <tbody>
-            <For each={producerRows()}>
-              {([name, row]) => (
-                <tr style={{ 'border-bottom': '1px solid #f4f4f4' }}>
-                  <td style={{ padding: '0.35rem 0.5rem', 'font-family': 'monospace' }}>{name}</td>
-                  <td
-                    style={{
-                      padding: '0.35rem 0.5rem',
-                      'text-align': 'right',
-                      'font-variant-numeric': 'tabular-nums',
-                    }}
-                  >
-                    {row.count}
-                  </td>
-                  <td
-                    style={{
-                      padding: '0.35rem 0.5rem',
-                      'text-align': 'right',
-                      'font-variant-numeric': 'tabular-nums',
-                    }}
-                  >
-                    {Math.round(row.cacheHitRate * 100)}%
-                  </td>
-                </tr>
-              )}
-            </For>
-          </tbody>
-        </table>
+        <DataTable
+          columns={[
+            {
+              key: 'name',
+              header: t('usage.col.name'),
+              mono: true,
+              sortValue: ([name]) => name,
+              cell: ([name]) => name,
+            },
+            {
+              key: 'calls',
+              header: t('usage.col.calls'),
+              align: 'right',
+              muted: true,
+              sortValue: ([, r]) => r.count,
+              cell: ([, r]) => fmtInt(r.count),
+            },
+            {
+              key: 'hit',
+              header: t('usage.col.cacheHit'),
+              align: 'right',
+              sortValue: ([, r]) => r.cacheHitRate,
+              cell: ([, r]) => <HitChip rate={r.cacheHitRate} />,
+            },
+          ]}
+          rows={producerRows()}
+          initialSort={{ key: 'calls', dir: 'desc' }}
+          maxRows={15}
+        />
       </Show>
     </Collapsible>
   );
 }
 
 // ---- Health: Errors (recent telemetry + queue failures + lint) -----------
+// Bucket a raw provider/pipeline error into a short reason, so 30 near-identical
+// failures collapse into a handful of tallies (the "by reason" chart).
+function normalizeErrorReason(msg: string): string {
+  const m = msg.toLowerCase();
+  if (m.includes('402') || m.includes('credits')) return 'OpenRouter credits (402)';
+  if (m.includes('non-array')) return 'Sefaria non-array response';
+  if (m.includes('hard timeout') || m.includes('body read aborted')) return 'Hard timeout';
+  if (m.includes('429') || m.includes('rate-limit')) return 'Rate-limited (429)';
+  if (m.includes('parse') || m.includes('json')) return 'Parse / JSON error';
+  const first = msg.split('\n')[0];
+  return first.length > 48 ? `${first.slice(0, 48)}…` : first;
+}
+
 function ErrorsSection(props: {
   recentErrors: RecentError[];
   health: HealthSectionData;
 }): JSX.Element {
   const d = () => props.health;
   const recentErrors = () => props.recentErrors;
+
+  const recentCols: Column<RecentError>[] = [
+    {
+      key: 'when',
+      header: t('usage.errors.col.when'),
+      muted: true,
+      sortValue: (e) => e.ts,
+      cell: (e) => fmtTime(e.ts),
+    },
+    {
+      key: 'where',
+      header: t('usage.errors.col.where'),
+      mono: true,
+      sortValue: (e) => displayEndpoint(e.endpoint),
+      cell: (e) => (
+        <>
+          {displayEndpoint(e.endpoint)}
+          <Show when={e.mark_id || e.enrichment_id}>
+            <span style={{ color: '#999' }}> · {e.mark_id ?? e.enrichment_id}</span>
+          </Show>
+        </>
+      ),
+    },
+    {
+      key: 'daf',
+      header: t('usage.col.daf'),
+      muted: true,
+      cell: (e) => `${e.tractate ?? ''} ${e.page ?? ''}`.trim() || '—',
+    },
+    {
+      key: 'kind',
+      header: t('usage.errors.col.kind'),
+      sortValue: (e) => e.error_kind ?? '',
+      cell: (e) => (
+        <>
+          <span style={{ color: '#a04030' }}>{e.error_kind ?? t('usage.errorKind.other')}</span>
+          <Show when={e.model}>
+            <span style={{ color: '#aaa', 'font-size': '0.72rem' }}> ({e.model})</span>
+          </Show>
+        </>
+      ),
+    },
+  ];
+
+  const jobReasons = (): RankedItem[] => {
+    const tally = new Map<string, number>();
+    for (const e of d().jobErrors) {
+      const r = normalizeErrorReason(e.error);
+      tally.set(r, (tally.get(r) ?? 0) + 1);
+    }
+    return [...tally.entries()].map(([label, value]) => ({ label, value, color: '#a04030' }));
+  };
+  const jobCols: Column<JobError>[] = [
+    {
+      key: 'when',
+      header: t('usage.errors.col.when'),
+      muted: true,
+      sortValue: (e) => e.ts,
+      cell: (e) => fmtTime(e.ts),
+    },
+    {
+      key: 'job',
+      header: t('usage.errors.col.job'),
+      mono: true,
+      muted: true,
+      sortValue: (e) => e.kind,
+      cell: (e) => `${e.kind}${e.id ? `=${e.id}` : ''}`,
+    },
+    {
+      key: 'daf',
+      header: t('usage.col.daf'),
+      muted: true,
+      cell: (e) => `${e.tractate} ${e.page}`,
+    },
+    {
+      key: 'error',
+      header: t('usage.errors.col.error'),
+      sortValue: (e) => normalizeErrorReason(e.error),
+      cell: (e) => (
+        <div
+          style={{
+            color: '#a04030',
+            'font-family': 'monospace',
+            'font-size': '0.72rem',
+            'white-space': 'pre-wrap',
+            'word-break': 'break-word',
+          }}
+        >
+          {e.error}
+        </div>
+      ),
+    },
+  ];
+
+  const lintCountItems = (): RankedItem[] =>
+    Object.entries(d().lintFailures.counts).map(([label, value]) => ({
+      label,
+      value,
+      color: '#c99a2e',
+    }));
+  const lintCols: Column<LintFailure>[] = [
+    {
+      key: 'when',
+      header: t('usage.errors.col.when'),
+      muted: true,
+      sortValue: (f) => f.at,
+      cell: (f) => fmtTime(f.at),
+    },
+    {
+      key: 'producer',
+      header: t('usage.lint.col.producer'),
+      mono: true,
+      muted: true,
+      sortValue: (f) => f.enrichmentId,
+      cell: (f) => `${f.enrichmentId}${f.lang === 'he' ? ' · he' : ''}`,
+    },
+    {
+      key: 'daf',
+      header: t('usage.col.daf'),
+      muted: true,
+      cell: (f) => `${f.tractate} ${f.page}`,
+    },
+    {
+      key: 'issues',
+      header: t('usage.lint.col.issues'),
+      cell: (f) => <span style={{ color: '#a16207' }}>{f.issues.join(' · ')}</span>,
+    },
+  ];
+
   return (
     <Collapsible id="health.errors" title={t('usage.health.errors')} defaultOpen>
-      <section style={{ 'margin-bottom': '1.2rem' }}>
+      <section style={{ 'margin-bottom': '1.4rem' }}>
         <SectionHeading title={t('usage.recentErrors.title')} hint={t('usage.recentErrors.hint')} />
         <Show
           when={recentErrors().length > 0}
           fallback={<p style={{ color: '#888' }}>{t('usage.none')}</p>}
         >
-          <table style={tableStyle}>
-            <thead>
-              <tr
-                style={{ 'text-align': 'left', 'border-bottom': '1px solid #eee', color: '#666' }}
-              >
-                <th style={thStyle}>{t('usage.errors.col.when')}</th>
-                <th style={thStyle}>{t('usage.errors.col.where')}</th>
-                <th style={thStyle}>{t('usage.col.daf')}</th>
-                <th style={thStyle}>{t('usage.errors.col.kind')}</th>
-              </tr>
-            </thead>
-            <tbody>
-              <For each={recentErrors()}>
-                {(e) => (
-                  <tr style={{ 'border-bottom': '1px solid #f4f4f4', 'vertical-align': 'top' }}>
-                    <td
-                      style={{
-                        padding: '0.35rem 0.5rem',
-                        color: '#999',
-                        'white-space': 'nowrap',
-                        'font-size': '0.75rem',
-                      }}
-                    >
-                      {fmtTime(e.ts)}
-                    </td>
-                    <td
-                      style={{
-                        padding: '0.35rem 0.5rem',
-                        'font-family': 'monospace',
-                        'font-size': '0.76rem',
-                      }}
-                    >
-                      {displayEndpoint(e.endpoint)}
-                      <Show when={e.mark_id || e.enrichment_id}>
-                        <span style={{ color: '#999' }}> · {e.mark_id ?? e.enrichment_id}</span>
-                      </Show>
-                    </td>
-                    <td
-                      style={{ padding: '0.35rem 0.5rem', color: '#666', 'white-space': 'nowrap' }}
-                    >
-                      {e.tractate} {e.page}
-                    </td>
-                    <td style={{ padding: '0.35rem 0.5rem' }}>
-                      <span style={{ color: '#a04030' }}>
-                        {e.error_kind ?? t('usage.errorKind.other')}
-                      </span>
-                      <Show when={e.model}>
-                        <span style={{ color: '#aaa', 'font-size': '0.72rem' }}> ({e.model})</span>
-                      </Show>
-                    </td>
-                  </tr>
-                )}
-              </For>
-            </tbody>
-          </table>
+          <DataTable
+            columns={recentCols}
+            rows={recentErrors()}
+            initialSort={{ key: 'when', dir: 'desc' }}
+            maxRows={12}
+          />
         </Show>
       </section>
 
@@ -3121,65 +3110,16 @@ function ErrorsSection(props: {
           when={d().jobErrors.length > 0}
           fallback={<p style={{ color: '#888' }}>{t('usage.none')}</p>}
         >
-          <table style={tableStyle}>
-            <thead>
-              <tr
-                style={{ 'text-align': 'left', 'border-bottom': '1px solid #eee', color: '#666' }}
-              >
-                <th style={thStyle}>{t('usage.errors.col.when')}</th>
-                <th style={thStyle}>{t('usage.errors.col.job')}</th>
-                <th style={thStyle}>{t('usage.col.daf')}</th>
-                <th style={thStyle}>{t('usage.errors.col.error')}</th>
-              </tr>
-            </thead>
-            <tbody>
-              <For each={d().jobErrors}>
-                {(e) => (
-                  <tr style={{ 'border-bottom': '1px solid #f4f4f4', 'vertical-align': 'top' }}>
-                    <td
-                      style={{
-                        padding: '0.4rem 0.5rem',
-                        color: '#999',
-                        'white-space': 'nowrap',
-                        'font-size': '0.75rem',
-                      }}
-                    >
-                      {fmtTime(e.ts)}
-                    </td>
-                    <td
-                      style={{
-                        padding: '0.4rem 0.5rem',
-                        'font-family': 'monospace',
-                        'font-size': '0.76rem',
-                        color: '#555',
-                        'white-space': 'nowrap',
-                      }}
-                    >
-                      {e.kind}
-                      {e.id ? `=${e.id}` : ''}
-                    </td>
-                    <td
-                      style={{ padding: '0.4rem 0.5rem', color: '#666', 'white-space': 'nowrap' }}
-                    >
-                      {e.tractate} {e.page}
-                    </td>
-                    <td
-                      style={{
-                        padding: '0.4rem 0.5rem',
-                        color: '#a04030',
-                        'font-family': 'monospace',
-                        'font-size': '0.72rem',
-                        'white-space': 'pre-wrap',
-                        'word-break': 'break-word',
-                      }}
-                    >
-                      {e.error}
-                    </td>
-                  </tr>
-                )}
-              </For>
-            </tbody>
-          </table>
+          <div style={{ 'margin-bottom': '0.8rem' }}>
+            <SectionHeading title={t('usage.errors.byReason')} />
+            <RankedBars items={jobReasons()} fmt={(n) => String(n)} labelWidth="16rem" />
+          </div>
+          <DataTable
+            columns={jobCols}
+            rows={d().jobErrors}
+            initialSort={{ key: 'when', dir: 'desc' }}
+            maxRows={10}
+          />
         </Show>
       </section>
 
@@ -3189,73 +3129,21 @@ function ErrorsSection(props: {
           hint={t('usage.lintFailures.hint')}
         />
         <Show when={Object.keys(d().lintFailures.counts).length > 0}>
-          <div
-            style={{
-              display: 'flex',
-              gap: '0.4rem',
-              'flex-wrap': 'wrap',
-              'margin-bottom': '0.5rem',
-            }}
-          >
-            <For each={Object.entries(d().lintFailures.counts).sort((a, b) => b[1] - a[1])}>
-              {([id, n]) => (
-                <span
-                  style={{
-                    'font-size': '0.74rem',
-                    'font-family': 'monospace',
-                    padding: '0.15rem 0.45rem',
-                    background: '#fef3c7',
-                    border: '1px solid #fde68a',
-                    'border-radius': '999px',
-                    color: '#92400e',
-                  }}
-                >
-                  {id} · {n}
-                </span>
-              )}
-            </For>
+          <div style={{ 'margin-bottom': '0.8rem' }}>
+            <SectionHeading title={t('usage.lint.byProducer')} />
+            <RankedBars items={lintCountItems()} fmt={(n) => String(n)} labelWidth="14rem" />
           </div>
         </Show>
         <Show
           when={d().lintFailures.recent.length > 0}
           fallback={<p style={{ color: '#888' }}>{t('usage.none')}</p>}
         >
-          <ul style={{ 'list-style': 'none', padding: 0, margin: 0, 'font-size': '0.8rem' }}>
-            <For each={d().lintFailures.recent}>
-              {(f) => (
-                <li style={{ padding: '0.4rem 0', 'border-bottom': '1px solid #f4f4f4' }}>
-                  <div
-                    style={{
-                      display: 'flex',
-                      gap: '0.6rem',
-                      'flex-wrap': 'wrap',
-                      'margin-bottom': '0.15rem',
-                    }}
-                  >
-                    <span style={{ color: '#999', 'white-space': 'nowrap' }}>{fmtTime(f.at)}</span>
-                    <span style={{ 'font-family': 'monospace', color: '#555' }}>
-                      {f.enrichmentId}
-                    </span>
-                    <span style={{ color: '#666' }}>
-                      {f.tractate} {f.page}
-                      {f.lang === 'he' ? ' · he' : ''}
-                    </span>
-                    <span style={{ color: '#92400e' }}>×{f.attempts}</span>
-                  </div>
-                  <div
-                    style={{
-                      color: '#a16207',
-                      'font-family': 'monospace',
-                      'font-size': '0.74rem',
-                      'white-space': 'pre-wrap',
-                    }}
-                  >
-                    {f.issues.join(' · ')}
-                  </div>
-                </li>
-              )}
-            </For>
-          </ul>
+          <DataTable
+            columns={lintCols}
+            rows={d().lintFailures.recent}
+            initialSort={{ key: 'when', dir: 'desc' }}
+            maxRows={12}
+          />
         </Show>
       </section>
     </Collapsible>

--- a/packages/talmud/src/client/i18n.ts
+++ b/packages/talmud/src/client/i18n.ts
@@ -1115,6 +1115,13 @@ const CATALOG = {
   },
   'usage.latency.byMark': { en: 'Marks', he: 'סימונים' },
   'usage.latency.byMark.hint': { en: 'per mark, across all runs', he: 'לכל סימון, בכל ההרצות' },
+  'usage.table.empty': { en: 'Nothing yet.', he: 'עדיין ריק.' },
+  'usage.table.showMore': { en: 'Show all ({count} more)', he: 'הצג הכול (עוד {count})' },
+  'usage.table.showLess': { en: 'Show less', he: 'הצג פחות' },
+  'usage.errors.byReason': { en: 'By reason', he: 'לפי סיבה' },
+  'usage.lint.byProducer': { en: 'By producer', he: 'לפי מפיק' },
+  'usage.lint.col.issues': { en: 'Issues', he: 'בעיות' },
+  'usage.lint.col.producer': { en: 'Producer', he: 'מפיק' },
   'usage.latency.byEnrichment': { en: 'Enrichments', he: 'העשרות' },
   'usage.latency.byEnrichment.hint': {
     en: 'per enrichment, across all runs',


### PR DESCRIPTION
Follow-up to #566/#568: "more visual representations in general, and a better more ordered table component in general."

## A shared, ordered table component
New `client/DataTable.tsx` — one sortable table behind every usage-page tabular view:
- **Click a header to sort** (asc/desc, indicator arrow); numerics right-align with tabular figures.
- Long lists **collapse behind "show all N"**.
- Inline cell primitives so numbers read at a glance: **`Meter`** (a bar sized by value), **`HitChip`** (cache-hit% on a red→amber→green heat scale), and **`RankedBars`** (a generic ranked horizontal-bar chart). All themed on `--accent`.

## Migrations + new visualizations
- **Latency** (by type / mark / enrichment): inline **p95 meter bars** colored by severity + **cache-hit chips**, sortable — and the always-empty **"Kinds" column is dropped**.
- **Cache efficiency**, **per-producer cost**, **per-model cost**: same DataTable (cost meters, hit chips), sortable + collapsible.
- **Errors**: a **"by reason" bar chart** — 30 near-identical failures collapse into a handful of tallies (Sefaria non-array · OpenRouter 402 · hard timeout · rate-limited) — over a sortable, collapsible table.
- **Lint failures**: a **per-producer bar chart** over a sortable table (was a chip row + freeform list).
- "Slowest producers" now reuses the generic `RankedBars` (the bespoke `LatencyBars` is gone).

## Verification
`pnpm typecheck`, `biome ci .` (exit 0), `pnpm test` (2,739) and `vite build` all green. Rendered the sortable table (p95 meters, hit chips, sort headers), the by-reason chart, and the errors table headless and eyeballed.

Note: the Content-In / Content-Out / Backlog tables still use the old inline `<table>`s — a natural follow-up to migrate onto `DataTable` too.