### PR TITLE
Add weekly parsha learning flow

### DIFF
--- a/packages/tanach/src/client/App.tsx
+++ b/packages/tanach/src/client/App.tsx
@@ -19,6 +19,7 @@ import {
 } from 'solid-js';
 import { BOOKS, SECTIONS, type Section } from '../lib/books.ts';
 import { hebrewNumeral } from '../lib/hebrew.ts';
+import type { ParshaStudy, WeeklyParsha } from '../lib/parsha.ts';
 import {
   KIND_GLYPH,
   MIDRASH_MIN,
@@ -30,6 +31,7 @@ import { ChapterLoadProgress } from './ChapterLoadProgress.tsx';
 import { reportLoad, resetChapterLoad } from './chapterLoad.ts';
 import { Inspector } from './Inspector.tsx';
 import { MikraotGedolot } from './MikraotGedolot.tsx';
+import { ParshaDrawer } from './ParshaDrawer.tsx';
 
 interface Verse {
   n: number;
@@ -152,13 +154,6 @@ interface EventSection {
   en: string;
   he: string;
 }
-interface Parsha {
-  name: string;
-  heName: string;
-  ref: string;
-  book: string;
-  chapter: number;
-}
 /** The Hebrew name of a book, for the Hebrew-mode chapter refs. */
 function heBook(name: string): string {
   return BOOKS.find((b) => b.name === name)?.he ?? name;
@@ -174,10 +169,10 @@ function inIsrael(): boolean {
   }
 }
 
-async function fetchParsha(): Promise<Parsha | null> {
+async function fetchParsha(): Promise<WeeklyParsha | null> {
   try {
     const res = await fetch(`/api/parsha?loc=${inIsrael() ? 'israel' : 'diaspora'}`);
-    return res.ok ? ((await res.json()) as Parsha) : null;
+    return res.ok ? ((await res.json()) as WeeklyParsha) : null;
   } catch {
     return null;
   }
@@ -188,7 +183,7 @@ interface SectionNote {
   he: string;
 }
 /** A whole-chapter pill the reader can open from the perek-pills row. */
-type PerekPill = 'overview' | 'geography' | 'tidbit';
+type PerekPill = 'parsha' | 'overview' | 'geography' | 'tidbit';
 interface Overview {
   book: string;
   chapter: number;
@@ -223,11 +218,13 @@ interface PerekTidbit {
 }
 /** The perek-pills, in display order. */
 const PEREK_PILLS: { id: PerekPill; label: string }[] = [
+  { id: 'parsha', label: 'Parsha' },
   { id: 'overview', label: 'Overview' },
   { id: 'geography', label: 'Geography' },
   { id: 'tidbit', label: 'Tidbit' },
 ];
 const PILL_KIND: Record<PerekPill, string> = {
+  parsha: 'Parsha',
   overview: 'Overview',
   geography: 'Geography',
   tidbit: 'Tidbit',
@@ -272,6 +269,11 @@ async function fetchEvents(loc: { book: string; chapter: number }): Promise<Even
 
 export function App(): JSX.Element {
   const [loc, setLoc] = createSignal(readUrl());
+  const [parshaFocus, setParshaFocus] = createSignal<{
+    book: string;
+    chapter: number;
+    verse: number;
+  } | null>(null);
 
   const writeUrl = (l: Loc) => {
     const p = new URLSearchParams({ book: l.book, chapter: String(l.chapter) });
@@ -529,6 +531,7 @@ export function App(): JSX.Element {
     const sel = selected();
     const src = source();
     const pv = new Set(placeVerses());
+    const focus = parshaFocus();
     paragraphs();
     requestAnimationFrame(() => {
       if (!scrollBand) return;
@@ -539,9 +542,29 @@ export function App(): JSX.Element {
         const vn = Number(e.dataset.vn);
         const inNote = sel && vn >= sel.start && vn <= sel.end;
         const inSource = src && vn === src.verse;
-        if (inNote || inSource || pv.has(vn)) e.classList.add('hl');
+        const inParshaFocus =
+          focus &&
+          focus.book === loc().book &&
+          focus.chapter === loc().chapter &&
+          focus.verse === vn;
+        if (inNote || inSource || inParshaFocus || pv.has(vn)) e.classList.add('hl');
       });
     });
+  });
+
+  createEffect(() => {
+    const focus = parshaFocus();
+    const chapter = data();
+    paragraphs();
+    if (!focus || !chapter || focus.book !== chapter.book || focus.chapter !== chapter.chapter)
+      return;
+    requestAnimationFrame(() =>
+      requestAnimationFrame(() =>
+        scrollBand
+          ?.querySelector(`.vtext[data-vn="${focus.verse}"]`)
+          ?.scrollIntoView({ behavior: 'smooth', block: 'center' }),
+      ),
+    );
   });
 
   // Verse-sources drawer: shows ONE source kind at a time (rishonim / gemara /
@@ -630,6 +653,22 @@ export function App(): JSX.Element {
     setInspectOpen(false);
     setPerekPill((cur) => (cur === id ? null : id));
   };
+  const openParshaText = (book: string, chapter: number, verse: number) => {
+    setParshaFocus({ book, chapter, verse });
+    setPerekPill(null);
+    goto(book, chapter);
+  };
+  const openWeeklyParsha = () => {
+    const weekly = parsha();
+    if (!weekly) return;
+    setSource(null);
+    setSelected(null);
+    setInspectOpen(false);
+    const alreadyThere = loc().book === weekly.book && loc().chapter === weekly.chapter;
+    goto(weekly.book, weekly.chapter);
+    if (alreadyThere) setPerekPill('parsha');
+    else queueMicrotask(() => setPerekPill('parsha'));
+  };
   const toggleInspect = () => {
     setSource(null);
     setSelected(null);
@@ -652,6 +691,10 @@ export function App(): JSX.Element {
   const [overview] = createResource(
     () => (perekPill() === 'overview' ? chapterKey() : undefined),
     (k) => fetchPill<Overview>(`/api/overview/${encodeURIComponent(k.book)}/${k.chapter}`),
+  );
+  const [parshaStudy] = createResource(
+    () => (perekPill() === 'parsha' && parsha() ? parsha()?.ref : undefined),
+    () => fetchPill<ParshaStudy>(`/api/parsha-study?loc=${inIsrael() ? 'israel' : 'diaspora'}`),
   );
   const [geography] = createResource(
     () => (perekPill() === 'geography' ? chapterKey() : undefined),
@@ -715,6 +758,11 @@ export function App(): JSX.Element {
     if (overview.loading) return null;
     const o = overview();
     return o && o.book === loc().book && o.chapter === loc().chapter ? o : null;
+  });
+  const currentParshaStudy = createMemo(() => {
+    if (parshaStudy.loading) return null;
+    const study = parshaStudy();
+    return study && study.ref === parsha()?.ref ? study : null;
   });
   // Opening a verse-source drawer closes any open pill / inspector (one panel).
   createEffect(() => {
@@ -804,7 +852,7 @@ export function App(): JSX.Element {
             <button
               type="button"
               class="parsha-btn"
-              onClick={() => goto(p().book, p().chapter)}
+              onClick={openWeeklyParsha}
               title={`This week's parsha — ${p().name} (${p().ref})`}
             >
               {loc().lang === 'he' ? p().heName || p().name : p().name}
@@ -1025,13 +1073,41 @@ export function App(): JSX.Element {
           <Drawer
             dir={loc().lang === 'he' ? 'rtl' : 'ltr'}
             title={
-              loc().lang === 'he'
-                ? `${heBook(loc().book)} ${hebrewNumeral(loc().chapter)}`
-                : `${loc().book} ${loc().chapter}`
+              pill === 'parsha'
+                ? loc().lang === 'he'
+                  ? parsha()?.heName || parsha()?.name || 'פרשה'
+                  : parsha()?.name || 'Parsha'
+                : loc().lang === 'he'
+                  ? `${heBook(loc().book)} ${hebrewNumeral(loc().chapter)}`
+                  : `${loc().book} ${loc().chapter}`
             }
             label={PILL_KIND[pill]}
             onClose={() => setPerekPill(null)}
           >
+            <Show when={pill === 'parsha'}>
+              <Show when={parsha.loading}>
+                <p class="comm-muted">Mapping this week's parsha…</p>
+              </Show>
+              <Show when={!parsha.loading && parsha() === null}>
+                <p class="comm-muted">Couldn't load this week's parsha. Try reopening.</p>
+              </Show>
+              <Show when={!!parsha() && parshaStudy.loading}>
+                <p class="comm-muted">Mapping this week's parsha…</p>
+              </Show>
+              <Show when={currentParshaStudy()}>
+                {(study) => (
+                  <ParshaDrawer
+                    study={study()}
+                    lang={loc().lang}
+                    location={inIsrael() ? 'israel' : 'diaspora'}
+                    onOpenText={openParshaText}
+                  />
+                )}
+              </Show>
+              <Show when={!parshaStudy.loading && parshaStudy() === null}>
+                <p class="comm-muted">{pillError('parsha overview')}</p>
+              </Show>
+            </Show>
             <Show when={pill === 'overview'}>
               <Show when={overview.loading}>
                 <p class="comm-muted">Reading the chapter…</p>

--- a/packages/tanach/src/client/ParshaDrawer.tsx
+++ b/packages/tanach/src/client/ParshaDrawer.tsx
@@ -1,0 +1,251 @@
+import { aiStatus, noteAiResponse, noteAiSuccess } from '@corpus/ui/aiStatus';
+import { Prose } from '@corpus/ui/Prose';
+import { createEffect, createResource, createSignal, For, type JSX, Show } from 'solid-js';
+import type {
+  ParshaFlowSection,
+  ParshaSectionKind,
+  ParshaStudy,
+  ParshaThread,
+} from '../lib/parsha.ts';
+
+export interface ParshaDrawerProps {
+  study: ParshaStudy;
+  lang: 'en' | 'he';
+  location: 'israel' | 'diaspora';
+  onOpenText: (book: string, chapter: number, verse: number) => void;
+}
+
+const KIND_LABEL: Record<ParshaSectionKind, { en: string; he: string }> = {
+  narrative: { en: 'Narrative', he: 'סיפור' },
+  law: { en: 'Halachah', he: 'הלכה' },
+  discourse: { en: 'Discourse', he: 'נאום ורעיון' },
+};
+
+function textFor(lang: 'en' | 'he', en: string, he: string): string {
+  return lang === 'he' ? he || en : en || he;
+}
+
+function sourceUrl(ref: string): string {
+  return `https://www.sefaria.org/${encodeURI(ref.replace(/ /g, '_'))}`;
+}
+
+export function ParshaDrawer(props: ParshaDrawerProps): JSX.Element {
+  const [selected, setSelected] = createSignal(0);
+  const [threadRequest, setThreadRequest] = createSignal<{ index: number } | null>(null);
+  const [copied, setCopied] = createSignal(false);
+  const [thread] = createResource(threadRequest, async ({ index }) => {
+    const response = await fetch(`/api/parsha-thread/${index}?loc=${props.location}`);
+    if (response.ok) {
+      noteAiSuccess();
+      return (await response.json()) as ParshaThread;
+    }
+    noteAiResponse(await response.json().catch(() => null));
+    return null;
+  });
+  let threadPanel: HTMLElement | undefined;
+  createEffect(() => {
+    if (!threadRequest()) return;
+    requestAnimationFrame(() =>
+      threadPanel?.scrollIntoView({ behavior: 'smooth', block: 'start' }),
+    );
+  });
+
+  const choose = (index: number) => {
+    setSelected(index);
+    if (threadRequest()?.index !== index) setThreadRequest(null);
+  };
+
+  const buildThread = (index: number) => {
+    setSelected(index);
+    setThreadRequest({ index });
+  };
+
+  const copyDvar = async () => {
+    const value = thread();
+    if (!value) return;
+    const text = textFor(props.lang, value.dvarEn, value.dvarHe);
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1500);
+  };
+
+  const selectedFlow = (): ParshaFlowSection | undefined => props.study.flow[selected()];
+
+  return (
+    <section class="parsha-study">
+      <p class="parsha-ref">{props.study.ref}</p>
+      <h3 class="perek-title">{textFor(props.lang, props.study.titleEn, props.study.titleHe)}</h3>
+      <Prose en={props.study.overviewEn} he={props.study.overviewHe} lang={props.lang} />
+
+      <section class="parsha-section">
+        <div class="parsha-section-head">
+          <h4>{props.lang === 'he' ? 'הרכב הפרשה' : 'What kind of reading is this?'}</h4>
+          <span>{props.lang === 'he' ? 'מפה משוערת' : 'editorial estimate'}</span>
+        </div>
+        <div class="parsha-composition" role="img" aria-label="Parsha composition">
+          <For each={['narrative', 'law', 'discourse'] as const}>
+            {(kind) => (
+              <span
+                class={`parsha-composition-${kind}`}
+                style={{ width: `${props.study.composition[kind]}%` }}
+                title={`${KIND_LABEL[kind][props.lang]} ${props.study.composition[kind]}%`}
+              />
+            )}
+          </For>
+        </div>
+        <div class="parsha-legend">
+          <For each={['narrative', 'law', 'discourse'] as const}>
+            {(kind) => (
+              <span>
+                <i class={`parsha-dot parsha-dot-${kind}`} />
+                {KIND_LABEL[kind][props.lang]} {props.study.composition[kind]}%
+              </span>
+            )}
+          </For>
+        </div>
+      </section>
+
+      <section class="parsha-section">
+        <div class="parsha-section-head">
+          <h4>{props.lang === 'he' ? 'מהלך הפרשה' : 'The flow of the parsha'}</h4>
+          <span>
+            {props.study.flow.length} {props.lang === 'he' ? 'יחידות' : 'moves'}
+          </span>
+        </div>
+        <ol class="parsha-flow">
+          <For each={props.study.flow}>
+            {(section, index) => (
+              <li>
+                <button
+                  type="button"
+                  class="parsha-flow-card"
+                  classList={{ active: selected() === index() }}
+                  onClick={() => choose(index())}
+                >
+                  <span class={`parsha-flow-node parsha-flow-node-${section.kind}`} />
+                  <span class="parsha-flow-copy">
+                    <span class="parsha-flow-meta">
+                      <b>{section.ref.replace(`${props.study.book} `, '')}</b>
+                      <i>{KIND_LABEL[section.kind][props.lang]}</i>
+                    </span>
+                    <strong>{textFor(props.lang, section.titleEn, section.titleHe)}</strong>
+                    <small>{textFor(props.lang, section.summaryEn, section.summaryHe)}</small>
+                  </span>
+                </button>
+                <Show when={selected() === index()}>
+                  <div class="parsha-flow-actions">
+                    <button
+                      type="button"
+                      onClick={() =>
+                        props.onOpenText(props.study.book, section.startChapter, section.startVerse)
+                      }
+                    >
+                      {props.lang === 'he' ? 'פתח בטקסט' : 'Open in the text'}
+                    </button>
+                    <button type="button" class="primary" onClick={() => buildThread(index())}>
+                      {props.lang === 'he' ? 'בנה דבר תורה' : 'Build a dvar Torah'}
+                    </button>
+                  </div>
+                </Show>
+              </li>
+            )}
+          </For>
+        </ol>
+      </section>
+
+      <section class="parsha-section">
+        <div class="parsha-section-head">
+          <h4>{props.lang === 'he' ? 'ציוני דרך' : 'Landmarks'}</h4>
+          <span>{props.lang === 'he' ? 'מקומות שכדאי להכיר' : 'find them quickly'}</span>
+        </div>
+        <div class="parsha-landmarks">
+          <For each={props.study.landmarks}>
+            {(landmark) => (
+              <button
+                type="button"
+                onClick={() => props.onOpenText(props.study.book, landmark.chapter, landmark.verse)}
+              >
+                <span>{landmark.ref.replace(`${props.study.book} `, '')}</span>
+                {textFor(props.lang, landmark.labelEn, landmark.labelHe)}
+              </button>
+            )}
+          </For>
+        </div>
+      </section>
+
+      <Show when={threadRequest()}>
+        <section class="parsha-thread" ref={(element) => (threadPanel = element)}>
+          <p class="parsha-thread-kicker">
+            {selectedFlow()?.ref} · {props.lang === 'he' ? 'מסלול לימוד' : 'study thread'}
+          </p>
+          <Show when={thread.loading}>
+            <p class="comm-muted">
+              {props.lang === 'he'
+                ? 'מחבר את הפסוקים למקורות ולדבר תורה…'
+                : 'Connecting the passage, sources, and dvar Torah…'}
+            </p>
+          </Show>
+          <Show when={!thread.loading && thread() === null}>
+            <p class="comm-muted">
+              {aiStatus()
+                ? props.lang === 'he'
+                  ? 'יצירת תוכן מושבתת כרגע.'
+                  : 'AI generation is paused right now.'
+                : props.lang === 'he'
+                  ? 'לא הצלחנו לבנות את מסלול הלימוד. נסו שוב.'
+                  : "Couldn't build this study thread. Try again."}
+            </p>
+          </Show>
+          <Show when={thread()}>
+            {(value) => (
+              <>
+                <h4>{textFor(props.lang, value().titleEn, value().titleHe)}</h4>
+                <div class="parsha-thread-block question">
+                  <span>{props.lang === 'he' ? 'השאלה' : 'The question'}</span>
+                  <Prose en={value().questionEn} he={value().questionHe} lang={props.lang} />
+                </div>
+                <div class="parsha-thread-block">
+                  <span>{props.lang === 'he' ? 'העומק' : 'The deeper idea'}</span>
+                  <Prose en={value().insightEn} he={value().insightHe} lang={props.lang} />
+                </div>
+                <Show when={value().sources.length}>
+                  <div class="parsha-thread-sources">
+                    <span>{props.lang === 'he' ? 'מקורות' : 'Sources that sharpen it'}</span>
+                    <For each={value().sources}>
+                      {(source) => (
+                        <a href={sourceUrl(source.ref)} target="_blank" rel="noreferrer">
+                          <b>{textFor(props.lang, source.labelEn, source.labelHe) || source.ref}</b>
+                          <small>
+                            {textFor(props.lang, source.contributionEn, source.contributionHe)}
+                          </small>
+                        </a>
+                      )}
+                    </For>
+                  </div>
+                </Show>
+                <div class="parsha-thread-block dvar">
+                  <span>{props.lang === 'he' ? 'דבר תורה מוכן' : 'Ready-to-share dvar Torah'}</span>
+                  <Prose
+                    en={value().dvarEn}
+                    he={value().dvarHe}
+                    lang={props.lang}
+                    class="parsha-dvar-copy"
+                  />
+                  <button type="button" class="parsha-copy" onClick={copyDvar}>
+                    {copied()
+                      ? props.lang === 'he'
+                        ? 'הועתק'
+                        : 'Copied'
+                      : props.lang === 'he'
+                        ? 'העתק דבר תורה'
+                        : 'Copy dvar Torah'}
+                  </button>
+                </div>
+              </>
+            )}
+          </Show>
+        </section>
+      </Show>
+    </section>
+  );
+}

--- a/packages/tanach/src/client/styles.css
+++ b/packages/tanach/src/client/styles.css
@@ -461,6 +461,331 @@ body {
   font-family: var(--font-hebrew);
 }
 
+/* Whole-parsha drawer: still the same reader panel, with a restrained map
+   vocabulary added inside it (composition strip, anchored flow, landmarks). */
+.parsha-study {
+  padding: 2px 0 24px;
+}
+.parsha-ref {
+  margin: 0 0 7px;
+  font-family: var(--font-ui);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: var(--accent);
+}
+.parsha-section {
+  padding: 18px 0 2px;
+  margin-top: 17px;
+  border-top: 1px solid var(--line);
+}
+.parsha-section-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+  font-family: var(--font-ui);
+}
+.parsha-section-head h4 {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.3;
+  text-transform: uppercase;
+  letter-spacing: 0.055em;
+  color: var(--ink);
+}
+.parsha-section-head span {
+  flex: none;
+  font-size: 10px;
+  color: var(--muted);
+}
+.ui-drawer[dir="rtl"] .parsha-section-head h4 {
+  font-family: var(--font-hebrew);
+  font-size: 14px;
+  text-transform: none;
+  letter-spacing: 0;
+}
+.parsha-composition {
+  display: flex;
+  width: 100%;
+  height: 8px;
+  overflow: hidden;
+  background: var(--surface-sunk);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+}
+.parsha-composition > span {
+  display: block;
+  min-width: 0;
+}
+.parsha-composition-narrative,
+.parsha-dot-narrative,
+.parsha-flow-node-narrative {
+  background: var(--accent);
+}
+.parsha-composition-law,
+.parsha-dot-law,
+.parsha-flow-node-law {
+  background: #3f6d65;
+}
+.parsha-composition-discourse,
+.parsha-dot-discourse,
+.parsha-flow-node-discourse {
+  background: #bd8750;
+}
+.parsha-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 13px;
+  margin-top: 9px;
+  font-family: var(--font-ui);
+  font-size: 10.5px;
+  color: var(--muted);
+}
+.parsha-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+.parsha-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+}
+.parsha-flow {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.parsha-flow li {
+  position: relative;
+  padding: 0 0 10px 18px;
+}
+.parsha-flow li:not(:last-child)::before {
+  content: "";
+  position: absolute;
+  top: 13px;
+  bottom: -2px;
+  left: 5px;
+  width: 1px;
+  background: var(--line);
+}
+.ui-drawer[dir="rtl"] .parsha-flow li {
+  padding: 0 18px 10px 0;
+}
+.ui-drawer[dir="rtl"] .parsha-flow li:not(:last-child)::before {
+  right: 5px;
+  left: auto;
+}
+.parsha-flow-card {
+  position: relative;
+  display: flex;
+  width: 100%;
+  gap: 11px;
+  padding: 8px 9px 9px;
+  text-align: left;
+  color: var(--ink);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  cursor: pointer;
+}
+.ui-drawer[dir="rtl"] .parsha-flow-card {
+  text-align: right;
+}
+.parsha-flow-card:hover,
+.parsha-flow-card.active {
+  background: var(--surface-sunk);
+  border-color: var(--line);
+}
+.parsha-flow-node {
+  position: absolute;
+  top: 13px;
+  left: -16px;
+  width: 8px;
+  height: 8px;
+  border: 2px solid var(--surface);
+  border-radius: 50%;
+  box-sizing: content-box;
+}
+.ui-drawer[dir="rtl"] .parsha-flow-node {
+  right: -16px;
+  left: auto;
+}
+.parsha-flow-copy {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  flex-direction: column;
+}
+.parsha-flow-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 2px;
+  font-family: var(--font-ui);
+  font-size: 9.5px;
+  color: var(--accent);
+}
+.parsha-flow-meta b {
+  font-weight: 600;
+}
+.parsha-flow-meta i {
+  font-style: normal;
+  color: var(--muted);
+}
+.parsha-flow-copy strong {
+  font-family: var(--font-serif);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.35;
+}
+.parsha-flow-copy small {
+  margin-top: 3px;
+  font-family: var(--font-serif);
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--muted);
+}
+.ui-drawer[dir="rtl"] .parsha-flow-copy strong,
+.ui-drawer[dir="rtl"] .parsha-flow-copy small {
+  font-family: var(--font-hebrew);
+}
+.parsha-flow-actions {
+  display: flex;
+  gap: 7px;
+  padding: 3px 8px 7px;
+}
+.parsha-flow-actions button,
+.parsha-copy {
+  padding: 5px 9px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--ink);
+  font-family: var(--font-ui);
+  font-size: 10.5px;
+  cursor: pointer;
+}
+.parsha-flow-actions button.primary {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: #fff;
+}
+.parsha-landmarks {
+  display: grid;
+  gap: 6px;
+}
+.parsha-landmarks button {
+  display: flex;
+  align-items: baseline;
+  gap: 9px;
+  width: 100%;
+  padding: 7px 9px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--ink);
+  text-align: left;
+  font-family: var(--font-serif);
+  font-size: 12.5px;
+  cursor: pointer;
+}
+.ui-drawer[dir="rtl"] .parsha-landmarks button {
+  text-align: right;
+  font-family: var(--font-hebrew);
+}
+.parsha-landmarks button:hover {
+  border-color: var(--accent);
+}
+.parsha-landmarks button span {
+  flex: none;
+  font-family: var(--font-ui);
+  font-size: 9.5px;
+  color: var(--accent);
+}
+.parsha-thread {
+  margin-top: 22px;
+  padding: 17px 15px 18px;
+  background: var(--surface-sunk);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+}
+.parsha-thread-kicker {
+  margin: 0 0 8px;
+  color: var(--accent);
+  font-family: var(--font-ui);
+  font-size: 9.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.parsha-thread > h4 {
+  margin: 0 0 14px;
+  font-size: 18px;
+  line-height: 1.3;
+}
+.parsha-thread-block {
+  padding: 12px 0;
+  border-top: 1px solid var(--line);
+}
+.parsha-thread-block > span,
+.parsha-thread-sources > span {
+  display: block;
+  margin-bottom: 5px;
+  font-family: var(--font-ui);
+  font-size: 9.5px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.055em;
+  color: var(--accent);
+}
+.parsha-thread-block .ui-prose {
+  margin: 0;
+  font-size: 13.5px;
+}
+.parsha-thread-block.question .ui-prose {
+  font-weight: 600;
+}
+.parsha-thread-sources {
+  padding: 12px 0;
+  border-top: 1px solid var(--line);
+}
+.parsha-thread-sources a {
+  display: block;
+  padding: 7px 0;
+  color: var(--ink);
+  text-decoration: none;
+}
+.parsha-thread-sources a + a {
+  border-top: 1px dotted var(--line);
+}
+.parsha-thread-sources a:hover b {
+  color: var(--accent);
+}
+.parsha-thread-sources b,
+.parsha-thread-sources small {
+  display: block;
+}
+.parsha-thread-sources b {
+  font-family: var(--font-ui);
+  font-size: 11px;
+}
+.parsha-thread-sources small {
+  margin-top: 2px;
+  color: var(--muted);
+  font-size: 11.5px;
+  line-height: 1.4;
+}
+.parsha-dvar-copy {
+  white-space: pre-line;
+}
+.parsha-copy {
+  margin-top: 10px;
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
 /* tidbit footer: a small flavor tag + how-editorial-the-reading note */
 .tidbit-meta {
   display: flex;

--- a/packages/tanach/src/lib/parsha.ts
+++ b/packages/tanach/src/lib/parsha.ts
@@ -1,0 +1,147 @@
+export type ParshaSectionKind = 'narrative' | 'law' | 'discourse';
+
+export interface ParshaRange {
+  book: string;
+  startChapter: number;
+  startVerse: number;
+  endChapter: number;
+  endVerse: number;
+}
+
+export interface WeeklyParsha extends ParshaRange {
+  name: string;
+  heName: string;
+  ref: string;
+  chapter: number;
+}
+
+export interface ParshaFlowSection {
+  startChapter: number;
+  startVerse: number;
+  endChapter: number;
+  endVerse: number;
+  ref: string;
+  kind: ParshaSectionKind;
+  titleEn: string;
+  titleHe: string;
+  summaryEn: string;
+  summaryHe: string;
+}
+
+export interface ParshaLandmark {
+  chapter: number;
+  verse: number;
+  ref: string;
+  labelEn: string;
+  labelHe: string;
+}
+
+export interface ParshaStudy {
+  name: string;
+  heName: string;
+  ref: string;
+  book: string;
+  startChapter: number;
+  titleEn: string;
+  titleHe: string;
+  overviewEn: string;
+  overviewHe: string;
+  composition: Record<ParshaSectionKind, number>;
+  flow: ParshaFlowSection[];
+  landmarks: ParshaLandmark[];
+}
+
+export interface ParshaThreadSource {
+  ref: string;
+  labelEn: string;
+  labelHe: string;
+  contributionEn: string;
+  contributionHe: string;
+}
+
+export interface ParshaThread {
+  titleEn: string;
+  titleHe: string;
+  questionEn: string;
+  questionHe: string;
+  insightEn: string;
+  insightHe: string;
+  dvarEn: string;
+  dvarHe: string;
+  sources: ParshaThreadSource[];
+}
+
+const PARSHA_REF_RE = /^(.+?)\s+(\d+):(\d+)\s*[-–—]\s*(?:(\d+):)?(\d+)$/;
+
+/** Parse the single-book range shape Sefaria uses for the weekly Torah portion. */
+export function parseParshaRef(ref: string): ParshaRange | null {
+  const match = ref.trim().match(PARSHA_REF_RE);
+  if (!match) return null;
+  const startChapter = Number(match[2]);
+  const startVerse = Number(match[3]);
+  const endChapter = match[4] ? Number(match[4]) : startChapter;
+  const endVerse = Number(match[5]);
+  if (
+    !match[1] ||
+    !Number.isInteger(startChapter) ||
+    !Number.isInteger(startVerse) ||
+    !Number.isInteger(endChapter) ||
+    !Number.isInteger(endVerse) ||
+    startChapter < 1 ||
+    startVerse < 1 ||
+    endChapter < startChapter ||
+    endVerse < 1
+  ) {
+    return null;
+  }
+  return { book: match[1], startChapter, startVerse, endChapter, endVerse };
+}
+
+export function formatParshaRange(
+  book: string,
+  range: Pick<ParshaRange, 'startChapter' | 'startVerse' | 'endChapter' | 'endVerse'>,
+): string {
+  const start = `${range.startChapter}:${range.startVerse}`;
+  const end =
+    range.endChapter === range.startChapter
+      ? String(range.endVerse)
+      : `${range.endChapter}:${range.endVerse}`;
+  return `${book} ${start}–${end}`;
+}
+
+export function pointInParsha(
+  range: ParshaRange,
+  point: { chapter: number; verse: number },
+): boolean {
+  if (point.chapter < range.startChapter || point.chapter > range.endChapter) return false;
+  if (point.chapter === range.startChapter && point.verse < range.startVerse) return false;
+  if (point.chapter === range.endChapter && point.verse > range.endVerse) return false;
+  return point.verse >= 1;
+}
+
+export function sectionInParsha(
+  range: ParshaRange,
+  section: Pick<ParshaRange, 'startChapter' | 'startVerse' | 'endChapter' | 'endVerse'>,
+): boolean {
+  const start = { chapter: section.startChapter, verse: section.startVerse };
+  const end = { chapter: section.endChapter, verse: section.endVerse };
+  if (!pointInParsha(range, start) || !pointInParsha(range, end)) return false;
+  return (
+    section.endChapter > section.startChapter ||
+    (section.endChapter === section.startChapter && section.endVerse >= section.startVerse)
+  );
+}
+
+/** Normalize an editorial percentage estimate so the three visible bars total 100. */
+export function normalizeParshaComposition(value: unknown): Record<ParshaSectionKind, number> {
+  const input = (value ?? {}) as Partial<Record<ParshaSectionKind, unknown>>;
+  const raw = (['narrative', 'law', 'discourse'] as const).map((key) => {
+    const n = Number(input[key]);
+    return Number.isFinite(n) && n > 0 ? n : 0;
+  });
+  const total = raw.reduce((sum, n) => sum + n, 0);
+  if (!total) return { narrative: 0, law: 0, discourse: 100 };
+  const rounded = raw.map((n) => Math.round((n / total) * 100));
+  rounded[2] += 100 - rounded.reduce((sum, n) => sum + n, 0);
+  return { narrative: rounded[0], law: rounded[1], discourse: rounded[2] };
+}

--- a/packages/tanach/src/worker/index.ts
+++ b/packages/tanach/src/worker/index.ts
@@ -19,8 +19,17 @@ import type { StoredArtifact } from '@corpus/core/store/envelope';
 import type { Context } from 'hono';
 import { Hono } from 'hono';
 import { isBook } from '../lib/books.ts';
+import {
+  formatParshaRange,
+  normalizeParshaComposition,
+  type ParshaFlowSection,
+  type ParshaLandmark,
+  type ParshaThread,
+  type WeeklyParsha,
+} from '../lib/parsha.ts';
 import { lookupPlace } from './gazetteer.ts';
 import { chapterRuns, chapterRunTree } from './inspect.ts';
+import { currentParsha } from './parsha-calendar.ts';
 import type { EventSection } from './producers/events.ts';
 import { translateHebrew } from './producers/translate.ts';
 import type { TanachEnv, TanachRunCtx } from './run-ports.ts';
@@ -336,43 +345,131 @@ app.get('/api/tidbit/:book/:chapter', async (c) => {
 // Returns the parsha name + the book/chapter it starts at, so the reader can
 // jump straight there. Cached ~6h (it only changes on Shabbat).
 app.get('/api/parsha', async (c) => {
-  // The weekly reading desyncs between Israel and the Diaspora for a few weeks a
-  // year (when a yom tov falls on Shabbat outside Israel). Sefaria's calendar
-  // takes diaspora=1 (default) / diaspora=0 (Israel).
   const israel = c.req.query('loc') === 'israel';
-  const cacheKey = `parsha:current:${israel ? 'il' : 'gola'}`;
-  const cached = await c.env.CACHE.get(cacheKey);
-  if (cached) return c.json(JSON.parse(cached));
-
-  let cal: {
-    calendar_items?: Array<{
-      title?: { en?: string };
-      displayValue?: { en?: string; he?: string };
-      ref?: string;
-    }>;
-  };
+  let parsha: WeeklyParsha | null;
   try {
-    const r = await fetch(`https://www.sefaria.org/api/calendars?diaspora=${israel ? 0 : 1}`);
-    cal = (await r.json()) as typeof cal;
+    parsha = await currentParsha(c.env.CACHE, israel, (promise) =>
+      c.executionCtx.waitUntil(promise),
+    );
   } catch (e) {
     return c.json({ error: `Calendar fetch failed: ${(e as Error).message}` }, 502);
   }
-  const parsha = (cal.calendar_items ?? []).find((it) => it?.title?.en === 'Parashat Hashavua');
-  const m = parsha?.ref?.match(/^(.+?)\s+(\d+):/);
-  if (!parsha || !m || !isBook(m[1])) {
-    return c.json({ error: `No addressable parsha (ref: ${parsha?.ref ?? 'none'})` }, 502);
+  if (!parsha) return c.json({ error: 'No addressable parsha' }, 502);
+  return c.json(parsha);
+});
+
+// Whole-parsha orientation: one cached smart note for the current weekly
+// reading, spanning chapter boundaries. The route injects the calendar
+// identity and deterministic display refs around the producer's semantic map.
+app.get('/api/parsha-study', async (c) => {
+  const israel = c.req.query('loc') === 'israel';
+  let parsha: WeeklyParsha | null;
+  try {
+    parsha = await currentParsha(c.env.CACHE, israel, (promise) =>
+      c.executionCtx.waitUntil(promise),
+    );
+  } catch (e) {
+    return c.json({ error: `Calendar fetch failed: ${(e as Error).message}` }, 502);
   }
-  const payload = {
-    name: parsha.displayValue?.en ?? parsha.title?.en ?? 'Parsha',
-    heName: parsha.displayValue?.he ?? '',
-    ref: parsha.ref,
-    book: m[1],
-    chapter: Number(m[2]),
+  if (!parsha) return c.json({ error: 'No addressable parsha' }, 502);
+
+  const rc: TanachRunCtx = { env: c.env, ctx: c.executionCtx, ref: parsha.ref };
+  let artifact: StoredArtifact;
+  try {
+    artifact = await runTanachEnrichment(rc, 'parsha-overview', parsha.book, parsha.ref, {
+      id: parsha.ref,
+      parshaName: parsha.name,
+      parshaRef: parsha.ref,
+    });
+  } catch (e) {
+    return runErrorResponse(c, e);
+  }
+  const parsed = (artifact.parsed ?? {}) as {
+    titleEn?: string;
+    titleHe?: string;
+    overviewEn?: string;
+    overviewHe?: string;
+    composition?: unknown;
+    flow?: Omit<ParshaFlowSection, 'ref'>[];
+    landmarks?: Omit<ParshaLandmark, 'ref'>[];
   };
-  c.executionCtx.waitUntil(
-    c.env.CACHE.put(cacheKey, JSON.stringify(payload), { expirationTtl: 6 * 3600 }),
-  );
-  return c.json(payload);
+  const flow = (parsed.flow ?? []).map((section) => ({
+    ...section,
+    ref: formatParshaRange(parsha.book, section),
+  }));
+  const landmarks = (parsed.landmarks ?? []).map((landmark) => ({
+    ...landmark,
+    ref: `${parsha.book} ${landmark.chapter}:${landmark.verse}`,
+  }));
+  c.header('Cache-Control', 'public, max-age=600, stale-while-revalidate=86400');
+  return c.json({
+    name: parsha.name,
+    heName: parsha.heName,
+    ref: parsha.ref,
+    book: parsha.book,
+    startChapter: parsha.startChapter,
+    titleEn: String(parsed.titleEn ?? '').trim(),
+    titleHe: String(parsed.titleHe ?? '').trim(),
+    overviewEn: String(parsed.overviewEn ?? '').trim(),
+    overviewHe: String(parsed.overviewHe ?? '').trim(),
+    composition: normalizeParshaComposition(parsed.composition),
+    flow,
+    landmarks,
+  });
+});
+
+// One selected flow unit -> grounded insight + source packet + dvar Torah.
+// The section index resolves through the cached overview, so clients cannot
+// float an unanchored passage into the thread producer.
+app.get('/api/parsha-thread/:section', async (c) => {
+  const rawSection = c.req.param('section');
+  if (!/^\d+$/.test(rawSection)) return c.json({ error: 'Bad parsha section' }, 400);
+  const sectionIndex = Number(rawSection);
+  const israel = c.req.query('loc') === 'israel';
+  let parsha: WeeklyParsha | null;
+  try {
+    parsha = await currentParsha(c.env.CACHE, israel, (promise) =>
+      c.executionCtx.waitUntil(promise),
+    );
+  } catch (e) {
+    return c.json({ error: `Calendar fetch failed: ${(e as Error).message}` }, 502);
+  }
+  if (!parsha) return c.json({ error: 'No addressable parsha' }, 502);
+
+  const rc: TanachRunCtx = { env: c.env, ctx: c.executionCtx, ref: parsha.ref };
+  let overview: StoredArtifact;
+  try {
+    overview = await runTanachEnrichment(rc, 'parsha-overview', parsha.book, parsha.ref, {
+      id: parsha.ref,
+      parshaName: parsha.name,
+      parshaRef: parsha.ref,
+    });
+  } catch (e) {
+    return runErrorResponse(c, e);
+  }
+  const sections =
+    (overview.parsed as { flow?: Omit<ParshaFlowSection, 'ref'>[] } | null)?.flow ?? [];
+  const section = sections[sectionIndex];
+  if (!section) return c.json({ error: 'Parsha section not found' }, 404);
+
+  let thread: StoredArtifact;
+  try {
+    thread = await runTanachEnrichment(rc, 'parsha-thread', parsha.book, parsha.ref, {
+      id: `${parsha.ref}#${sectionIndex}`,
+      parshaName: parsha.name,
+      parshaRef: parsha.ref,
+      ...section,
+    });
+  } catch (e) {
+    return runErrorResponse(c, e);
+  }
+  c.header('Cache-Control', 'public, max-age=600, stale-while-revalidate=86400');
+  return c.json({
+    parsha: parsha.name,
+    parshaRef: parsha.ref,
+    section: { ...section, ref: formatParshaRange(parsha.book, section) },
+    ...((thread.parsed ?? {}) as ParshaThread),
+  });
 });
 
 // Section note (second producer, composes on events): a short bilingual p'shat

--- a/packages/tanach/src/worker/parsha-calendar.ts
+++ b/packages/tanach/src/worker/parsha-calendar.ts
@@ -1,0 +1,62 @@
+import { isBook } from '../lib/books.ts';
+import { parseParshaRef, type WeeklyParsha } from '../lib/parsha.ts';
+
+interface CalendarItem {
+  title?: { en?: string };
+  displayValue?: { en?: string; he?: string };
+  ref?: string;
+}
+
+function normalizeParsha(value: unknown): WeeklyParsha | null {
+  if (!value || typeof value !== 'object') return null;
+  const raw = value as Partial<WeeklyParsha>;
+  if (typeof raw.ref !== 'string') return null;
+  const range = parseParshaRef(raw.ref);
+  if (!range || !isBook(range.book)) return null;
+  return {
+    name: String(raw.name ?? 'Parsha'),
+    heName: String(raw.heName ?? ''),
+    ref: raw.ref,
+    ...range,
+    chapter: range.startChapter,
+  };
+}
+
+/** Current weekly portion, location-aware and cached for six hours. */
+export async function currentParsha(
+  cache: KVNamespace,
+  israel: boolean,
+  waitUntil?: (promise: Promise<unknown>) => void,
+): Promise<WeeklyParsha | null> {
+  const cacheKey = `parsha:current:${israel ? 'il' : 'gola'}`;
+  const cached = await cache.get(cacheKey);
+  if (cached) {
+    try {
+      const parsed = normalizeParsha(JSON.parse(cached));
+      if (parsed) return parsed;
+    } catch {
+      // A malformed calendar cache is a miss; the live calendar repairs it.
+    }
+  }
+
+  const response = await fetch(`https://www.sefaria.org/api/calendars?diaspora=${israel ? 0 : 1}`);
+  if (!response.ok) throw new Error(`Calendar fetch failed: HTTP ${response.status}`);
+  const calendar = (await response.json()) as { calendar_items?: CalendarItem[] };
+  const item = (calendar.calendar_items ?? []).find(
+    (candidate) => candidate?.title?.en === 'Parashat Hashavua',
+  );
+  const range = item?.ref ? parseParshaRef(item.ref) : null;
+  if (!item?.ref || !range || !isBook(range.book)) return null;
+
+  const payload: WeeklyParsha = {
+    name: item.displayValue?.en ?? item.title?.en ?? 'Parsha',
+    heName: item.displayValue?.he ?? '',
+    ref: item.ref,
+    ...range,
+    chapter: range.startChapter,
+  };
+  const write = cache.put(cacheKey, JSON.stringify(payload), { expirationTtl: 6 * 3600 });
+  if (waitUntil) waitUntil(write);
+  else await write;
+  return payload;
+}

--- a/packages/tanach/src/worker/producers/defs.ts
+++ b/packages/tanach/src/worker/producers/defs.ts
@@ -4,7 +4,7 @@
  * that a queue-less, registry-less app's producers fit the SAME shape the
  * talmud registry projects into.
  *
- * Five producers:
+ * Producer recipes for chapter, verse, and weekly-parsha study surfaces:
  *   events            — mark; discovers verse anchors on the tanach spine
  *   note              — enrichment; inherits its anchor from an events section
  *   synthesis         — enrichment; per-verse (commentary overview)
@@ -36,6 +36,14 @@ import {
 } from './midrash.ts';
 import { NOTE_SCHEMA, NOTE_SYSTEM, NOTE_USER_TEMPLATE } from './note.ts';
 import { OVERVIEW_SCHEMA, OVERVIEW_SYSTEM, OVERVIEW_USER_TEMPLATE } from './overview.ts';
+import {
+  PARSHA_OVERVIEW_SCHEMA,
+  PARSHA_OVERVIEW_SYSTEM,
+  PARSHA_OVERVIEW_USER_TEMPLATE,
+  PARSHA_THREAD_SCHEMA,
+  PARSHA_THREAD_SYSTEM,
+  PARSHA_THREAD_USER_TEMPLATE,
+} from './parsha.ts';
 import { SYNTHESIS_SCHEMA, SYNTHESIS_SYSTEM, SYNTHESIS_USER_TEMPLATE } from './synthesis.ts';
 import { TIDBIT_SCHEMA, TIDBIT_SYSTEM, TIDBIT_USER_TEMPLATE } from './tidbit.ts';
 import { TRANSLATE_SCHEMA, TRANSLATE_SYSTEM, TRANSLATE_USER_TEMPLATE } from './translate.ts';
@@ -44,6 +52,8 @@ export type TanachProducerId =
   | 'events'
   | 'note'
   | 'overview'
+  | 'parsha-overview'
+  | 'parsha-thread'
   | 'geography'
   | 'tidbit'
   | 'synthesis'
@@ -96,6 +106,26 @@ const overviewExtractor: TanachLLMExtractor = {
   max_tokens: 1400,
   temperature: 0.3,
   tag: 'tanach:overview',
+};
+
+const parshaOverviewExtractor: TanachLLMExtractor = {
+  kind: 'llm',
+  system_prompt: PARSHA_OVERVIEW_SYSTEM,
+  user_prompt_template: PARSHA_OVERVIEW_USER_TEMPLATE,
+  output_schema: PARSHA_OVERVIEW_SCHEMA,
+  max_tokens: 5200,
+  temperature: 0.25,
+  tag: 'tanach:parsha-overview',
+};
+
+const parshaThreadExtractor: TanachLLMExtractor = {
+  kind: 'llm',
+  system_prompt: PARSHA_THREAD_SYSTEM,
+  user_prompt_template: PARSHA_THREAD_USER_TEMPLATE,
+  output_schema: PARSHA_THREAD_SCHEMA,
+  max_tokens: 4200,
+  temperature: 0.35,
+  tag: 'tanach:parsha-thread',
 };
 
 const geographyExtractor: TanachLLMExtractor = {
@@ -200,6 +230,36 @@ export const TANACH_PRODUCERS: Record<TanachProducerId, Producer> = {
     scope: 'local',
     key_shape: 'enrich', // nominal — template owns overview:v1:{book}:{chapter}
     cacheVersion: '1',
+    source: 'code',
+  },
+  'parsha-overview': {
+    id: 'parsha-overview',
+    label: 'Parsha overview',
+    description: 'A bilingual whole-parsha synopsis, composition map, flow, and landmarks',
+    kind: 'enrichment',
+    inputs: [{ source: 'parsha-verses' }],
+    recipe: { extractor: parshaOverviewExtractor },
+    anchoring: { behavior: 'aggregates', precision: 'division', spine: 'tanach' },
+    cardinality: 'one',
+    scope: 'local',
+    key_shape: 'enrich',
+    cacheVersion: '1',
+    passes: ['parsha-overview-shape'],
+    source: 'code',
+  },
+  'parsha-thread': {
+    id: 'parsha-thread',
+    label: 'Parsha study thread',
+    description: 'A grounded deeper insight and ready-to-share dvar Torah for one parsha unit',
+    kind: 'enrichment',
+    inputs: [{ source: 'parsha-thread-material' }],
+    recipe: { extractor: parshaThreadExtractor },
+    anchoring: { behavior: 'inherits', precision: 'segment', spine: 'tanach' },
+    cardinality: 'per-input',
+    scope: 'local',
+    key_shape: 'enrich',
+    cacheVersion: '1',
+    passes: ['parsha-thread-sources'],
     source: 'code',
   },
   geography: {
@@ -349,7 +409,15 @@ export function markRunDefOf(id: 'events'): TanachMarkDef {
 }
 
 export function enrichRunDefOf(
-  id: 'note' | 'overview' | 'geography' | 'tidbit' | 'synthesis' | 'midrash-synthesis',
+  id:
+    | 'note'
+    | 'overview'
+    | 'parsha-overview'
+    | 'parsha-thread'
+    | 'geography'
+    | 'tidbit'
+    | 'synthesis'
+    | 'midrash-synthesis',
 ): TanachEnrichmentDef {
   const p = TANACH_PRODUCERS[id];
   const ext = p.recipe.extractor as TanachLLMExtractor;
@@ -368,5 +436,6 @@ export function enrichRunDefOf(
     max_tokens: ext.max_tokens,
     temperature: ext.temperature,
     tag: ext.tag,
+    passes: p.passes,
   };
 }

--- a/packages/tanach/src/worker/producers/parsha.ts
+++ b/packages/tanach/src/worker/producers/parsha.ts
@@ -1,0 +1,186 @@
+/** Recipes for the weekly parsha overview and its on-demand study thread. */
+
+export const PARSHA_OVERVIEW_SYSTEM = `You are building the orientation layer for a weekly Torah-portion learning tool. The reader should understand the WHOLE parsha before opening a commentary or preparing a dvar Torah.
+
+Return a bilingual map of the supplied parsha.
+
+OVERVIEW
+- Give one short descriptive title and a concrete 4-6 sentence synopsis of the whole portion.
+- Explain its movement: what changes from the beginning to the end, rather than listing topics.
+- Stay on p'shat. Do not preach, survey commentators, or invent background.
+
+COMPOSITION
+- Estimate the share of the reading that is narrative, law, and discourse.
+- "discourse" includes exhortation, covenant speech, theology, blessing, rebuke, and extended instruction that is not a discrete law.
+- Return whole-number percentages totaling 100. This is an editorial map, not a scholarly statistic.
+
+FLOW
+- Divide the whole portion into 5-9 consecutive learning units.
+- Give exact numeric start/end chapter and verse anchors inside the supplied range.
+- Every unit gets one kind: narrative, law, or discourse; a short title; and a one-sentence summary showing how it advances the parsha.
+- Cover the portion in order without wandering outside its range. Prefer meaningful units over chapter boundaries.
+
+LANDMARKS
+- Name 3-6 scenes, commands, speeches, or verses a learner is especially likely to recognize or want to find again.
+- Anchor each to one exact verse in the supplied range.
+
+BILINGUAL
+- Give natural English and natural Hebrew for every title, synopsis, summary, and landmark label.
+- Hebrew must be Hebrew script, not transliteration.
+
+No markdown. No citations or source names. Use only the supplied Torah text.`;
+
+export const PARSHA_OVERVIEW_USER_TEMPLATE =
+  'Weekly portion: {{parsha_name}}\nRange: {{parsha_ref}}\n\n{{verses_text}}';
+
+const RANGE_PROPERTIES = {
+  startChapter: { type: 'integer', minimum: 1 },
+  startVerse: { type: 'integer', minimum: 1 },
+  endChapter: { type: 'integer', minimum: 1 },
+  endVerse: { type: 'integer', minimum: 1 },
+} as const;
+
+export const PARSHA_OVERVIEW_SCHEMA = {
+  name: 'parsha_overview',
+  strict: true,
+  schema: {
+    type: 'object',
+    additionalProperties: false,
+    required: [
+      'titleEn',
+      'titleHe',
+      'overviewEn',
+      'overviewHe',
+      'composition',
+      'flow',
+      'landmarks',
+    ],
+    properties: {
+      titleEn: { type: 'string' },
+      titleHe: { type: 'string' },
+      overviewEn: { type: 'string' },
+      overviewHe: { type: 'string' },
+      composition: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['narrative', 'law', 'discourse'],
+        properties: {
+          narrative: { type: 'integer', minimum: 0, maximum: 100 },
+          law: { type: 'integer', minimum: 0, maximum: 100 },
+          discourse: { type: 'integer', minimum: 0, maximum: 100 },
+        },
+      },
+      flow: {
+        type: 'array',
+        minItems: 5,
+        maxItems: 9,
+        items: {
+          type: 'object',
+          additionalProperties: false,
+          required: [
+            'startChapter',
+            'startVerse',
+            'endChapter',
+            'endVerse',
+            'kind',
+            'titleEn',
+            'titleHe',
+            'summaryEn',
+            'summaryHe',
+          ],
+          properties: {
+            ...RANGE_PROPERTIES,
+            kind: { type: 'string', enum: ['narrative', 'law', 'discourse'] },
+            titleEn: { type: 'string' },
+            titleHe: { type: 'string' },
+            summaryEn: { type: 'string' },
+            summaryHe: { type: 'string' },
+          },
+        },
+      },
+      landmarks: {
+        type: 'array',
+        minItems: 3,
+        maxItems: 6,
+        items: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['chapter', 'verse', 'labelEn', 'labelHe'],
+          properties: {
+            chapter: { type: 'integer', minimum: 1 },
+            verse: { type: 'integer', minimum: 1 },
+            labelEn: { type: 'string' },
+            labelHe: { type: 'string' },
+          },
+        },
+      },
+    },
+  },
+};
+
+export const PARSHA_THREAD_SYSTEM = `You are helping a Torah learner turn one anchored section of the weekly parsha into a grounded dvar Torah.
+
+Build a clear study thread in four layers:
+1. One genuine guiding question raised by the Torah passage.
+2. A concise deeper insight that answers it from the words and structure of the passage.
+3. Up to four supplied traditional sources that materially sharpen the idea. Use ONLY sources present in the source packet, copy each source ref exactly, and omit sources that do not help. If the packet is empty, return an empty sources array and keep the idea text-based.
+4. A ready-to-share dvar Torah: 4-6 short paragraphs, specific enough to teach, with a clear opening question, textual turn, and practical landing. Do not flatten the source into a slogan.
+
+Ground every claim. Never invent a quotation, commentator, midrash, wordplay, or source. Do not call something a direct quote unless the supplied words support it. Avoid generic sermon language and phrases such as "this teaches us" or "we see that." No markdown.
+
+Give natural English and natural Hebrew for every field. Hebrew must be Hebrew script, not transliteration.`;
+
+export const PARSHA_THREAD_USER_TEMPLATE = `Parsha: {{parsha_name}} ({{parsha_ref}})
+Selected section: {{section_title}} ({{section_ref}})
+
+TORAH PASSAGE
+{{verses_text}}
+
+AVAILABLE SOURCE PACKET
+{{sources_text}}`;
+
+export const PARSHA_THREAD_SCHEMA = {
+  name: 'parsha_thread',
+  strict: true,
+  schema: {
+    type: 'object',
+    additionalProperties: false,
+    required: [
+      'titleEn',
+      'titleHe',
+      'questionEn',
+      'questionHe',
+      'insightEn',
+      'insightHe',
+      'dvarEn',
+      'dvarHe',
+      'sources',
+    ],
+    properties: {
+      titleEn: { type: 'string' },
+      titleHe: { type: 'string' },
+      questionEn: { type: 'string' },
+      questionHe: { type: 'string' },
+      insightEn: { type: 'string' },
+      insightHe: { type: 'string' },
+      dvarEn: { type: 'string' },
+      dvarHe: { type: 'string' },
+      sources: {
+        type: 'array',
+        maxItems: 4,
+        items: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['ref', 'labelEn', 'labelHe', 'contributionEn', 'contributionHe'],
+          properties: {
+            ref: { type: 'string' },
+            labelEn: { type: 'string' },
+            labelHe: { type: 'string' },
+            contributionEn: { type: 'string' },
+            contributionHe: { type: 'string' },
+          },
+        },
+      },
+    },
+  },
+};

--- a/packages/tanach/src/worker/run-ports.ts
+++ b/packages/tanach/src/worker/run-ports.ts
@@ -50,6 +50,15 @@ import type { StoredArtifact } from '@corpus/core/store/envelope';
 import type { ArtifactAddress, KeyTemplate, ProducerKeyInfo } from '@corpus/core/store/key-schemes';
 import { templateKeyScheme } from '@corpus/core/store/key-schemes';
 import type { UsageEntry } from '@corpus/core/telemetry/types';
+import {
+  formatParshaRange,
+  normalizeParshaComposition,
+  type ParshaRange,
+  type ParshaSectionKind,
+  parseParshaRef,
+  pointInParsha,
+  sectionInParsha,
+} from '../lib/parsha.ts';
 import type { TanachEnrichmentDef, TanachMarkDef } from './producers/defs.ts';
 import { enrichRunDefOf, markRunDefOf } from './producers/defs.ts';
 import type { EventSection } from './producers/events.ts';
@@ -105,6 +114,8 @@ const KEY_TEMPLATES: Record<string, KeyTemplate> = {
   // Chapter-scoped: the key ignores the instance (there's one overview per
   // chapter), so enrichmentAddress('overview', …) carries no verse/range.
   overview: { key: (a: TanachAddress) => `overview:v1:${a.unit?.work}:${a.unit?.unit}` },
+  'parsha-overview': { key: (a: TanachAddress) => `parsha-overview:v1:${a.instanceId}` },
+  'parsha-thread': { key: (a: TanachAddress) => `parsha-thread:v1:${a.instanceId}` },
   // Chapter-scoped like overview (one geography per chapter; instance ignored).
   // v2: the output now carries per-place verse numbers (for click-to-highlight).
   geography: { key: (a: TanachAddress) => `geography:v2:${a.unit?.work}:${a.unit?.unit}` },
@@ -154,11 +165,27 @@ export function enrichmentAddress(
     const [start, end] = instanceId.split('-');
     return { unit, instanceId, start, end };
   }
+  // Parsha pieces key on their explicit ref/range instance rather than chapter.
+  if (id === 'parsha-overview' || id === 'parsha-thread') {
+    return { unit, instanceId };
+  }
   // Chapter-scoped (overview / geography / tidbit): key uses only {work}:{unit}.
   if (id === 'overview' || id === 'geography' || id === 'tidbit') {
     return { unit, instanceId };
   }
   return { unit, instanceId, verse: instanceId };
+}
+
+/** Guard an index-keyed parsha thread against a regenerated overview moving
+ *  that index to a different anchored passage. */
+export function enrichmentSectionRange(id: string, markInput: unknown): string | null {
+  if (id !== 'parsha-thread' || !markInput || typeof markInput !== 'object') return null;
+  const input = markInput as Record<string, unknown>;
+  const parts = [input.startChapter, input.startVerse, input.endChapter, input.endVerse].map(
+    Number,
+  );
+  if (!parts.every((part) => Number.isInteger(part) && part >= 1)) return null;
+  return `${parts[0]}:${parts[1]}-${parts[2]}:${parts[3]}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -249,6 +276,163 @@ const chapterVersesResolver: SourceResolver<TanachRunCtx> = async ({
   out.vars.max_verse = verses.length;
   out.vars.verses_text = versesText;
   recordSource(out, 'chapter-verses', versesText);
+};
+
+interface NumberedVerse {
+  chapter: number;
+  verse: number;
+  text: string;
+}
+
+function plainText(value: string): string {
+  return value
+    .replace(/<[^>]+>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+async function versesInRange(range: ParshaRange): Promise<NumberedVerse[]> {
+  const chapters = await Promise.all(
+    Array.from({ length: range.endChapter - range.startChapter + 1 }, (_, index) => {
+      const chapter = range.startChapter + index;
+      return fetchChapterText(range.book, String(chapter)).then((text) => ({ chapter, text }));
+    }),
+  );
+  const verses: NumberedVerse[] = [];
+  for (const { chapter, text } of chapters) {
+    const en = asVerses(text.text);
+    const he = asVerses(text.he);
+    const first = chapter === range.startChapter ? range.startVerse : 1;
+    const last = chapter === range.endChapter ? range.endVerse : Math.max(en.length, he.length);
+    for (let verse = first; verse <= last; verse++) {
+      const body = plainText(en[verse - 1] || he[verse - 1] || '');
+      if (body) verses.push({ chapter, verse, text: body });
+    }
+  }
+  return verses;
+}
+
+const parshaVersesResolver: SourceResolver<TanachRunCtx> = async ({ out, markInput }) => {
+  const input = markInput as { parshaRef?: string; parshaName?: string };
+  const range = input.parshaRef ? parseParshaRef(input.parshaRef) : null;
+  if (!range) throw new TanachSourceError(404, 'Unresolvable parsha range');
+  const verses = await versesInRange(range);
+  if (!verses.length) throw new TanachSourceError(404, 'No parsha text found');
+  const versesText = verses.map((v) => `${v.chapter}:${v.verse}. ${v.text}`).join('\n');
+  out.vars.parsha_name = input.parshaName ?? '';
+  out.vars.parsha_ref = input.parshaRef ?? '';
+  out.vars.verses_text = versesText;
+  out.vars.chapter_lengths = JSON.stringify(
+    Object.fromEntries(
+      [...new Set(verses.map((verse) => verse.chapter))].map((chapter) => [
+        chapter,
+        Math.max(
+          ...verses.filter((verse) => verse.chapter === chapter).map((verse) => verse.verse),
+        ),
+      ]),
+    ),
+  );
+  recordSource(out, 'parsha-verses', versesText);
+};
+
+interface ThreadSource {
+  ref: string;
+  label: string;
+  text: string;
+}
+
+const parshaThreadResolver: SourceResolver<TanachRunCtx> = async ({ out, markInput }) => {
+  const input = markInput as {
+    parshaName?: string;
+    parshaRef?: string;
+    titleEn?: string;
+    startChapter?: number;
+    startVerse?: number;
+    endChapter?: number;
+    endVerse?: number;
+  };
+  const parsha = input.parshaRef ? parseParshaRef(input.parshaRef) : null;
+  const section = {
+    startChapter: Number(input.startChapter),
+    startVerse: Number(input.startVerse),
+    endChapter: Number(input.endChapter),
+    endVerse: Number(input.endVerse),
+  };
+  if (!parsha || !sectionInParsha(parsha, section)) {
+    throw new TanachSourceError(404, 'Unresolvable parsha section');
+  }
+  const sectionRange: ParshaRange = { book: parsha.book, ...section };
+  const sectionRef = formatParshaRange(parsha.book, sectionRange);
+  const sefariaSectionRef = sectionRef.replace('–', '-');
+  const verses = await versesInRange(sectionRange);
+  if (!verses.length) throw new TanachSourceError(404, 'No section text found');
+  const versesText = verses.map((v) => `${v.chapter}:${v.verse}. ${v.text}`).join('\n');
+
+  const commentaryAnchors = [
+    verses[0],
+    verses[Math.floor(verses.length / 2)],
+    verses.at(-1),
+  ].filter(
+    (verse, index, all): verse is NumberedVerse =>
+      !!verse &&
+      all.findIndex(
+        (candidate) => candidate?.chapter === verse.chapter && candidate.verse === verse.verse,
+      ) === index,
+  );
+  const [commentaryGroups, talmud, midrash] = await Promise.all([
+    Promise.all(
+      commentaryAnchors.map(async (anchor) => ({
+        anchor,
+        commentaries: await fetchVerseCommentaries(
+          parsha.book,
+          String(anchor.chapter),
+          String(anchor.verse),
+        ).catch(() => []),
+      })),
+    ),
+    fetchPassages(sefariaSectionRef, 'Talmud', 4, true).catch(() => ({ count: 0, passages: [] })),
+    fetchPassages(sefariaSectionRef, 'Midrash', 4).catch(() => ({ count: 0, passages: [] })),
+  ]);
+  const sources: ThreadSource[] = [
+    ...commentaryGroups.flatMap(({ anchor, commentaries }) =>
+      commentaries.slice(0, 2).map((commentary) => ({
+        ref: `${commentary.en} on ${parsha.book} ${anchor.chapter}:${anchor.verse}`,
+        label: `${commentary.en} · ${anchor.chapter}:${anchor.verse}`,
+        text: plainText(
+          (commentary.enText.length ? commentary.enText : commentary.he).join(' '),
+        ).slice(0, 900),
+      })),
+    ),
+    ...talmud.passages.map((passage) => ({
+      ref: passage.ref,
+      label: passage.ref,
+      text: plainText(passage.en || passage.he).slice(0, 900),
+    })),
+    ...midrash.passages.map((passage) => ({
+      ref: passage.ref,
+      label: passage.ref,
+      text: plainText(passage.en || passage.he).slice(0, 900),
+    })),
+  ].filter((source) => source.ref && source.text);
+  const unique = [...new Map(sources.map((source) => [source.ref, source])).values()].slice(0, 10);
+  const sourcesText = unique.length
+    ? unique
+        .map(
+          (source, index) =>
+            `[S${index + 1}] REF: ${source.ref}\nSOURCE: ${source.label}\n${source.text}`,
+        )
+        .join('\n\n')
+    : 'No linked traditional sources were available. Build the idea from the Torah passage alone.';
+
+  out.vars.parsha_name = input.parshaName ?? '';
+  out.vars.parsha_ref = input.parshaRef ?? '';
+  out.vars.section_title = input.titleEn ?? '';
+  out.vars.section_ref = sectionRef;
+  out.vars.verses_text = versesText;
+  out.vars.sources_text = sourcesText;
+  out.vars.source_refs = JSON.stringify(unique.map((source) => source.ref));
+  recordSource(out, 'parsha-thread-material', `${versesText}\n\n${sourcesText}`);
 };
 
 /** The [start..end] verse slice + header for the note prompt. */
@@ -360,6 +544,8 @@ const midrashPassagesResolver: SourceResolver<TanachRunCtx> = async ({
 const RESOLVE_PORTS: ResolveInputsPorts<TanachRunCtx, TanachEnrichmentDef, TanachMarkDef> = {
   sources: {
     'chapter-verses': chapterVersesResolver,
+    'parsha-verses': parshaVersesResolver,
+    'parsha-thread-material': parshaThreadResolver,
     'section-verses': sectionVersesResolver,
     'verse-text': verseTextResolver,
     commentaries: commentariesResolver,
@@ -372,6 +558,8 @@ const RESOLVE_PORTS: ResolveInputsPorts<TanachRunCtx, TanachEnrichmentDef, Tanac
   loadEnrichmentDef: async (_rc, id) =>
     id === 'note' ||
     id === 'overview' ||
+    id === 'parsha-overview' ||
+    id === 'parsha-thread' ||
     id === 'geography' ||
     id === 'tidbit' ||
     id === 'synthesis' ||
@@ -432,8 +620,7 @@ const RUN_PORTS: RunProducerPorts<TanachRunCtx, TanachEnrichmentDef, TanachMarkD
         temperature: def.temperature,
       },
     }),
-  // No title-keyed section enrichments in tanach — keys are verse/range-exact.
-  sectionRange: () => null,
+  sectionRange: (def, markInput) => enrichmentSectionRange(def.id, markInput),
   resolveInputs: (rc, dependencies, book, chapter, markInput, bypassCache, parentChain) =>
     resolveInputs(
       RESOLVE_PORTS,
@@ -480,9 +667,122 @@ const RUN_PORTS: RunProducerPorts<TanachRunCtx, TanachEnrichmentDef, TanachMarkD
       tag: def.tag,
     });
   },
-  // No check layer in tanach (no def declares passes, so core never calls
-  // these — kept honest as no-ops rather than stubs that pretend to check).
-  runChecks: async (_rc, a) => ({ parsed: a.parsed, issues: [] }),
+  runChecks: async (_rc, a) => {
+    if (a.def.id === 'parsha-overview') {
+      const range = parseParshaRef(String(a.inputs.vars.parsha_ref ?? ''));
+      const parsed = (a.parsed ?? {}) as Record<string, unknown>;
+      if (!range) {
+        return { parsed, issues: [{ severity: 'hard', message: 'Invalid parsha range' }] };
+      }
+      let chapterLengths: Record<string, number> = {};
+      try {
+        chapterLengths = JSON.parse(String(a.inputs.vars.chapter_lengths ?? '{}')) as Record<
+          string,
+          number
+        >;
+      } catch {
+        // Missing internal source metadata rejects all generated anchors below.
+      }
+      const verseExists = (chapter: number, verse: number) => {
+        const lastVerse = Number(chapterLengths[String(chapter)] ?? 0);
+        return Number.isInteger(verse) && verse >= 1 && verse <= lastVerse;
+      };
+      const flow = (Array.isArray(parsed.flow) ? parsed.flow : [])
+        .filter((item): item is Record<string, unknown> => !!item && typeof item === 'object')
+        .map((item) => ({
+          startChapter: Number(item.startChapter),
+          startVerse: Number(item.startVerse),
+          endChapter: Number(item.endChapter),
+          endVerse: Number(item.endVerse),
+          kind: String(item.kind) as ParshaSectionKind,
+          titleEn: String(item.titleEn ?? '').trim(),
+          titleHe: String(item.titleHe ?? '').trim(),
+          summaryEn: String(item.summaryEn ?? '').trim(),
+          summaryHe: String(item.summaryHe ?? '').trim(),
+        }))
+        .filter(
+          (item) =>
+            ['narrative', 'law', 'discourse'].includes(item.kind) &&
+            item.titleEn &&
+            verseExists(item.startChapter, item.startVerse) &&
+            verseExists(item.endChapter, item.endVerse) &&
+            sectionInParsha(range, item),
+        )
+        .sort(
+          (left, right) =>
+            left.startChapter - right.startChapter || left.startVerse - right.startVerse,
+        )
+        .slice(0, 9);
+      const landmarks = (Array.isArray(parsed.landmarks) ? parsed.landmarks : [])
+        .filter((item): item is Record<string, unknown> => !!item && typeof item === 'object')
+        .map((item) => ({
+          chapter: Number(item.chapter),
+          verse: Number(item.verse),
+          labelEn: String(item.labelEn ?? '').trim(),
+          labelHe: String(item.labelHe ?? '').trim(),
+        }))
+        .filter(
+          (item) =>
+            item.labelEn && pointInParsha(range, item) && verseExists(item.chapter, item.verse),
+        )
+        .slice(0, 6);
+      const normalized = {
+        ...parsed,
+        titleEn: String(parsed.titleEn ?? '').trim(),
+        titleHe: String(parsed.titleHe ?? '').trim(),
+        overviewEn: String(parsed.overviewEn ?? '').trim(),
+        overviewHe: String(parsed.overviewHe ?? '').trim(),
+        composition: normalizeParshaComposition(parsed.composition),
+        flow,
+        landmarks,
+      };
+      const issues =
+        flow.length >= 3
+          ? []
+          : [{ severity: 'hard', message: 'Parsha flow has fewer than three anchored units' }];
+      return { parsed: normalized, issues };
+    }
+    if (a.def.id === 'parsha-thread') {
+      const parsed = (a.parsed ?? {}) as Record<string, unknown>;
+      let allowed = new Set<string>();
+      try {
+        allowed = new Set(JSON.parse(String(a.inputs.vars.source_refs ?? '[]')) as string[]);
+      } catch {
+        // Bad internal source metadata means no citations survive.
+      }
+      const sources = (Array.isArray(parsed.sources) ? parsed.sources : [])
+        .filter(
+          (source): source is Record<string, unknown> => !!source && typeof source === 'object',
+        )
+        .map((source) => ({
+          ref: String(source.ref ?? '').trim(),
+          labelEn: String(source.labelEn ?? '').trim(),
+          labelHe: String(source.labelHe ?? '').trim(),
+          contributionEn: String(source.contributionEn ?? '').trim(),
+          contributionHe: String(source.contributionHe ?? '').trim(),
+        }))
+        .filter((source) => allowed.has(source.ref))
+        .slice(0, 4);
+      const normalized = {
+        ...parsed,
+        titleEn: String(parsed.titleEn ?? '').trim(),
+        titleHe: String(parsed.titleHe ?? '').trim(),
+        questionEn: String(parsed.questionEn ?? '').trim(),
+        questionHe: String(parsed.questionHe ?? '').trim(),
+        insightEn: String(parsed.insightEn ?? '').trim(),
+        insightHe: String(parsed.insightHe ?? '').trim(),
+        dvarEn: String(parsed.dvarEn ?? '').trim(),
+        dvarHe: String(parsed.dvarHe ?? '').trim(),
+        sources,
+      };
+      const issues =
+        normalized.dvarEn || normalized.dvarHe
+          ? []
+          : [{ severity: 'hard', message: 'Parsha thread has no dvar Torah' }];
+      return { parsed: normalized, issues };
+    }
+    return { parsed: a.parsed, issues: [] };
+  },
   lintGate: async () => true,
   costStamp: (model, usage, lang, cacheVersion) => {
     const u = usage as LLMUsage | null | undefined;
@@ -569,12 +869,31 @@ const RUN_PORTS: RunProducerPorts<TanachRunCtx, TanachEnrichmentDef, TanachMarkD
     // gate their emptiness upstream (source resolvers raise 404 when there's
     // nothing to synthesize).
     enrichmentPostParse: (_rc, a) => {
-      // overview + tidbit share the title/en/he shape; reject an empty-but-valid
+      // Overview-like producers reject an empty-but-valid
       // generation so it isn't pinned (truncated JSON parses to blank fields).
-      if ((a.def.id !== 'overview' && a.def.id !== 'tidbit') || a.parse_error || !a.parsed) return;
-      const p = a.parsed as { titleEn?: string; en?: string; he?: string };
+      if (
+        !['overview', 'tidbit', 'parsha-overview', 'parsha-thread'].includes(a.def.id) ||
+        a.parse_error ||
+        !a.parsed
+      )
+        return;
+      const p = a.parsed as {
+        titleEn?: string;
+        en?: string;
+        he?: string;
+        overviewEn?: string;
+        overviewHe?: string;
+        dvarEn?: string;
+        dvarHe?: string;
+      };
       const empty =
-        !String(p.titleEn ?? '').trim() && !String(p.en ?? '').trim() && !String(p.he ?? '').trim();
+        !String(p.titleEn ?? '').trim() &&
+        !String(p.en ?? '').trim() &&
+        !String(p.he ?? '').trim() &&
+        !String(p.overviewEn ?? '').trim() &&
+        !String(p.overviewHe ?? '').trim() &&
+        !String(p.dvarEn ?? '').trim() &&
+        !String(p.dvarHe ?? '').trim();
       if (empty) throw new Error(`${a.def.id}: empty generation (not caching)`);
     },
   },
@@ -598,7 +917,15 @@ export async function runTanachEvents(
 
 export async function runTanachEnrichment(
   rc: TanachRunCtx,
-  id: 'note' | 'overview' | 'geography' | 'tidbit' | 'synthesis' | 'midrash-synthesis',
+  id:
+    | 'note'
+    | 'overview'
+    | 'parsha-overview'
+    | 'parsha-thread'
+    | 'geography'
+    | 'tidbit'
+    | 'synthesis'
+    | 'midrash-synthesis',
   book: string,
   chapter: string,
   /** The instance the enrichment is FOR. Its `id` field is the legacy key

--- a/packages/tanach/src/worker/warm-cron.ts
+++ b/packages/tanach/src/worker/warm-cron.ts
@@ -19,7 +19,8 @@
  * Bump CURSOR_KEY to force a re-warm (e.g. a producer version bump).
  */
 
-import { isBook } from '../lib/books.ts';
+import type { WeeklyParsha } from '../lib/parsha.ts';
+import { currentParsha } from './parsha-calendar.ts';
 import {
   runTanachEnrichment,
   runTanachEvents,
@@ -28,9 +29,8 @@ import {
 } from './run-ports.ts';
 import { computeSourcesIndex, readSourcesIndex } from './sources-index.ts';
 
-// v4: tidbit prompt bumped to v2 — reset the done-set so the cron re-warms the
-// parsha's tidbits (regenerated under the new recipe; everything else cache-hits).
-const CURSOR_KEY = 'tanach-warm-cursor:v4';
+// v5: warm the whole-parsha overview before the chapter-level reader pieces.
+const CURSOR_KEY = 'tanach-warm-cursor:v5';
 /** Chapter-level enrichments that power the reader's pills + section labels. */
 const CHAPTER_PRODUCERS = ['overview', 'geography', 'tidbit', 'events'] as const;
 /** Entries warmed per tick — small so one invocation stays well within the
@@ -38,12 +38,14 @@ const CHAPTER_PRODUCERS = ['overview', 'geography', 'tidbit', 'events'] as const
 const BATCH = 8;
 
 type WarmEntry =
+  | { kind: 'parsha'; producer: 'parsha-overview' }
   | { kind: 'chapter'; producer: (typeof CHAPTER_PRODUCERS)[number]; chapter: number }
   | { kind: 'srcindex'; chapter: number }
   | { kind: 'verse'; producer: 'synthesis' | 'midrash-synthesis'; chapter: number; verse: number };
 
 /** Stable id for the completed-set cursor. */
 function entryId(e: WarmEntry): string {
+  if (e.kind === 'parsha') return `p:${e.producer}`;
   if (e.kind === 'chapter') return `c:${e.chapter}:${e.producer}`;
   if (e.kind === 'srcindex') return `i:${e.chapter}`;
   return `v:${e.chapter}:${e.producer}:${e.verse}`;
@@ -54,35 +56,6 @@ interface WarmCursor {
   ref: string;
   /** Entry ids already warmed (cache-respecting, so this only grows). */
   done: string[];
-}
-
-interface ParshaRange {
-  book: string;
-  startCh: number;
-  endCh: number;
-  ref: string;
-}
-
-/** This week's parsha as a chapter range, from Sefaria's calendar (diaspora).
- *  The ref looks like "Numbers 19:1-25:9" (a double parsha) or "Genesis 1:1-6:8";
- *  we take the book + the start..end chapters. null when unresolvable. */
-async function currentParsha(): Promise<ParshaRange | null> {
-  let cal: {
-    calendar_items?: Array<{ title?: { en?: string }; ref?: string }>;
-  };
-  try {
-    const r = await fetch('https://www.sefaria.org/api/calendars?diaspora=1');
-    cal = (await r.json()) as typeof cal;
-  } catch {
-    return null;
-  }
-  const p = (cal.calendar_items ?? []).find((it) => it?.title?.en === 'Parashat Hashavua');
-  const m = p?.ref?.match(/^(.+?)\s+(\d+):\d+(?:\s*-\s*(\d+):\d+)?/);
-  if (!p?.ref || !m || !isBook(m[1])) return null;
-  const startCh = Number(m[2]);
-  const endCh = m[3] ? Number(m[3]) : startCh;
-  if (!Number.isFinite(startCh) || !Number.isFinite(endCh) || endCh < startCh) return null;
-  return { book: m[1], startCh, endCh, ref: p.ref };
 }
 
 async function readCursor(cache: KVNamespace): Promise<WarmCursor> {
@@ -99,11 +72,11 @@ async function readCursor(cache: KVNamespace): Promise<WarmCursor> {
  *  then the sources indexes, then the per-verse deep content gated by whichever
  *  indexes are already cached (an uncached chapter contributes a `srcindex`
  *  entry instead; its verses join the list once that index warms). */
-async function buildWorkList(cache: KVNamespace, parsha: ParshaRange): Promise<WarmEntry[]> {
-  const pills: WarmEntry[] = [];
+async function buildWorkList(cache: KVNamespace, parsha: WeeklyParsha): Promise<WarmEntry[]> {
+  const pills: WarmEntry[] = [{ kind: 'parsha', producer: 'parsha-overview' }];
   const indexes: WarmEntry[] = [];
   const verses: WarmEntry[] = [];
-  for (let ch = parsha.startCh; ch <= parsha.endCh; ch++) {
+  for (let ch = parsha.startChapter; ch <= parsha.endChapter; ch++) {
     for (const producer of CHAPTER_PRODUCERS)
       pills.push({ kind: 'chapter', producer, chapter: ch });
     const idx = await readSourcesIndex(cache, parsha.book, String(ch));
@@ -124,22 +97,32 @@ async function buildWorkList(cache: KVNamespace, parsha: ParshaRange): Promise<W
 async function warmEntry(
   env: TanachEnv,
   ctx: ExecutionContext,
-  book: string,
+  parsha: WeeklyParsha,
   e: WarmEntry,
 ): Promise<void> {
   try {
+    if (e.kind === 'parsha') {
+      const rc: TanachRunCtx = { env, ctx, ref: parsha.ref };
+      await runTanachEnrichment(rc, e.producer, parsha.book, parsha.ref, {
+        id: parsha.ref,
+        parshaName: parsha.name,
+        parshaRef: parsha.ref,
+      });
+      return;
+    }
     if (e.kind === 'srcindex') {
-      await computeSourcesIndex(env.CACHE, book, String(e.chapter));
+      await computeSourcesIndex(env.CACHE, parsha.book, String(e.chapter));
       return;
     }
     if (e.kind === 'chapter') {
-      const rc: TanachRunCtx = { env, ctx, ref: `${book} ${e.chapter}` };
-      if (e.producer === 'events') await runTanachEvents(rc, book, String(e.chapter));
-      else await runTanachEnrichment(rc, e.producer, book, String(e.chapter), { id: 'perek' });
+      const rc: TanachRunCtx = { env, ctx, ref: `${parsha.book} ${e.chapter}` };
+      if (e.producer === 'events') await runTanachEvents(rc, parsha.book, String(e.chapter));
+      else
+        await runTanachEnrichment(rc, e.producer, parsha.book, String(e.chapter), { id: 'perek' });
       return;
     }
-    const rc: TanachRunCtx = { env, ctx, ref: `${book} ${e.chapter}:${e.verse}` };
-    await runTanachEnrichment(rc, e.producer, book, String(e.chapter), {
+    const rc: TanachRunCtx = { env, ctx, ref: `${parsha.book} ${e.chapter}:${e.verse}` };
+    await runTanachEnrichment(rc, e.producer, parsha.book, String(e.chapter), {
       id: String(e.verse),
       verse: String(e.verse),
     });
@@ -150,7 +133,7 @@ async function warmEntry(
 
 export async function runTanachWarm(env: TanachEnv, ctx: ExecutionContext): Promise<void> {
   if (!env.CACHE) return;
-  const parsha = await currentParsha();
+  const parsha = await currentParsha(env.CACHE, false).catch(() => null);
   if (!parsha) return;
 
   const entries = await buildWorkList(env.CACHE, parsha);
@@ -163,7 +146,7 @@ export async function runTanachWarm(env: TanachEnv, ctx: ExecutionContext): Prom
     if (warmed >= BATCH) break;
     const id = entryId(e);
     if (done.has(id)) continue;
-    await warmEntry(env, ctx, parsha.book, e);
+    await warmEntry(env, ctx, parsha, e);
     done.add(id);
     warmed++;
   }

--- a/packages/tanach/tests/parsha.test.ts
+++ b/packages/tanach/tests/parsha.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatParshaRange,
+  normalizeParshaComposition,
+  parseParshaRef,
+  pointInParsha,
+  sectionInParsha,
+} from '../src/lib/parsha';
+
+describe('weekly parsha references', () => {
+  it('parses same-chapter and cross-chapter Sefaria ranges', () => {
+    expect(parseParshaRef('Leviticus 6:1-8:36')).toEqual({
+      book: 'Leviticus',
+      startChapter: 6,
+      startVerse: 1,
+      endChapter: 8,
+      endVerse: 36,
+    });
+    expect(parseParshaRef('Deuteronomy 29:9-30:20')).toEqual({
+      book: 'Deuteronomy',
+      startChapter: 29,
+      startVerse: 9,
+      endChapter: 30,
+      endVerse: 20,
+    });
+    expect(parseParshaRef('Numbers 8:1-26')).toEqual({
+      book: 'Numbers',
+      startChapter: 8,
+      startVerse: 1,
+      endChapter: 8,
+      endVerse: 26,
+    });
+  });
+
+  it('formats and bounds anchored flow sections', () => {
+    const parsha = parseParshaRef('Deuteronomy 7:12-11:25');
+    expect(parsha).not.toBeNull();
+    if (!parsha) return;
+    expect(formatParshaRange(parsha.book, parsha)).toBe('Deuteronomy 7:12–11:25');
+    expect(pointInParsha(parsha, { chapter: 10, verse: 12 })).toBe(true);
+    expect(pointInParsha(parsha, { chapter: 7, verse: 11 })).toBe(false);
+    expect(
+      sectionInParsha(parsha, {
+        startChapter: 10,
+        startVerse: 12,
+        endChapter: 10,
+        endVerse: 22,
+      }),
+    ).toBe(true);
+  });
+
+  it('normalizes editorial composition estimates to 100 percent', () => {
+    expect(normalizeParshaComposition({ narrative: 1, law: 1, discourse: 2 })).toEqual({
+      narrative: 25,
+      law: 25,
+      discourse: 50,
+    });
+    expect(normalizeParshaComposition({})).toEqual({ narrative: 0, law: 0, discourse: 100 });
+  });
+});

--- a/packages/tanach/tests/producer-defs.test.ts
+++ b/packages/tanach/tests/producer-defs.test.ts
@@ -22,14 +22,16 @@ describe('tanach spine registry', () => {
   });
 });
 
-describe('the seven producers as core Producer objects', () => {
-  it('declares all eight with their model shapes', () => {
+describe('the ten producers as core Producer objects', () => {
+  it('declares all ten with their model shapes', () => {
     expect(Object.keys(TANACH_PRODUCERS).sort()).toEqual([
       'events',
       'geography',
       'midrash-synthesis',
       'note',
       'overview',
+      'parsha-overview',
+      'parsha-thread',
       'synthesis',
       'tidbit',
       'translate',
@@ -71,6 +73,18 @@ describe('the seven producers as core Producer objects', () => {
     expect(overview.scope).toBe('local');
     expect(overview.cacheVersion).toBe('1'); // overview:v1:*
 
+    expect(TANACH_PRODUCERS['parsha-overview'].anchoring).toEqual({
+      behavior: 'aggregates',
+      precision: 'division',
+      spine: 'tanach',
+    });
+    expect(TANACH_PRODUCERS['parsha-overview'].inputs).toEqual([{ source: 'parsha-verses' }]);
+    expect(TANACH_PRODUCERS['parsha-thread'].anchoring).toEqual({
+      behavior: 'inherits',
+      precision: 'segment',
+      spine: 'tanach',
+    });
+
     const tidbit = TANACH_PRODUCERS.tidbit;
     expect(tidbit.kind).toBe('enrichment');
     expect(tidbit.anchoring).toEqual({
@@ -91,6 +105,12 @@ describe('the seven producers as core Producer objects', () => {
       events: { max_tokens: 900, temperature: 0.2, tag: 'tanach:events' },
       note: { max_tokens: 700, temperature: 0.3, tag: 'tanach:note' },
       overview: { max_tokens: 1400, temperature: 0.3, tag: 'tanach:overview' },
+      'parsha-overview': {
+        max_tokens: 5200,
+        temperature: 0.25,
+        tag: 'tanach:parsha-overview',
+      },
+      'parsha-thread': { max_tokens: 4200, temperature: 0.35, tag: 'tanach:parsha-thread' },
       geography: { max_tokens: 900, temperature: 0.2, tag: 'tanach:geography' },
       tidbit: { max_tokens: 1800, temperature: 0.45, tag: 'tanach:tidbit' },
       synthesis: { max_tokens: 800, temperature: 0.3, tag: 'tanach:synthesis' },
@@ -132,6 +152,9 @@ describe('the seven producers as core Producer objects', () => {
     const overview = enrichRunDefOf('overview');
     expect(overview.dependencies).toEqual(['chapter-verses']);
     expect(overview.system_prompt.length).toBeGreaterThan(50);
+
+    expect(enrichRunDefOf('parsha-overview').dependencies).toEqual(['parsha-verses']);
+    expect(enrichRunDefOf('parsha-thread').dependencies).toEqual(['parsha-thread-material']);
 
     const geography = enrichRunDefOf('geography');
     expect(geography.dependencies).toEqual(['chapter-verses']);

--- a/packages/tanach/tests/producer-keys.test.ts
+++ b/packages/tanach/tests/producer-keys.test.ts
@@ -17,7 +17,11 @@ import { instanceIdOf } from '@corpus/core/cache/keys';
 import type { ProducerKeyInfo } from '@corpus/core/store/key-schemes';
 import { describe, expect, it } from 'vitest';
 import { enrichRunDefOf, markRunDefOf } from '../src/worker/producers/defs';
-import { enrichmentAddress, TANACH_KEY_SCHEME } from '../src/worker/run-ports';
+import {
+  enrichmentAddress,
+  enrichmentSectionRange,
+  TANACH_KEY_SCHEME,
+} from '../src/worker/run-ports';
 
 function info(
   def: { id: string; cache_version: string },
@@ -64,6 +68,34 @@ describe('key byte-parity with the legacy literals', () => {
     expect(
       TANACH_KEY_SCHEME.key(def, enrichmentAddress('midrash-synthesis', '2', 'Exodus', '3')),
     ).toBe('midrash-synth:v1:Exodus:3:2');
+  });
+
+  it('parsha pieces — keyed by the weekly range and selected flow index', async () => {
+    const overviewDef = info(enrichRunDefOf('parsha-overview'), 'enrich');
+    const overviewId = await instanceIdOf({ id: 'Deuteronomy 7:12-11:25' });
+    expect(
+      TANACH_KEY_SCHEME.key(
+        overviewDef,
+        enrichmentAddress('parsha-overview', overviewId, 'Deuteronomy', '7'),
+      ),
+    ).toBe('parsha-overview:v1:deuteronomy_7_12-11_25');
+
+    const threadDef = info(enrichRunDefOf('parsha-thread'), 'enrich');
+    const threadId = await instanceIdOf({ id: 'Deuteronomy 7:12-11:25#4' });
+    expect(
+      TANACH_KEY_SCHEME.key(
+        threadDef,
+        enrichmentAddress('parsha-thread', threadId, 'Deuteronomy', '7'),
+      ),
+    ).toBe('parsha-thread:v1:deuteronomy_7_12-11_25_4');
+    expect(
+      enrichmentSectionRange('parsha-thread', {
+        startChapter: 10,
+        startVerse: 12,
+        endChapter: 10,
+        endVerse: 22,
+      }),
+    ).toBe('10:12-10:22');
   });
 
   it('previousKey is null (no SWR decrement in the literal templates)', () => {


### PR DESCRIPTION
## Summary\n\n- add a weekly Parsha pill and reader-native overview drawer\n- map the portion into anchored narrative, halachah, and discourse units\n- add landmark jumps plus source-grounded study threads and ready-to-share divrei Torah\n- warm and cache the whole-parsha overview with range and source validation\n\n## Verification\n\n- pnpm lint\n- pnpm typecheck\n- pnpm test\n- pnpm --filter tanach build