### PR TITLE
Link GitHub and Tanach from the daf footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This is a pnpm workspace with two corpus apps and a shared engine:
 | Path | Purpose |
 | --- | --- |
 | `packages/talmud` | The Solid.js reader and Hono/Cloudflare Workers API at [talmud.dev](https://talmud.dev) |
-| `packages/tanach` | A sibling Tanach reader built on the same corpus model |
+| `packages/tanach` | The sibling [Tanach reader](https://tanach.dev), built on the same corpus model |
 | `packages/core` | Corpus-agnostic spines, anchors, artifacts, producers, context, caching, and runtime code |
 | `packages/ui` | Shared components and design tokens |
 

--- a/packages/talmud/src/client/DafViewer.tsx
+++ b/packages/talmud/src/client/DafViewer.tsx
@@ -3968,6 +3968,32 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
               >
                 {t('dev.mcpGuide')}
               </a>
+              {' · '}
+              <a
+                href="https://github.com/Shaun-Regenbaum/talmud"
+                target="_blank"
+                rel="noreferrer"
+                style={{
+                  color: 'inherit',
+                  'text-decoration': 'none',
+                  'border-bottom': '1px dotted #bbb',
+                }}
+              >
+                {t('dev.github')}
+              </a>
+              {' · '}
+              <a
+                href="https://tanach.dev"
+                target="_blank"
+                rel="noreferrer"
+                style={{
+                  color: 'inherit',
+                  'text-decoration': 'none',
+                  'border-bottom': '1px dotted #bbb',
+                }}
+              >
+                {t('dev.tanach')}
+              </a>
             </footer>
           </section>
 

--- a/packages/talmud/src/client/i18n.ts
+++ b/packages/talmud/src/client/i18n.ts
@@ -126,6 +126,8 @@ const CATALOG = {
   'dev.alignmentDebug': { en: 'Alignment debug', he: 'ניפוי יישור' },
   'dev.mcpGuide': { en: 'Connect via MCP', he: 'חיבור דרך MCP' },
   'dev.people': { en: 'People', he: 'חכמים' },
+  'dev.github': { en: 'GitHub', he: 'GitHub' },
+  'dev.tanach': { en: 'Tanach', he: 'תנ״ך' },
 
   // — Argument sidebar —
   'argument.title': { en: 'Argument', he: 'סוגיה' },


### PR DESCRIPTION
## Summary

- add external GitHub and Tanach links to the bottom of every daf
- translate the new footer labels in English and Hebrew
- link the Tanach workspace entry in the repository README to tanach.dev

## Why

Readers currently have no direct path from the daf to the public source repository. The same monorepo also contains the sibling Tanach reader, but that relationship is easy to miss.

## Impact

The footer now exposes both destinations without changing the reader hierarchy: Talmud remains primary, while Tanach is presented as a sibling project.

## Validation

- pnpm lint (passes; four pre-existing warnings)
- pnpm typecheck
- pnpm test (2,957 tests)
- pnpm build
- git diff --check