### PR TITLE
Leak sentinel: age offenders via provenance, auto-evict residue

### DIFF
--- a/packages/talmud/src/worker/whole-daf-leak-watch.ts
+++ b/packages/talmud/src/worker/whole-daf-leak-watch.ts
@@ -16,8 +16,19 @@
  * A leaked key can only exist if some path ran without the collapse — catching
  * it within minutes of the first leaked write instead of at the next invoice.
  *
+ * Age matters: three times now (07-16: 41 keys, 08-05: 1 key) the alert fired
+ * on RESIDUE — pre-fix leaked keys that survived a cleanup sweep — and, with
+ * enrichment entries never expiring, one immortal straggler emails daily
+ * forever. So offenders are aged via their envelope's provenance.createdAt:
+ * ones older than RESIDUE_MIN_AGE_DAYS are auto-evicted (a non-canonical key
+ * is unreachable by construction — every read path derives the canonical
+ * instance id — so deleting it only silences the alert), while young ones are
+ * the live-leak signal and are kept in place as evidence, re-alerting daily.
+ *
  * Cost: one bounded KV list per producer per tick (~6 lists / 5 min), zero
- * reads of values. Pure classification helpers exported for tests.
+ * reads of values — except when offenders exist: then one bounded read (and
+ * possibly delete) per offender. Pure classification helpers exported for
+ * tests.
  */
 
 import { instanceIdOf } from '@corpus/core/cache/keys';
@@ -67,13 +78,71 @@ export function leakedKeys(names: string[], prefix: string, canonicalIid: string
   return out;
 }
 
+/** A leaked key at least this old is residue (a pre-fix straggler a cleanup
+ *  missed), not a live leak, and is safe to auto-evict. A LIVE leak announces
+ *  itself with keys written today; a week of margin keeps a slow-drip leak
+ *  alerting rather than being quietly swallowed. */
+export const RESIDUE_MIN_AGE_DAYS = 7;
+
+export interface OffenderVerdict {
+  key: string;
+  /** gone: vanished between list and read (already deleted). human: authored
+   *  artifact, never touched. residue: old (or pre-provenance) — auto-evict.
+   *  fresh: young — the live-leak signal, kept in place. */
+  verdict: 'gone' | 'human' | 'residue' | 'fresh';
+  createdAt: string | null;
+  ageDays: number | null;
+  evicted?: boolean;
+}
+
+/** Age one offender via its envelope's provenance. Pure: the raw KV value (or
+ *  null) comes in, the verdict comes out; the caller does the I/O. A value
+ *  with no parseable createdAt predates provenance stamping (#361) and is
+ *  ancient by definition → residue. */
+export function classifyOffender(key: string, raw: string | null, nowMs: number): OffenderVerdict {
+  if (raw === null) return { key, verdict: 'gone', createdAt: null, ageDays: null };
+  let createdAt: string | null = null;
+  let authority: string | null = null;
+  try {
+    const v = JSON.parse(raw) as { provenance?: { createdAt?: string; authority?: string } };
+    createdAt = v?.provenance?.createdAt ?? null;
+    authority = v?.provenance?.authority ?? null;
+  } catch {
+    // unparseable value: pre-envelope garbage, ages as "no createdAt"
+  }
+  const ts = createdAt === null ? Number.NaN : Date.parse(createdAt);
+  const ageDays = Number.isNaN(ts) ? null : (nowMs - ts) / 86_400_000;
+  if (authority === 'human') return { key, verdict: 'human', createdAt, ageDays };
+  const residue = ageDays === null || ageDays > RESIDUE_MIN_AGE_DAYS;
+  return { key, verdict: residue ? 'residue' : 'fresh', createdAt, ageDays };
+}
+
 const LIST_PAGE_LIMIT = 1000;
 const MAX_PAGES_PER_TARGET = 3;
+/** Bound on per-offender reads/deletes per tick; anything beyond waits for the
+ *  next tick (evictions shrink the list, so the window slides forward). */
+const MAX_INSPECT_PER_TICK = 50;
+
+function offenderLine(c: OffenderVerdict): string {
+  const age =
+    c.ageDays === null
+      ? 'age unknown (pre-provenance)'
+      : `written ${c.createdAt} (${Math.floor(c.ageDays)}d ago)`;
+  const tag =
+    c.verdict === 'fresh'
+      ? 'FRESH — live leak?'
+      : c.verdict === 'human'
+        ? 'human-authored, kept'
+        : c.evicted
+          ? 'residue, auto-evicted'
+          : 'residue, evict FAILED';
+  return `  ${c.key} — ${age} [${tag}]`;
+}
 
 /**
- * Audit every whole-daf enrichment's key family; email once per day if any
- * non-canonical key exists. Best-effort and self-contained: failures are
- * logged, never thrown into the cron.
+ * Audit every whole-daf enrichment's key family; age + auto-evict residue;
+ * email once per day if any non-canonical key existed. Best-effort and
+ * self-contained: failures are logged, never thrown into the cron.
  */
 export async function checkWholeDafLeakAndAlert(env: LeakWatchEnv, nowMs: number): Promise<void> {
   const cache = env.CACHE;
@@ -99,26 +168,71 @@ export async function checkWholeDafLeakAndAlert(env: LeakWatchEnv, nowMs: number
     }
     if (found.length === 0) return;
 
-    console.error('[leak-watch] non-canonical whole-daf keys:', found.length, found.slice(0, 5));
+    // Eviction runs every tick (not just on alert days) so residue drains even
+    // after the day's email has gone out.
+    const offenders: OffenderVerdict[] = [];
+    for (const key of found.slice(0, MAX_INSPECT_PER_TICK)) {
+      let raw: string | null = null;
+      try {
+        raw = await cache.get(key);
+      } catch {}
+      const c = classifyOffender(key, raw, nowMs);
+      if (c.verdict === 'gone') continue;
+      if (c.verdict === 'residue') {
+        try {
+          await cache.delete(key);
+          c.evicted = true;
+        } catch {}
+      }
+      offenders.push(c);
+    }
+    const uninspected = Math.max(0, found.length - MAX_INSPECT_PER_TICK);
+    if (offenders.length === 0 && uninspected === 0) return; // all already gone
+
+    const fresh = offenders.filter((c) => c.verdict === 'fresh');
+    // Only claim self-healed when every offender was actually seen and aged as
+    // residue; uninspected keys could be fresh, so they keep the loud subject.
+    const selfHealed = fresh.length === 0 && uninspected === 0;
+    console.error(
+      '[leak-watch] non-canonical whole-daf keys:',
+      found.length,
+      `fresh=${fresh.length}`,
+      found.slice(0, 5),
+    );
     const dayBucket = Math.floor(nowMs / 86_400_000);
     const dedupeKey = `health-alert:wholedaf-leak:${dayBucket}`;
     if (await cache.get(dedupeKey)) return; // already alerted today
     if (env.EMAIL) {
+      const verdictLine =
+        fresh.length > 0
+          ? `${fresh.length} key(s) are FRESH (younger than ${RESIDUE_MIN_AGE_DAYS}d) — a code ` +
+            `path is LEAKING NOW. Check isWholeDafEnrichment call sites (it must read BOTH def ` +
+            `shapes: target_mark and mark) and any new run path that derives a cache key from ` +
+            `raw mark_input. Diagnostic: one identical leaked iid across dafim = a constant ` +
+            `(null/undefined) input; many distinct iids = per-caller fan-out. Fresh keys are ` +
+            `kept in place as evidence; residue was auto-evicted.`
+          : selfHealed
+            ? `All were RESIDUE (older than ${RESIDUE_MIN_AGE_DAYS}d — pre-fix stragglers a ` +
+              `cleanup missed) and were auto-evicted. Leaked keys are unreachable (all read ` +
+              `paths use the canonical instance id), so no action is needed and this alert ` +
+              `self-silences; any evict marked FAILED retries next tick.`
+            : `Every inspected key was RESIDUE (auto-evicted), but ${uninspected} offender(s) ` +
+              `exceeded this tick's inspection cap and are not yet aged — they process on the ` +
+              `next ticks. If this alert repeats tomorrow with FRESH keys, treat it as a live ` +
+              `leak.`;
       await env.EMAIL.send({
         from: 'health@shaunregenbaum.com',
         to: 'shaunregenbaum@gmail.com',
-        subject: `[talmud] whole-daf cache-key LEAK: ${found.length} non-canonical key(s)`,
+        subject: selfHealed
+          ? `[talmud] whole-daf cache-key residue: ${found.length} key(s) auto-evicted`
+          : `[talmud] whole-daf cache-key LEAK: ${found.length} non-canonical key(s), ${fresh.length} fresh`,
         text:
           `${found.length} whole-daf enrichment cache key(s) exist under a NON-canonical ` +
-          `instance id — some code path is running a whole-daf enrichment with a caller-derived ` +
-          `instance instead of the {fields:{}} collapse. This is the #426/#534 leak class: the ` +
-          `identical piece regenerates (and bills) once per calling section/rabbi, ~20x per daf.\n\n` +
-          `First offenders:\n${found
-            .slice(0, 8)
-            .map((k) => `  ${k}`)
-            .join('\n')}\n\n` +
-          `Check isWholeDafEnrichment call sites (it must read BOTH def shapes: target_mark and ` +
-          `mark) and any new run path that derives a cache key from raw mark_input.\n` +
+          `instance id — the #426/#534 leak class: a whole-daf piece cached per calling ` +
+          `section/rabbi instead of the {fields:{}} collapse.\n\n${verdictLine}\n\n` +
+          `Offenders:\n${offenders.slice(0, 8).map(offenderLine).join('\n')}\n` +
+          `${offenders.length > 8 ? `  …plus ${offenders.length - 8} more inspected\n` : ''}` +
+          `${uninspected > 0 ? `  …plus ${uninspected} not yet inspected (next ticks)\n` : ''}\n` +
           `Spend: https://talmud.shaunregenbaum.com/usage\n`,
       });
     }

--- a/packages/talmud/tests/whole-daf-leak-watch.test.ts
+++ b/packages/talmud/tests/whole-daf-leak-watch.test.ts
@@ -1,6 +1,12 @@
 import { instanceIdOf } from '@corpus/core/cache/keys';
 import { describe, expect, it } from 'vitest';
-import { leakedKeys, leakWatchTargets } from '../src/worker/whole-daf-leak-watch';
+import {
+  checkWholeDafLeakAndAlert,
+  classifyOffender,
+  leakedKeys,
+  leakWatchTargets,
+  RESIDUE_MIN_AGE_DAYS,
+} from '../src/worker/whole-daf-leak-watch';
 
 // The sentinel exists because this leak class shipped twice (#426, #534) and
 // burned real money both times, silently. These tests pin its two pure parts:
@@ -64,5 +70,154 @@ describe('leakedKeys', () => {
 
   it('the pinned canonical constant IS instanceIdOf({fields:{}})', async () => {
     expect(await instanceIdOf({ fields: {} })).toBe(CANON);
+  });
+});
+
+// The 07-16 and 08-05 alerts were both pre-fix residue re-alerting daily, not
+// live leaks. classifyOffender is the residue/fresh split that lets the
+// sentinel self-heal residue while keeping fresh keys screaming.
+describe('classifyOffender', () => {
+  const NOW = Date.parse('2026-08-05T09:00:00Z');
+  const day = 86_400_000;
+  const envelope = (createdAt?: string, authority = 'ai') =>
+    JSON.stringify({ content: 'x', provenance: { authority, createdAt } });
+
+  it('old key → residue; young key → fresh', () => {
+    const old = classifyOffender('k', envelope(new Date(NOW - 48 * day).toISOString()), NOW);
+    expect(old.verdict).toBe('residue');
+    expect(Math.floor(old.ageDays ?? 0)).toBe(48);
+    const young = classifyOffender('k', envelope(new Date(NOW - 1 * day).toISOString()), NOW);
+    expect(young.verdict).toBe('fresh');
+  });
+
+  it(`the boundary is ${RESIDUE_MIN_AGE_DAYS} days`, () => {
+    const justUnder = new Date(NOW - (RESIDUE_MIN_AGE_DAYS * day - 1000)).toISOString();
+    const justOver = new Date(NOW - (RESIDUE_MIN_AGE_DAYS * day + 1000)).toISOString();
+    expect(classifyOffender('k', envelope(justUnder), NOW).verdict).toBe('fresh');
+    expect(classifyOffender('k', envelope(justOver), NOW).verdict).toBe('residue');
+  });
+
+  it('no createdAt (pre-#361 value) and unparseable values age as ancient → residue', () => {
+    expect(classifyOffender('k', envelope(undefined), NOW).verdict).toBe('residue');
+    expect(classifyOffender('k', '{"content":"x"}', NOW).verdict).toBe('residue');
+    expect(classifyOffender('k', 'not json at all', NOW).verdict).toBe('residue');
+  });
+
+  it('a human-authored artifact is never eviction-eligible, however old', () => {
+    const c = classifyOffender(
+      'k',
+      envelope(new Date(NOW - 400 * day).toISOString(), 'human'),
+      NOW,
+    );
+    expect(c.verdict).toBe('human');
+  });
+
+  it('a key that vanished between list and read is gone', () => {
+    expect(classifyOffender('k', null, NOW).verdict).toBe('gone');
+  });
+});
+
+// Wiring test with a fake KV: both real leaks (#426, #534) regressed through
+// PLUMBING while logic-level tests stayed green, so drive the actual
+// checkWholeDafLeakAndAlert flow: list → classify → evict residue → email.
+describe('checkWholeDafLeakAndAlert', () => {
+  const NOW = Date.parse('2026-08-05T09:00:00Z');
+  const day = 86_400_000;
+  const CANON = 'f35cd02cd97b';
+
+  function fakeWorld(seed: Record<string, string>) {
+    const store = new Map(Object.entries(seed));
+    const deleted: string[] = [];
+    const sent: { subject: string; text: string }[] = [];
+    const kv = {
+      list: async ({ prefix }: { prefix: string }) => ({
+        keys: [...store.keys()].filter((k) => k.startsWith(prefix)).map((name) => ({ name })),
+        list_complete: true,
+      }),
+      get: async (key: string) => store.get(key) ?? null,
+      put: async (key: string, value: string) => {
+        store.set(key, value);
+      },
+      delete: async (key: string) => {
+        store.delete(key);
+        deleted.push(key);
+      },
+    };
+    const env = {
+      CACHE: kv as unknown as KVNamespace,
+      EMAIL: {
+        send: async (m: { subject: string; text: string }) => {
+          sent.push(m);
+        },
+      },
+    };
+    return { env, deleted, sent, store };
+  }
+
+  const prefix = () => {
+    const t = leakWatchTargets().find((t) => t.id === 'daf-background.concepts');
+    if (!t) throw new Error('daf-background.concepts not a leak-watch target');
+    return `enrich:daf-background.concepts:${t.version}:`;
+  };
+  const envelope = (ageDaysNum: number, authority = 'ai') =>
+    JSON.stringify({
+      content: 'x',
+      provenance: { authority, createdAt: new Date(NOW - ageDaysNum * day).toISOString() },
+    });
+
+  it('evicts residue, keeps fresh + human + canonical, and emails the split once', async () => {
+    const p = prefix();
+    const { env, deleted, sent } = fakeWorld({
+      [`${p}${CANON}:berakhot:2a`]: envelope(60),
+      [`${p}rava:pesachim:6a`]: envelope(48),
+      [`${p}some_section_title:sanhedrin:74a`]: envelope(1),
+      [`${p}manual_note:shabbat:21a`]: envelope(60, 'human'),
+    });
+
+    await checkWholeDafLeakAndAlert(env, NOW);
+
+    expect(deleted).toEqual([`${p}rava:pesachim:6a`]);
+    expect(sent).toHaveLength(1);
+    const mail = sent[0];
+    expect(mail.subject).toContain('LEAK');
+    expect(mail.subject).toContain('1 fresh');
+    expect(mail.text).toContain('rava:pesachim:6a — written');
+    expect(mail.text).toContain('residue, auto-evicted');
+    expect(mail.text).toContain('FRESH — live leak?');
+    expect(mail.text).toContain('human-authored, kept');
+    expect(mail.text).not.toContain(`${CANON}:berakhot:2a`);
+
+    // Same day again: dedupe suppresses a second email, nothing more deleted.
+    await checkWholeDafLeakAndAlert(env, NOW + 60_000);
+    expect(sent).toHaveLength(1);
+    expect(deleted).toHaveLength(1);
+  });
+
+  it('all-residue: auto-evicts, sends ONE self-silencing email, then goes quiet', async () => {
+    const p = prefix();
+    const { env, deleted, sent } = fakeWorld({
+      [`${p}${CANON}:berakhot:2a`]: envelope(60),
+      [`${p}rava:pesachim:6a`]: envelope(48),
+    });
+
+    await checkWholeDafLeakAndAlert(env, NOW);
+    expect(deleted).toEqual([`${p}rava:pesachim:6a`]);
+    expect(sent).toHaveLength(1);
+    expect(sent[0].subject).toContain('auto-evicted');
+    expect(sent[0].text).toContain('no action is needed');
+
+    // Next day: the residue is gone, so no alert at all.
+    await checkWholeDafLeakAndAlert(env, NOW + day);
+    expect(sent).toHaveLength(1);
+  });
+
+  it('a clean family stays silent', async () => {
+    const p = prefix();
+    const { env, sent } = fakeWorld({
+      [`${p}${CANON}:berakhot:2a`]: envelope(60),
+      [`${p}he:${CANON}:berakhot:2a`]: envelope(60),
+    });
+    await checkWholeDafLeakAndAlert(env, NOW);
+    expect(sent).toHaveLength(0);
   });
 });


### PR DESCRIPTION
The whole-daf cache-key leak sentinel (#536) has now fired three times on **residue** — pre-fix leaked keys that survived a cleanup sweep (41 keys on 07-16, 1 key today) — rather than on a live leak. Enrichment entries never expire and the alert is existence-based with a daily dedupe, so a single immortal straggler emails every day until someone hand-deletes it. Today's offender (`enrich:daf-background.concepts:5:rava:pesachim:6a`) was written 2026-06-18, during the original #426 window, and slipped through all three cleanups; it has been deleted by hand, and a fresh sweep of all six whole-daf families (7,672 keys, all versions) confirms zero other non-canonical keys.

This PR teaches the sentinel the residue/live split so the next straggler self-heals:

- **Age each offender** by reading its envelope's `provenance.createdAt` (pure `classifyOffender`, exported + tested). No/unparseable createdAt = pre-#361 value = ancient.
- **Auto-evict residue** (older than 7 days). A non-canonical key is unreachable by construction — every read path derives the canonical instance id — so eviction only silences the alert. Human-authored artifacts are never evicted; deletes are capped per tick.
- **Keep fresh keys** (younger than 7 days) in place as live-leak evidence, re-alerting daily as before.
- **Honest email**: per-key age + verdict lines; the subject distinguishes "residue: N auto-evicted" (one email, then silence) from "LEAK: N keys, F fresh". Uninspected overflow past the per-tick cap keeps the loud subject rather than claiming self-healed.
- **Wiring test** with a fake KV drives the real list → classify → evict → email flow, since both actual leaks (#426, #534) regressed through plumbing while logic-level tests stayed green.

Costs nothing new in the steady state: value reads (and deletes) happen only when offenders exist.