### PR TITLE
Tanach parsha drawer: click a move to highlight its range + close reading

### DIFF
--- a/packages/tanach/src/client/App.tsx
+++ b/packages/tanach/src/client/App.tsx
@@ -18,7 +18,7 @@ import {
 } from 'solid-js';
 import { BOOKS, SECTIONS, type Section } from '../lib/books.ts';
 import { hebrewNumeral } from '../lib/hebrew.ts';
-import type { ParshaStudy, WeeklyParsha } from '../lib/parsha.ts';
+import type { ParshaFlowSection, ParshaStudy, WeeklyParsha } from '../lib/parsha.ts';
 import {
   KIND_GLYPH,
   MIDRASH_MIN,
@@ -245,10 +245,15 @@ async function fetchEvents(loc: { book: string; chapter: number }): Promise<Even
 
 export function App(): JSX.Element {
   const [loc, setLoc] = createSignal(readUrl());
+  // The verse RANGE the parsha drawer is pointing at (a flow move, a landmark,
+  // or an "Open in the text" jump — a single verse is a degenerate range). The
+  // reader highlights whatever slice of it falls in the visible chapter.
   const [parshaFocus, setParshaFocus] = createSignal<{
     book: string;
-    chapter: number;
-    verse: number;
+    startChapter: number;
+    startVerse: number;
+    endChapter: number;
+    endVerse: number;
   } | null>(null);
 
   const writeUrl = (l: Loc) => {
@@ -518,11 +523,14 @@ export function App(): JSX.Element {
         const vn = Number(e.dataset.vn);
         const inNote = sel && vn >= sel.start && vn <= sel.end;
         const inSource = src && vn === src.verse;
+        const chapterNow = loc().chapter;
         const inParshaFocus =
           focus &&
           focus.book === loc().book &&
-          focus.chapter === loc().chapter &&
-          focus.verse === vn;
+          chapterNow >= focus.startChapter &&
+          chapterNow <= focus.endChapter &&
+          vn >= (chapterNow === focus.startChapter ? focus.startVerse : 1) &&
+          (chapterNow === focus.endChapter ? vn <= focus.endVerse : true);
         if (inNote || inSource || inParshaFocus || pv.has(vn)) e.classList.add('hl');
       });
     });
@@ -532,12 +540,12 @@ export function App(): JSX.Element {
     const focus = parshaFocus();
     const chapter = data();
     paragraphs();
-    if (!focus || !chapter || focus.book !== chapter.book || focus.chapter !== chapter.chapter)
+    if (!focus || !chapter || focus.book !== chapter.book || focus.startChapter !== chapter.chapter)
       return;
     requestAnimationFrame(() =>
       requestAnimationFrame(() =>
         scrollBand
-          ?.querySelector(`.vtext[data-vn="${focus.verse}"]`)
+          ?.querySelector(`.vtext[data-vn="${focus.startVerse}"]`)
           ?.scrollIntoView({ behavior: 'smooth', block: 'center' }),
       ),
     );
@@ -630,9 +638,35 @@ export function App(): JSX.Element {
     setPerekPill((cur) => (cur === id ? null : id));
   };
   const openParshaText = (book: string, chapter: number, verse: number) => {
-    setParshaFocus({ book, chapter, verse });
+    setParshaFocus({
+      book,
+      startChapter: chapter,
+      startVerse: verse,
+      endChapter: chapter,
+      endVerse: verse,
+    });
     setPerekPill(null);
     goto(book, chapter);
+  };
+  // Selecting a flow move in the parsha drawer: highlight its whole verse
+  // range in the reader (navigating to its first chapter if needed) while the
+  // drawer STAYS OPEN alongside the close reading. Null clears the highlight.
+  const focusParshaSection = (section: ParshaFlowSection | null) => {
+    if (!section) {
+      setParshaFocus(null);
+      return;
+    }
+    const study = currentParshaStudy();
+    if (!study) return;
+    setParshaFocus({
+      book: study.book,
+      startChapter: section.startChapter,
+      startVerse: section.startVerse,
+      endChapter: section.endChapter,
+      endVerse: section.endVerse,
+    });
+    if (loc().book !== study.book || loc().chapter !== section.startChapter)
+      goto(study.book, section.startChapter);
   };
   const openWeeklyParsha = () => {
     const weekly = parsha();
@@ -724,9 +758,13 @@ export function App(): JSX.Element {
       setInspectOpen(false);
     }
   });
+  // A chapter change invalidates the chapter-scoped pills (overview /
+  // geography / tidbit) — but NOT the parsha drawer, which is parsha-scoped
+  // and deliberately navigates the reader across its chapters (a flow move's
+  // range highlight) while staying open.
   createEffect(() => {
     chapterKey();
-    setPerekPill(null);
+    setPerekPill((cur) => (cur === 'parsha' ? cur : null));
     setInspectOpen(false);
   });
 
@@ -1047,6 +1085,7 @@ export function App(): JSX.Element {
                     lang={loc().lang}
                     location={inIsrael() ? 'israel' : 'diaspora'}
                     onOpenText={openParshaText}
+                    onFocusRange={focusParshaSection}
                   />
                 )}
               </Show>

--- a/packages/tanach/src/client/ParshaDrawer.tsx
+++ b/packages/tanach/src/client/ParshaDrawer.tsx
@@ -1,18 +1,24 @@
 import { aiStatus, noteAiResponse, noteAiSuccess } from '@corpus/ui/aiStatus';
 import { Prose } from '@corpus/ui/Prose';
 import { createEffect, createResource, createSignal, For, type JSX, Show } from 'solid-js';
-import type {
-  ParshaFlowSection,
-  ParshaSectionKind,
-  ParshaStudy,
-  ParshaThread,
+import {
+  type ParshaFlowSection,
+  type ParshaSectionKind,
+  type ParshaSectionStudy,
+  type ParshaStudy,
+  type ParshaThread,
+  sanitizeParshaTerms,
 } from '../lib/parsha.ts';
+import { TermedProse } from './TermedProse.tsx';
 
 export interface ParshaDrawerProps {
   study: ParshaStudy;
   lang: 'en' | 'he';
   location: 'israel' | 'diaspora';
   onOpenText: (book: string, chapter: number, verse: number) => void;
+  /** Highlight a flow section's verse range in the reader (null clears it).
+   *  Fires on selecting a move — the drawer stays open. */
+  onFocusRange: (section: ParshaFlowSection | null) => void;
 }
 
 const KIND_LABEL: Record<ParshaSectionKind, { en: string; he: string }> = {
@@ -30,7 +36,7 @@ function sourceUrl(ref: string): string {
 }
 
 export function ParshaDrawer(props: ParshaDrawerProps): JSX.Element {
-  const [selected, setSelected] = createSignal(0);
+  const [selected, setSelected] = createSignal<number | null>(null);
   const [threadRequest, setThreadRequest] = createSignal<{ index: number } | null>(null);
   const [copied, setCopied] = createSignal(false);
   const [thread] = createResource(threadRequest, async ({ index }) => {
@@ -42,6 +48,20 @@ export function ParshaDrawer(props: ParshaDrawerProps): JSX.Element {
     noteAiResponse(await response.json().catch(() => null));
     return null;
   });
+  // The selected move's in-depth close reading (cached server-side; warm-cron
+  // pre-warms it, so this is usually instant).
+  const [deep] = createResource(
+    () => (selected() === null ? null : { index: selected() as number }),
+    async ({ index }) => {
+      const response = await fetch(`/api/parsha-section/${index}?loc=${props.location}`);
+      if (response.ok) {
+        noteAiSuccess();
+        return (await response.json()) as ParshaSectionStudy;
+      }
+      noteAiResponse(await response.json().catch(() => null));
+      return null;
+    },
+  );
   let threadPanel: HTMLElement | undefined;
   createEffect(() => {
     if (!threadRequest()) return;
@@ -50,15 +70,28 @@ export function ParshaDrawer(props: ParshaDrawerProps): JSX.Element {
     );
   });
 
+  // Selecting a move highlights its verse range in the reader and opens its
+  // close reading in place; selecting it again collapses and clears both.
   const choose = (index: number) => {
+    if (selected() === index) {
+      setSelected(null);
+      setThreadRequest(null);
+      props.onFocusRange(null);
+      return;
+    }
     setSelected(index);
     if (threadRequest()?.index !== index) setThreadRequest(null);
+    props.onFocusRange(props.study.flow[index] ?? null);
   };
 
   const buildThread = (index: number) => {
-    setSelected(index);
     setThreadRequest({ index });
   };
+
+  /** The hover-hint pool for a section's close reading: its own terms first
+   *  (they win a surface collision), then the whole-parsha pool. */
+  const deepTerms = (value: ParshaSectionStudy) =>
+    sanitizeParshaTerms([...(value.terms ?? []), ...(props.study.terms ?? [])]);
 
   const copyDvar = async () => {
     const value = thread();
@@ -69,13 +102,21 @@ export function ParshaDrawer(props: ParshaDrawerProps): JSX.Element {
     window.setTimeout(() => setCopied(false), 1500);
   };
 
-  const selectedFlow = (): ParshaFlowSection | undefined => props.study.flow[selected()];
+  const selectedFlow = (): ParshaFlowSection | undefined => {
+    const index = selected();
+    return index === null ? undefined : props.study.flow[index];
+  };
 
   return (
     <section class="parsha-study">
       <p class="parsha-ref">{props.study.ref}</p>
       <h3 class="perek-title">{textFor(props.lang, props.study.titleEn, props.study.titleHe)}</h3>
-      <Prose en={props.study.overviewEn} he={props.study.overviewHe} lang={props.lang} />
+      <TermedProse
+        en={props.study.overviewEn}
+        he={props.study.overviewHe}
+        lang={props.lang}
+        terms={props.study.terms ?? []}
+      />
 
       <section class="parsha-section">
         <div class="parsha-section-head">
@@ -133,18 +174,55 @@ export function ParshaDrawer(props: ParshaDrawerProps): JSX.Element {
                   </span>
                 </button>
                 <Show when={selected() === index()}>
-                  <div class="parsha-flow-actions">
-                    <button
-                      type="button"
-                      onClick={() =>
-                        props.onOpenText(props.study.book, section.startChapter, section.startVerse)
-                      }
-                    >
-                      {props.lang === 'he' ? 'פתח בטקסט' : 'Open in the text'}
-                    </button>
-                    <button type="button" class="primary" onClick={() => buildThread(index())}>
-                      {props.lang === 'he' ? 'בנה דבר תורה' : 'Build a dvar Torah'}
-                    </button>
+                  <div class="parsha-flow-deep">
+                    <Show when={deep.loading}>
+                      <p class="comm-muted">
+                        {props.lang === 'he'
+                          ? 'קורא את הקטע מקרוב…'
+                          : 'Reading the passage closely…'}
+                      </p>
+                    </Show>
+                    {/* deep.error first: reading deep() while the resource is
+                        errored (a rejected fetch, not a non-ok status) would
+                        rethrow and break the drawer subtree. */}
+                    <Show when={!deep.loading && (deep.error || deep() === null)}>
+                      <p class="comm-muted">
+                        {aiStatus()
+                          ? props.lang === 'he'
+                            ? 'יצירת תוכן מושבתת כרגע.'
+                            : 'AI generation is paused right now.'
+                          : props.lang === 'he'
+                            ? 'לא הצלחנו לקרוא את הקטע. נסו שוב.'
+                            : "Couldn't read this passage. Try again."}
+                      </p>
+                    </Show>
+                    <Show when={!deep.loading && !deep.error && deep()}>
+                      {(value) => (
+                        <TermedProse
+                          en={value().en}
+                          he={value().he}
+                          lang={props.lang}
+                          terms={deepTerms(value())}
+                        />
+                      )}
+                    </Show>
+                    <div class="parsha-flow-actions">
+                      <button
+                        type="button"
+                        onClick={() =>
+                          props.onOpenText(
+                            props.study.book,
+                            section.startChapter,
+                            section.startVerse,
+                          )
+                        }
+                      >
+                        {props.lang === 'he' ? 'פתח בטקסט' : 'Open in the text'}
+                      </button>
+                      <button type="button" class="primary" onClick={() => buildThread(index())}>
+                        {props.lang === 'he' ? 'בנה דבר תורה' : 'Build a dvar Torah'}
+                      </button>
+                    </div>
                   </div>
                 </Show>
               </li>

--- a/packages/tanach/src/client/TermedProse.tsx
+++ b/packages/tanach/src/client/TermedProse.tsx
@@ -1,0 +1,129 @@
+/**
+ * TermedProse — the parsha drawer's reading-prose block: the shared Prose
+ * treatment (language preference + fallback, direction, reading fonts via
+ * .ui-prose) plus the Talmud reader's term convention — Hebrew script inline
+ * in the English prose, dotted-underlined, with the English hint one hover
+ * (or focus) away. Hebrew-mode prose renders plain: it has no glosses to
+ * surface, matching the talmud convention that Hebrew is the base there.
+ *
+ * Matching is by the terms' Hebrew surfaces only (see tokenizeTermMentions);
+ * Hebrew runs the pool doesn't know (verse quotes) still get bidi-isolated in
+ * a <bdi> so surrounding English punctuation keeps its position.
+ */
+import { createSignal, For, type JSX, Show } from 'solid-js';
+import { Portal } from 'solid-js/web';
+import { type ParshaTerm, tokenizeTermMentions } from '../lib/parsha.ts';
+
+// A maximal Hebrew run — letters plus internal maqaf/geresh/gershayim/spaces,
+// starting and ending on a Hebrew character — isolated in a <bdi> so the bidi
+// algorithm can't reorder the English punctuation around it.
+const HE_RUN = /([֐-׿יִ-ﭏ](?:[֐-׿יִ-ﭏ־׳״' -]*[֐-׿יִ-ﭏ׳״])?)/g;
+const isHe = (s: string): boolean => /[֐-׿יִ-ﭏ]/.test(s);
+
+function BidiText(props: { text: string }): JSX.Element {
+  const parts = () =>
+    props.text
+      .split(HE_RUN)
+      .filter((part) => part !== '')
+      .map((part) => ({ text: part, he: isHe(part) }));
+  return <For each={parts()}>{(part) => (part.he ? <bdi>{part.text}</bdi> : part.text)}</For>;
+}
+
+export interface TermedProseProps {
+  en?: string;
+  he?: string;
+  /** Preferred language; falls back to the other when the preferred is empty. */
+  lang: 'en' | 'he';
+  /** The hover-hint pool (Hebrew surface -> short English meaning). */
+  terms: readonly ParshaTerm[];
+  class?: string;
+}
+
+interface TermTip {
+  term: ParshaTerm;
+  x: number;
+  y: number;
+  /** Flipped below the term when there's no headroom above it. */
+  below: boolean;
+}
+
+export function TermedProse(props: TermedProseProps): JSX.Element {
+  const shown = (): 'en' | 'he' => {
+    if (props.lang === 'he') return props.he ? 'he' : 'en';
+    return props.en ? 'en' : 'he';
+  };
+  const text = (): string => (shown() === 'he' ? props.he : props.en) ?? '';
+  // Blank-line paragraphs (the deep-reading producer separates them with one).
+  const paragraphs = (): string[] =>
+    text()
+      .split(/\n{2,}/)
+      .map((p) => p.trim())
+      .filter(Boolean);
+
+  const [tip, setTip] = createSignal<TermTip | null>(null);
+  const showTip = (term: ParshaTerm, el: HTMLElement) => {
+    const r = el.getBoundingClientRect();
+    // Clamp the tooltip's CENTER so its body (max-width 18rem, centered by the
+    // -50% transform) stays on-screen — terms sit at line ends inside the
+    // fixed right drawer — and flip below the term when there's no headroom.
+    const halfWidth = Math.min(144, (window.innerWidth - 32) / 2);
+    const x = Math.min(
+      Math.max(r.left + r.width / 2, 16 + halfWidth),
+      window.innerWidth - 16 - halfWidth,
+    );
+    const below = r.top < 96;
+    setTip({ term, x, y: below ? r.bottom : r.top, below });
+  };
+
+  return (
+    <>
+      <For each={paragraphs()}>
+        {(para) => (
+          <p
+            class="ui-prose"
+            classList={props.class ? { [props.class]: true } : undefined}
+            dir={shown() === 'he' ? 'rtl' : 'ltr'}
+          >
+            <Show when={shown() === 'en'} fallback={para}>
+              <For each={tokenizeTermMentions(para, props.terms)}>
+                {(part) =>
+                  part.kind === 'term' && part.term ? (
+                    // biome-ignore lint/a11y/useSemanticElements: inline span inside flowing prose; a button element would break text layout and selection/copy (same convention as the talmud reader's ConceptMention)
+                    <span
+                      class="parsha-term"
+                      tabIndex={0}
+                      role="button"
+                      aria-label={`${part.term.he}: ${part.term.en}`}
+                      onMouseEnter={(e) => showTip(part.term as ParshaTerm, e.currentTarget)}
+                      onMouseLeave={() => setTip(null)}
+                      onFocus={(e) => showTip(part.term as ParshaTerm, e.currentTarget)}
+                      onBlur={() => setTip(null)}
+                    >
+                      {part.value}
+                    </span>
+                  ) : (
+                    <BidiText text={part.value} />
+                  )
+                }
+              </For>
+            </Show>
+          </p>
+        )}
+      </For>
+      <Show when={tip()}>
+        {(t) => (
+          <Portal>
+            <div
+              class="parsha-term-tip"
+              classList={{ below: t().below }}
+              style={{ left: `${t().x}px`, top: `${t().y + (t().below ? 8 : -8)}px` }}
+            >
+              <bdi>{t().term.he}</bdi>
+              <span>{t().term.en}</span>
+            </div>
+          </Portal>
+        )}
+      </Show>
+    </>
+  );
+}

--- a/packages/tanach/src/client/styles.css
+++ b/packages/tanach/src/client/styles.css
@@ -648,10 +648,66 @@ body {
 .ui-drawer[dir="rtl"] .parsha-flow-copy small {
   font-family: var(--font-hebrew);
 }
+/* The selected move's in-place close reading (deep dive under the card). */
+.parsha-flow-deep {
+  margin: 2px 0 4px;
+  padding: 4px 9px 2px;
+  border-left: 2px solid var(--line);
+}
+.ui-drawer[dir="rtl"] .parsha-flow-deep {
+  border-left: none;
+  border-right: 2px solid var(--line);
+}
+.parsha-flow-deep .ui-prose {
+  margin: 0 0 8px;
+  font-size: 12.5px;
+  line-height: 1.55;
+}
+
+/* An inline Hebrew term in English prose — dotted-underlined, hint on hover
+   (the talmud reader's concept-link treatment). */
+.parsha-term {
+  /* A span, not <bdi>, so it can carry role="button" — isolate manually. */
+  unicode-bidi: isolate;
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-decoration-color: var(--muted);
+  text-underline-offset: 2px;
+  cursor: help;
+}
+.parsha-term-tip {
+  position: fixed;
+  z-index: 1000;
+  max-width: 18rem;
+  transform: translate(-50%, -100%);
+  padding: 5px 9px 6px;
+  border-radius: 6px;
+  background: var(--ink);
+  color: var(--surface);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
+  font-size: 11.5px;
+  line-height: 1.45;
+  pointer-events: none;
+}
+.parsha-term-tip.below {
+  transform: translate(-50%, 0);
+}
+.parsha-term-tip bdi {
+  display: block;
+  font-family: var(--font-hebrew);
+  font-weight: 600;
+}
+.parsha-term-tip span {
+  font-family: var(--font-ui);
+}
+
 .parsha-flow-actions {
   display: flex;
   gap: 7px;
   padding: 3px 8px 7px;
+}
+.parsha-flow-deep .parsha-flow-actions {
+  padding: 0 0 5px;
 }
 .parsha-flow-actions button,
 .parsha-copy {

--- a/packages/tanach/src/lib/parsha.ts
+++ b/packages/tanach/src/lib/parsha.ts
@@ -36,6 +36,14 @@ export interface ParshaLandmark {
   labelHe: string;
 }
 
+/** A Hebrew term the parsha prose uses inline (the talmud reader's gloss
+ *  convention): `he` is the exact Hebrew-script surface as written in the
+ *  prose, `en` the short English meaning shown as the hover hint. */
+export interface ParshaTerm {
+  he: string;
+  en: string;
+}
+
 export interface ParshaStudy {
   name: string;
   heName: string;
@@ -49,6 +57,16 @@ export interface ParshaStudy {
   composition: Record<ParshaSectionKind, number>;
   flow: ParshaFlowSection[];
   landmarks: ParshaLandmark[];
+  terms: ParshaTerm[];
+}
+
+/** The in-depth close reading of one flow section (the click-a-move surface). */
+export interface ParshaSectionStudy {
+  titleEn: string;
+  titleHe: string;
+  en: string;
+  he: string;
+  terms: ParshaTerm[];
 }
 
 export interface ParshaThreadSource {
@@ -130,6 +148,66 @@ export function sectionInParsha(
     section.endChapter > section.startChapter ||
     (section.endChapter === section.startChapter && section.endVerse >= section.startVerse)
   );
+}
+
+const HAS_HEBREW = /[\u0590-\u05FF]/;
+
+/** Keep only well-formed hover-hint terms: a Hebrew-script surface plus a short
+ *  English meaning, deduped by surface (first entry wins, so a section's own
+ *  terms can outrank the whole-parsha pool when concatenated ahead of it). */
+export function sanitizeParshaTerms(value: unknown, cap = 24): ParshaTerm[] {
+  const list = Array.isArray(value) ? value : [];
+  const seen = new Set<string>();
+  const out: ParshaTerm[] = [];
+  for (const item of list) {
+    if (!item || typeof item !== 'object') continue;
+    const he = String((item as Record<string, unknown>).he ?? '').trim();
+    const en = String((item as Record<string, unknown>).en ?? '').trim();
+    if (!he || !en || he.length > 60 || en.length > 120) continue;
+    if (!HAS_HEBREW.test(he) || HAS_HEBREW.test(en)) continue;
+    if (seen.has(he)) continue;
+    seen.add(he);
+    out.push({ he, en });
+  }
+  return out.slice(0, cap);
+}
+
+export interface TermMentionPart {
+  kind: 'text' | 'term';
+  value: string;
+  term?: ParshaTerm;
+}
+
+/** Split prose into plain-text and term-mention parts, matching ONLY the
+ *  Hebrew surfaces — the English meanings are everyday words ("blessing",
+ *  "curse") and matching them would mis-fire, whereas Hebrew script inside
+ *  English prose is unambiguous. Longest surface wins at a position; a match
+ *  must not touch adjacent Hebrew letters (so a prefixed form like הברכה is
+ *  left alone rather than half-underlined). Pure, shared with tests. */
+export function tokenizeTermMentions(
+  text: string,
+  terms: readonly ParshaTerm[],
+): TermMentionPart[] {
+  if (!text) return [];
+  const usable = terms.filter((t) => t.he && HAS_HEBREW.test(t.he));
+  if (!usable.length) return [{ kind: 'text', value: text }];
+  const bySurface = new Map<string, ParshaTerm>();
+  for (const t of usable) if (!bySurface.has(t.he)) bySurface.set(t.he, t);
+  const surfaces = [...bySurface.keys()]
+    .sort((a, b) => b.length - a.length)
+    .map((s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+  const re = new RegExp(`(?<![\\u0590-\\u05FF])(${surfaces.join('|')})(?![\\u0590-\\u05FF])`, 'gu');
+  const out: TermMentionPart[] = [];
+  let last = 0;
+  for (let m = re.exec(text); m !== null; m = re.exec(text)) {
+    const term = bySurface.get(m[1]);
+    if (!term) continue;
+    if (m.index > last) out.push({ kind: 'text', value: text.slice(last, m.index) });
+    out.push({ kind: 'term', value: m[1], term });
+    last = m.index + m[0].length;
+  }
+  if (last < text.length) out.push({ kind: 'text', value: text.slice(last) });
+  return out;
 }
 
 /** Normalize an editorial percentage estimate so the three visible bars total 100. */

--- a/packages/tanach/src/worker/index.ts
+++ b/packages/tanach/src/worker/index.ts
@@ -24,7 +24,9 @@ import {
   normalizeParshaComposition,
   type ParshaFlowSection,
   type ParshaLandmark,
+  type ParshaSectionStudy,
   type ParshaThread,
+  sanitizeParshaTerms,
   type WeeklyParsha,
 } from '../lib/parsha.ts';
 import { lookupPlace } from './gazetteer.ts';
@@ -393,6 +395,7 @@ app.get('/api/parsha-study', async (c) => {
     composition?: unknown;
     flow?: Omit<ParshaFlowSection, 'ref'>[];
     landmarks?: Omit<ParshaLandmark, 'ref'>[];
+    terms?: unknown;
   };
   const flow = (parsed.flow ?? []).map((section) => ({
     ...section,
@@ -416,14 +419,26 @@ app.get('/api/parsha-study', async (c) => {
     composition: normalizeParshaComposition(parsed.composition),
     flow,
     landmarks,
+    terms: sanitizeParshaTerms(parsed.terms),
   });
 });
 
-// One selected flow unit -> grounded insight + source packet + dvar Torah.
-// The section index resolves through the cached overview, so clients cannot
-// float an unanchored passage into the thread producer.
-app.get('/api/parsha-thread/:section', async (c) => {
-  const rawSection = c.req.param('section');
+/** Shared front half of the per-section routes (close reading / thread):
+ *  resolve the calendar parsha, run/read the cached overview, and pick the
+ *  anchored flow section by index — so a client can never float an unanchored
+ *  passage into a section-scoped producer. Returns a Response on failure. */
+async function resolveParshaSection(
+  c: Context<{ Bindings: Env }>,
+  rawSection: string,
+): Promise<
+  | {
+      parsha: WeeklyParsha;
+      rc: TanachRunCtx;
+      sectionIndex: number;
+      section: Omit<ParshaFlowSection, 'ref'>;
+    }
+  | Response
+> {
   if (!/^\d+$/.test(rawSection)) return c.json({ error: 'Bad parsha section' }, 400);
   const sectionIndex = Number(rawSection);
   const israel = c.req.query('loc') === 'israel';
@@ -452,6 +467,43 @@ app.get('/api/parsha-thread/:section', async (c) => {
     (overview.parsed as { flow?: Omit<ParshaFlowSection, 'ref'>[] } | null)?.flow ?? [];
   const section = sections[sectionIndex];
   if (!section) return c.json({ error: 'Parsha section not found' }, 404);
+  return { parsha, rc, sectionIndex, section };
+}
+
+// One selected flow unit -> an in-depth bilingual close reading (the
+// click-a-move surface), with the terms pool for hover hints.
+app.get('/api/parsha-section/:section', async (c) => {
+  const resolved = await resolveParshaSection(c, c.req.param('section'));
+  if (resolved instanceof Response) return resolved;
+  const { parsha, rc, sectionIndex, section } = resolved;
+
+  let study: StoredArtifact;
+  try {
+    study = await runTanachEnrichment(rc, 'parsha-section', parsha.book, parsha.ref, {
+      id: `${parsha.ref}#${sectionIndex}`,
+      parshaName: parsha.name,
+      parshaRef: parsha.ref,
+      ...section,
+    });
+  } catch (e) {
+    return runErrorResponse(c, e);
+  }
+  c.header('Cache-Control', 'public, max-age=600, stale-while-revalidate=86400');
+  return c.json({
+    parsha: parsha.name,
+    parshaRef: parsha.ref,
+    section: { ...section, ref: formatParshaRange(parsha.book, section) },
+    ...((study.parsed ?? {}) as ParshaSectionStudy),
+  });
+});
+
+// One selected flow unit -> grounded insight + source packet + dvar Torah.
+// The section index resolves through the cached overview, so clients cannot
+// float an unanchored passage into the thread producer.
+app.get('/api/parsha-thread/:section', async (c) => {
+  const resolved = await resolveParshaSection(c, c.req.param('section'));
+  if (resolved instanceof Response) return resolved;
+  const { parsha, rc, sectionIndex, section } = resolved;
 
   let thread: StoredArtifact;
   try {

--- a/packages/tanach/src/worker/producers/defs.ts
+++ b/packages/tanach/src/worker/producers/defs.ts
@@ -40,6 +40,9 @@ import {
   PARSHA_OVERVIEW_SCHEMA,
   PARSHA_OVERVIEW_SYSTEM,
   PARSHA_OVERVIEW_USER_TEMPLATE,
+  PARSHA_SECTION_SCHEMA,
+  PARSHA_SECTION_SYSTEM,
+  PARSHA_SECTION_USER_TEMPLATE,
   PARSHA_THREAD_SCHEMA,
   PARSHA_THREAD_SYSTEM,
   PARSHA_THREAD_USER_TEMPLATE,
@@ -53,6 +56,7 @@ export type TanachProducerId =
   | 'note'
   | 'overview'
   | 'parsha-overview'
+  | 'parsha-section'
   | 'parsha-thread'
   | 'geography'
   | 'tidbit'
@@ -113,9 +117,22 @@ const parshaOverviewExtractor: TanachLLMExtractor = {
   system_prompt: PARSHA_OVERVIEW_SYSTEM,
   user_prompt_template: PARSHA_OVERVIEW_USER_TEMPLATE,
   output_schema: PARSHA_OVERVIEW_SCHEMA,
-  max_tokens: 5200,
+  // v2 adds the terms array on top of the bilingual map — a little more headroom.
+  max_tokens: 5600,
   temperature: 0.25,
   tag: 'tanach:parsha-overview',
+};
+
+const parshaSectionExtractor: TanachLLMExtractor = {
+  kind: 'llm',
+  system_prompt: PARSHA_SECTION_SYSTEM,
+  user_prompt_template: PARSHA_SECTION_USER_TEMPLATE,
+  output_schema: PARSHA_SECTION_SCHEMA,
+  // Bilingual 2-3 paragraph close reading + the terms array — roomier than the
+  // chapter overview (1400) but well under the whole-parsha map (5600).
+  max_tokens: 2800,
+  temperature: 0.3,
+  tag: 'tanach:parsha-section',
 };
 
 const parshaThreadExtractor: TanachLLMExtractor = {
@@ -243,8 +260,25 @@ export const TANACH_PRODUCERS: Record<TanachProducerId, Producer> = {
     cardinality: 'one',
     scope: 'local',
     key_shape: 'enrich',
-    cacheVersion: '1',
+    // v2: prose follows PARSHA_HEBREW_STYLE and the output carries the terms
+    // pool for hover hints — bump regenerates this week's map with the new recipe.
+    cacheVersion: '2',
     passes: ['parsha-overview-shape'],
+    source: 'code',
+  },
+  'parsha-section': {
+    id: 'parsha-section',
+    label: 'Parsha close reading',
+    description: 'An in-depth bilingual close reading of one parsha flow unit',
+    kind: 'enrichment',
+    inputs: [{ source: 'parsha-section-verses' }],
+    recipe: { extractor: parshaSectionExtractor },
+    anchoring: { behavior: 'inherits', precision: 'segment', spine: 'tanach' },
+    cardinality: 'per-input',
+    scope: 'local',
+    key_shape: 'enrich',
+    cacheVersion: '1',
+    passes: ['parsha-section-shape'],
     source: 'code',
   },
   'parsha-thread': {
@@ -258,7 +292,9 @@ export const TANACH_PRODUCERS: Record<TanachProducerId, Producer> = {
     cardinality: 'per-input',
     scope: 'local',
     key_shape: 'enrich',
-    cacheVersion: '1',
+    // v2: the thread prose follows PARSHA_HEBREW_STYLE too, so the whole
+    // drawer reads in one voice.
+    cacheVersion: '2',
     passes: ['parsha-thread-sources'],
     source: 'code',
   },
@@ -413,6 +449,7 @@ export function enrichRunDefOf(
     | 'note'
     | 'overview'
     | 'parsha-overview'
+    | 'parsha-section'
     | 'parsha-thread'
     | 'geography'
     | 'tidbit'

--- a/packages/tanach/src/worker/producers/parsha.ts
+++ b/packages/tanach/src/worker/producers/parsha.ts
@@ -1,4 +1,46 @@
-/** Recipes for the weekly parsha overview and its on-demand study thread. */
+/** Recipes for the weekly parsha overview, the per-unit close reading, and the
+ *  on-demand study thread. */
+
+/**
+ * The English-prose Hebrew style every parsha producer shares — the tanach cut
+ * of the talmud reader's gloss convention: Hebrew script is the anchor for the
+ * text's own key words, the English meaning rides in parens on first mention,
+ * and the reader's hover hint (built from the `terms` array where the schema
+ * carries one) covers every later mention.
+ */
+export const PARSHA_HEBREW_STYLE = `STYLE — Hebrew + English mixing (apply UNIFORMLY across all English prose fields):
+
+Plain English is the BASE; Hebrew script is the anchor for the portion's own key words. Weave in Hebrew where a word is genuinely the text's term or a standing term of Jewish learning — not on every common word.
+
+FORM A (DEFAULT) — Hebrew script first, English gloss in parens. Use for the passage's key words and technical terms:
+  "a ברכה (blessing) and a קללה (curse)", "the מקום אשר יבחר (place God will choose)", "מעשר שני (the second tithe)"
+FORM B — English first, Hebrew in parens. Use ONLY for proper nouns and standing English-first terms:
+  "Mount Gerizim (הר גריזים)", "Passover (פסח)", "the Levite (הלוי)"
+
+GLOSS ONCE: gloss a term on its FIRST use in a field; write it bare afterwards.
+
+HARD RULES (output is rejected if violated):
+- NEVER write a transliteration — not in parens "(bracha)", not bare "maaser sheni". Hebrew script paired with an English meaning, always.
+- Verbatim quotes from the verses go in Hebrew script inside quote marks — never transliteration in quotes.
+- Hebrew-language fields are natural Hebrew with NO parenthetical English glosses.
+- SCRIPT HYGIENE: emit ONLY English + Hebrew script (plus ordinary punctuation) — no other writing system, no emoji.`;
+
+/** Appended only where the schema carries a `terms` array (overview, section). */
+export const PARSHA_TERMS_RULE = `TERMS
+- Return every Hebrew term or phrase your English prose uses in the "terms" array: "he" is the exact Hebrew script as written in the prose, "en" is a short English meaning.
+- The reader's hover hints are built from this array, so the "he" spelling must match the prose exactly.
+- 4-12 terms; no duplicates; short phrases, never full sentences.`;
+
+const TERMS_SCHEMA = {
+  type: 'array',
+  maxItems: 12,
+  items: {
+    type: 'object',
+    additionalProperties: false,
+    required: ['he', 'en'],
+    properties: { he: { type: 'string' }, en: { type: 'string' } },
+  },
+} as const;
 
 export const PARSHA_OVERVIEW_SYSTEM = `You are building the orientation layer for a weekly Torah-portion learning tool. The reader should understand the WHOLE parsha before opening a commentary or preparing a dvar Torah.
 
@@ -28,7 +70,11 @@ BILINGUAL
 - Give natural English and natural Hebrew for every title, synopsis, summary, and landmark label.
 - Hebrew must be Hebrew script, not transliteration.
 
-No markdown. No citations or source names. Use only the supplied Torah text.`;
+No markdown. No citations or source names. Use only the supplied Torah text.
+
+${PARSHA_HEBREW_STYLE}
+
+${PARSHA_TERMS_RULE}`;
 
 export const PARSHA_OVERVIEW_USER_TEMPLATE =
   'Weekly portion: {{parsha_name}}\nRange: {{parsha_ref}}\n\n{{verses_text}}';
@@ -54,12 +100,14 @@ export const PARSHA_OVERVIEW_SCHEMA = {
       'composition',
       'flow',
       'landmarks',
+      'terms',
     ],
     properties: {
       titleEn: { type: 'string' },
       titleHe: { type: 'string' },
       overviewEn: { type: 'string' },
       overviewHe: { type: 'string' },
+      terms: TERMS_SCHEMA,
       composition: {
         type: 'object',
         additionalProperties: false,
@@ -118,6 +166,43 @@ export const PARSHA_OVERVIEW_SCHEMA = {
   },
 };
 
+export const PARSHA_SECTION_SYSTEM = `You are helping a Torah learner slow down inside ONE section of the weekly parsha. The reader clicked this section on a flow map of the whole portion, and the passage is highlighted in the text beside this note.
+
+Write a close, in-depth reading of JUST the supplied passage:
+- A short descriptive title (2-6 words) naming what the section is.
+- 2-3 substantial paragraphs: what happens or what is commanded, movement by movement — how the passage is built, which words repeat or carry it, what changes between its first verse and its last, and what it contributes to the parsha around it. Separate paragraphs with a blank line.
+- Concrete and specific to the supplied verses; a learner should come away able to walk someone else through the passage.
+- Stay on p'shat (the plain, contextual sense): no homily, no commentators, no midrash, no invented background. Deeper source-work belongs to the dvar Torah step, which the reader can take next.
+
+No markdown. Give natural English and natural Hebrew for every field. Hebrew must be Hebrew script, not transliteration.
+
+${PARSHA_HEBREW_STYLE}
+
+${PARSHA_TERMS_RULE}`;
+
+export const PARSHA_SECTION_USER_TEMPLATE = `Weekly portion: {{parsha_name}} ({{parsha_ref}})
+Section: {{section_title}} ({{section_ref}})
+
+TORAH PASSAGE
+{{verses_text}}`;
+
+export const PARSHA_SECTION_SCHEMA = {
+  name: 'parsha_section',
+  strict: true,
+  schema: {
+    type: 'object',
+    additionalProperties: false,
+    required: ['titleEn', 'titleHe', 'en', 'he', 'terms'],
+    properties: {
+      titleEn: { type: 'string' },
+      titleHe: { type: 'string' },
+      en: { type: 'string' },
+      he: { type: 'string' },
+      terms: TERMS_SCHEMA,
+    },
+  },
+};
+
 export const PARSHA_THREAD_SYSTEM = `You are helping a Torah learner turn one anchored section of the weekly parsha into a grounded dvar Torah.
 
 Build a clear study thread in four layers:
@@ -128,7 +213,9 @@ Build a clear study thread in four layers:
 
 Ground every claim. Never invent a quotation, commentator, midrash, wordplay, or source. Do not call something a direct quote unless the supplied words support it. Avoid generic sermon language and phrases such as "this teaches us" or "we see that." No markdown.
 
-Give natural English and natural Hebrew for every field. Hebrew must be Hebrew script, not transliteration.`;
+Give natural English and natural Hebrew for every field. Hebrew must be Hebrew script, not transliteration.
+
+${PARSHA_HEBREW_STYLE}`;
 
 export const PARSHA_THREAD_USER_TEMPLATE = `Parsha: {{parsha_name}} ({{parsha_ref}})
 Selected section: {{section_title}} ({{section_ref}})

--- a/packages/tanach/src/worker/run-ports.ts
+++ b/packages/tanach/src/worker/run-ports.ts
@@ -57,7 +57,9 @@ import {
   type ParshaSectionKind,
   parseParshaRef,
   pointInParsha,
+  sanitizeParshaTerms,
   sectionInParsha,
+  type WeeklyParsha,
 } from '../lib/parsha.ts';
 import type { TanachEnrichmentDef, TanachMarkDef } from './producers/defs.ts';
 import { enrichRunDefOf, markRunDefOf } from './producers/defs.ts';
@@ -114,8 +116,12 @@ const KEY_TEMPLATES: Record<string, KeyTemplate> = {
   // Chapter-scoped: the key ignores the instance (there's one overview per
   // chapter), so enrichmentAddress('overview', …) carries no verse/range.
   overview: { key: (a: TanachAddress) => `overview:v1:${a.unit?.work}:${a.unit?.unit}` },
-  'parsha-overview': { key: (a: TanachAddress) => `parsha-overview:v1:${a.instanceId}` },
-  'parsha-thread': { key: (a: TanachAddress) => `parsha-thread:v1:${a.instanceId}` },
+  // v2: prose follows PARSHA_HEBREW_STYLE (Hebrew script + gloss-once) and the
+  // overview carries the terms pool for hover hints; the thread matches the
+  // same voice. One weekly parsha, so the bump re-pays cents, not dollars.
+  'parsha-overview': { key: (a: TanachAddress) => `parsha-overview:v2:${a.instanceId}` },
+  'parsha-section': { key: (a: TanachAddress) => `parsha-section:v1:${a.instanceId}` },
+  'parsha-thread': { key: (a: TanachAddress) => `parsha-thread:v2:${a.instanceId}` },
   // Chapter-scoped like overview (one geography per chapter; instance ignored).
   // v2: the output now carries per-place verse numbers (for click-to-highlight).
   geography: { key: (a: TanachAddress) => `geography:v2:${a.unit?.work}:${a.unit?.unit}` },
@@ -166,7 +172,7 @@ export function enrichmentAddress(
     return { unit, instanceId, start, end };
   }
   // Parsha pieces key on their explicit ref/range instance rather than chapter.
-  if (id === 'parsha-overview' || id === 'parsha-thread') {
+  if (id === 'parsha-overview' || id === 'parsha-section' || id === 'parsha-thread') {
     return { unit, instanceId };
   }
   // Chapter-scoped (overview / geography / tidbit): key uses only {work}:{unit}.
@@ -176,10 +182,26 @@ export function enrichmentAddress(
   return { unit, instanceId, verse: instanceId };
 }
 
-/** Guard an index-keyed parsha thread against a regenerated overview moving
- *  that index to a different anchored passage. */
+/** The overview's literal KV key for a weekly parsha — lets the warm-cron gate
+ *  per-section warming on whether the overview map is already cached. */
+export async function parshaOverviewCacheKey(parsha: WeeklyParsha): Promise<string> {
+  const def = enrichRunDefOf('parsha-overview');
+  const instanceId = await instanceIdOf({ id: parsha.ref });
+  return TANACH_KEY_SCHEME.key(
+    keyInfoOf(def, 'enrich'),
+    enrichmentAddress('parsha-overview', instanceId, parsha.book, parsha.ref),
+  );
+}
+
+/** Guard an index-keyed parsha piece (close reading / thread) against a
+ *  regenerated overview moving that index to a different anchored passage. */
 export function enrichmentSectionRange(id: string, markInput: unknown): string | null {
-  if (id !== 'parsha-thread' || !markInput || typeof markInput !== 'object') return null;
+  if (
+    (id !== 'parsha-thread' && id !== 'parsha-section') ||
+    !markInput ||
+    typeof markInput !== 'object'
+  )
+    return null;
   const input = markInput as Record<string, unknown>;
   const parts = [input.startChapter, input.startVerse, input.endChapter, input.endVerse].map(
     Number,
@@ -342,16 +364,27 @@ interface ThreadSource {
   text: string;
 }
 
-const parshaThreadResolver: SourceResolver<TanachRunCtx> = async ({ out, markInput }) => {
-  const input = markInput as {
-    parshaName?: string;
-    parshaRef?: string;
-    titleEn?: string;
-    startChapter?: number;
-    startVerse?: number;
-    endChapter?: number;
-    endVerse?: number;
-  };
+/** The markInput shape every per-section parsha producer receives: the route
+ *  spreads the anchored flow section over the parsha identity. */
+interface ParshaSectionInput {
+  parshaName?: string;
+  parshaRef?: string;
+  titleEn?: string;
+  startChapter?: number;
+  startVerse?: number;
+  endChapter?: number;
+  endVerse?: number;
+}
+
+/** Resolve + bound-check one flow section against its parsha, then fetch its
+ *  verse text — the shared front half of the section and thread resolvers. */
+async function resolveSectionPassage(input: ParshaSectionInput): Promise<{
+  parsha: ParshaRange;
+  sectionRange: ParshaRange;
+  sectionRef: string;
+  verses: NumberedVerse[];
+  versesText: string;
+}> {
   const parsha = input.parshaRef ? parseParshaRef(input.parshaRef) : null;
   const section = {
     startChapter: Number(input.startChapter),
@@ -364,10 +397,29 @@ const parshaThreadResolver: SourceResolver<TanachRunCtx> = async ({ out, markInp
   }
   const sectionRange: ParshaRange = { book: parsha.book, ...section };
   const sectionRef = formatParshaRange(parsha.book, sectionRange);
-  const sefariaSectionRef = sectionRef.replace('–', '-');
   const verses = await versesInRange(sectionRange);
   if (!verses.length) throw new TanachSourceError(404, 'No section text found');
   const versesText = verses.map((v) => `${v.chapter}:${v.verse}. ${v.text}`).join('\n');
+  return { parsha, sectionRange, sectionRef, verses, versesText };
+}
+
+/** The close-reading producer's input: just the section's own verses (no
+ *  source packet — the deep dive stays on p'shat; sources join at the thread). */
+const parshaSectionVersesResolver: SourceResolver<TanachRunCtx> = async ({ out, markInput }) => {
+  const input = markInput as ParshaSectionInput;
+  const { sectionRef, versesText } = await resolveSectionPassage(input);
+  out.vars.parsha_name = input.parshaName ?? '';
+  out.vars.parsha_ref = input.parshaRef ?? '';
+  out.vars.section_title = input.titleEn ?? '';
+  out.vars.section_ref = sectionRef;
+  out.vars.verses_text = versesText;
+  recordSource(out, 'parsha-section-verses', versesText);
+};
+
+const parshaThreadResolver: SourceResolver<TanachRunCtx> = async ({ out, markInput }) => {
+  const input = markInput as ParshaSectionInput;
+  const { parsha, sectionRef, verses, versesText } = await resolveSectionPassage(input);
+  const sefariaSectionRef = sectionRef.replace('–', '-');
 
   const commentaryAnchors = [
     verses[0],
@@ -545,6 +597,7 @@ const RESOLVE_PORTS: ResolveInputsPorts<TanachRunCtx, TanachEnrichmentDef, Tanac
   sources: {
     'chapter-verses': chapterVersesResolver,
     'parsha-verses': parshaVersesResolver,
+    'parsha-section-verses': parshaSectionVersesResolver,
     'parsha-thread-material': parshaThreadResolver,
     'section-verses': sectionVersesResolver,
     'verse-text': verseTextResolver,
@@ -559,6 +612,7 @@ const RESOLVE_PORTS: ResolveInputsPorts<TanachRunCtx, TanachEnrichmentDef, Tanac
     id === 'note' ||
     id === 'overview' ||
     id === 'parsha-overview' ||
+    id === 'parsha-section' ||
     id === 'parsha-thread' ||
     id === 'geography' ||
     id === 'tidbit' ||
@@ -735,11 +789,28 @@ const RUN_PORTS: RunProducerPorts<TanachRunCtx, TanachEnrichmentDef, TanachMarkD
         composition: normalizeParshaComposition(parsed.composition),
         flow,
         landmarks,
+        terms: sanitizeParshaTerms(parsed.terms),
       };
       const issues =
         flow.length >= 3
           ? []
           : [{ severity: 'hard', message: 'Parsha flow has fewer than three anchored units' }];
+      return { parsed: normalized, issues };
+    }
+    if (a.def.id === 'parsha-section') {
+      const parsed = (a.parsed ?? {}) as Record<string, unknown>;
+      const normalized = {
+        ...parsed,
+        titleEn: String(parsed.titleEn ?? '').trim(),
+        titleHe: String(parsed.titleHe ?? '').trim(),
+        en: String(parsed.en ?? '').trim(),
+        he: String(parsed.he ?? '').trim(),
+        terms: sanitizeParshaTerms(parsed.terms),
+      };
+      const issues =
+        normalized.en || normalized.he
+          ? []
+          : [{ severity: 'hard', message: 'Parsha close reading has no prose' }];
       return { parsed: normalized, issues };
     }
     if (a.def.id === 'parsha-thread') {
@@ -872,7 +943,9 @@ const RUN_PORTS: RunProducerPorts<TanachRunCtx, TanachEnrichmentDef, TanachMarkD
       // Overview-like producers reject an empty-but-valid
       // generation so it isn't pinned (truncated JSON parses to blank fields).
       if (
-        !['overview', 'tidbit', 'parsha-overview', 'parsha-thread'].includes(a.def.id) ||
+        !['overview', 'tidbit', 'parsha-overview', 'parsha-section', 'parsha-thread'].includes(
+          a.def.id,
+        ) ||
         a.parse_error ||
         !a.parsed
       )
@@ -921,6 +994,7 @@ export async function runTanachEnrichment(
     | 'note'
     | 'overview'
     | 'parsha-overview'
+    | 'parsha-section'
     | 'parsha-thread'
     | 'geography'
     | 'tidbit'

--- a/packages/tanach/src/worker/warm-cron.ts
+++ b/packages/tanach/src/worker/warm-cron.ts
@@ -18,9 +18,10 @@
  * Bump CURSOR_KEY to force a re-warm (e.g. a producer version bump).
  */
 
-import type { WeeklyParsha } from '../lib/parsha.ts';
+import type { ParshaFlowSection, WeeklyParsha } from '../lib/parsha.ts';
 import { currentParsha } from './parsha-calendar.ts';
 import {
+  parshaOverviewCacheKey,
   runTanachEnrichment,
   runTanachEvents,
   type TanachEnv,
@@ -28,8 +29,9 @@ import {
 } from './run-ports.ts';
 import { computeSourcesIndex, readSourcesIndex } from './sources-index.ts';
 
-// v5: warm the whole-parsha overview before the chapter-level reader pieces.
-const CURSOR_KEY = 'tanach-warm-cursor:v5';
+// v6: parsha overview recipe v2 (Hebrew term style + hover-hint terms pool)
+// plus per-section close readings — re-warm this week's parsha surfaces.
+const CURSOR_KEY = 'tanach-warm-cursor:v6';
 /** Chapter-level enrichments that power the visible reader + section labels. */
 const CHAPTER_PRODUCERS = ['geography', 'events'] as const;
 /** Entries warmed per tick — small so one invocation stays well within the
@@ -38,6 +40,7 @@ const BATCH = 8;
 
 type WarmEntry =
   | { kind: 'parsha'; producer: 'parsha-overview' }
+  | { kind: 'parsha-section'; index: number; section: Omit<ParshaFlowSection, 'ref'> }
   | { kind: 'chapter'; producer: (typeof CHAPTER_PRODUCERS)[number]; chapter: number }
   | { kind: 'srcindex'; chapter: number }
   | { kind: 'verse'; producer: 'synthesis' | 'midrash-synthesis'; chapter: number; verse: number };
@@ -45,6 +48,7 @@ type WarmEntry =
 /** Stable id for the completed-set cursor. */
 function entryId(e: WarmEntry): string {
   if (e.kind === 'parsha') return `p:${e.producer}`;
+  if (e.kind === 'parsha-section') return `s:${e.index}`;
   if (e.kind === 'chapter') return `c:${e.chapter}:${e.producer}`;
   if (e.kind === 'srcindex') return `i:${e.chapter}`;
   return `v:${e.chapter}:${e.producer}:${e.verse}`;
@@ -73,6 +77,16 @@ async function readCursor(cache: KVNamespace): Promise<WarmCursor> {
  *  entry instead; its verses join the list once that index warms). */
 async function buildWorkList(cache: KVNamespace, parsha: WeeklyParsha): Promise<WarmEntry[]> {
   const surfaces: WarmEntry[] = [{ kind: 'parsha', producer: 'parsha-overview' }];
+  // Per-section close readings, gated (like srcindex -> verses) on the cached
+  // overview map: an uncached overview contributes only the overview entry;
+  // its sections join the list on the tick after it warms.
+  const overview = (await cache.get(await parshaOverviewCacheKey(parsha), 'json')) as {
+    parsed?: { flow?: Omit<ParshaFlowSection, 'ref'>[] };
+  } | null;
+  for (const [index, section] of (overview?.parsed?.flow ?? []).entries()) {
+    if (Number.isInteger(section?.startChapter))
+      surfaces.push({ kind: 'parsha-section', index, section });
+  }
   const indexes: WarmEntry[] = [];
   const verses: WarmEntry[] = [];
   for (let ch = parsha.startChapter; ch <= parsha.endChapter; ch++) {
@@ -106,6 +120,16 @@ async function warmEntry(
         id: parsha.ref,
         parshaName: parsha.name,
         parshaRef: parsha.ref,
+      });
+      return;
+    }
+    if (e.kind === 'parsha-section') {
+      const rc: TanachRunCtx = { env, ctx, ref: parsha.ref };
+      await runTanachEnrichment(rc, 'parsha-section', parsha.book, parsha.ref, {
+        id: `${parsha.ref}#${e.index}`,
+        parshaName: parsha.name,
+        parshaRef: parsha.ref,
+        ...e.section,
       });
       return;
     }

--- a/packages/tanach/tests/parsha.test.ts
+++ b/packages/tanach/tests/parsha.test.ts
@@ -4,7 +4,9 @@ import {
   normalizeParshaComposition,
   parseParshaRef,
   pointInParsha,
+  sanitizeParshaTerms,
   sectionInParsha,
+  tokenizeTermMentions,
 } from '../src/lib/parsha';
 
 describe('weekly parsha references', () => {
@@ -56,5 +58,52 @@ describe('weekly parsha references', () => {
       discourse: 50,
     });
     expect(normalizeParshaComposition({})).toEqual({ narrative: 0, law: 0, discourse: 100 });
+  });
+});
+
+describe('hover-hint terms', () => {
+  it('keeps only Hebrew-surface + English-meaning pairs, first entry winning a collision', () => {
+    expect(
+      sanitizeParshaTerms([
+        { he: 'ברכה', en: 'blessing' },
+        { he: ' קללה ', en: ' curse ' }, // trimmed
+        { he: 'ברכה', en: 'a different blessing' }, // duplicate surface — dropped
+        { he: 'bracha', en: 'transliteration, not script' }, // no Hebrew — dropped
+        { he: 'מעשר', en: 'מעשר' }, // Hebrew "meaning" is no hint — dropped
+        { he: '', en: 'empty' },
+        'not an object',
+      ]),
+    ).toEqual([
+      { he: 'ברכה', en: 'blessing' },
+      { he: 'קללה', en: 'curse' },
+    ]);
+  });
+
+  it('tokenizes Hebrew surfaces only, longest first, without touching attached prefixes', () => {
+    const terms = [
+      { he: 'מעשר', en: 'tithe' },
+      { he: 'מעשר שני', en: 'the second tithe' },
+      { he: 'ברכה', en: 'blessing' },
+    ];
+    expect(tokenizeTermMentions('sets a ברכה (blessing) before them', terms)).toEqual([
+      { kind: 'text', value: 'sets a ' },
+      { kind: 'term', value: 'ברכה', term: { he: 'ברכה', en: 'blessing' } },
+      { kind: 'text', value: ' (blessing) before them' },
+    ]);
+    // The longer surface wins where both could match.
+    expect(tokenizeTermMentions('the law of מעשר שני applies', terms).map((p) => p.kind)).toEqual([
+      'text',
+      'term',
+      'text',
+    ]);
+    expect(tokenizeTermMentions('the law of מעשר שני applies', terms)[1].value).toBe('מעשר שני');
+    // An attached prefix form (הברכה) is not half-underlined.
+    expect(tokenizeTermMentions('וזאת הברכה', terms)).toEqual([
+      { kind: 'text', value: 'וזאת הברכה' },
+    ]);
+    // English meanings are never matched (they are everyday words).
+    expect(tokenizeTermMentions('a blessing and a curse', terms)).toEqual([
+      { kind: 'text', value: 'a blessing and a curse' },
+    ]);
   });
 });

--- a/packages/tanach/tests/producer-defs.test.ts
+++ b/packages/tanach/tests/producer-defs.test.ts
@@ -22,8 +22,8 @@ describe('tanach spine registry', () => {
   });
 });
 
-describe('the ten producers as core Producer objects', () => {
-  it('declares all ten with their model shapes', () => {
+describe('the eleven producers as core Producer objects', () => {
+  it('declares all eleven with their model shapes', () => {
     expect(Object.keys(TANACH_PRODUCERS).sort()).toEqual([
       'events',
       'geography',
@@ -31,6 +31,7 @@ describe('the ten producers as core Producer objects', () => {
       'note',
       'overview',
       'parsha-overview',
+      'parsha-section',
       'parsha-thread',
       'synthesis',
       'tidbit',
@@ -79,11 +80,22 @@ describe('the ten producers as core Producer objects', () => {
       spine: 'tanach',
     });
     expect(TANACH_PRODUCERS['parsha-overview'].inputs).toEqual([{ source: 'parsha-verses' }]);
+    expect(TANACH_PRODUCERS['parsha-overview'].cacheVersion).toBe('2'); // parsha-overview:v2:*
+    expect(TANACH_PRODUCERS['parsha-section'].anchoring).toEqual({
+      behavior: 'inherits',
+      precision: 'segment',
+      spine: 'tanach',
+    });
+    expect(TANACH_PRODUCERS['parsha-section'].inputs).toEqual([
+      { source: 'parsha-section-verses' },
+    ]);
+    expect(TANACH_PRODUCERS['parsha-section'].cardinality).toBe('per-input');
     expect(TANACH_PRODUCERS['parsha-thread'].anchoring).toEqual({
       behavior: 'inherits',
       precision: 'segment',
       spine: 'tanach',
     });
+    expect(TANACH_PRODUCERS['parsha-thread'].cacheVersion).toBe('2'); // parsha-thread:v2:*
 
     const tidbit = TANACH_PRODUCERS.tidbit;
     expect(tidbit.kind).toBe('enrichment');
@@ -106,10 +118,11 @@ describe('the ten producers as core Producer objects', () => {
       note: { max_tokens: 700, temperature: 0.3, tag: 'tanach:note' },
       overview: { max_tokens: 1400, temperature: 0.3, tag: 'tanach:overview' },
       'parsha-overview': {
-        max_tokens: 5200,
+        max_tokens: 5600,
         temperature: 0.25,
         tag: 'tanach:parsha-overview',
       },
+      'parsha-section': { max_tokens: 2800, temperature: 0.3, tag: 'tanach:parsha-section' },
       'parsha-thread': { max_tokens: 4200, temperature: 0.35, tag: 'tanach:parsha-thread' },
       geography: { max_tokens: 900, temperature: 0.2, tag: 'tanach:geography' },
       tidbit: { max_tokens: 1800, temperature: 0.45, tag: 'tanach:tidbit' },
@@ -154,6 +167,7 @@ describe('the ten producers as core Producer objects', () => {
     expect(overview.system_prompt.length).toBeGreaterThan(50);
 
     expect(enrichRunDefOf('parsha-overview').dependencies).toEqual(['parsha-verses']);
+    expect(enrichRunDefOf('parsha-section').dependencies).toEqual(['parsha-section-verses']);
     expect(enrichRunDefOf('parsha-thread').dependencies).toEqual(['parsha-thread-material']);
 
     const geography = enrichRunDefOf('geography');

--- a/packages/tanach/tests/producer-keys.test.ts
+++ b/packages/tanach/tests/producer-keys.test.ts
@@ -78,7 +78,16 @@ describe('key byte-parity with the legacy literals', () => {
         overviewDef,
         enrichmentAddress('parsha-overview', overviewId, 'Deuteronomy', '7'),
       ),
-    ).toBe('parsha-overview:v1:deuteronomy_7_12-11_25');
+    ).toBe('parsha-overview:v2:deuteronomy_7_12-11_25');
+
+    const sectionDef = info(enrichRunDefOf('parsha-section'), 'enrich');
+    const sectionId = await instanceIdOf({ id: 'Deuteronomy 7:12-11:25#2' });
+    expect(
+      TANACH_KEY_SCHEME.key(
+        sectionDef,
+        enrichmentAddress('parsha-section', sectionId, 'Deuteronomy', '7'),
+      ),
+    ).toBe('parsha-section:v1:deuteronomy_7_12-11_25_2');
 
     const threadDef = info(enrichRunDefOf('parsha-thread'), 'enrich');
     const threadId = await instanceIdOf({ id: 'Deuteronomy 7:12-11:25#4' });
@@ -87,15 +96,19 @@ describe('key byte-parity with the legacy literals', () => {
         threadDef,
         enrichmentAddress('parsha-thread', threadId, 'Deuteronomy', '7'),
       ),
-    ).toBe('parsha-thread:v1:deuteronomy_7_12-11_25_4');
-    expect(
-      enrichmentSectionRange('parsha-thread', {
-        startChapter: 10,
-        startVerse: 12,
-        endChapter: 10,
-        endVerse: 22,
-      }),
-    ).toBe('10:12-10:22');
+    ).toBe('parsha-thread:v2:deuteronomy_7_12-11_25_4');
+    // Both index-keyed per-section pieces carry the range guard, so a
+    // regenerated overview that moves an index invalidates the cached value.
+    for (const id of ['parsha-section', 'parsha-thread'] as const) {
+      expect(
+        enrichmentSectionRange(id, {
+          startChapter: 10,
+          startVerse: 12,
+          endChapter: 10,
+          endVerse: 22,
+        }),
+      ).toBe('10:12-10:22');
+    }
   });
 
   it('previousKey is null (no SWR decrement in the literal templates)', () => {


### PR DESCRIPTION
## What

Reworks the "flow of the parsha" panel from PR #573 around the click-a-move interaction, and brings tanach's parsha prose onto the talmud reader's Hebrew-term style.

**Click a flow move →**
- its full verse range highlights in the reader (`parshaFocus` is now a range, highlighted per visible chapter; the reader navigates to the move's first chapter and the drawer **stays open** — the chapter-change pill auto-close now exempts the parsha-scoped drawer);
- an in-depth **close reading** of that passage opens in place under the card (new cached `parsha-section` producer — bilingual 2-3 paragraph p'shat reading of just that passage);
- "Open in the text" and "Build a dvar Torah" become follow-on actions inside the expanded card, instead of a dvar Torah being the up-front primary action for every move.

**Hebrew style, same as talmud**
- All parsha producers (overview / close reading / thread) now write English prose per `PARSHA_HEBREW_STYLE` — Hebrew script as the anchor for the portion's key words ("a ברכה (blessing) and a קללה (curse)"), gloss on first mention only, hard no-transliteration rules — the tanach cut of the talmud `HEBREW_GLOSS_STYLE`.
- Overview + close reading also return a `terms` pool ({he, en}); the new `TermedProse` component renders those mentions dotted-underlined with a hover/focus hint, matching the talmud concept-link treatment (Hebrew-only matching for precision; bidi-isolated runs; viewport-clamped tooltip).

## Cache/infra

- New key family `parsha-section:v1:*`, carrying the same `section_range` guard as the thread (a regenerated overview that moves an index invalidates the cached value).
- `parsha-overview`/`parsha-thread` bump to **v2** (recipe change) — one weekly parsha, so the regen is cents.
- Warm-cron cursor bumps to v6 and now also warms each flow unit's close reading, gated on the cached overview map (same pattern as srcindex → verses).

## Tests

- Key byte-parity goldens updated + `parsha-section` added; range-guard covered for both per-section pieces.
- New unit tests for `sanitizeParshaTerms` / `tokenizeTermMentions` (dedupe, longest-first, attached-prefix and English-word non-matching).
- `pnpm typecheck`, `pnpm test` (75 tanach + 2741 talmud), `pnpm lint`, and the vite build all pass.