### PR TITLE
Draw the weekly parsha as a map coloured by kind of reading

### DIFF
--- a/packages/tanach/src/client/ParshaDrawer.tsx
+++ b/packages/tanach/src/client/ParshaDrawer.tsx
@@ -3,12 +3,12 @@ import { Prose } from '@corpus/ui/Prose';
 import { createEffect, createResource, createSignal, For, type JSX, Show } from 'solid-js';
 import {
   type ParshaFlowSection,
-  type ParshaSectionKind,
   type ParshaSectionStudy,
   type ParshaStudy,
   type ParshaThread,
   sanitizeParshaTerms,
 } from '../lib/parsha.ts';
+import { PARSHA_KIND_LABEL, ParshaMap } from './ParshaMap.tsx';
 import { TermedProse } from './TermedProse.tsx';
 
 export interface ParshaDrawerProps {
@@ -20,12 +20,6 @@ export interface ParshaDrawerProps {
    *  Fires on selecting a move — the drawer stays open. */
   onFocusRange: (section: ParshaFlowSection | null) => void;
 }
-
-const KIND_LABEL: Record<ParshaSectionKind, { en: string; he: string }> = {
-  narrative: { en: 'Narrative', he: 'סיפור' },
-  law: { en: 'Halachah', he: 'הלכה' },
-  discourse: { en: 'Discourse', he: 'נאום ורעיון' },
-};
 
 function textFor(lang: 'en' | 'he', en: string, he: string): string {
   return lang === 'he' ? he || en : en || he;
@@ -70,6 +64,18 @@ export function ParshaDrawer(props: ParshaDrawerProps): JSX.Element {
     );
   });
 
+  // A move can be picked from the map, where the band that just opened is
+  // often far down the drawer — bring it into view. 'nearest' leaves a band
+  // that is already on screen exactly where it is.
+  const moveRows: (HTMLElement | undefined)[] = [];
+  createEffect(() => {
+    const index = selected();
+    if (index === null) return;
+    requestAnimationFrame(() =>
+      moveRows[index]?.scrollIntoView({ behavior: 'smooth', block: 'nearest' }),
+    );
+  });
+
   // Selecting a move highlights its verse range in the reader and opens its
   // close reading in place; selecting it again collapses and clears both.
   const choose = (index: number) => {
@@ -107,6 +113,19 @@ export function ParshaDrawer(props: ParshaDrawerProps): JSX.Element {
     return index === null ? undefined : props.study.flow[index];
   };
 
+  const verseCount = (index: number): number | undefined =>
+    props.study.map?.units.find((span) => span.index === index)?.verses;
+
+  /** A band stands as tall as its passage is long — the strip's proportions,
+   *  read down the list. Floors at a comfortable tap target, so a six-verse
+   *  unit is still a row and not a sliver. Uniform when there is no map. */
+  const bandStyle = (index: number): { 'min-height': string } | undefined => {
+    const map = props.study.map;
+    const verses = verseCount(index);
+    if (!map?.totalVerses || !verses) return undefined;
+    return { 'min-height': `${Math.round(30 + (verses / map.totalVerses) * 150)}px` };
+  };
+
   return (
     <section class="parsha-study">
       <p class="parsha-ref">{props.study.ref}</p>
@@ -118,37 +137,27 @@ export function ParshaDrawer(props: ParshaDrawerProps): JSX.Element {
         terms={props.study.terms ?? []}
       />
 
-      <section class="parsha-section">
-        <div class="parsha-section-head">
-          <h4>{props.lang === 'he' ? 'הרכב הפרשה' : 'What kind of reading is this?'}</h4>
-          <span>{props.lang === 'he' ? 'מפה משוערת' : 'editorial estimate'}</span>
-        </div>
-        <div class="parsha-composition" role="img" aria-label="Parsha composition">
-          <For each={['narrative', 'law', 'discourse'] as const}>
-            {(kind) => (
-              <span
-                class={`parsha-composition-${kind}`}
-                style={{ width: `${props.study.composition[kind]}%` }}
-                title={`${KIND_LABEL[kind][props.lang]} ${props.study.composition[kind]}%`}
-              />
-            )}
-          </For>
-        </div>
-        <div class="parsha-legend">
-          <For each={['narrative', 'law', 'discourse'] as const}>
-            {(kind) => (
-              <span>
-                <i class={`parsha-dot parsha-dot-${kind}`} />
-                {KIND_LABEL[kind][props.lang]} {props.study.composition[kind]}%
-              </span>
-            )}
-          </For>
-        </div>
-      </section>
+      <Show when={props.study.map}>
+        <section class="parsha-section">
+          <div class="parsha-section-head">
+            <h4>{props.lang === 'he' ? 'הרכב הפרשה' : 'What kind of reading is this?'}</h4>
+            <span>
+              {props.study.map?.totalVerses} {props.lang === 'he' ? 'פסוקים' : 'verses'}
+            </span>
+          </div>
+          <ParshaMap
+            study={props.study}
+            lang={props.lang}
+            selected={selected()}
+            onSelect={choose}
+            onOpenVerse={(chapter, verse) => props.onOpenText(props.study.book, chapter, verse)}
+          />
+        </section>
+      </Show>
 
       <section class="parsha-section">
         <div class="parsha-section-head">
-          <h4>{props.lang === 'he' ? 'מהלך הפרשה' : 'The flow of the parsha'}</h4>
+          <h4>{props.lang === 'he' ? 'מהלך הפרשה' : 'The parsha, move by move'}</h4>
           <span>
             {props.study.flow.length} {props.lang === 'he' ? 'יחידות' : 'moves'}
           </span>
@@ -156,25 +165,42 @@ export function ParshaDrawer(props: ParshaDrawerProps): JSX.Element {
         <ol class="parsha-flow">
           <For each={props.study.flow}>
             {(section, index) => (
-              <li>
+              <li ref={(element) => (moveRows[index()] = element)}>
                 <button
                   type="button"
-                  class="parsha-flow-card"
+                  class="parsha-band"
                   classList={{ active: selected() === index() }}
+                  style={bandStyle(index())}
                   onClick={() => choose(index())}
                 >
-                  <span class={`parsha-flow-node parsha-flow-node-${section.kind}`} />
-                  <span class="parsha-flow-copy">
-                    <span class="parsha-flow-meta">
-                      <b>{section.ref.replace(`${props.study.book} `, '')}</b>
-                      <i>{KIND_LABEL[section.kind][props.lang]}</i>
-                    </span>
-                    <strong>{textFor(props.lang, section.titleEn, section.titleHe)}</strong>
-                    <small>{textFor(props.lang, section.summaryEn, section.summaryHe)}</small>
+                  <span class={`parsha-band-stripe parsha-kind-${section.kind}`} />
+                  <span class="parsha-band-title">
+                    {textFor(props.lang, section.titleEn, section.titleHe)}
+                  </span>
+                  {/* A verse RANGE is Latin digits joined by a dash: without
+                      its own direction it reorders to "17:7–16:18" inside the
+                      Hebrew drawer. */}
+                  <span class="parsha-band-ref" dir="ltr">
+                    {section.ref.replace(`${props.study.book} `, '')}
                   </span>
                 </button>
                 <Show when={selected() === index()}>
                   <div class="parsha-flow-deep">
+                    <p class="parsha-flow-kicker">
+                      <span dir="ltr">{section.ref.replace(`${props.study.book} `, '')}</span> ·{' '}
+                      {PARSHA_KIND_LABEL[section.kind][props.lang]}
+                      <Show when={verseCount(index())}>
+                        {(count) => (
+                          <>
+                            {' · '}
+                            {count()} {props.lang === 'he' ? 'פסוקים' : 'verses'}
+                          </>
+                        )}
+                      </Show>
+                    </p>
+                    <p class="parsha-flow-summary">
+                      {textFor(props.lang, section.summaryEn, section.summaryHe)}
+                    </p>
                     <Show when={deep.loading}>
                       <p class="comm-muted">
                         {props.lang === 'he'

--- a/packages/tanach/src/client/ParshaMap.tsx
+++ b/packages/tanach/src/client/ParshaMap.tsx
@@ -1,0 +1,162 @@
+/**
+ * The whole weekly portion as one object: a proportional strip of the parsha,
+ * one segment per flow unit, coloured by what KIND of reading it is.
+ *
+ * Every layer sits on the same axis — verses from the portion's first verse —
+ * so the drawing is pure arithmetic on `study.map`:
+ *   aliyot rail   the week's seven divisions (from the calendar, not the model)
+ *   the strip     the AI's flow units, at their true verse extents
+ *   pins          landmarks, at their exact verse
+ *   chapter ticks where 17, 18, 19 … begin
+ *
+ * Segments are positioned absolutely rather than tiled, so a portion the model
+ * left a gap in shows the gap instead of silently stretching its neighbours.
+ * The strip is the flow list's other face: selecting here selects there.
+ */
+import { For, type JSX, Show } from 'solid-js';
+import { hebrewNumeral } from '../lib/hebrew.ts';
+import type { ParshaFlowSection, ParshaSectionKind, ParshaStudy } from '../lib/parsha.ts';
+
+export const PARSHA_KIND_LABEL: Record<ParshaSectionKind, { en: string; he: string }> = {
+  narrative: { en: 'Narrative', he: 'סיפור' },
+  law: { en: 'Halachah', he: 'הלכה' },
+  discourse: { en: 'Discourse', he: 'נאום ורעיון' },
+  poetry: { en: 'Poetry', he: 'שירה' },
+  records: { en: 'Records', he: 'רשימות' },
+};
+
+/** Display order for the legend — the reading kinds as the Torah tends to run
+ *  them, not the arbitrary order a given portion happens to use. */
+const LEGEND_ORDER: ParshaSectionKind[] = ['narrative', 'law', 'discourse', 'poetry', 'records'];
+
+export interface ParshaMapProps {
+  study: ParshaStudy;
+  lang: 'en' | 'he';
+  selected: number | null;
+  onSelect: (index: number) => void;
+  onOpenVerse: (chapter: number, verse: number) => void;
+}
+
+export function ParshaMap(props: ParshaMapProps): JSX.Element {
+  const map = () => props.study.map;
+  const total = () => map()?.totalVerses ?? 0;
+  const pct = (n: number) => `${(n / total()) * 100}%`;
+  const unitAt = (index: number): ParshaFlowSection | undefined => props.study.flow[index];
+
+  /** Chapter numbers, thinned so two labels never sit on top of each other —
+   *  a portion that opens mid-chapter (Shoftim starts at 16:18) would
+   *  otherwise print "16 17" in the same few pixels. The opening chapter
+   *  always survives; a crowded later one is dropped. */
+  const chapterTicks = () => {
+    const total = map()?.totalVerses ?? 0;
+    const kept: { chapter: number; offset: number }[] = [];
+    for (const tick of map()?.chapters ?? []) {
+      const at = (tick.offset / total) * 100;
+      const previous = kept.at(-1);
+      if (previous && at - (previous.offset / total) * 100 < 5) continue;
+      kept.push(tick);
+    }
+    return kept;
+  };
+  const label = (kind: ParshaSectionKind) => PARSHA_KIND_LABEL[kind][props.lang];
+  const shortRef = (ref: string) => ref.replace(`${props.study.book} `, '');
+
+  return (
+    <Show when={map()}>
+      {(value) => (
+        <>
+          <Show when={value().aliyot.length}>
+            <div class="parsha-map-aliyot">
+              <For each={value().aliyot}>
+                {(aliyah) => (
+                  <i
+                    style={{ 'inset-inline-start': pct(aliyah.offset), width: pct(aliyah.verses) }}
+                    title={`${props.lang === 'he' ? 'עלייה' : 'Aliyah'} ${aliyah.n} · ${shortRef(aliyah.ref)}`}
+                  >
+                    {hebrewNumeral(aliyah.n)}
+                  </i>
+                )}
+              </For>
+            </div>
+          </Show>
+
+          <div class="parsha-map-strip">
+            <For each={value().units}>
+              {(span) => {
+                const unit = unitAt(span.index);
+                if (!unit) return null;
+                // An accessor, not a value: these rows are not recreated when
+                // the language changes (the units array is the same), so a
+                // snapshot would leave the tooltips in the old language.
+                const title = () =>
+                  props.lang === 'he' ? unit.titleHe || unit.titleEn : unit.titleEn;
+                return (
+                  <button
+                    type="button"
+                    class={`parsha-map-unit parsha-kind-${unit.kind}`}
+                    classList={{ active: props.selected === span.index }}
+                    style={{ 'inset-inline-start': pct(span.offset), width: pct(span.verses) }}
+                    title={`${title()} · ${shortRef(unit.ref)} · ${span.verses} ${
+                      props.lang === 'he' ? 'פסוקים' : 'verses'
+                    }`}
+                    aria-label={title()}
+                    onClick={() => props.onSelect(span.index)}
+                  >
+                    <span>{span.index + 1}</span>
+                  </button>
+                );
+              }}
+            </For>
+          </div>
+
+          <Show when={value().landmarks.length}>
+            <div class="parsha-map-pins">
+              <For each={value().landmarks}>
+                {(pin) => {
+                  const landmark = props.study.landmarks[pin.index];
+                  if (!landmark) return null;
+                  const text = () =>
+                    props.lang === 'he' ? landmark.labelHe || landmark.labelEn : landmark.labelEn;
+                  return (
+                    <button
+                      type="button"
+                      class="parsha-map-pin"
+                      style={{ 'inset-inline-start': pct(pin.offset + 0.5) }}
+                      title={`${shortRef(landmark.ref)} · ${text()}`}
+                      aria-label={text()}
+                      onClick={() => props.onOpenVerse(landmark.chapter, landmark.verse)}
+                    />
+                  );
+                }}
+              </For>
+            </div>
+          </Show>
+
+          <div class="parsha-map-chapters">
+            <For each={chapterTicks()}>
+              {(tick) => (
+                <i
+                  classList={{ first: tick.offset === 0 }}
+                  style={{ 'inset-inline-start': pct(tick.offset) }}
+                >
+                  {tick.chapter}
+                </i>
+              )}
+            </For>
+          </div>
+
+          <div class="parsha-legend">
+            <For each={LEGEND_ORDER.filter((kind) => props.study.composition[kind])}>
+              {(kind) => (
+                <span>
+                  <i class={`parsha-dot parsha-kind-${kind}`} />
+                  {label(kind)} {props.study.composition[kind]}%
+                </span>
+              )}
+            </For>
+          </div>
+        </>
+      )}
+    </Show>
+  );
+}

--- a/packages/tanach/src/client/styles.css
+++ b/packages/tanach/src/client/styles.css
@@ -501,33 +501,144 @@ body {
   text-transform: none;
   letter-spacing: 0;
 }
-.parsha-composition {
-  display: flex;
-  width: 100%;
-  height: 8px;
-  overflow: hidden;
-  background: var(--surface-sunk);
-  border: 1px solid var(--line);
-  border-radius: 999px;
-}
-.parsha-composition > span {
-  display: block;
-  min-width: 0;
-}
-.parsha-composition-narrative,
-.parsha-dot-narrative,
-.parsha-flow-node-narrative {
+/* ---- the reading kinds ----
+   One colour per kind, used by every surface that speaks about kind: the map's
+   segments, a band's stripe, the legend dots. Narrative keeps the app accent;
+   poetry and records join in a cooler violet and a dry olive so a portion that
+   is mostly song or mostly inventory can't be mistaken for law or story. */
+.parsha-kind-narrative {
   background: var(--accent);
 }
-.parsha-composition-law,
-.parsha-dot-law,
-.parsha-flow-node-law {
+.parsha-kind-law {
   background: #3f6d65;
 }
-.parsha-composition-discourse,
-.parsha-dot-discourse,
-.parsha-flow-node-discourse {
+.parsha-kind-discourse {
   background: #bd8750;
+}
+.parsha-kind-poetry {
+  background: #6a5b8c;
+}
+.parsha-kind-records {
+  background: #767c66;
+}
+
+/* ---- the parsha map ----
+   Layers stacked on one verse axis; everything inside is positioned by
+   inset-inline-start so the whole map mirrors under the Hebrew RTL drawer
+   (a Torah scroll runs the other way, and so should its map). */
+.parsha-map-aliyot,
+.parsha-map-strip,
+.parsha-map-pins,
+.parsha-map-chapters {
+  position: relative;
+  width: 100%;
+}
+.parsha-map-aliyot {
+  height: 13px;
+  margin-bottom: 4px;
+}
+.parsha-map-aliyot i {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  font-style: normal;
+  font-family: var(--font-hebrew);
+  font-size: 9.5px;
+  line-height: 12px;
+  text-align: center;
+  color: var(--accent);
+  background: var(--parchment);
+  border: 1px solid var(--parchment-edge);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.parsha-map-strip {
+  height: 30px;
+  background: var(--surface-sunk);
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  overflow: hidden;
+}
+.parsha-map-unit {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  padding: 0;
+  font-family: var(--font-ui);
+  font-size: 10px;
+  font-weight: 700;
+  color: rgba(255, 255, 255, 0.94);
+  border: none;
+  border-inline-end: 1px solid rgba(255, 255, 255, 0.55);
+  cursor: pointer;
+}
+.parsha-map-unit:last-child {
+  border-inline-end: none;
+}
+.parsha-map-unit:hover {
+  filter: brightness(1.12);
+}
+.parsha-map-unit.active {
+  outline: 2px solid var(--ink);
+  outline-offset: -2px;
+}
+/* The number is a correlation aid to the list below; it only fits on the
+   wider segments, and hiding it is better than clipping it. */
+.parsha-map-unit span {
+  display: block;
+  overflow: hidden;
+}
+.parsha-map-pins {
+  height: 11px;
+  margin-top: 4px;
+}
+.parsha-map-pin {
+  position: absolute;
+  top: 0;
+  width: 7px;
+  height: 7px;
+  padding: 0;
+  transform: translateX(-3.5px) rotate(45deg);
+  background: var(--surface);
+  border: 1.5px solid var(--accent-strong);
+  cursor: pointer;
+}
+.parsha-map-pin:hover {
+  background: var(--accent);
+}
+.parsha-map-chapters {
+  height: 14px;
+  font-family: var(--font-ui);
+  font-size: 9.5px;
+  color: var(--muted);
+}
+.parsha-map-chapters i {
+  position: absolute;
+  top: 3px;
+  font-style: normal;
+  transform: translateX(-50%);
+}
+/* A hairline back up to the strip, so the number reads as a position on the
+   portion rather than a loose digit. */
+.parsha-map-chapters i::before {
+  content: "";
+  position: absolute;
+  top: -4px;
+  inset-inline-start: 50%;
+  width: 1px;
+  height: 3px;
+  background: var(--line);
+}
+.parsha-map-chapters i.first::before {
+  inset-inline-start: 0;
+}
+.ui-drawer[dir="rtl"] .parsha-map-chapters i {
+  transform: translateX(50%);
+}
+/* The opening chapter sits at the very edge, so it hangs inward instead. */
+.parsha-map-chapters i.first,
+.ui-drawer[dir="rtl"] .parsha-map-chapters i.first {
+  transform: none;
 }
 .parsha-legend {
   display: flex;
@@ -555,103 +666,77 @@ body {
 }
 .parsha-flow li {
   position: relative;
-  padding: 0 0 10px 18px;
 }
-.parsha-flow li:not(:last-child)::before {
-  content: "";
-  position: absolute;
-  top: 13px;
-  bottom: -2px;
-  left: 5px;
-  width: 1px;
-  background: var(--line);
-}
-.ui-drawer[dir="rtl"] .parsha-flow li {
-  padding: 0 18px 10px 0;
-}
-.ui-drawer[dir="rtl"] .parsha-flow li:not(:last-child)::before {
-  right: 5px;
-  left: auto;
-}
-.parsha-flow-card {
+
+/* ---- a flow move, collapsed ----
+   One row per move: a kind stripe, the title, its verse range. The row stands
+   as tall as its passage is long (min-height set inline from the map), so the
+   strip's proportions read again down the list. Clicking opens the move in
+   place. */
+.parsha-band {
   position: relative;
   display: flex;
+  align-items: center;
+  gap: 9px;
   width: 100%;
-  gap: 11px;
-  padding: 8px 9px 9px;
+  margin-bottom: 3px;
+  padding: 0 10px 0 0;
   text-align: left;
   color: var(--ink);
-  background: transparent;
-  border: 1px solid transparent;
-  border-radius: 7px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  overflow: hidden;
   cursor: pointer;
 }
-.ui-drawer[dir="rtl"] .parsha-flow-card {
+.ui-drawer[dir="rtl"] .parsha-band {
+  padding: 0 0 0 10px;
   text-align: right;
 }
-.parsha-flow-card:hover,
-.parsha-flow-card.active {
+.parsha-band:hover {
   background: var(--surface-sunk);
-  border-color: var(--line);
 }
-.parsha-flow-node {
-  position: absolute;
-  top: 13px;
-  left: -16px;
-  width: 8px;
-  height: 8px;
-  border: 2px solid var(--surface);
-  border-radius: 50%;
-  box-sizing: content-box;
+.parsha-band.active {
+  background: var(--surface-sunk);
+  border-color: var(--ink);
 }
-.ui-drawer[dir="rtl"] .parsha-flow-node {
-  right: -16px;
-  left: auto;
+.parsha-band-stripe {
+  flex: none;
+  align-self: stretch;
+  width: 5px;
 }
-.parsha-flow-copy {
-  display: flex;
+.parsha-band-title {
   flex: 1;
   min-width: 0;
-  flex-direction: column;
+  overflow: hidden;
+  font-family: var(--font-serif);
+  font-size: 13.5px;
+  font-weight: 600;
+  line-height: 1.3;
 }
-.parsha-flow-meta {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  margin-bottom: 2px;
+.ui-drawer[dir="rtl"] .parsha-band-title {
+  font-family: var(--font-hebrew);
+  font-size: 15px;
+}
+.parsha-band-ref,
+.parsha-flow-kicker span[dir="ltr"] {
+  flex: none;
   font-family: var(--font-ui);
   font-size: 9.5px;
-  color: var(--accent);
-}
-.parsha-flow-meta b {
-  font-weight: 600;
-}
-.parsha-flow-meta i {
-  font-style: normal;
   color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  /* Isolated so the range keeps its own reading order in the RTL drawer. */
+  unicode-bidi: isolate;
 }
-.parsha-flow-copy strong {
-  font-family: var(--font-serif);
-  font-size: 14px;
-  font-weight: 600;
-  line-height: 1.35;
+.parsha-flow-kicker span[dir="ltr"] {
+  font-size: inherit;
+  color: inherit;
 }
-.parsha-flow-copy small {
-  margin-top: 3px;
-  font-family: var(--font-serif);
-  font-size: 12px;
-  line-height: 1.45;
-  color: var(--muted);
-}
-.ui-drawer[dir="rtl"] .parsha-flow-copy strong,
-.ui-drawer[dir="rtl"] .parsha-flow-copy small {
-  font-family: var(--font-hebrew);
-}
+
 /* The selected move's in-place close reading (deep dive under the card). */
 .parsha-flow-deep {
-  margin: 2px 0 4px;
-  padding: 4px 9px 2px;
+  margin: 0 0 10px;
+  padding: 6px 9px 2px;
   border-left: 2px solid var(--line);
 }
 .ui-drawer[dir="rtl"] .parsha-flow-deep {
@@ -662,6 +747,26 @@ body {
   margin: 0 0 8px;
   font-size: 12.5px;
   line-height: 1.55;
+}
+/* The opened move's own header line: where it sits, what kind it is, how long. */
+.parsha-flow-kicker {
+  margin: 0 0 5px;
+  font-family: var(--font-ui);
+  font-size: 9.5px;
+  letter-spacing: 0.03em;
+  color: var(--accent);
+}
+/* The one-line summary, which the collapsed band leaves out. */
+.parsha-flow-summary {
+  margin: 0 0 9px;
+  font-family: var(--font-serif);
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--muted);
+}
+.ui-drawer[dir="rtl"] .parsha-flow-summary {
+  font-family: var(--font-hebrew);
+  font-size: 13.5px;
 }
 
 /* An inline Hebrew term in English prose — dotted-underlined, hint on hover

--- a/packages/tanach/src/lib/parsha.ts
+++ b/packages/tanach/src/lib/parsha.ts
@@ -1,4 +1,17 @@
-export type ParshaSectionKind = 'narrative' | 'law' | 'discourse';
+/** What KIND of reading a passage is — the one dimension the parsha map
+ *  colours by. Five values, not three: a Torah year that only knows narrative /
+ *  law / discourse paints Ha'azinu and the Song of the Sea as "discourse" and
+ *  the Pekudei inventory or the Bemidbar census as "law", which is the one
+ *  thing they are not. */
+export type ParshaSectionKind = 'narrative' | 'law' | 'discourse' | 'poetry' | 'records';
+
+export const PARSHA_KINDS: readonly ParshaSectionKind[] = [
+  'narrative',
+  'law',
+  'discourse',
+  'poetry',
+  'records',
+];
 
 export interface ParshaRange {
   book: string;
@@ -13,6 +26,10 @@ export interface WeeklyParsha extends ParshaRange {
   heName: string;
   ref: string;
   chapter: number;
+  /** The week's seven aliyot as Sefaria refs, from the calendar payload's
+   *  `extraDetails.aliyot`. Empty when the calendar omits them (or when a
+   *  pre-aliyot entry is still warm in KV). */
+  aliyot: string[];
 }
 
 export interface ParshaFlowSection {
@@ -44,6 +61,36 @@ export interface ParshaTerm {
   en: string;
 }
 
+/** Where a flow unit, a landmark, or an aliyah SITS in the portion, measured
+ *  in verses from its first verse. This is the whole map: every layer is an
+ *  offset plus a length on one 0..totalVerses axis, so the client draws them
+ *  without knowing anything about chapter lengths. */
+export interface ParshaSpan {
+  /** Index into the study's own `flow` / `landmarks` array. */
+  index: number;
+  offset: number;
+  verses: number;
+}
+
+export interface ParshaAliyahSpan extends ParshaSpan {
+  /** 1-7. Maftir is deliberately absent: it re-reads the end of the seventh
+   *  aliyah, so drawing it as an eighth band would double-count the portion. */
+  n: number;
+  ref: string;
+}
+
+/** The deterministic layer under the AI's flow — verse extents, the seven
+ *  aliyot, and where each chapter begins. Null when the book's chapter lengths
+ *  can't be resolved; the reader then falls back to the un-mapped list rather
+ *  than drawing a portion at made-up proportions. */
+export interface ParshaMap {
+  totalVerses: number;
+  units: ParshaSpan[];
+  landmarks: ParshaSpan[];
+  aliyot: ParshaAliyahSpan[];
+  chapters: { chapter: number; offset: number }[];
+}
+
 export interface ParshaStudy {
   name: string;
   heName: string;
@@ -54,7 +101,11 @@ export interface ParshaStudy {
   titleHe: string;
   overviewEn: string;
   overviewHe: string;
-  composition: Record<ParshaSectionKind, number>;
+  /** MEASURED from the anchored units (verses per kind), not asserted by the
+   *  model — so the legend can never disagree with the map above it. Empty
+   *  when there is no map to measure. */
+  composition: Partial<Record<ParshaSectionKind, number>>;
+  map: ParshaMap | null;
   flow: ParshaFlowSection[];
   landmarks: ParshaLandmark[];
   terms: ParshaTerm[];
@@ -210,16 +261,177 @@ export function tokenizeTermMentions(
   return out;
 }
 
-/** Normalize an editorial percentage estimate so the three visible bars total 100. */
-export function normalizeParshaComposition(value: unknown): Record<ParshaSectionKind, number> {
-  const input = (value ?? {}) as Partial<Record<ParshaSectionKind, unknown>>;
-  const raw = (['narrative', 'law', 'discourse'] as const).map((key) => {
-    const n = Number(input[key]);
-    return Number.isFinite(n) && n > 0 ? n : 0;
+/** How far into the portion a verse sits, counted in verses from its first —
+ *  the one coordinate every layer of the map shares. Null if the point falls
+ *  outside the portion or a chapter length is missing. `chapterLengths` is
+ *  1-indexed by chapter number (Sefaria's book shape). */
+export function verseOffset(
+  range: ParshaRange,
+  chapterLengths: readonly number[],
+  point: { chapter: number; verse: number },
+): number | null {
+  if (!pointInParsha(range, point)) return null;
+  // pointInParsha only bounds the point by the portion's ends, so a verse that
+  // doesn't exist in a chapter the portion passes THROUGH (18:99) would sail
+  // past it and place a span off the end of the strip.
+  const own = chapterLengths[point.chapter - 1];
+  if (!Number.isFinite(own) || point.verse > own) return null;
+  let offset = 0;
+  for (let chapter = range.startChapter; chapter < point.chapter; chapter++) {
+    const length = chapterLengths[chapter - 1];
+    if (!Number.isFinite(length) || length < 1) return null;
+    offset += chapter === range.startChapter ? length - range.startVerse + 1 : length;
+  }
+  return (
+    offset +
+    (point.chapter === range.startChapter ? point.verse - range.startVerse : point.verse - 1)
+  );
+}
+
+function spanOf(
+  range: ParshaRange,
+  chapterLengths: readonly number[],
+  section: Pick<ParshaRange, 'startChapter' | 'startVerse' | 'endChapter' | 'endVerse'>,
+  index: number,
+): ParshaSpan | null {
+  if (!sectionInParsha(range, section)) return null;
+  const start = verseOffset(range, chapterLengths, {
+    chapter: section.startChapter,
+    verse: section.startVerse,
   });
-  const total = raw.reduce((sum, n) => sum + n, 0);
-  if (!total) return { narrative: 0, law: 0, discourse: 100 };
-  const rounded = raw.map((n) => Math.round((n / total) * 100));
-  rounded[2] += 100 - rounded.reduce((sum, n) => sum + n, 0);
-  return { narrative: rounded[0], law: rounded[1], discourse: rounded[2] };
+  const end = verseOffset(range, chapterLengths, {
+    chapter: section.endChapter,
+    verse: section.endVerse,
+  });
+  if (start === null || end === null || end < start) return null;
+  return { index, offset: start, verses: end - start + 1 };
+}
+
+/**
+ * Lay the portion out on one verse axis: the AI's flow units, the landmarks,
+ * the seven aliyot, and the chapter starts, each as an offset + length. Pure —
+ * the route supplies the book's chapter lengths, everything else is arithmetic.
+ *
+ * Returns null when the portion itself can't be measured. Individual layers
+ * degrade independently: a unit that doesn't sit inside the portion is dropped
+ * from the map (it still renders in the list), and an unparseable aliyah ref
+ * costs only that band.
+ */
+export function buildParshaMap(input: {
+  range: ParshaRange;
+  chapterLengths: readonly number[];
+  flow: readonly Pick<
+    ParshaFlowSection,
+    'startChapter' | 'startVerse' | 'endChapter' | 'endVerse'
+  >[];
+  landmarks: readonly { chapter: number; verse: number }[];
+  aliyot: readonly string[];
+}): ParshaMap | null {
+  const { range, chapterLengths } = input;
+  const last = verseOffset(range, chapterLengths, {
+    chapter: range.endChapter,
+    verse: range.endVerse,
+  });
+  if (last === null) return null;
+  const totalVerses = last + 1;
+
+  const units: ParshaSpan[] = [];
+  input.flow.forEach((section, index) => {
+    const span = spanOf(range, chapterLengths, section, index);
+    if (span) units.push(span);
+  });
+
+  const landmarks: ParshaSpan[] = [];
+  input.landmarks.forEach((landmark, index) => {
+    const offset = verseOffset(range, chapterLengths, landmark);
+    if (offset !== null) landmarks.push({ index, offset, verses: 1 });
+  });
+
+  // The calendar lists seven aliyot plus maftir, and maftir re-reads the tail
+  // of the seventh — so only the seven divide the portion.
+  const aliyot: ParshaAliyahSpan[] = [];
+  input.aliyot.slice(0, 7).forEach((ref, index) => {
+    const parsed = parseParshaRef(ref);
+    if (!parsed || parsed.book !== range.book) return;
+    const span = spanOf(range, chapterLengths, parsed, index);
+    if (span) aliyot.push({ ...span, n: index + 1, ref });
+  });
+
+  const chapters: { chapter: number; offset: number }[] = [];
+  for (let chapter = range.startChapter; chapter <= range.endChapter; chapter++) {
+    const offset =
+      chapter === range.startChapter
+        ? 0
+        : verseOffset(range, chapterLengths, { chapter, verse: 1 });
+    if (offset !== null) chapters.push({ chapter, offset });
+  }
+
+  return { totalVerses, units, landmarks, aliyot, chapters };
+}
+
+/**
+ * The share of the PORTION each kind of reading takes, counted verse by verse
+ * off the anchored units.
+ *
+ * Deliberately painted rather than summed: units are supposed to tile the
+ * portion, but nothing forces them to. Summing unit lengths would double-count
+ * an overlap and would quietly renormalize a gap away — ten law verses in a
+ * hundred-verse portion reporting "law 100%". Painting each verse once (a
+ * later unit wins the overlap, exactly as it wins on the drawn strip) makes
+ * the percentages shares of the whole portion, so an incompletely covered
+ * portion honestly totals less than 100.
+ *
+ * Largest-remainder rounding, so a fully covered portion totals exactly 100
+ * and a kind with any verses at all never rounds away to nothing. Kinds with
+ * no verses are absent rather than zero.
+ */
+export function measureComposition(
+  totalVerses: number,
+  units: readonly { kind: ParshaSectionKind; offset: number; verses: number }[],
+): Partial<Record<ParshaSectionKind, number>> {
+  if (!(totalVerses > 0)) return {};
+  const painted: (ParshaSectionKind | undefined)[] = new Array(totalVerses);
+  for (const unit of units) {
+    if (!PARSHA_KINDS.includes(unit.kind) || !(unit.verses > 0)) continue;
+    const from = Math.max(0, unit.offset);
+    const to = Math.min(totalVerses, unit.offset + unit.verses);
+    for (let at = from; at < to; at += 1) painted[at] = unit.kind;
+  }
+  const verses = new Map<ParshaSectionKind, number>();
+  let counted = 0;
+  for (const kind of painted) {
+    if (!kind) continue;
+    verses.set(kind, (verses.get(kind) ?? 0) + 1);
+    counted += 1;
+  }
+  if (!counted) return {};
+  const shares = [...verses.entries()].map(([kind, n]) => {
+    const exact = (n / totalVerses) * 100;
+    const floor = Math.floor(exact);
+    return { kind, whole: Math.max(1, floor), remainder: exact - floor };
+  });
+  // Hand out whatever the floors left over (or claw back what the min-1 floor
+  // overspent) one point at a time, largest fractional part first. The target
+  // is the COVERED share, not a flat 100 — an uncovered stretch of the portion
+  // is left uncounted instead of being handed to whichever kind rounds best.
+  const target = Math.round((counted / totalVerses) * 100);
+  let slack = target - shares.reduce((sum, s) => sum + s.whole, 0);
+  const byRemainder = [...shares].sort((a, b) => b.remainder - a.remainder);
+  for (let step = 0; slack > 0 && step < 100; step += 1) {
+    byRemainder[step % byRemainder.length].whole += 1;
+    slack -= 1;
+  }
+  const bySize = [...shares].sort((a, b) => b.whole - a.whole);
+  for (let step = 0; slack < 0 && step < 100; step += 1) {
+    const share = bySize[step % bySize.length];
+    if (share.whole <= 1) continue;
+    share.whole -= 1;
+    slack += 1;
+  }
+  const out: Partial<Record<ParshaSectionKind, number>> = {};
+  for (const kind of PARSHA_KINDS) {
+    const share = shares.find((s) => s.kind === kind);
+    if (share) out[kind] = share.whole;
+  }
+  return out;
 }

--- a/packages/tanach/src/worker/index.ts
+++ b/packages/tanach/src/worker/index.ts
@@ -20,10 +20,12 @@ import type { Context } from 'hono';
 import { Hono } from 'hono';
 import { isBook } from '../lib/books.ts';
 import {
+  buildParshaMap,
   formatParshaRange,
-  normalizeParshaComposition,
+  measureComposition,
   type ParshaFlowSection,
   type ParshaLandmark,
+  type ParshaSectionKind,
   type ParshaSectionStudy,
   type ParshaThread,
   sanitizeParshaTerms,
@@ -36,7 +38,13 @@ import type { EventSection } from './producers/events.ts';
 import { translateHebrew } from './producers/translate.ts';
 import type { TanachEnv, TanachRunCtx } from './run-ports.ts';
 import { runTanachEnrichment, runTanachEvents, TanachSourceError } from './run-ports.ts';
-import { asVerses, fetchPassages, fetchVerseCommentaries, sefaria } from './sefaria-sources.ts';
+import {
+  asVerses,
+  bookChapterLengths,
+  fetchPassages,
+  fetchVerseCommentaries,
+  sefaria,
+} from './sefaria-sources.ts';
 import { computeSourcesIndex } from './sources-index.ts';
 import { readUsage, recordUsage } from './usage.ts';
 import { runTanachWarm } from './warm-cron.ts';
@@ -392,7 +400,6 @@ app.get('/api/parsha-study', async (c) => {
     titleHe?: string;
     overviewEn?: string;
     overviewHe?: string;
-    composition?: unknown;
     flow?: Omit<ParshaFlowSection, 'ref'>[];
     landmarks?: Omit<ParshaLandmark, 'ref'>[];
     terms?: unknown;
@@ -405,6 +412,31 @@ app.get('/api/parsha-study', async (c) => {
     ...landmark,
     ref: `${parsha.book} ${landmark.chapter}:${landmark.verse}`,
   }));
+
+  // The deterministic half of the drawer: real verse extents, the seven
+  // aliyot, chapter starts. The reader draws the map from this, and the
+  // legend's percentages are COUNTED off it rather than asserted by the model.
+  const chapterLengths = await bookChapterLengths(c.env.CACHE, parsha.book, (promise) =>
+    c.executionCtx.waitUntil(promise),
+  );
+  const map = chapterLengths
+    ? buildParshaMap({
+        range: parsha,
+        chapterLengths,
+        flow,
+        landmarks,
+        aliyot: parsha.aliyot,
+      })
+    : null;
+  const composition = measureComposition(
+    map?.totalVerses ?? 0,
+    (map?.units ?? []).map((span) => ({
+      kind: flow[span.index]?.kind as ParshaSectionKind,
+      offset: span.offset,
+      verses: span.verses,
+    })),
+  );
+
   c.header('Cache-Control', 'public, max-age=600, stale-while-revalidate=86400');
   return c.json({
     name: parsha.name,
@@ -416,7 +448,8 @@ app.get('/api/parsha-study', async (c) => {
     titleHe: String(parsed.titleHe ?? '').trim(),
     overviewEn: String(parsed.overviewEn ?? '').trim(),
     overviewHe: String(parsed.overviewHe ?? '').trim(),
-    composition: normalizeParshaComposition(parsed.composition),
+    composition,
+    map,
     flow,
     landmarks,
     terms: sanitizeParshaTerms(parsed.terms),

--- a/packages/tanach/src/worker/parsha-calendar.ts
+++ b/packages/tanach/src/worker/parsha-calendar.ts
@@ -5,6 +5,20 @@ interface CalendarItem {
   title?: { en?: string };
   displayValue?: { en?: string; he?: string };
   ref?: string;
+  /** The calendar hands us the week's aliyot for free — seven refs plus
+   *  maftir, which re-reads the tail of the seventh. */
+  extraDetails?: { aliyot?: unknown };
+}
+
+/** The aliyah refs as strings, POSITIONS PRESERVED — a bad entry becomes an
+ *  empty string rather than being spliced out, because position is what makes
+ *  the fourth ref the fourth aliyah (and the eighth entry maftir). Anything
+ *  unparseable is dropped later, per band, when the map is built. A cache
+ *  entry written before aliyot were captured simply has none, which costs the
+ *  map its aliyah rail for at most the six-hour calendar TTL. */
+function normalizeAliyot(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.slice(0, 8).map((ref) => (typeof ref === 'string' ? ref : ''));
 }
 
 function normalizeParsha(value: unknown): WeeklyParsha | null {
@@ -19,6 +33,7 @@ function normalizeParsha(value: unknown): WeeklyParsha | null {
     ref: raw.ref,
     ...range,
     chapter: range.startChapter,
+    aliyot: normalizeAliyot(raw.aliyot),
   };
 }
 
@@ -54,6 +69,7 @@ export async function currentParsha(
     ref: item.ref,
     ...range,
     chapter: range.startChapter,
+    aliyot: normalizeAliyot(item.extraDetails?.aliyot),
   };
   const write = cache.put(cacheKey, JSON.stringify(payload), { expirationTtl: 6 * 3600 });
   if (waitUntil) waitUntil(write);

--- a/packages/tanach/src/worker/producers/defs.ts
+++ b/packages/tanach/src/worker/producers/defs.ts
@@ -252,7 +252,7 @@ export const TANACH_PRODUCERS: Record<TanachProducerId, Producer> = {
   'parsha-overview': {
     id: 'parsha-overview',
     label: 'Parsha overview',
-    description: 'A bilingual whole-parsha synopsis, composition map, flow, and landmarks',
+    description: 'A bilingual whole-parsha synopsis, flow map, and landmarks',
     kind: 'enrichment',
     inputs: [{ source: 'parsha-verses' }],
     recipe: { extractor: parshaOverviewExtractor },
@@ -261,8 +261,11 @@ export const TANACH_PRODUCERS: Record<TanachProducerId, Producer> = {
     scope: 'local',
     key_shape: 'enrich',
     // v3: PARSHA_HEBREW_STYLE tightened to the talmud reader's literal
-    // convention (dense Hebrew-first Form A; Hebrew inside quote marks).
-    cacheVersion: '3',
+    //     convention (dense Hebrew-first Form A; Hebrew inside quote marks).
+    // v4: the composition estimate is gone (the route now COUNTS the split off
+    //     the anchored units), `kind` gains poetry + records, and unit titles
+    //     are capped at 2-5 words so they fit the map's bands.
+    cacheVersion: '4',
     passes: ['parsha-overview-shape'],
     source: 'code',
   },

--- a/packages/tanach/src/worker/producers/parsha.ts
+++ b/packages/tanach/src/worker/producers/parsha.ts
@@ -56,16 +56,19 @@ OVERVIEW
 - Explain its movement: what changes from the beginning to the end, rather than listing topics.
 - Stay on p'shat. Do not preach, survey commentators, or invent background.
 
-COMPOSITION
-- Estimate the share of the reading that is narrative, law, and discourse.
-- "discourse" includes exhortation, covenant speech, theology, blessing, rebuke, and extended instruction that is not a discrete law.
-- Return whole-number percentages totaling 100. This is an editorial map, not a scholarly statistic.
-
 FLOW
 - Divide the whole portion into 5-9 consecutive learning units.
 - Give exact numeric start/end chapter and verse anchors inside the supplied range.
-- Every unit gets one kind: narrative, law, or discourse; a short title; and a one-sentence summary showing how it advances the parsha.
+- Every unit gets one kind, a title of 2-5 words (it is read as a single line on a map, so keep it short and concrete), and a one-sentence summary showing how it advances the parsha.
 - Cover the portion in order without wandering outside its range. Prefer meaningful units over chapter boundaries.
+
+KIND — what sort of reading the unit is. Choose the one that dominates it:
+- narrative: something happens, in time — a scene, a journey, an incident.
+- law: a rule, a case, or a procedure the reader is to follow.
+- discourse: speech that is neither story nor statute — exhortation, covenant, rebuke, blessing, theology, extended instruction.
+- poetry: sustained verse — song, oracle, poetic blessing (שירת הים, האזינו, the oracles of בלעם).
+- records: a genealogy, a census, an inventory, or an itinerary — a passage whose substance is the list itself.
+The reader's map is coloured by this field, so a unit that is mostly a poem must not be filed as discourse, and a list of names or objects must not be filed as narrative or law.
 
 LANDMARKS
 - Name 3-6 scenes, commands, speeches, or verses a learner is especially likely to recognize or want to find again.
@@ -97,32 +100,13 @@ export const PARSHA_OVERVIEW_SCHEMA = {
   schema: {
     type: 'object',
     additionalProperties: false,
-    required: [
-      'titleEn',
-      'titleHe',
-      'overviewEn',
-      'overviewHe',
-      'composition',
-      'flow',
-      'landmarks',
-      'terms',
-    ],
+    required: ['titleEn', 'titleHe', 'overviewEn', 'overviewHe', 'flow', 'landmarks', 'terms'],
     properties: {
       titleEn: { type: 'string' },
       titleHe: { type: 'string' },
       overviewEn: { type: 'string' },
       overviewHe: { type: 'string' },
       terms: TERMS_SCHEMA,
-      composition: {
-        type: 'object',
-        additionalProperties: false,
-        required: ['narrative', 'law', 'discourse'],
-        properties: {
-          narrative: { type: 'integer', minimum: 0, maximum: 100 },
-          law: { type: 'integer', minimum: 0, maximum: 100 },
-          discourse: { type: 'integer', minimum: 0, maximum: 100 },
-        },
-      },
       flow: {
         type: 'array',
         minItems: 5,
@@ -143,7 +127,10 @@ export const PARSHA_OVERVIEW_SCHEMA = {
           ],
           properties: {
             ...RANGE_PROPERTIES,
-            kind: { type: 'string', enum: ['narrative', 'law', 'discourse'] },
+            kind: {
+              type: 'string',
+              enum: ['narrative', 'law', 'discourse', 'poetry', 'records'],
+            },
             titleEn: { type: 'string' },
             titleHe: { type: 'string' },
             summaryEn: { type: 'string' },

--- a/packages/tanach/src/worker/run-ports.ts
+++ b/packages/tanach/src/worker/run-ports.ts
@@ -52,7 +52,7 @@ import { templateKeyScheme } from '@corpus/core/store/key-schemes';
 import type { UsageEntry } from '@corpus/core/telemetry/types';
 import {
   formatParshaRange,
-  normalizeParshaComposition,
+  PARSHA_KINDS,
   type ParshaRange,
   type ParshaSectionKind,
   parseParshaRef,
@@ -121,7 +121,10 @@ const KEY_TEMPLATES: Record<string, KeyTemplate> = {
   // for the passage's key words and quoted phrases (dense Form A; the English
   // quote + Hebrew-in-parens inversion is rejected). One weekly parsha, so
   // each bump re-pays cents, not dollars.
-  'parsha-overview': { key: (a: TanachAddress) => `parsha-overview:v3:${a.instanceId}` },
+  // overview v4: the composition estimate is gone (the route counts the split
+  // off the anchored units instead), `kind` gains poetry + records, and unit
+  // titles are capped at 2-5 words to fit the map's bands.
+  'parsha-overview': { key: (a: TanachAddress) => `parsha-overview:v4:${a.instanceId}` },
   'parsha-section': { key: (a: TanachAddress) => `parsha-section:v2:${a.instanceId}` },
   'parsha-thread': { key: (a: TanachAddress) => `parsha-thread:v3:${a.instanceId}` },
   // Chapter-scoped like overview (one geography per chapter; instance ignored).
@@ -758,7 +761,7 @@ const RUN_PORTS: RunProducerPorts<TanachRunCtx, TanachEnrichmentDef, TanachMarkD
         }))
         .filter(
           (item) =>
-            ['narrative', 'law', 'discourse'].includes(item.kind) &&
+            (PARSHA_KINDS as readonly string[]).includes(item.kind) &&
             item.titleEn &&
             verseExists(item.startChapter, item.startVerse) &&
             verseExists(item.endChapter, item.endVerse) &&
@@ -788,7 +791,6 @@ const RUN_PORTS: RunProducerPorts<TanachRunCtx, TanachEnrichmentDef, TanachMarkD
         titleHe: String(parsed.titleHe ?? '').trim(),
         overviewEn: String(parsed.overviewEn ?? '').trim(),
         overviewHe: String(parsed.overviewHe ?? '').trim(),
-        composition: normalizeParshaComposition(parsed.composition),
         flow,
         landmarks,
         terms: sanitizeParshaTerms(parsed.terms),

--- a/packages/tanach/src/worker/sefaria-sources.ts
+++ b/packages/tanach/src/worker/sefaria-sources.ts
@@ -11,6 +11,61 @@ import { COMMENTATORS } from '../lib/commentators.ts';
 
 export const sefaria = new SefariaClient();
 
+/**
+ * Verse counts per chapter for a book, 1-indexed by chapter — Sefaria's shape
+ * API (`/api/shape/Deuteronomy` -> `chapters: [46, 37, …]`). This is what lets
+ * the parsha map place a unit at its true extent instead of an equal slice.
+ *
+ * Deliberately fetched rather than hand-kept in `books.ts` (see that file's
+ * note on chapter counts), and cached for thirty days: the shape of a
+ * biblical book does not change, so the only reason to re-ask is a Sefaria
+ * data fix. Null on any failure — callers draw no map rather than a wrong one.
+ */
+export async function bookChapterLengths(
+  cache: KVNamespace,
+  book: string,
+  waitUntil?: (promise: Promise<unknown>) => void,
+): Promise<number[] | null> {
+  const cacheKey = `shape:v1:${book}`;
+  const cached = await cache.get(cacheKey);
+  if (cached) {
+    try {
+      const parsed = JSON.parse(cached) as unknown;
+      if (Array.isArray(parsed) && parsed.every((n) => Number.isInteger(n) && n > 0)) {
+        return parsed as number[];
+      }
+    } catch {
+      // A malformed shape cache is a miss; the live fetch below repairs it.
+    }
+  }
+
+  let chapters: unknown;
+  try {
+    const response = await fetch(`https://www.sefaria.org/api/shape/${encodeURIComponent(book)}`);
+    if (!response.ok) return null;
+    const body = (await response.json()) as unknown;
+    // The endpoint answers with a list (a complex title can shape into several
+    // entries); take the one that IS this book, else the first. A bare object
+    // is accepted too, so a shape response that isn't wrapped still works.
+    type ShapeEntry = { book?: string; chapters?: unknown };
+    const entry: ShapeEntry | null = Array.isArray(body)
+      ? ((body as ShapeEntry[]).find((candidate) => candidate?.book === book) ??
+        (body[0] as ShapeEntry) ??
+        null)
+      : ((body as ShapeEntry) ?? null);
+    chapters = entry?.chapters;
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(chapters) || !chapters.every((n) => Number.isInteger(n) && n > 0)) return null;
+
+  const lengths = chapters as number[];
+  const write = cache.put(cacheKey, JSON.stringify(lengths), { expirationTtl: 30 * 24 * 3600 });
+  if (waitUntil) waitUntil(write);
+  else await write;
+  return lengths;
+}
+
 /** Strip Sefaria's inline footnote apparatus (the marker + the expanded note
  *  text), which otherwise renders mid-verse. Keeps benign inline tags like the
  *  large/small-letter <big>/<small> markup. */

--- a/packages/tanach/src/worker/warm-cron.ts
+++ b/packages/tanach/src/worker/warm-cron.ts
@@ -31,7 +31,10 @@ import { computeSourcesIndex, readSourcesIndex } from './sources-index.ts';
 
 // v7: parsha recipes tightened to the talmud-literal Hebrew style (dense
 // Hebrew-first prose) — re-warm this week's parsha surfaces.
-const CURSOR_KEY = 'tanach-warm-cursor:v7';
+// v8: parsha-overview moved to v4 (five reading kinds, short unit titles, no
+// composition estimate), so this week's overview — and the per-unit close
+// readings whose indexes hang off it — warm again.
+const CURSOR_KEY = 'tanach-warm-cursor:v8';
 /** Chapter-level enrichments that power the visible reader + section labels. */
 const CHAPTER_PRODUCERS = ['geography', 'events'] as const;
 /** Entries warmed per tick — small so one invocation stays well within the

--- a/packages/tanach/tests/parsha.test.ts
+++ b/packages/tanach/tests/parsha.test.ts
@@ -1,13 +1,29 @@
 import { describe, expect, it } from 'vitest';
 import {
+  buildParshaMap,
   formatParshaRange,
-  normalizeParshaComposition,
+  measureComposition,
   parseParshaRef,
   pointInParsha,
   sanitizeParshaTerms,
   sectionInParsha,
   tokenizeTermMentions,
+  verseOffset,
 } from '../src/lib/parsha';
+
+/** Deuteronomy's verse counts per chapter (Sefaria's book shape). */
+const DEUTERONOMY = [
+  46, 37, 29, 49, 30, 25, 26, 20, 29, 22, 32, 31, 19, 29, 23, 22, 20, 22, 21, 20, 23, 29, 26, 22,
+  19, 19, 26, 69, 28, 20, 30, 52, 29, 12,
+];
+/** Shoftim: 16:18-21:9 — 5 verses of ch. 16, then 20 + 22 + 21 + 20, then 9. */
+const SHOFTIM = {
+  book: 'Deuteronomy',
+  startChapter: 16,
+  startVerse: 18,
+  endChapter: 21,
+  endVerse: 9,
+};
 
 describe('weekly parsha references', () => {
   it('parses same-chapter and cross-chapter Sefaria ranges', () => {
@@ -50,14 +66,131 @@ describe('weekly parsha references', () => {
       }),
     ).toBe(true);
   });
+});
 
-  it('normalizes editorial composition estimates to 100 percent', () => {
-    expect(normalizeParshaComposition({ narrative: 1, law: 1, discourse: 2 })).toEqual({
-      narrative: 25,
-      law: 25,
-      discourse: 50,
+describe('the parsha map', () => {
+  it('counts verses from the portion’s first verse, across chapters', () => {
+    expect(verseOffset(SHOFTIM, DEUTERONOMY, { chapter: 16, verse: 18 })).toBe(0);
+    expect(verseOffset(SHOFTIM, DEUTERONOMY, { chapter: 16, verse: 22 })).toBe(4);
+    // ch. 16 contributes 5 verses (18-22), so 17:1 is the sixth.
+    expect(verseOffset(SHOFTIM, DEUTERONOMY, { chapter: 17, verse: 1 })).toBe(5);
+    expect(verseOffset(SHOFTIM, DEUTERONOMY, { chapter: 18, verse: 1 })).toBe(25);
+    expect(verseOffset(SHOFTIM, DEUTERONOMY, { chapter: 21, verse: 9 })).toBe(96);
+    // Outside the portion, and inside a chapter whose length we don't have.
+    expect(verseOffset(SHOFTIM, DEUTERONOMY, { chapter: 16, verse: 17 })).toBeNull();
+    expect(verseOffset(SHOFTIM, DEUTERONOMY, { chapter: 21, verse: 10 })).toBeNull();
+    expect(verseOffset(SHOFTIM, [], { chapter: 18, verse: 1 })).toBeNull();
+    // A verse that doesn't exist in a chapter the portion passes through:
+    // inside the portion's ends, but off the end of chapter 18 (22 verses).
+    expect(verseOffset(SHOFTIM, DEUTERONOMY, { chapter: 18, verse: 23 })).toBeNull();
+  });
+
+  it('lays the units, landmarks, aliyot and chapter starts on one axis', () => {
+    const map = buildParshaMap({
+      range: SHOFTIM,
+      chapterLengths: DEUTERONOMY,
+      flow: [
+        { startChapter: 16, startVerse: 18, endChapter: 17, endVerse: 7 },
+        { startChapter: 20, startVerse: 1, endChapter: 20, endVerse: 20 },
+        // Outside the portion — dropped from the map, still listed in the drawer.
+        { startChapter: 21, startVerse: 10, endChapter: 21, endVerse: 23 },
+      ],
+      landmarks: [
+        { chapter: 16, verse: 20 },
+        { chapter: 22, verse: 1 },
+      ],
+      aliyot: [
+        'Deuteronomy 16:18-17:13',
+        'Deuteronomy 17:14-17:20',
+        // A bad entry costs its own band and NOTHING ELSE: the refs after it
+        // keep their ordinals, and maftir (the eighth) stays out of the seven.
+        'not a ref',
+        'Deuteronomy 18:6-18:13',
+        'Deuteronomy 18:14-19:13',
+        'Deuteronomy 19:14-20:9',
+        'Deuteronomy 20:10-21:9',
+        'Deuteronomy 21:7-21:9',
+      ],
     });
-    expect(normalizeParshaComposition({})).toEqual({ narrative: 0, law: 0, discourse: 100 });
+    expect(map).not.toBeNull();
+    if (!map) return;
+    expect(map.totalVerses).toBe(97);
+    expect(map.units).toEqual([
+      { index: 0, offset: 0, verses: 12 },
+      { index: 1, offset: 68, verses: 20 },
+    ]);
+    expect(map.landmarks).toEqual([{ index: 0, offset: 2, verses: 1 }]);
+    // Seven at most, positionally numbered — the maftir eighth never appears,
+    // and the entries after the bad one keep their own ordinals.
+    expect(map.aliyot.map((a) => a.n)).toEqual([1, 2, 4, 5, 6, 7]);
+    expect(map.aliyot[0]).toMatchObject({ offset: 0, verses: 18 });
+    expect(map.aliyot.at(-1)).toMatchObject({ n: 7, ref: 'Deuteronomy 20:10-21:9' });
+    expect(map.chapters).toEqual([
+      { chapter: 16, offset: 0 },
+      { chapter: 17, offset: 5 },
+      { chapter: 18, offset: 25 },
+      { chapter: 19, offset: 47 },
+      { chapter: 20, offset: 68 },
+      { chapter: 21, offset: 88 },
+    ]);
+  });
+
+  it('draws no map at all when the book’s chapter lengths are missing', () => {
+    expect(
+      buildParshaMap({
+        range: SHOFTIM,
+        chapterLengths: [],
+        flow: [{ startChapter: 16, startVerse: 18, endChapter: 17, endVerse: 7 }],
+        landmarks: [],
+        aliyot: [],
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('measured composition', () => {
+  it('counts the split off the anchored units, totalling 100', () => {
+    expect(
+      measureComposition(97, [
+        { kind: 'law', offset: 0, verses: 83 },
+        { kind: 'discourse', offset: 83, verses: 14 },
+      ]),
+    ).toEqual({ law: 86, discourse: 14 });
+  });
+
+  it('never rounds a kind that is present away to nothing', () => {
+    const split = measureComposition(1000, [
+      { kind: 'narrative', offset: 0, verses: 999 },
+      { kind: 'poetry', offset: 999, verses: 1 },
+    ]);
+    expect(split.poetry).toBe(1);
+    expect(split.narrative).toBe(99);
+  });
+
+  it('measures shares of the PORTION, so a gap is left uncounted', () => {
+    // Ten law verses in a hundred-verse portion is 10%, not 100%.
+    expect(measureComposition(100, [{ kind: 'law', offset: 0, verses: 10 }])).toEqual({ law: 10 });
+  });
+
+  it('paints an overlap once, the later unit winning as it does on the strip', () => {
+    expect(
+      measureComposition(100, [
+        { kind: 'law', offset: 0, verses: 80 },
+        { kind: 'narrative', offset: 40, verses: 60 },
+      ]),
+    ).toEqual({ narrative: 60, law: 40 });
+  });
+
+  it('ignores unknown kinds, empty units, and an empty portion', () => {
+    expect(
+      measureComposition(100, [
+        { kind: 'law', offset: 0, verses: 10 },
+        { kind: 'prophecy' as never, offset: 10, verses: 90 },
+        { kind: 'records', offset: 10, verses: 0 },
+      ]),
+    ).toEqual({ law: 10 });
+    expect(measureComposition(100, [])).toEqual({});
+    expect(measureComposition(0, [{ kind: 'law', offset: 0, verses: 5 }])).toEqual({});
   });
 });
 

--- a/packages/tanach/tests/producer-defs.test.ts
+++ b/packages/tanach/tests/producer-defs.test.ts
@@ -80,7 +80,7 @@ describe('the eleven producers as core Producer objects', () => {
       spine: 'tanach',
     });
     expect(TANACH_PRODUCERS['parsha-overview'].inputs).toEqual([{ source: 'parsha-verses' }]);
-    expect(TANACH_PRODUCERS['parsha-overview'].cacheVersion).toBe('3'); // parsha-overview:v3:*
+    expect(TANACH_PRODUCERS['parsha-overview'].cacheVersion).toBe('4'); // parsha-overview:v4:*
     expect(TANACH_PRODUCERS['parsha-section'].anchoring).toEqual({
       behavior: 'inherits',
       precision: 'segment',

--- a/packages/tanach/tests/producer-keys.test.ts
+++ b/packages/tanach/tests/producer-keys.test.ts
@@ -78,7 +78,7 @@ describe('key byte-parity with the legacy literals', () => {
         overviewDef,
         enrichmentAddress('parsha-overview', overviewId, 'Deuteronomy', '7'),
       ),
-    ).toBe('parsha-overview:v3:deuteronomy_7_12-11_25');
+    ).toBe('parsha-overview:v4:deuteronomy_7_12-11_25');
 
     const sectionDef = info(enrichRunDefOf('parsha-section'), 'enrich');
     const sectionId = await instanceIdOf({ id: 'Deuteronomy 7:12-11:25#2' });


### PR DESCRIPTION
The Tanach parsha drawer opened a portion with a paragraph and a flat list — no picture of the week. It also answered *"what kind of reading is this?"* twice, from two independent AI fields that could disagree: a percentage bar from `composition` and coloured dots from `flow[].kind`. For Shoftim the bar claimed **10% narrative** while not one of the nine anchored units was narrative (counted off the units: halachah 86%, discourse 14%).

Both problems have the same fix: draw the portion.

## The map

`/api/parsha-study` now returns a `map` — every layer on one axis, verses from the portion's first verse. Three of its four layers are deterministic and cost nothing:

| Layer | Source |
| --- | --- |
| Verse extents | Sefaria `/api/shape/<book>`, cached 30 days |
| The seven aliyot | `extraDetails.aliyot`, already in the payload `/api/parsha` fetches |
| Chapter starts | derived from the same verse counts |
| Kind per unit | the `parsha-overview` producer (already paid) |

The reader draws a proportional strip above the flow: segment width = verse count, colour = kind, aliyot riding above, chapter ticks below, landmarks pinned. Clicking a segment selects that move and the list below scrolls to it. Segments are positioned, not tiled, so a portion the model left a gap in shows the gap rather than silently stretching its neighbours. The whole map mirrors under the Hebrew drawer, so it runs the way a scroll does.

The flow list becomes bands — kind stripe, title, verse range, each row as tall as its passage is long — that open in place to the summary and close reading they used to print inline.

## Honesty

Composition is **counted** off the anchored units instead of asserted, painted verse by verse so an overlap can't double-count and a gap can't be renormalized away (ten law verses in a hundred-verse portion report 10%, not 100%). The producer's `composition` field is gone.

## Five kinds, not three

Three was too few for a Torah year: Ha'azinu is a poem that would be filed as `discourse`, and the Pekudei inventory and the Bemidbar census are neither `law` nor `narrative`. `kind` gains `poetry` (שירה) and `records` (רשימות). Unit titles are capped at 2-5 words so a band doesn't truncate.

## Cache

`parsha-overview` v3 → v4 — key template, `cacheVersion`, and the warm cursor (v7 → v8) together. One weekly portion, so the bump re-pays cents.

## Checks

`pnpm typecheck`, `pnpm test` (82 tanach, 2764 talmud), `pnpm lint`, `pnpm --filter tanach build` all pass. New unit tests cover the verse arithmetic (including a verse that doesn't exist in a chapter the portion passes through), the aliyah numbering staying positional when an entry is malformed, the no-chapter-lengths degrade, and the overlap/gap composition cases.

Verified in the running reader against the live Shoftim payload — English and Hebrew, collapsed and expanded, strip → list selection, and the range highlight in the text.