### PR TITLE
Simplify Tanach reader pills

### DIFF
--- a/packages/tanach/src/client/App.tsx
+++ b/packages/tanach/src/client/App.tsx
@@ -5,7 +5,6 @@ import { Drawer } from '@corpus/ui/Drawer';
 import { fitBbox, GeoMap } from '@corpus/ui/GeoMap';
 import { LangToggle } from '@corpus/ui/LangToggle';
 import { Pill, PillRow } from '@corpus/ui/Pill';
-import { Prose } from '@corpus/ui/Prose';
 import {
   createEffect,
   createMemo,
@@ -182,16 +181,8 @@ interface SectionNote {
   en: string;
   he: string;
 }
-/** A whole-chapter pill the reader can open from the perek-pills row. */
-type PerekPill = 'parsha' | 'overview' | 'geography' | 'tidbit';
-interface Overview {
-  book: string;
-  chapter: number;
-  titleEn: string;
-  titleHe: string;
-  en: string;
-  he: string;
-}
+/** A reader-level pill opened from the row above the text. */
+type PerekPill = 'parsha' | 'geography';
 interface GeoPlace {
   en: string;
   he: string;
@@ -205,29 +196,14 @@ interface PerekGeography {
   chapter: number;
   places: GeoPlace[];
 }
-interface PerekTidbit {
-  book: string;
-  chapter: number;
-  flavor: string;
-  titleEn: string;
-  titleHe: string;
-  en: string;
-  he: string;
-  textConfidence: string;
-  readingConfidence: string;
-}
-/** The perek-pills, in display order. */
+/** Reader pills, in display order. */
 const PEREK_PILLS: { id: PerekPill; label: string }[] = [
   { id: 'parsha', label: 'Parsha' },
-  { id: 'overview', label: 'Overview' },
   { id: 'geography', label: 'Geography' },
-  { id: 'tidbit', label: 'Tidbit' },
 ];
 const PILL_KIND: Record<PerekPill, string> = {
   parsha: 'Parsha',
-  overview: 'Overview',
   geography: 'Geography',
-  tidbit: 'Tidbit',
 };
 
 interface CommentaryEntry {
@@ -638,7 +614,7 @@ export function App(): JSX.Element {
     setSource(null);
   });
 
-  // Perek-level pills (Overview, …): a chapter-scoped drawer, mutually
+  // Reader-level pills: one shared drawer, mutually
   // exclusive with the verse-source drawer (both are the same fixed right
   // panel). Opening a pill lazily fetches its enrichment (warm in KV after the
   // first reader); the resource only fires while its pill is open.
@@ -688,10 +664,6 @@ export function App(): JSX.Element {
     noteAiResponse(await res.json().catch(() => null));
     return null;
   };
-  const [overview] = createResource(
-    () => (perekPill() === 'overview' ? chapterKey() : undefined),
-    (k) => fetchPill<Overview>(`/api/overview/${encodeURIComponent(k.book)}/${k.chapter}`),
-  );
   const [parshaStudy] = createResource(
     () => (perekPill() === 'parsha' && parsha() ? parsha()?.ref : undefined),
     () => fetchPill<ParshaStudy>(`/api/parsha-study?loc=${inIsrael() ? 'israel' : 'diaspora'}`),
@@ -700,10 +672,6 @@ export function App(): JSX.Element {
     () => (perekPill() === 'geography' ? chapterKey() : undefined),
     (k) => fetchPill<PerekGeography>(`/api/geography/${encodeURIComponent(k.book)}/${k.chapter}`),
   );
-  const [tidbit] = createResource(
-    () => (perekPill() === 'tidbit' ? chapterKey() : undefined),
-    (k) => fetchPill<PerekTidbit>(`/api/tidbit/${encodeURIComponent(k.book)}/${k.chapter}`),
-  );
   // Drawer copy for a failed pill fetch. "Try reopening" is only honest advice
   // for a transient blip — while AI is paused (banner up), reopening cannot
   // help, so say what's actually happening instead.
@@ -711,15 +679,8 @@ export function App(): JSX.Element {
     aiStatus()
       ? `AI generation is paused right now, so the ${what} for this chapter isn't available yet. Chapters that were already generated still work.`
       : `Couldn't load the ${what} — try reopening.`;
-  // Only the tidbit for the chapter on screen (createResource retains the prior
-  // value across a refetch — same guard as overview/geography).
-  const currentTidbit = createMemo(() => {
-    if (tidbit.loading) return null;
-    const t = tidbit();
-    return t && t.book === loc().book && t.chapter === loc().chapter ? t : null;
-  });
   // Only the geography for the chapter on screen (createResource retains the
-  // previous chapter's value across a refetch — same guard as the overview).
+  // previous chapter's value across a refetch).
   const currentGeography = createMemo(() => {
     if (geography.loading) return null;
     const g = geography();
@@ -751,14 +712,6 @@ export function App(): JSX.Element {
   createEffect(() => {
     if (perekPill() !== 'geography') clearPlace();
   });
-  // createResource keeps the PREVIOUS chapter's value during a refetch, so the
-  // drawer must not render it: only show the overview once it has loaded AND
-  // its echoed book/chapter match the chapter on screen (else show loading).
-  const currentOverview = createMemo(() => {
-    if (overview.loading) return null;
-    const o = overview();
-    return o && o.book === loc().book && o.chapter === loc().chapter ? o : null;
-  });
   const currentParshaStudy = createMemo(() => {
     if (parshaStudy.loading) return null;
     const study = parshaStudy();
@@ -781,8 +734,7 @@ export function App(): JSX.Element {
   // Reset first (this effect is created before the reporters, so on a chapter
   // change it runs first and clears the previous chapter's entries); then each
   // piece reports its state. The always-on chapter pieces key by a stable id so
-  // they overwrite across chapters; the overview reports only while its pill is
-  // open (its resource keeps a stale value across chapters otherwise).
+  // they overwrite across chapters.
   createEffect(() => {
     chapterKey();
     resetChapterLoad();
@@ -801,12 +753,6 @@ export function App(): JSX.Element {
     if (sourcesIndex.loading) reportLoad('sources', 'Sources', 'loading');
     else if (sourcesIndex.error) reportLoad('sources', 'Sources', 'error');
     else if (sourcesIndex() !== undefined) reportLoad('sources', 'Sources', 'ok');
-  });
-  createEffect(() => {
-    if (perekPill() !== 'overview') return;
-    if (overview.loading) reportLoad('overview', 'Overview', 'loading');
-    else if (overview.error) reportLoad('overview', 'Overview', 'error');
-    else if (overview()) reportLoad('overview', 'Overview', 'ok');
   });
 
   return (
@@ -1066,7 +1012,7 @@ export function App(): JSX.Element {
         />
       </Show>
 
-      {/* Perek-level pill drawer (Overview, …) — same fixed right panel as the
+      {/* Reader-level pill drawer — same fixed right panel as the
           verse-source drawer, mutually exclusive with it */}
       <Show when={perekPill()} keyed>
         {(pill) => (
@@ -1108,31 +1054,6 @@ export function App(): JSX.Element {
                 <p class="comm-muted">{pillError('parsha overview')}</p>
               </Show>
             </Show>
-            <Show when={pill === 'overview'}>
-              <Show when={overview.loading}>
-                <p class="comm-muted">Reading the chapter…</p>
-              </Show>
-              <Show when={currentOverview()}>
-                {(o) => (
-                  <section class="perek-overview">
-                    <Show
-                      when={
-                        loc().lang === 'he'
-                          ? o().titleHe || o().titleEn
-                          : o().titleEn || o().titleHe
-                      }
-                    >
-                      {(title) => <h3 class="perek-title">{title()}</h3>}
-                    </Show>
-                    <Prose en={o().en} he={o().he} lang={loc().lang} />
-                  </section>
-                )}
-              </Show>
-              {/* fetched but failed (overview() is null, not undefined) */}
-              <Show when={!overview.loading && overview() === null}>
-                <p class="comm-muted">{pillError('overview')}</p>
-              </Show>
-            </Show>
             <Show when={pill === 'geography'}>
               <Show when={geography.loading}>
                 <p class="comm-muted">Mapping the chapter…</p>
@@ -1168,40 +1089,6 @@ export function App(): JSX.Element {
               </Show>
               <Show when={!geography.loading && geography() === null}>
                 <p class="comm-muted">{pillError('geography')}</p>
-              </Show>
-            </Show>
-            <Show when={pill === 'tidbit'}>
-              <Show when={tidbit.loading}>
-                <p class="comm-muted">Finding the tidbit…</p>
-              </Show>
-              <Show when={currentTidbit()}>
-                {(t) => (
-                  <section class="perek-overview perek-tidbit">
-                    <Show
-                      when={
-                        loc().lang === 'he'
-                          ? t().titleHe || t().titleEn
-                          : t().titleEn || t().titleHe
-                      }
-                    >
-                      {(title) => <h3 class="perek-title">{title()}</h3>}
-                    </Show>
-                    <Prose en={t().en} he={t().he} lang={loc().lang} />
-                    <Show when={t().flavor || t().readingConfidence}>
-                      <p class="tidbit-meta">
-                        <Show when={t().flavor}>
-                          {(f) => <span class="tidbit-flavor">{f().replace('-', ' ')}</span>}
-                        </Show>
-                        <Show when={t().readingConfidence}>
-                          {(rc) => <span class="tidbit-conf">reading: {rc()}</span>}
-                        </Show>
-                      </p>
-                    </Show>
-                  </section>
-                )}
-              </Show>
-              <Show when={!tidbit.loading && tidbit() === null}>
-                <p class="comm-muted">{pillError('tidbit')}</p>
               </Show>
             </Show>
           </Drawer>

--- a/packages/tanach/src/client/chapterLoad.ts
+++ b/packages/tanach/src/client/chapterLoad.ts
@@ -6,7 +6,7 @@
  * reports its state into this tiny registry and the bar derives a fraction
  * from it. A piece enters the registry the moment it starts loading and is
  * "done" on ok/error, so the bar reflects BOTH the auto-loaded chapter pieces
- * (text, sections, sources) and any on-demand ones (the overview, a note) the
+ * (text, sections, sources) and any on-demand ones (such as a note) the
  * moment they fire. resetChapterLoad() clears it on chapter change so a stale
  * piece from the previous chapter never counts.
  */

--- a/packages/tanach/src/client/styles.css
+++ b/packages/tanach/src/client/styles.css
@@ -441,15 +441,11 @@ body {
   font-style: italic;
 }
 
-/* perek-level pills (Overview, …) now render via @corpus/ui's <Pill>/<PillRow>
+/* Reader-level pills render via @corpus/ui's <Pill>/<PillRow>
    (.ui-pill / .ui-pill-row in @corpus/ui/components.css). Tanach's parchment
    chip look is preserved through the --pill-bg / --pill-border theme tokens. */
 
-/* perek drawer body (rendered inside @corpus/ui's <Drawer>): the overview's
-   title heading. The prose itself is @corpus/ui's <Prose> (.ui-prose). */
-.perek-overview {
-  padding: 6px 0 12px;
-}
+/* Drawer title heading. The prose itself is @corpus/ui's <Prose> (.ui-prose). */
 .perek-title {
   margin: 0 0 10px;
   font-size: 20px;
@@ -784,28 +780,6 @@ body {
   margin-top: 10px;
   border-color: var(--accent);
   color: var(--accent);
-}
-
-/* tidbit footer: a small flavor tag + how-editorial-the-reading note */
-.tidbit-meta {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  margin: 14px 0 0;
-  padding-top: 10px;
-  border-top: 1px solid var(--line);
-  font-family: var(--font-ui);
-  font-size: 11px;
-  color: var(--muted);
-}
-.tidbit-flavor {
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  font-weight: 600;
-  color: var(--accent);
-}
-.tidbit-conf {
-  font-variant-numeric: tabular-nums;
 }
 
 /* word/phrase translation gloss (text selection) */

--- a/packages/tanach/src/worker/index.ts
+++ b/packages/tanach/src/worker/index.ts
@@ -301,7 +301,8 @@ app.get('/api/geography/:book/:chapter', async (c) => {
 
 // Perek tidbit (whole-chapter enrichment): ONE curated "did you notice…" — the
 // against-the-grain reading the Overview deliberately leaves out — opened from
-// the reader's "Tidbit" pill. Chapter-scoped (tidbit:v1:{book}:{chapter}).
+// available for future composed study surfaces. Chapter-scoped
+// (tidbit:v1:{book}:{chapter}).
 app.get('/api/tidbit/:book/:chapter', async (c) => {
   const book = c.req.param('book');
   const chapter = c.req.param('chapter');

--- a/packages/tanach/src/worker/producers/overview.ts
+++ b/packages/tanach/src/worker/producers/overview.ts
@@ -11,7 +11,7 @@
  *
  * Strictly p'shat (plain, contextual sense) — the same discipline the events
  * and note producers keep. Interesting against-the-grain readings drawn from
- * midrash and the commentators belong to the (forthcoming) tidbit pill, not
+ * midrash and the commentators belong to deeper section-specific study, not
  * here; this pill is the plain orientation.
  *
  * This module carries the producer's RECIPE (prompts + schema); the run goes

--- a/packages/tanach/src/worker/warm-cron.ts
+++ b/packages/tanach/src/worker/warm-cron.ts
@@ -1,14 +1,13 @@
 /**
  * Tanach warm-cron — keeps THIS WEEK'S parsha fully warm so a reader opening
- * the weekly portion never waits on a cold LLM, neither on the chapter pills
- * (Overview / Geography / Tidbit) + section anchors NOR on a verse's commentary
- * / midrash synthesis.
+ * the weekly portion never waits on a cold generation, from the whole-parsha
+ * map and visible chapter surfaces through verse commentary / midrash synthesis.
  *
  * Each tick resolves the current parsha (Sefaria's calendar), expands it to its
  * chapter range, and warms a small BATCH of the not-yet-done work, tracked by a
  * completed-set cursor:
  *
- *   1. chapter-level pills + section anchors (overview, geography, tidbit, events)
+ *   1. visible chapter-level surfaces + section anchors (geography, events)
  *   2. the per-chapter sources index (srcidx — no LLM; also gates step 3)
  *   3. per-VERSE deep content, gated by the index: commentary `synthesis` where
  *      there are commentators, `midrash-synthesis` where there is midrash.
@@ -31,8 +30,8 @@ import { computeSourcesIndex, readSourcesIndex } from './sources-index.ts';
 
 // v5: warm the whole-parsha overview before the chapter-level reader pieces.
 const CURSOR_KEY = 'tanach-warm-cursor:v5';
-/** Chapter-level enrichments that power the reader's pills + section labels. */
-const CHAPTER_PRODUCERS = ['overview', 'geography', 'tidbit', 'events'] as const;
+/** Chapter-level enrichments that power the visible reader + section labels. */
+const CHAPTER_PRODUCERS = ['geography', 'events'] as const;
 /** Entries warmed per tick — small so one invocation stays well within the
  *  scheduled CPU/subrequest budget even when every entry is cold. */
 const BATCH = 8;
@@ -68,17 +67,17 @@ async function readCursor(cache: KVNamespace): Promise<WarmCursor> {
   }
 }
 
-/** The ordered work-list. Pills + section anchors first (the visible surface),
+/** The ordered work-list. Visible surfaces + section anchors first,
  *  then the sources indexes, then the per-verse deep content gated by whichever
  *  indexes are already cached (an uncached chapter contributes a `srcindex`
  *  entry instead; its verses join the list once that index warms). */
 async function buildWorkList(cache: KVNamespace, parsha: WeeklyParsha): Promise<WarmEntry[]> {
-  const pills: WarmEntry[] = [{ kind: 'parsha', producer: 'parsha-overview' }];
+  const surfaces: WarmEntry[] = [{ kind: 'parsha', producer: 'parsha-overview' }];
   const indexes: WarmEntry[] = [];
   const verses: WarmEntry[] = [];
   for (let ch = parsha.startChapter; ch <= parsha.endChapter; ch++) {
     for (const producer of CHAPTER_PRODUCERS)
-      pills.push({ kind: 'chapter', producer, chapter: ch });
+      surfaces.push({ kind: 'chapter', producer, chapter: ch });
     const idx = await readSourcesIndex(cache, parsha.book, String(ch));
     if (!idx) {
       indexes.push({ kind: 'srcindex', chapter: ch });
@@ -91,7 +90,7 @@ async function buildWorkList(cache: KVNamespace, parsha: WeeklyParsha): Promise<
         verses.push({ kind: 'verse', producer: 'midrash-synthesis', chapter: ch, verse: v.verse });
     }
   }
-  return [...pills, ...indexes, ...verses];
+  return [...surfaces, ...indexes, ...verses];
 }
 
 async function warmEntry(


### PR DESCRIPTION
## Summary\n\n- remove Overview and Tidbit from the Tanach reader pill row\n- remove their now-unused drawer resources and client styling\n- stop pre-warming those hidden chapter enrichments while preserving their APIs and producers\n- keep Parsha and Geography as the reader-level pills\n\n## Verification\n\n- pnpm lint\n- pnpm typecheck\n- pnpm test\n- pnpm --filter tanach build