### PR TITLE
Unroll the parsha map down the drawer as one column

### DIFF
--- a/packages/tanach/src/client/ParshaDrawer.tsx
+++ b/packages/tanach/src/client/ParshaDrawer.tsx
@@ -64,16 +64,13 @@ export function ParshaDrawer(props: ParshaDrawerProps): JSX.Element {
     );
   });
 
-  // A move can be picked from the map, where the band that just opened is
-  // often far down the drawer — bring it into view. 'nearest' leaves a band
-  // that is already on screen exactly where it is.
-  const moveRows: (HTMLElement | undefined)[] = [];
+  // The detail opens below the column, which on a tall portion sits under the
+  // fold — bring it into view. 'nearest' leaves it alone when it is already
+  // on screen, so picking a second move doesn't jump the drawer around.
+  let openMove: HTMLElement | undefined;
   createEffect(() => {
-    const index = selected();
-    if (index === null) return;
-    requestAnimationFrame(() =>
-      moveRows[index]?.scrollIntoView({ behavior: 'smooth', block: 'nearest' }),
-    );
+    if (selected() === null) return;
+    requestAnimationFrame(() => openMove?.scrollIntoView({ behavior: 'smooth', block: 'nearest' }));
   });
 
   // Selecting a move highlights its verse range in the reader and opens its
@@ -116,15 +113,13 @@ export function ParshaDrawer(props: ParshaDrawerProps): JSX.Element {
   const verseCount = (index: number): number | undefined =>
     props.study.map?.units.find((span) => span.index === index)?.verses;
 
-  /** A band stands as tall as its passage is long — the strip's proportions,
-   *  read down the list. Floors at a comfortable tap target, so a six-verse
-   *  unit is still a row and not a sliver. Uniform when there is no map. */
-  const bandStyle = (index: number): { 'min-height': string } | undefined => {
-    const map = props.study.map;
-    const verses = verseCount(index);
-    if (!map?.totalVerses || !verses) return undefined;
-    return { 'min-height': `${Math.round(30 + (verses / map.totalVerses) * 150)}px` };
-  };
+  /** Draw the column only when the map accounts for EVERY move. `buildParshaMap`
+   *  drops a unit it can't place on the verse axis, and the column has no row
+   *  for a move it can't position — so a partial map would make that move
+   *  vanish from the drawer entirely. The plain list stands in instead: less
+   *  picture, nothing lost. */
+  const drawColumn = (): boolean =>
+    !!props.study.map && props.study.map.units.length === props.study.flow.length;
 
   return (
     <section class="parsha-study">
@@ -137,14 +132,47 @@ export function ParshaDrawer(props: ParshaDrawerProps): JSX.Element {
         terms={props.study.terms ?? []}
       />
 
-      <Show when={props.study.map}>
-        <section class="parsha-section">
-          <div class="parsha-section-head">
-            <h4>{props.lang === 'he' ? 'הרכב הפרשה' : 'What kind of reading is this?'}</h4>
-            <span>
-              {props.study.map?.totalVerses} {props.lang === 'he' ? 'פסוקים' : 'verses'}
-            </span>
-          </div>
+      <section class="parsha-section">
+        <div class="parsha-section-head">
+          <h4>{props.lang === 'he' ? 'מהלך הפרשה' : 'The parsha, move by move'}</h4>
+          <span>
+            {drawColumn()
+              ? `${props.study.map?.totalVerses} ${props.lang === 'he' ? 'פסוקים' : 'verses'} · `
+              : ''}
+            {props.study.flow.length} {props.lang === 'he' ? 'יחידות' : 'moves'}
+          </span>
+        </div>
+
+        {/* The column IS the list: every move's title sits beside its own
+            stretch of the portion. Where there is no map to draw, the plain
+            list below stands in. */}
+        <Show
+          when={drawColumn()}
+          fallback={
+            <ol class="parsha-flow">
+              <For each={props.study.flow}>
+                {(section, index) => (
+                  <li>
+                    <button
+                      type="button"
+                      class="parsha-band"
+                      classList={{ active: selected() === index() }}
+                      onClick={() => choose(index())}
+                    >
+                      <span class={`parsha-band-stripe parsha-kind-${section.kind}`} />
+                      <span class="parsha-band-title">
+                        {textFor(props.lang, section.titleEn, section.titleHe)}
+                      </span>
+                      <span class="parsha-band-ref" dir="ltr">
+                        {section.ref.replace(`${props.study.book} `, '')}
+                      </span>
+                    </button>
+                  </li>
+                )}
+              </For>
+            </ol>
+          }
+        >
           <ParshaMap
             study={props.study}
             lang={props.lang}
@@ -152,109 +180,77 @@ export function ParshaDrawer(props: ParshaDrawerProps): JSX.Element {
             onSelect={choose}
             onOpenVerse={(chapter, verse) => props.onOpenText(props.study.book, chapter, verse)}
           />
-        </section>
-      </Show>
+        </Show>
 
-      <section class="parsha-section">
-        <div class="parsha-section-head">
-          <h4>{props.lang === 'he' ? 'מהלך הפרשה' : 'The parsha, move by move'}</h4>
-          <span>
-            {props.study.flow.length} {props.lang === 'he' ? 'יחידות' : 'moves'}
-          </span>
-        </div>
-        <ol class="parsha-flow">
-          <For each={props.study.flow}>
-            {(section, index) => (
-              <li ref={(element) => (moveRows[index()] = element)}>
+        {/* The selected move opens BELOW the column — the titles are placed by
+            their verse positions, so nothing can expand in place without
+            breaking the map's geometry. */}
+        <Show when={selectedFlow()}>
+          {(section) => (
+            <div class="parsha-flow-deep" ref={(element) => (openMove = element)}>
+              <p class="parsha-flow-kicker">
+                <span dir="ltr">{section().ref.replace(`${props.study.book} `, '')}</span> ·{' '}
+                {PARSHA_KIND_LABEL[section().kind][props.lang]}
+                <Show when={verseCount(selected() ?? -1)}>
+                  {(count) => (
+                    <>
+                      {' · '}
+                      {count()} {props.lang === 'he' ? 'פסוקים' : 'verses'}
+                    </>
+                  )}
+                </Show>
+              </p>
+              <h5 class="parsha-flow-title">
+                {textFor(props.lang, section().titleEn, section().titleHe)}
+              </h5>
+              <p class="parsha-flow-summary">
+                {textFor(props.lang, section().summaryEn, section().summaryHe)}
+              </p>
+              <Show when={deep.loading}>
+                <p class="comm-muted">
+                  {props.lang === 'he' ? 'קורא את הקטע מקרוב…' : 'Reading the passage closely…'}
+                </p>
+              </Show>
+              {/* deep.error first: reading deep() while the resource is
+                  errored (a rejected fetch, not a non-ok status) would
+                  rethrow and break the drawer subtree. */}
+              <Show when={!deep.loading && (deep.error || deep() === null)}>
+                <p class="comm-muted">
+                  {aiStatus()
+                    ? props.lang === 'he'
+                      ? 'יצירת תוכן מושבתת כרגע.'
+                      : 'AI generation is paused right now.'
+                    : props.lang === 'he'
+                      ? 'לא הצלחנו לקרוא את הקטע. נסו שוב.'
+                      : "Couldn't read this passage. Try again."}
+                </p>
+              </Show>
+              <Show when={!deep.loading && !deep.error && deep()}>
+                {(value) => (
+                  <TermedProse
+                    en={value().en}
+                    he={value().he}
+                    lang={props.lang}
+                    terms={deepTerms(value())}
+                  />
+                )}
+              </Show>
+              <div class="parsha-flow-actions">
                 <button
                   type="button"
-                  class="parsha-band"
-                  classList={{ active: selected() === index() }}
-                  style={bandStyle(index())}
-                  onClick={() => choose(index())}
+                  onClick={() =>
+                    props.onOpenText(props.study.book, section().startChapter, section().startVerse)
+                  }
                 >
-                  <span class={`parsha-band-stripe parsha-kind-${section.kind}`} />
-                  <span class="parsha-band-title">
-                    {textFor(props.lang, section.titleEn, section.titleHe)}
-                  </span>
-                  {/* A verse RANGE is Latin digits joined by a dash: without
-                      its own direction it reorders to "17:7–16:18" inside the
-                      Hebrew drawer. */}
-                  <span class="parsha-band-ref" dir="ltr">
-                    {section.ref.replace(`${props.study.book} `, '')}
-                  </span>
+                  {props.lang === 'he' ? 'פתח בטקסט' : 'Open in the text'}
                 </button>
-                <Show when={selected() === index()}>
-                  <div class="parsha-flow-deep">
-                    <p class="parsha-flow-kicker">
-                      <span dir="ltr">{section.ref.replace(`${props.study.book} `, '')}</span> ·{' '}
-                      {PARSHA_KIND_LABEL[section.kind][props.lang]}
-                      <Show when={verseCount(index())}>
-                        {(count) => (
-                          <>
-                            {' · '}
-                            {count()} {props.lang === 'he' ? 'פסוקים' : 'verses'}
-                          </>
-                        )}
-                      </Show>
-                    </p>
-                    <p class="parsha-flow-summary">
-                      {textFor(props.lang, section.summaryEn, section.summaryHe)}
-                    </p>
-                    <Show when={deep.loading}>
-                      <p class="comm-muted">
-                        {props.lang === 'he'
-                          ? 'קורא את הקטע מקרוב…'
-                          : 'Reading the passage closely…'}
-                      </p>
-                    </Show>
-                    {/* deep.error first: reading deep() while the resource is
-                        errored (a rejected fetch, not a non-ok status) would
-                        rethrow and break the drawer subtree. */}
-                    <Show when={!deep.loading && (deep.error || deep() === null)}>
-                      <p class="comm-muted">
-                        {aiStatus()
-                          ? props.lang === 'he'
-                            ? 'יצירת תוכן מושבתת כרגע.'
-                            : 'AI generation is paused right now.'
-                          : props.lang === 'he'
-                            ? 'לא הצלחנו לקרוא את הקטע. נסו שוב.'
-                            : "Couldn't read this passage. Try again."}
-                      </p>
-                    </Show>
-                    <Show when={!deep.loading && !deep.error && deep()}>
-                      {(value) => (
-                        <TermedProse
-                          en={value().en}
-                          he={value().he}
-                          lang={props.lang}
-                          terms={deepTerms(value())}
-                        />
-                      )}
-                    </Show>
-                    <div class="parsha-flow-actions">
-                      <button
-                        type="button"
-                        onClick={() =>
-                          props.onOpenText(
-                            props.study.book,
-                            section.startChapter,
-                            section.startVerse,
-                          )
-                        }
-                      >
-                        {props.lang === 'he' ? 'פתח בטקסט' : 'Open in the text'}
-                      </button>
-                      <button type="button" class="primary" onClick={() => buildThread(index())}>
-                        {props.lang === 'he' ? 'בנה דבר תורה' : 'Build a dvar Torah'}
-                      </button>
-                    </div>
-                  </div>
-                </Show>
-              </li>
-            )}
-          </For>
-        </ol>
+                <button type="button" class="primary" onClick={() => buildThread(selected() ?? 0)}>
+                  {props.lang === 'he' ? 'בנה דבר תורה' : 'Build a dvar Torah'}
+                </button>
+              </div>
+            </div>
+          )}
+        </Show>
       </section>
 
       <section class="parsha-section">

--- a/packages/tanach/src/client/ParshaMap.tsx
+++ b/packages/tanach/src/client/ParshaMap.tsx
@@ -1,21 +1,28 @@
 /**
- * The whole weekly portion as one object: a proportional strip of the parsha,
- * one segment per flow unit, coloured by what KIND of reading it is.
+ * The whole weekly portion as one column — the parsha turned on its side and
+ * unrolled down the drawer.
  *
- * Every layer sits on the same axis — verses from the portion's first verse —
- * so the drawing is pure arithmetic on `study.map`:
- *   aliyot rail   the week's seven divisions (from the calendar, not the model)
- *   the strip     the AI's flow units, at their true verse extents
- *   pins          landmarks, at their exact verse
- *   chapter ticks where 17, 18, 19 … begin
+ * Four rails share one axis (verses from the portion's first verse), so the
+ * drawing is arithmetic on `study.map` and nothing has to be correlated by eye:
+ *   chapters   where 17, 18, 19 … begin
+ *   aliyot     the week's seven divisions (from the calendar, not the model)
+ *   ribbon     the flow units at their true extents, coloured by kind, with
+ *              landmarks marked on them
+ *   titles     each move's name, written beside its own stretch of ribbon
  *
- * Segments are positioned absolutely rather than tiled, so a portion the model
- * left a gap in shows the gap instead of silently stretching its neighbours.
- * The strip is the flow list's other face: selecting here selects there.
+ * A move's title IS its segment — clicking either selects the move, and the
+ * detail opens below the column. The ribbon stays exactly proportional; only
+ * the titles are nudged apart (`layoutParshaColumn`), because a short unit
+ * cannot hold a line of text.
  */
 import { For, type JSX, Show } from 'solid-js';
 import { hebrewNumeral } from '../lib/hebrew.ts';
-import type { ParshaFlowSection, ParshaSectionKind, ParshaStudy } from '../lib/parsha.ts';
+import {
+  layoutParshaColumn,
+  type ParshaFlowSection,
+  type ParshaSectionKind,
+  type ParshaStudy,
+} from '../lib/parsha.ts';
 
 export const PARSHA_KIND_LABEL: Record<ParshaSectionKind, { en: string; he: string }> = {
   narrative: { en: 'Narrative', he: 'סיפור' },
@@ -29,6 +36,12 @@ export const PARSHA_KIND_LABEL: Record<ParshaSectionKind, { en: string; he: stri
  *  them, not the arbitrary order a given portion happens to use. */
 const LEGEND_ORDER: ParshaSectionKind[] = ['narrative', 'law', 'discourse', 'poetry', 'records'];
 
+/** The column's nominal height, and the least room a title needs. The column
+ *  grows past NOMINAL_H only when a portion's units are so lopsided that the
+ *  nudged titles run past the bottom. */
+const NOMINAL_H = 430;
+const MIN_LABEL_GAP = 24;
+
 export interface ParshaMapProps {
   study: ParshaStudy;
   lang: 'en' | 'he';
@@ -40,88 +53,79 @@ export interface ParshaMapProps {
 export function ParshaMap(props: ParshaMapProps): JSX.Element {
   const map = () => props.study.map;
   const total = () => map()?.totalVerses ?? 0;
-  const pct = (n: number) => `${(n / total()) * 100}%`;
   const unitAt = (index: number): ParshaFlowSection | undefined => props.study.flow[index];
-
-  /** Chapter numbers, thinned so two labels never sit on top of each other —
-   *  a portion that opens mid-chapter (Shoftim starts at 16:18) would
-   *  otherwise print "16 17" in the same few pixels. The opening chapter
-   *  always survives; a crowded later one is dropped. */
-  const chapterTicks = () => {
-    const total = map()?.totalVerses ?? 0;
-    const kept: { chapter: number; offset: number }[] = [];
-    for (const tick of map()?.chapters ?? []) {
-      const at = (tick.offset / total) * 100;
-      const previous = kept.at(-1);
-      if (previous && at - (previous.offset / total) * 100 < 5) continue;
-      kept.push(tick);
-    }
-    return kept;
-  };
-  const label = (kind: ParshaSectionKind) => PARSHA_KIND_LABEL[kind][props.lang];
   const shortRef = (ref: string) => ref.replace(`${props.study.book} `, '');
+  /** The reader's language, falling back to the other one rather than to an
+   *  empty label — both sides of every bilingual pair are optional in practice. */
+  const pick = (en: string, he: string) => (props.lang === 'he' ? he || en : en || he);
+  /** A verse offset as a pixel position down the drawn column. */
+  const y = (offset: number) => (offset / total()) * NOMINAL_H;
+
+  const column = () =>
+    layoutParshaColumn(map()?.units ?? [], {
+      totalVerses: total(),
+      height: NOMINAL_H,
+      minGap: MIN_LABEL_GAP,
+    });
 
   return (
     <Show when={map()}>
       {(value) => (
         <>
-          <Show when={value().aliyot.length}>
-            <div class="parsha-map-aliyot">
-              <For each={value().aliyot}>
-                {(aliyah) => (
-                  <i
-                    style={{ 'inset-inline-start': pct(aliyah.offset), width: pct(aliyah.verses) }}
-                    title={`${props.lang === 'he' ? 'עלייה' : 'Aliyah'} ${aliyah.n} · ${shortRef(aliyah.ref)}`}
-                  >
-                    {hebrewNumeral(aliyah.n)}
-                  </i>
-                )}
+          <div class="parsha-column" style={{ height: `${column().height}px` }}>
+            <div class="parsha-column-chapters">
+              <For each={value().chapters}>
+                {(tick) => <i style={{ top: `${y(tick.offset)}px` }}>{tick.chapter}</i>}
               </For>
             </div>
-          </Show>
 
-          <div class="parsha-map-strip">
-            <For each={value().units}>
-              {(span) => {
-                const unit = unitAt(span.index);
-                if (!unit) return null;
-                // An accessor, not a value: these rows are not recreated when
-                // the language changes (the units array is the same), so a
-                // snapshot would leave the tooltips in the old language.
-                const title = () =>
-                  props.lang === 'he' ? unit.titleHe || unit.titleEn : unit.titleEn;
-                return (
-                  <button
-                    type="button"
-                    class={`parsha-map-unit parsha-kind-${unit.kind}`}
-                    classList={{ active: props.selected === span.index }}
-                    style={{ 'inset-inline-start': pct(span.offset), width: pct(span.verses) }}
-                    title={`${title()} · ${shortRef(unit.ref)} · ${span.verses} ${
-                      props.lang === 'he' ? 'פסוקים' : 'verses'
-                    }`}
-                    aria-label={title()}
-                    onClick={() => props.onSelect(span.index)}
-                  >
-                    <span>{span.index + 1}</span>
-                  </button>
-                );
-              }}
-            </For>
-          </div>
+            <Show when={value().aliyot.length}>
+              <div class="parsha-column-aliyot">
+                <For each={value().aliyot}>
+                  {(aliyah) => (
+                    <i
+                      style={{
+                        top: `${y(aliyah.offset)}px`,
+                        height: `${Math.max(11, y(aliyah.verses) - 2)}px`,
+                      }}
+                      title={`${props.lang === 'he' ? 'עלייה' : 'Aliyah'} ${aliyah.n} · ${shortRef(aliyah.ref)}`}
+                    >
+                      {hebrewNumeral(aliyah.n)}
+                    </i>
+                  )}
+                </For>
+              </div>
+            </Show>
 
-          <Show when={value().landmarks.length}>
-            <div class="parsha-map-pins">
+            <div class="parsha-column-ribbon">
+              <For each={column().rows}>
+                {(row) => {
+                  const unit = unitAt(row.index);
+                  if (!unit) return null;
+                  const title = () => pick(unit.titleEn, unit.titleHe);
+                  return (
+                    <button
+                      type="button"
+                      class={`parsha-column-seg parsha-kind-${unit.kind}`}
+                      classList={{ active: props.selected === row.index }}
+                      style={{ top: `${row.segTop}px`, height: `${row.segHeight}px` }}
+                      title={`${title()} · ${shortRef(unit.ref)}`}
+                      aria-label={title()}
+                      onClick={() => props.onSelect(row.index)}
+                    />
+                  );
+                }}
+              </For>
               <For each={value().landmarks}>
                 {(pin) => {
                   const landmark = props.study.landmarks[pin.index];
                   if (!landmark) return null;
-                  const text = () =>
-                    props.lang === 'he' ? landmark.labelHe || landmark.labelEn : landmark.labelEn;
+                  const text = () => pick(landmark.labelEn, landmark.labelHe);
                   return (
                     <button
                       type="button"
-                      class="parsha-map-pin"
-                      style={{ 'inset-inline-start': pct(pin.offset + 0.5) }}
+                      class="parsha-column-pin"
+                      style={{ top: `${y(pin.offset + 0.5) - 3}px` }}
                       title={`${shortRef(landmark.ref)} · ${text()}`}
                       aria-label={text()}
                       onClick={() => props.onOpenVerse(landmark.chapter, landmark.verse)}
@@ -130,19 +134,31 @@ export function ParshaMap(props: ParshaMapProps): JSX.Element {
                 }}
               </For>
             </div>
-          </Show>
 
-          <div class="parsha-map-chapters">
-            <For each={chapterTicks()}>
-              {(tick) => (
-                <i
-                  classList={{ first: tick.offset === 0 }}
-                  style={{ 'inset-inline-start': pct(tick.offset) }}
-                >
-                  {tick.chapter}
-                </i>
-              )}
-            </For>
+            <div class="parsha-column-titles">
+              <For each={column().rows}>
+                {(row) => {
+                  const unit = unitAt(row.index);
+                  if (!unit) return null;
+                  return (
+                    <button
+                      type="button"
+                      class="parsha-column-title"
+                      classList={{ active: props.selected === row.index }}
+                      style={{ top: `${row.labelTop}px` }}
+                      onClick={() => props.onSelect(row.index)}
+                    >
+                      <span class="t">{pick(unit.titleEn, unit.titleHe)}</span>
+                      {/* A verse RANGE is Latin digits joined by a dash: without
+                          its own direction it reorders inside the Hebrew drawer. */}
+                      <span class="r" dir="ltr">
+                        {shortRef(unit.ref)}
+                      </span>
+                    </button>
+                  );
+                }}
+              </For>
+            </div>
           </div>
 
           <div class="parsha-legend">
@@ -150,7 +166,7 @@ export function ParshaMap(props: ParshaMapProps): JSX.Element {
               {(kind) => (
                 <span>
                   <i class={`parsha-dot parsha-kind-${kind}`} />
-                  {label(kind)} {props.study.composition[kind]}%
+                  {PARSHA_KIND_LABEL[kind][props.lang]} {props.study.composition[kind]}%
                 </span>
               )}
             </For>

--- a/packages/tanach/src/client/styles.css
+++ b/packages/tanach/src/client/styles.css
@@ -522,29 +522,52 @@ body {
   background: #767c66;
 }
 
-/* ---- the parsha map ----
-   Layers stacked on one verse axis; everything inside is positioned by
-   inset-inline-start so the whole map mirrors under the Hebrew RTL drawer
-   (a Torah scroll runs the other way, and so should its map). */
-.parsha-map-aliyot,
-.parsha-map-strip,
-.parsha-map-pins,
-.parsha-map-chapters {
-  position: relative;
+/* ---- the parsha column ----
+   The portion unrolled down the drawer: four rails on one verse axis, laid out
+   with logical properties so the whole thing mirrors in the Hebrew drawer (a
+   scroll runs the other way, and so should its map). */
+.parsha-column {
+  display: flex;
   width: 100%;
 }
-.parsha-map-aliyot {
-  height: 13px;
-  margin-bottom: 4px;
+.parsha-column-chapters {
+  position: relative;
+  flex: none;
+  width: 22px;
 }
-.parsha-map-aliyot i {
+.parsha-column-chapters i {
   position: absolute;
-  top: 0;
-  bottom: 0;
+  inset-inline-end: 5px;
+  font-style: normal;
+  font-family: var(--font-ui);
+  font-size: 9px;
+  color: var(--muted);
+  transform: translateY(-4px);
+}
+/* A hairline out to the aliyot rail, so the number reads as a position. */
+.parsha-column-chapters i::after {
+  content: "";
+  position: absolute;
+  inset-inline-end: -5px;
+  top: 7px;
+  width: 4px;
+  height: 1px;
+  background: var(--line);
+}
+.parsha-column-aliyot {
+  position: relative;
+  flex: none;
+  width: 13px;
+}
+.parsha-column-aliyot i {
+  position: absolute;
+  inset-inline-start: 0;
+  width: 11px;
+  padding-top: 3px;
   font-style: normal;
   font-family: var(--font-hebrew);
-  font-size: 9.5px;
-  line-height: 12px;
+  font-size: 9px;
+  line-height: 1;
   text-align: center;
   color: var(--accent);
   background: var(--parchment);
@@ -552,94 +575,103 @@ body {
   border-radius: 2px;
   overflow: hidden;
 }
-.parsha-map-strip {
-  height: 30px;
+.parsha-column-ribbon {
+  position: relative;
+  flex: none;
+  width: 13px;
+  margin-inline: 3px 9px;
   background: var(--surface-sunk);
-  border: 1px solid var(--line);
-  border-radius: 5px;
+  border-radius: 3px;
   overflow: hidden;
 }
-.parsha-map-unit {
+.parsha-column-seg {
   position: absolute;
-  top: 0;
-  bottom: 0;
+  inset-inline: 0;
   padding: 0;
-  font-family: var(--font-ui);
-  font-size: 10px;
-  font-weight: 700;
-  color: rgba(255, 255, 255, 0.94);
   border: none;
-  border-inline-end: 1px solid rgba(255, 255, 255, 0.55);
   cursor: pointer;
+  /* An INSET hairline, not a border: a border would grow the box and the
+     segment stacked beneath would paint over it, so a run of same-kind moves
+     would read as one undivided block. */
+  box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.8);
 }
-.parsha-map-unit:last-child {
-  border-inline-end: none;
-}
-.parsha-map-unit:hover {
+.parsha-column-seg:hover {
   filter: brightness(1.12);
 }
-.parsha-map-unit.active {
-  outline: 2px solid var(--ink);
-  outline-offset: -2px;
+.parsha-column-seg.active {
+  box-shadow: inset 0 0 0 2px var(--fg);
 }
-/* The number is a correlation aid to the list below; it only fits on the
-   wider segments, and hiding it is better than clipping it. */
-.parsha-map-unit span {
-  display: block;
-  overflow: hidden;
-}
-.parsha-map-pins {
-  height: 11px;
-  margin-top: 4px;
-}
-.parsha-map-pin {
+.parsha-column-pin {
   position: absolute;
-  top: 0;
-  width: 7px;
-  height: 7px;
+  inset-inline-start: 50%;
+  width: 5px;
+  height: 5px;
+  margin-inline-start: -2.5px;
   padding: 0;
-  transform: translateX(-3.5px) rotate(45deg);
+  transform: rotate(45deg);
   background: var(--surface);
-  border: 1.5px solid var(--accent-strong);
+  border: 1px solid var(--accent-strong);
   cursor: pointer;
 }
-.parsha-map-pin:hover {
+.parsha-column-pin:hover {
   background: var(--accent);
 }
-.parsha-map-chapters {
-  height: 14px;
-  font-family: var(--font-ui);
-  font-size: 9.5px;
-  color: var(--muted);
+.parsha-column-titles {
+  position: relative;
+  flex: 1;
+  min-width: 0;
 }
-.parsha-map-chapters i {
+.parsha-column-title {
   position: absolute;
-  top: 3px;
-  font-style: normal;
-  transform: translateX(-50%);
+  inset-inline: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+  padding: 0;
+  text-align: start;
+  background: transparent;
+  border: none;
+  color: var(--ink);
+  cursor: pointer;
 }
-/* A hairline back up to the strip, so the number reads as a position on the
-   portion rather than a loose digit. */
-.parsha-map-chapters i::before {
+/* The connector back to the ribbon. */
+.parsha-column-title::before {
   content: "";
   position: absolute;
-  top: -4px;
-  inset-inline-start: 50%;
-  width: 1px;
-  height: 3px;
+  inset-inline-start: -9px;
+  top: 8px;
+  width: 7px;
+  height: 1px;
   background: var(--line);
 }
-.parsha-map-chapters i.first::before {
-  inset-inline-start: 0;
+.parsha-column-title .t {
+  flex: 1;
+  min-width: 0;
+  font-family: var(--font-serif);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.25;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
-.ui-drawer[dir="rtl"] .parsha-map-chapters i {
-  transform: translateX(50%);
+.ui-drawer[dir="rtl"] .parsha-column-title .t {
+  font-family: var(--font-hebrew);
+  font-size: 14.5px;
 }
-/* The opening chapter sits at the very edge, so it hangs inward instead. */
-.parsha-map-chapters i.first,
-.ui-drawer[dir="rtl"] .parsha-map-chapters i.first {
-  transform: none;
+.parsha-column-title .r {
+  flex: none;
+  font-family: var(--font-ui);
+  font-size: 9px;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  unicode-bidi: isolate;
 }
+.parsha-column-title:hover .t,
+.parsha-column-title.active .t {
+  color: var(--accent-strong);
+}
+
 .parsha-legend {
   display: flex;
   flex-wrap: wrap;
@@ -668,11 +700,10 @@ body {
   position: relative;
 }
 
-/* ---- a flow move, collapsed ----
-   One row per move: a kind stripe, the title, its verse range. The row stands
-   as tall as its passage is long (min-height set inline from the map), so the
-   strip's proportions read again down the list. Clicking opens the move in
-   place. */
+/* ---- a flow move as a plain row ----
+   The fallback list, shown only when there is no map to draw (the book's
+   chapter lengths wouldn't resolve): a kind stripe, the title, its verse
+   range. Selecting one opens the same detail panel the column opens. */
 .parsha-band {
   position: relative;
   display: flex;
@@ -733,9 +764,9 @@ body {
   color: inherit;
 }
 
-/* The selected move's in-place close reading (deep dive under the card). */
+/* The selected move's close reading, opened under the column. */
 .parsha-flow-deep {
-  margin: 0 0 10px;
+  margin: 16px 0 4px;
   padding: 6px 9px 2px;
   border-left: 2px solid var(--line);
 }
@@ -756,7 +787,20 @@ body {
   letter-spacing: 0.03em;
   color: var(--accent);
 }
-/* The one-line summary, which the collapsed band leaves out. */
+/* The opened move names itself again — the column's own title is a small
+   label beside a ribbon, not a heading. */
+.parsha-flow-title {
+  margin: 0 0 4px;
+  font-family: var(--font-serif);
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.25;
+}
+.ui-drawer[dir="rtl"] .parsha-flow-title {
+  font-family: var(--font-hebrew);
+  font-size: 16.5px;
+}
+/* The one-line summary, which the column leaves out. */
 .parsha-flow-summary {
   margin: 0 0 9px;
   font-family: var(--font-serif);

--- a/packages/tanach/src/lib/parsha.ts
+++ b/packages/tanach/src/lib/parsha.ts
@@ -369,6 +369,48 @@ export function buildParshaMap(input: {
   return { totalVerses, units, landmarks, aliyot, chapters };
 }
 
+/** One move's place in the drawn column: where its stretch of the ribbon
+ *  actually is, and where its title can be written without landing on its
+ *  neighbour's. */
+export interface ParshaColumnRow {
+  index: number;
+  /** The ribbon segment — exactly proportional, never nudged. */
+  segTop: number;
+  segHeight: number;
+  /** The title's baseline row, pushed down where the segment is too short to
+   *  hold a line of text. */
+  labelTop: number;
+}
+
+/**
+ * Lay the portion out as a vertical column: the ribbon keeps true proportions
+ * (it is the map, and a nudged map lies), while the titles beside it are
+ * pushed down just enough to stay legible.
+ *
+ * A two-verse unit is four pixels tall on a 430px column — its title has to
+ * sit lower than its segment or overlap the next one. Each label therefore
+ * takes the later of its own segment top and `minGap` below the previous
+ * label, and the column grows if the last one runs past the bottom.
+ */
+export function layoutParshaColumn(
+  spans: readonly ParshaSpan[],
+  options: { totalVerses: number; height: number; minGap: number },
+): { rows: ParshaColumnRow[]; height: number } {
+  const { totalVerses, height, minGap } = options;
+  if (!(totalVerses > 0) || !(height > 0)) return { rows: [], height };
+  const rows: ParshaColumnRow[] = [];
+  let previous = Number.NEGATIVE_INFINITY;
+  for (const span of [...spans].sort((a, b) => a.offset - b.offset)) {
+    const segTop = (span.offset / totalVerses) * height;
+    const segHeight = (span.verses / totalVerses) * height;
+    const labelTop = Math.max(segTop, previous + minGap);
+    previous = labelTop;
+    rows.push({ index: span.index, segTop, segHeight, labelTop });
+  }
+  const last = rows.at(-1);
+  return { rows, height: last ? Math.max(height, last.labelTop + minGap) : height };
+}
+
 /**
  * The share of the PORTION each kind of reading takes, counted verse by verse
  * off the anchored units.

--- a/packages/tanach/tests/parsha.test.ts
+++ b/packages/tanach/tests/parsha.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildParshaMap,
   formatParshaRange,
+  layoutParshaColumn,
   measureComposition,
   parseParshaRef,
   pointInParsha,
@@ -145,6 +146,52 @@ describe('the parsha map', () => {
         aliyot: [],
       }),
     ).toBeNull();
+  });
+});
+
+describe('the drawn column', () => {
+  const spans = [
+    { index: 0, offset: 0, verses: 50 },
+    { index: 1, offset: 50, verses: 2 },
+    { index: 2, offset: 52, verses: 2 },
+    { index: 3, offset: 54, verses: 46 },
+  ];
+
+  it('keeps the ribbon proportional and only nudges the titles', () => {
+    const { rows } = layoutParshaColumn(spans, { totalVerses: 100, height: 400, minGap: 24 });
+    // Segments are exactly proportional — the ribbon is the map.
+    expect(rows.map((r) => [r.segTop, r.segHeight])).toEqual([
+      [0, 200],
+      [200, 8],
+      [208, 8],
+      [216, 184],
+    ]);
+    // Two 2-verse moves are 8px of ribbon; their titles get 24px of room each.
+    expect(rows.map((r) => r.labelTop)).toEqual([0, 200, 224, 248]);
+  });
+
+  it('grows the column when the nudged titles run past the bottom', () => {
+    const crowded = Array.from({ length: 9 }, (_, i) => ({ index: i, offset: i, verses: 1 }));
+    const { rows, height } = layoutParshaColumn(crowded, {
+      totalVerses: 100,
+      height: 100,
+      minGap: 24,
+    });
+    expect(rows.at(-1)?.labelTop).toBe(192);
+    expect(height).toBe(216);
+  });
+
+  it('reads the portion in verse order however the spans arrive', () => {
+    const { rows } = layoutParshaColumn([...spans].reverse(), {
+      totalVerses: 100,
+      height: 400,
+      minGap: 24,
+    });
+    expect(rows.map((r) => r.index)).toEqual([0, 1, 2, 3]);
+  });
+
+  it('draws nothing for an unmeasurable portion', () => {
+    expect(layoutParshaColumn(spans, { totalVerses: 0, height: 400, minGap: 24 }).rows).toEqual([]);
   });
 });
 


### PR DESCRIPTION
The drawer carried two objects that said the same thing: a horizontal strip of the portion, and a list of bands beneath it. Reading it meant correlating a segment above with a row below.

They are now one thing. The portion runs **down** the drawer as a ribbon, and each move's title is written beside its own stretch of it — the row *is* the segment. Chapter numbers and the seven aliyot ride alongside on the same verse axis; landmarks are marked on the ribbon itself.

This is variation D from the design round; the four alternatives were rendered against live Shoftim data before picking.

## The one piece of real logic

The ribbon stays **exactly** proportional, because a nudged map lies. Only the titles move: `layoutParshaColumn` pushes each label down far enough to clear its neighbour — a two-verse unit is four pixels of ribbon and cannot hold a line of text — and grows the column if the last label runs past the bottom. Pure, and unit-tested for the nudge, the growth, the ordering, and the unmeasurable-portion case.

Selecting a move opens its detail **below** the column instead of in place: the titles are positioned by verse, so nothing can expand between them without breaking the geometry.

## Degrade paths

- The column draws only when the map accounts for **every** move. `buildParshaMap` drops a unit it can't place on the verse axis, and the column has no row for a move it can't position — a partial column would make that move vanish from the drawer entirely. The plain list stands in instead: less picture, nothing lost.
- Every bilingual label falls back to the other language rather than rendering blank.
- Verse ranges keep `dir="ltr"`, so they don't reorder in the Hebrew drawer.

## RTL

The whole column is laid out with logical properties, so it mirrors: in Hebrew the rails sit on the right and the titles run left, the way a scroll does.

## Scope

No producer, schema, or cache change — the same `/api/parsha-study` payload, drawn differently.

## Checks

`pnpm typecheck`, `pnpm test` (86 tanach), `pnpm lint`, `pnpm --filter tanach build` all pass. Verified in the running reader against the live Shoftim payload: English and Hebrew, unselected and selected, column and the no-map fallback list.