### PR TITLE
Gate generation on real daf extents; degrade permanent Sefaria ref errors

### DIFF
--- a/packages/talmud/src/client/DafViewer.tsx
+++ b/packages/talmud/src/client/DafViewer.tsx
@@ -13,7 +13,7 @@ import { dedupeBy, partitionSections } from '../lib/argumentMoves';
 import { DafRenderer } from '../lib/daf-render';
 import type { DafGeoModel } from '../lib/geographyModel';
 import type { TalmudPageData } from '../lib/sefref';
-import { dafRefHe, TRACTATE_OPTIONS } from '../lib/sefref';
+import { clampAmud, dafRefHe, TRACTATE_OPTIONS } from '../lib/sefref';
 import { conceptToTerm, glossaryForDaf, type Term } from '../lib/terms/registry';
 import {
   ArgumentSidebar,
@@ -413,10 +413,14 @@ export interface DafViewerProps {
 
 export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
   const params = new URLSearchParams(window.location.search);
-  const [tractate, setTractate] = createSignal(
-    props.initialTractate ?? params.get('tractate') ?? 'Berakhot',
+  const initialTractate = props.initialTractate ?? params.get('tractate') ?? 'Berakhot';
+  const [tractate, setTractate] = createSignal(initialTractate);
+  // Clamp the arrival page too — a shared/stale URL past the tractate's end
+  // (?page=32b on Megillah) would otherwise open a page that doesn't exist
+  // and trigger generation for it.
+  const [page, setPage] = createSignal(
+    clampAmud(initialTractate, props.initialPage ?? params.get('page') ?? '2a'),
   );
-  const [page, setPage] = createSignal(props.initialPage ?? params.get('page') ?? '2a');
   const [active, setActive] = createSignal<ActiveWord | null>(null);
 
   // Daf sizing. On desktop, scale down for narrow viewports; on phones the
@@ -843,7 +847,10 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
     const p = page();
     const controller = new AbortController();
     const timer = setTimeout(() => {
-      for (const np of [nextPage(p), prevPage(p)]) {
+      // clampAmud folds an off-the-end neighbour back onto the current page;
+      // the Set drop skips it (nothing to prefetch past the tractate's end).
+      for (const np of new Set([clampAmud(t, nextPage(p)), clampAmud(t, prevPage(p))])) {
+        if (np === p) continue;
         void fetch(`/api/daf/${encodeURIComponent(t)}/${np}`, { signal: controller.signal }).catch(
           () => {},
         );
@@ -2616,9 +2623,13 @@ export default function DafViewer(props: DafViewerProps = {}): JSX.Element {
     window.history.replaceState({}, '', u.toString());
   };
 
+  // Clamp navigation to the tractate's real extent — "next" from Megillah 32a
+  // must not land on 32b (no such page; generating it bills a full daf of LLM
+  // calls that all fail on permanent Sefaria ref errors). Covers the arrow
+  // keys, the ‹/› buttons, the free daf-number input, and the amud toggle.
   const go = (p: string) => {
     clearActive();
-    setPage(p);
+    setPage(clampAmud(tractate(), p));
     syncUrl();
   };
 

--- a/packages/talmud/src/lib/sefref/amudim.ts
+++ b/packages/talmud/src/lib/sefref/amudim.ts
@@ -107,3 +107,38 @@ export function* iterAmudim(tractate: string): Generator<string> {
     if (a) yield a;
   }
 }
+
+/**
+ * Whether `page` names a real amud of `tractate`: known tractate, well-formed
+ * 'Na'/'Nb' page, and within [2a, end amud]. Note the end amud matters, not
+ * just the daf number — Megillah ends at 32a, so "Megillah 32b" is invalid.
+ * The gate for the generation entrances (/api/daf-generate, /api/run): an
+ * out-of-range page must never spawn a Workflow or a queue job — Sefaria
+ * answers such refs with a permanent error object, so every enqueued producer
+ * hard-fails on every retry, and the LLM steps bill for a page that doesn't
+ * exist.
+ */
+export function isValidAmud(tractate: string, page: string): boolean {
+  const end = TRACTATE_END_AMUD[tractate.toLowerCase()];
+  if (!end) return false;
+  const cur = amudToNumber(page.trim());
+  const endNum = amudToNumber(end);
+  const startNum = amudToNumber(START_AMUD);
+  if (cur == null || endNum == null || startNum == null) return false;
+  return cur >= startNum && cur <= endNum;
+}
+
+/**
+ * Clamp a candidate page into the tractate's real range: past the end -> the
+ * end amud, before 2a / malformed / unknown tractate -> unchanged (the
+ * caller's existing fallback applies). Reader nav uses this so "next" from
+ * the last amud stays put instead of walking onto a page that doesn't exist.
+ */
+export function clampAmud(tractate: string, page: string): string {
+  const end = TRACTATE_END_AMUD[tractate.toLowerCase()];
+  if (!end) return page;
+  const cur = amudToNumber(page.trim());
+  const endNum = amudToNumber(end);
+  if (cur == null || endNum == null) return page;
+  return cur > endNum ? end : page.trim();
+}

--- a/packages/talmud/src/worker/commentary.ts
+++ b/packages/talmud/src/worker/commentary.ts
@@ -48,7 +48,8 @@ export async function fetchCommentaryWorks(
   page: string,
   bypassCache = false,
 ): Promise<
-  { works: CommentaryWork[]; tractate: string; page: string; fetchedAt: string } | { error: string }
+  | { works: CommentaryWork[]; tractate: string; page: string; fetchedAt: string }
+  | { error: string; permanent?: boolean }
 > {
   const cache = env.CACHE;
   const cacheKey = keyForCommentaryWorks(tractate, page);
@@ -88,6 +89,17 @@ export async function fetchCommentaryWorks(
     return { error: `Sefaria links non-JSON: ${String(err)}` };
   }
   if (!Array.isArray(parsed)) {
+    // A 200 whose JSON is {"error": "..."} is Sefaria's DELIBERATE answer for
+    // a ref it can't resolve ("Megillah ends at Daf 32a.", "Could not find
+    // title in reference: Shekalim 2a") — deterministic for that ref, so
+    // retrying can never succeed. Flag it permanent so callers degrade to
+    // empty instead of throwing into a queue-retry loop. Any other non-array
+    // shape stays transient (throw -> retry).
+    const errMsg =
+      parsed !== null && typeof parsed === 'object' && 'error' in parsed
+        ? String((parsed as { error: unknown }).error)
+        : null;
+    if (errMsg) return { error: `Sefaria links ref error: ${errMsg}`, permanent: true };
     return { error: `Sefaria links non-array response (${typeof parsed})` };
   }
   const raw = parsed as Array<{

--- a/packages/talmud/src/worker/index.ts
+++ b/packages/talmud/src/worker/index.ts
@@ -83,7 +83,7 @@ import {
 } from '../lib/rabbi/types';
 import type { EntityPiece } from '../lib/registry/entity';
 import { adjacentAmud, sefariaAPI, type TalmudPageData, TRACTATE_OPTIONS } from '../lib/sefref';
-import { iterAmudim, TRACTATE_END_AMUD } from '../lib/sefref/amudim';
+import { isValidAmud, iterAmudim, TRACTATE_END_AMUD } from '../lib/sefref/amudim';
 import { getDafyomiMasechet } from '../lib/sefref/dafyomi/masechtos';
 import { fetchHebrewBooksDaf } from '../lib/sefref/hebrewbooks/client';
 import { estimateShasCost } from '../lib/shasCost';
@@ -3395,6 +3395,13 @@ app.post('/api/daf-generate/:tractate/:page', async (c) => {
   if (!wf) return c.json({ error: 'DAF_WARM_WORKFLOW binding not available' }, 503);
   const tractate = c.req.param('tractate');
   const page = c.req.param('page');
+  // A page outside the tractate's real extent (e.g. Megillah 32b — Megillah
+  // ends at 32a) must not spawn a Workflow: every Sefaria-backed step gets a
+  // permanent ref error, the queue retries hard-fail, and the LLM steps bill
+  // for a daf that doesn't exist. 404 now, before any budget/breaker checks.
+  if (!isValidAmud(tractate, page)) {
+    return c.json({ generating: false, error: `unknown daf: ${tractate} ${page}` }, 404);
+  }
   const lang: 'en' | 'he' = c.req.query('lang') === 'he' ? 'he' : 'en';
   const gate = await checkBudget(c.env, { custom: false });
   if (!gate.ok) {
@@ -4132,7 +4139,15 @@ const isRishonTitle = (title: string): boolean =>
 const COMPUTED_FNS: Record<string, ComputedMarkFn> = {
   'rishonim-from-sefaria': async (env, tractate, page) => {
     const result = await fetchCommentaryWorks(env, tractate, page);
-    if ('error' in result) throw new Error(result.error);
+    // A permanent ref error (Sefaria has no such ref — e.g. Shekalim, which
+    // has no Bavli text under that title on Sefaria) can never succeed on
+    // retry: complete with an empty mark (cached; the chip just doesn't
+    // render) instead of hard-failing the queue job forever. Transient
+    // errors still throw so the queue retries.
+    if ('error' in result) {
+      if (result.permanent) return { instances: [] };
+      throw new Error(result.error);
+    }
     // Regroup by segment, filtering to the rishonim allowlist. Each instance
     // = one commented segment with the per-rishon comment payloads attached
     // for downstream synthesis.
@@ -4409,8 +4424,10 @@ async function runExtractorFannedOut(
       try {
         p = JSON.parse(r.content) as { instances?: unknown[] };
       } catch (err) {
+        // finish_reason distinguishes a max_tokens truncation ('length' — the
+        // section's moves outgrew the per-section cap) from model garbage.
         throw new Error(
-          `fan-out ${fanOutMarkId}: section JSON parse failed: ${String(err).slice(0, 120)}`,
+          `fan-out ${fanOutMarkId}: section JSON parse failed (finish=${r.finish_reason}): ${String(err).slice(0, 120)}`,
         );
       }
       if (Array.isArray(p.instances)) mergedInstances.push(...p.instances);
@@ -5571,6 +5588,12 @@ app.post('/api/run', async (c) => {
   const raw = parsed.value;
   const body = raw as Partial<JobMessage>;
   if (!body.tractate || !body.page) return c.json({ error: 'tractate and page required' }, 400);
+  // Same daf-extent gate as /api/daf-generate: a producer run on a page that
+  // doesn't exist is a doomed queue job (permanent Sefaria ref error on every
+  // retry) — refuse it at the entrance instead.
+  if (!isValidAmud(body.tractate, body.page)) {
+    return c.json({ error: `unknown daf: ${body.tractate} ${body.page}` }, 404);
+  }
 
   // Hijack lockdown: the privileged knobs let a caller run arbitrary prompts
   // (ad_hoc), pick an expensive model (model_override), or force fresh paid runs

--- a/packages/talmud/tests/daf-bounds.test.ts
+++ b/packages/talmud/tests/daf-bounds.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { clampAmud, isValidAmud, TRACTATE_END_AMUD } from '../src/lib/sefref/amudim';
+import { TRACTATE_OPTIONS } from '../src/lib/sefref/tractates';
+import { fetchCommentaryWorks } from '../src/worker/commentary';
+import type { Bindings } from '../src/worker/types';
+
+// Pages past a tractate's end used to reach the generation pipeline (the
+// reader's "next" walked off Megillah 32a onto 32b, /api/daf-generate spawned
+// a Workflow for it, every Sefaria-backed producer got a permanent ref error,
+// and each queue retry logged another hard failure while the LLM steps billed
+// for a page that doesn't exist). These pin the gates that stop that.
+
+describe('isValidAmud', () => {
+  it('accepts real pages, including tractate ends', () => {
+    expect(isValidAmud('Megillah', '2a')).toBe(true);
+    expect(isValidAmud('Megillah', '32a')).toBe(true);
+    expect(isValidAmud('Avodah Zarah', '76b')).toBe(true);
+    expect(isValidAmud('Shekalim', '22b')).toBe(true);
+    expect(isValidAmud('Berakhot', '64a')).toBe(true);
+  });
+
+  it('rejects pages past the end — amud-granular, not just the daf number', () => {
+    // Megillah ends at 32a: the daf number is in range but 32b does not exist.
+    expect(isValidAmud('Megillah', '32b')).toBe(false);
+    expect(isValidAmud('Avodah Zarah', '98a')).toBe(false);
+    expect(isValidAmud('Berakhot', '64b')).toBe(false);
+    expect(isValidAmud('Shekalim', '23a')).toBe(false);
+  });
+
+  it('rejects pages before 2a, malformed pages, and unknown tractates', () => {
+    expect(isValidAmud('Megillah', '1a')).toBe(false);
+    expect(isValidAmud('Megillah', '1b')).toBe(false);
+    expect(isValidAmud('Megillah', '0a')).toBe(false);
+    expect(isValidAmud('Megillah', '2c')).toBe(false);
+    expect(isValidAmud('Megillah', 'abc')).toBe(false);
+    expect(isValidAmud('Megillah', '')).toBe(false);
+    expect(isValidAmud('Bava Nonexistent', '2a')).toBe(false);
+  });
+
+  it('covers every tractate the reader offers', () => {
+    for (const opt of TRACTATE_OPTIONS) {
+      expect(TRACTATE_END_AMUD[opt.value.toLowerCase()], opt.value).toBeTruthy();
+      expect(isValidAmud(opt.value, '2a'), opt.value).toBe(true);
+    }
+  });
+});
+
+describe('clampAmud', () => {
+  it('folds past-the-end pages onto the end amud', () => {
+    expect(clampAmud('Megillah', '32b')).toBe('32a');
+    expect(clampAmud('Megillah', '99a')).toBe('32a');
+    expect(clampAmud('Avodah Zarah', '98a')).toBe('76b');
+  });
+
+  it('leaves in-range pages unchanged', () => {
+    expect(clampAmud('Megillah', '2a')).toBe('2a');
+    expect(clampAmud('Megillah', '32a')).toBe('32a');
+    expect(clampAmud('Shekalim', '22b')).toBe('22b');
+  });
+
+  it('passes through malformed pages and unknown tractates unchanged', () => {
+    expect(clampAmud('Megillah', 'abc')).toBe('abc');
+    expect(clampAmud('Bava Nonexistent', '99a')).toBe('99a');
+  });
+});
+
+// Sefaria answers an unresolvable ref with a 200 whose body is an error
+// OBJECT (e.g. {"error": "Megillah ends at Daf 32a."}) — deterministic for
+// that ref. fetchCommentaryWorks must flag that shape permanent so the
+// rishonim mark completes empty instead of hard-failing every queue retry
+// (Shekalim: Sefaria has no Bavli text under that title at all, so the daf is
+// valid in-app but this fetch permanently errors).
+describe('fetchCommentaryWorks — Sefaria error-object classification', () => {
+  const env = {} as Bindings;
+  afterEach(() => vi.unstubAllGlobals());
+
+  const stubFetch = (body: string, init?: ResponseInit) =>
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(body, init)),
+    );
+
+  it('marks a 200 {"error": ...} object permanent', async () => {
+    stubFetch(JSON.stringify({ error: 'Could not find title in reference: Shekalim 2a' }));
+    const r = await fetchCommentaryWorks(env, 'Shekalim', '2a');
+    expect(r).toMatchObject({ permanent: true });
+    expect('error' in r && r.error).toContain('Could not find title');
+  });
+
+  it('keeps other non-array JSON transient (no permanent flag)', async () => {
+    stubFetch(JSON.stringify({ unexpected: 'shape' }));
+    const r = await fetchCommentaryWorks(env, 'Berakhot', '2a');
+    expect('error' in r && r.error).toContain('non-array');
+    expect((r as { permanent?: boolean }).permanent).toBeUndefined();
+  });
+
+  it('keeps HTTP failures and non-JSON transient', async () => {
+    stubFetch('gateway timeout', { status: 503 });
+    const r1 = await fetchCommentaryWorks(env, 'Berakhot', '2a');
+    expect((r1 as { permanent?: boolean }).permanent).toBeUndefined();
+    stubFetch('<html>rate limited</html>');
+    const r2 = await fetchCommentaryWorks(env, 'Berakhot', '2a');
+    expect((r2 as { permanent?: boolean }).permanent).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem

Queue-failure telemetry showed 30 hard exceptions in the enrichment queue consumer over the past week, 24 of them `Sefaria links non-array response (object)` on `mark=rishonim`. Two distinct causes:

**Nonexistent pages reached the generation pipeline.** Megillah 32b and Avodah Zarah 98a do not exist (Megillah ends at 32a, AZ at 76b), but nothing validated page extents anywhere: reader nav walked off the end of a tractate unbounded, `/api/daf-generate` spawned a full warm Workflow for the fake page, and every Sefaria-backed producer then hard-failed **every retry** on a permanent ref error (`{"error": "Megillah ends at Daf 32a."}`) — while the LLM steps billed real money for a daf that doesn't exist. The same dafs show up in content-check telemetry with *every* anchor out of range, confirming generation ran against garbage.

**Shekalim can never succeed on Sefaria.** The daf is valid in-app (HebrewBooks serves the Vilna text) but Sefaria has no Bavli title `Shekalim` — its links API answers `{"error": "Could not find title in reference: Shekalim 2a"}` deterministically, so the rishonim job hard-failed forever.

## Fix

- **`amudim.ts`**: `isValidAmud` + `clampAmud` built on the existing `TRACTATE_END_AMUD` extents (re-verified against Sefaria's shape API for all 36 Sefaria tractates). End **amud** matters, not just the daf number — 32a valid, 32b not.
- **Server gates**: `/api/daf-generate` and `/api/run` 404 an out-of-range daf before any budget check, Workflow, or enqueue. (Global-scope producers still pass a real context daf in the body, so they are unaffected.)
- **Reader**: `go()` clamps all navigation (arrow keys, ‹/› buttons, free daf-number input, amud toggle), the arrival URL is clamped, and neighbour prefetch skips off-the-end pages.
- **`fetchCommentaryWorks`**: a 200 whose JSON is an `{"error": ...}` **object** is Sefaria's deliberate, deterministic answer for an unresolvable ref — now flagged `permanent`. `rishonim-from-sefaria` completes with an empty mark on permanent errors (cached; the chip just doesn't render) instead of throwing into an eternal retry loop. HTTP failures / non-JSON / other odd shapes stay transient and still throw → queue retries as before.
- **Diagnostics**: fan-out section JSON parse errors now include `finish_reason`, so a `max_tokens` truncation (the likely cause of the observed `Unterminated string` argument-move failure) is distinguishable from model garbage.

The remaining 3 failures in the window were OpenRouter 402s (out of credits — expected pause behavior, no change).

## Tests

New `daf-bounds.test.ts`: extent validation incl. amud-granular ends and every reader tractate having bounds; clamp behavior; permanent-vs-transient classification of Sefaria responses (mocked fetch). Full suite: 203 files / 2764 tests pass, typecheck + lint clean.