### PR TITLE
Parsha prose: Hebrew script is the default surface, matching the talmud style

### DIFF
--- a/packages/tanach/src/worker/producers/defs.ts
+++ b/packages/tanach/src/worker/producers/defs.ts
@@ -260,9 +260,9 @@ export const TANACH_PRODUCERS: Record<TanachProducerId, Producer> = {
     cardinality: 'one',
     scope: 'local',
     key_shape: 'enrich',
-    // v2: prose follows PARSHA_HEBREW_STYLE and the output carries the terms
-    // pool for hover hints — bump regenerates this week's map with the new recipe.
-    cacheVersion: '2',
+    // v3: PARSHA_HEBREW_STYLE tightened to the talmud reader's literal
+    // convention (dense Hebrew-first Form A; Hebrew inside quote marks).
+    cacheVersion: '3',
     passes: ['parsha-overview-shape'],
     source: 'code',
   },
@@ -277,7 +277,8 @@ export const TANACH_PRODUCERS: Record<TanachProducerId, Producer> = {
     cardinality: 'per-input',
     scope: 'local',
     key_shape: 'enrich',
-    cacheVersion: '1',
+    // v2: the tightened PARSHA_HEBREW_STYLE (dense Hebrew-first prose).
+    cacheVersion: '2',
     passes: ['parsha-section-shape'],
     source: 'code',
   },
@@ -292,9 +293,9 @@ export const TANACH_PRODUCERS: Record<TanachProducerId, Producer> = {
     cardinality: 'per-input',
     scope: 'local',
     key_shape: 'enrich',
-    // v2: the thread prose follows PARSHA_HEBREW_STYLE too, so the whole
-    // drawer reads in one voice.
-    cacheVersion: '2',
+    // v3: the tightened PARSHA_HEBREW_STYLE, so the whole drawer reads in
+    // one voice.
+    cacheVersion: '3',
     passes: ['parsha-thread-sources'],
     source: 'code',
   },

--- a/packages/tanach/src/worker/producers/parsha.ts
+++ b/packages/tanach/src/worker/producers/parsha.ts
@@ -10,18 +10,23 @@
  */
 export const PARSHA_HEBREW_STYLE = `STYLE — Hebrew + English mixing (apply UNIFORMLY across all English prose fields):
 
-Plain English is the BASE; Hebrew script is the anchor for the portion's own key words. Weave in Hebrew where a word is genuinely the text's term or a standing term of Jewish learning — not on every common word.
+English carries the grammar; HEBREW SCRIPT carries the content. Every key word or phrase of the passage itself, and every standing term of Jewish learning, appears AS Hebrew with a short English gloss in parens on first mention. A paragraph should carry SEVERAL Hebrew anchors — if a paragraph has fewer than two, you are under-hebraizing. Ordinary connective English ("the passage then", "the people must not") stays English; the nouns and verbs that carry the Torah's meaning go Hebrew.
 
-FORM A (DEFAULT) — Hebrew script first, English gloss in parens. Use for the passage's key words and technical terms:
-  "a ברכה (blessing) and a קללה (curse)", "the מקום אשר יבחר (place God will choose)", "מעשר שני (the second tithe)"
-FORM B — English first, Hebrew in parens. Use ONLY for proper nouns and standing English-first terms:
+FORM A (DEFAULT) — Hebrew script first, English gloss in parens. The passage's own words, legal/ritual terms, repeated key phrases:
+  "a ברכה (blessing) and a קללה (curse)", "each case opens with כי (if)", "the מסית (enticer) receives no pity", "burned כליל (entire, as a whole-offering)", "the עיר הנדחת (subverted town)", "מעשר שני (the second tithe)"
+FORM B — English first, Hebrew in parens. ONLY for proper nouns and standing English-first terms:
   "Mount Gerizim (הר גריזים)", "Passover (פסח)", "the Levite (הלוי)"
 
-GLOSS ONCE: gloss a term on its FIRST use in a field; write it bare afterwards.
+QUOTING THE VERSES: the Torah's words go in Hebrew script INSIDE the quote marks, English gloss in parens after — "תבער הרע מקרבך" (sweep out the evil from your midst), "וכל ישראל ישמעו ויראו" (all Israel will hear and be afraid).
+  WRONG: the phrase 'sweep out evil from your midst' (תבער הרע מקרבך) — an English quote with the Hebrew demoted to parens.
+  RIGHT: the refrain "תבער הרע מקרבך" (sweep out the evil from your midst).
+
+GLOSS ONCE: gloss a term on its FIRST use in a field; write it bare afterwards (the reader's hover hint covers every later mention).
 
 HARD RULES (output is rejected if violated):
 - NEVER write a transliteration — not in parens "(bracha)", not bare "maaser sheni". Hebrew script paired with an English meaning, always.
-- Verbatim quotes from the verses go in Hebrew script inside quote marks — never transliteration in quotes.
+- NEVER quote the Torah in English only, and never put the Hebrew of a quoted phrase in the parens — the Hebrew IS the quote; the English is the gloss.
+- Once the passage's Hebrew word for a thing is introduced (נביא, חרם, מצוות), keep using the Hebrew word — do not slide back into a fresh English translation of it.
 - Hebrew-language fields are natural Hebrew with NO parenthetical English glosses.
 - SCRIPT HYGIENE: emit ONLY English + Hebrew script (plus ordinary punctuation) — no other writing system, no emoji.`;
 
@@ -29,11 +34,11 @@ HARD RULES (output is rejected if violated):
 export const PARSHA_TERMS_RULE = `TERMS
 - Return every Hebrew term or phrase your English prose uses in the "terms" array: "he" is the exact Hebrew script as written in the prose, "en" is a short English meaning.
 - The reader's hover hints are built from this array, so the "he" spelling must match the prose exactly.
-- 4-12 terms; no duplicates; short phrases, never full sentences.`;
+- 6-16 terms; no duplicates; short phrases, never full sentences.`;
 
 const TERMS_SCHEMA = {
   type: 'array',
-  maxItems: 12,
+  maxItems: 16,
   items: {
     type: 'object',
     additionalProperties: false,

--- a/packages/tanach/src/worker/run-ports.ts
+++ b/packages/tanach/src/worker/run-ports.ts
@@ -116,12 +116,14 @@ const KEY_TEMPLATES: Record<string, KeyTemplate> = {
   // Chapter-scoped: the key ignores the instance (there's one overview per
   // chapter), so enrichmentAddress('overview', …) carries no verse/range.
   overview: { key: (a: TanachAddress) => `overview:v1:${a.unit?.work}:${a.unit?.unit}` },
-  // v2: prose follows PARSHA_HEBREW_STYLE (Hebrew script + gloss-once) and the
-  // overview carries the terms pool for hover hints; the thread matches the
-  // same voice. One weekly parsha, so the bump re-pays cents, not dollars.
-  'parsha-overview': { key: (a: TanachAddress) => `parsha-overview:v2:${a.instanceId}` },
-  'parsha-section': { key: (a: TanachAddress) => `parsha-section:v1:${a.instanceId}` },
-  'parsha-thread': { key: (a: TanachAddress) => `parsha-thread:v2:${a.instanceId}` },
+  // overview v3 / section v2 / thread v3: PARSHA_HEBREW_STYLE tightened to the
+  // talmud reader's literal convention — Hebrew script is the DEFAULT surface
+  // for the passage's key words and quoted phrases (dense Form A; the English
+  // quote + Hebrew-in-parens inversion is rejected). One weekly parsha, so
+  // each bump re-pays cents, not dollars.
+  'parsha-overview': { key: (a: TanachAddress) => `parsha-overview:v3:${a.instanceId}` },
+  'parsha-section': { key: (a: TanachAddress) => `parsha-section:v2:${a.instanceId}` },
+  'parsha-thread': { key: (a: TanachAddress) => `parsha-thread:v3:${a.instanceId}` },
   // Chapter-scoped like overview (one geography per chapter; instance ignored).
   // v2: the output now carries per-place verse numbers (for click-to-highlight).
   geography: { key: (a: TanachAddress) => `geography:v2:${a.unit?.work}:${a.unit?.unit}` },

--- a/packages/tanach/src/worker/warm-cron.ts
+++ b/packages/tanach/src/worker/warm-cron.ts
@@ -29,9 +29,9 @@ import {
 } from './run-ports.ts';
 import { computeSourcesIndex, readSourcesIndex } from './sources-index.ts';
 
-// v6: parsha overview recipe v2 (Hebrew term style + hover-hint terms pool)
-// plus per-section close readings — re-warm this week's parsha surfaces.
-const CURSOR_KEY = 'tanach-warm-cursor:v6';
+// v7: parsha recipes tightened to the talmud-literal Hebrew style (dense
+// Hebrew-first prose) — re-warm this week's parsha surfaces.
+const CURSOR_KEY = 'tanach-warm-cursor:v7';
 /** Chapter-level enrichments that power the visible reader + section labels. */
 const CHAPTER_PRODUCERS = ['geography', 'events'] as const;
 /** Entries warmed per tick — small so one invocation stays well within the

--- a/packages/tanach/tests/producer-defs.test.ts
+++ b/packages/tanach/tests/producer-defs.test.ts
@@ -80,7 +80,7 @@ describe('the eleven producers as core Producer objects', () => {
       spine: 'tanach',
     });
     expect(TANACH_PRODUCERS['parsha-overview'].inputs).toEqual([{ source: 'parsha-verses' }]);
-    expect(TANACH_PRODUCERS['parsha-overview'].cacheVersion).toBe('2'); // parsha-overview:v2:*
+    expect(TANACH_PRODUCERS['parsha-overview'].cacheVersion).toBe('3'); // parsha-overview:v3:*
     expect(TANACH_PRODUCERS['parsha-section'].anchoring).toEqual({
       behavior: 'inherits',
       precision: 'segment',
@@ -95,7 +95,7 @@ describe('the eleven producers as core Producer objects', () => {
       precision: 'segment',
       spine: 'tanach',
     });
-    expect(TANACH_PRODUCERS['parsha-thread'].cacheVersion).toBe('2'); // parsha-thread:v2:*
+    expect(TANACH_PRODUCERS['parsha-thread'].cacheVersion).toBe('3'); // parsha-thread:v3:*
 
     const tidbit = TANACH_PRODUCERS.tidbit;
     expect(tidbit.kind).toBe('enrichment');

--- a/packages/tanach/tests/producer-keys.test.ts
+++ b/packages/tanach/tests/producer-keys.test.ts
@@ -78,7 +78,7 @@ describe('key byte-parity with the legacy literals', () => {
         overviewDef,
         enrichmentAddress('parsha-overview', overviewId, 'Deuteronomy', '7'),
       ),
-    ).toBe('parsha-overview:v2:deuteronomy_7_12-11_25');
+    ).toBe('parsha-overview:v3:deuteronomy_7_12-11_25');
 
     const sectionDef = info(enrichRunDefOf('parsha-section'), 'enrich');
     const sectionId = await instanceIdOf({ id: 'Deuteronomy 7:12-11:25#2' });
@@ -87,7 +87,7 @@ describe('key byte-parity with the legacy literals', () => {
         sectionDef,
         enrichmentAddress('parsha-section', sectionId, 'Deuteronomy', '7'),
       ),
-    ).toBe('parsha-section:v1:deuteronomy_7_12-11_25_2');
+    ).toBe('parsha-section:v2:deuteronomy_7_12-11_25_2');
 
     const threadDef = info(enrichRunDefOf('parsha-thread'), 'enrich');
     const threadId = await instanceIdOf({ id: 'Deuteronomy 7:12-11:25#4' });
@@ -96,7 +96,7 @@ describe('key byte-parity with the legacy literals', () => {
         threadDef,
         enrichmentAddress('parsha-thread', threadId, 'Deuteronomy', '7'),
       ),
-    ).toBe('parsha-thread:v2:deuteronomy_7_12-11_25_4');
+    ).toBe('parsha-thread:v3:deuteronomy_7_12-11_25_4');
     // Both index-keyed per-section pieces carry the range guard, so a
     // regenerated overview that moves an index invalidates the cached value.
     for (const id of ['parsha-section', 'parsha-thread'] as const) {


### PR DESCRIPTION
Follow-up to #575. The first cut of `PARSHA_HEBREW_STYLE` still yielded English-base prose with occasional Hebrew asides — including the inverted quote form the talmud style explicitly rejects ("'sweep out evil from your midst' (תבער הרע מקרבך)").

Tightened to the talmud reader's literal convention:

- **Hebrew script is the DEFAULT surface** for the passage's key words and standing terms — dense Form A, several anchors per paragraph, with an explicit "fewer than two per paragraph = under-hebraizing" bar.
- **Verse quotes carry the Hebrew inside the quote marks**, English gloss in parens after ("תבער הרע מקרבך" (sweep out the evil from your midst)); the English-quote-with-Hebrew-parens inversion is named and rejected.
- Once a Hebrew word is introduced (נביא, חרם, מצוות), the prose keeps using it rather than sliding back to English.
- Terms pool widens to 16 to match the density.

Recipe change → `parsha-overview` v3, `parsha-section` v2, `parsha-thread` v3, warm cursor v7 (one weekly parsha — regen is cents). Key goldens + cacheVersion pins updated; typecheck/tests/lint pass.