### PR TITLE
Fix geography returning an empty map on place-dense chapters

### DIFF
--- a/packages/tanach/src/lib/geography.ts
+++ b/packages/tanach/src/lib/geography.ts
@@ -11,7 +11,18 @@
  *                  gazetteer entry are the same place named twice, but two
  *                  different entries that happen to share a coordinate are
  *                  two places and both belong on the map
+ *   a hard cap     so a town-list chapter yields a readable map, whatever the
+ *                  model returned
  */
+
+/** The most pins one chapter's map carries. The producer is asked for at most
+ *  this many, but on the deployed path that instruction is prompt guidance
+ *  rather than a provider-enforced grammar (first-party DeepSeek can't honour
+ *  json_schema, so the schema is inlined as text — see core llm.ts
+ *  `inlineSchemaForFirstParty`). The cap is therefore applied HERE too, where
+ *  it actually holds: a border survey that comes back with a hundred towns
+ *  becomes a readable map instead of a wall of dots. */
+export const MAX_MAPPED_PLACES = 40;
 
 export interface NamedPlace {
   en?: string;
@@ -36,20 +47,29 @@ export interface GazetteerHit {
 /**
  * Resolve the producer's named places to mappable ones.
  *
- * Deduping on the gazetteer ENTRY rather than on `lat,lng` matters: the
- * gazetteer gives several unlocated biblical names the same fallback point
- * (Havilah and Babylon both sit at 32.5433, 44.4222), and keying on the
- * coordinate silently dropped the second one — Genesis 10 lost Havilah
- * entirely. Names that resolve to the same entry (Ai / Aiath / Aija) still
- * collapse to one pin, which is the case dedupe is actually for.
+ * Dedupe keys on the gazetteer ENTRY, not on `lat,lng`. The coordinate is not
+ * an identity: the gazetteer parks many unlocated biblical names on a regional
+ * fallback point — 774 of its 1330 entries share a coordinate with another,
+ * and the Jerusalem point alone carries 57 names — so keying on the coordinate
+ * deleted real places wholesale (Genesis 10 lost Havilah, which the data files
+ * at Babylon's point).
+ *
+ * The trade this makes: OpenBible also records some alias pairs as separate
+ * entries at one site (Ai / Aiath, Ephrath / Bethlehem), and those now draw
+ * two pins, which the map's de-overlap spiral fans apart. That is a small
+ * cosmetic cost — both names really are in the text — against a systematic
+ * loss of places the reader was never shown at all. Entry granularity is the
+ * gazetteer's own notion of a place, so it is what we defer to.
  */
 export function locatePlaces(
   places: readonly NamedPlace[] | undefined,
   lookup: (name: string) => GazetteerHit | null,
+  cap: number = MAX_MAPPED_PLACES,
 ): LocatedPlace[] {
   const seen = new Set<string>();
   const out: LocatedPlace[] = [];
   for (const place of places ?? []) {
+    if (out.length >= cap) break;
     const en = String(place?.en ?? '').trim();
     if (!en) continue;
     const hit = lookup(en);

--- a/packages/tanach/src/lib/geography.ts
+++ b/packages/tanach/src/lib/geography.ts
@@ -1,0 +1,70 @@
+/**
+ * Joining the geography producer's NAMED places to real coordinates.
+ *
+ * The producer only names places; coordinates come deterministically from the
+ * bundled gazetteer (worker/gazetteer.ts). This module is the join, kept pure
+ * (the lookup is injected) so the rules below are testable:
+ *
+ *   place-or-omit  a name the gazetteer can't locate is dropped, because a
+ *                  wrong pin is worse than a missing one
+ *   one pin per PLACE, not per point — two names that resolve to the SAME
+ *                  gazetteer entry are the same place named twice, but two
+ *                  different entries that happen to share a coordinate are
+ *                  two places and both belong on the map
+ */
+
+export interface NamedPlace {
+  en?: string;
+  he?: string;
+  verses?: number[];
+}
+
+export interface LocatedPlace {
+  en: string;
+  he: string;
+  lat: number;
+  lng: number;
+  verses: number[];
+}
+
+export interface GazetteerHit {
+  name: string;
+  lat: number;
+  lng: number;
+}
+
+/**
+ * Resolve the producer's named places to mappable ones.
+ *
+ * Deduping on the gazetteer ENTRY rather than on `lat,lng` matters: the
+ * gazetteer gives several unlocated biblical names the same fallback point
+ * (Havilah and Babylon both sit at 32.5433, 44.4222), and keying on the
+ * coordinate silently dropped the second one — Genesis 10 lost Havilah
+ * entirely. Names that resolve to the same entry (Ai / Aiath / Aija) still
+ * collapse to one pin, which is the case dedupe is actually for.
+ */
+export function locatePlaces(
+  places: readonly NamedPlace[] | undefined,
+  lookup: (name: string) => GazetteerHit | null,
+): LocatedPlace[] {
+  const seen = new Set<string>();
+  const out: LocatedPlace[] = [];
+  for (const place of places ?? []) {
+    const en = String(place?.en ?? '').trim();
+    if (!en) continue;
+    const hit = lookup(en);
+    if (!hit) continue;
+    if (seen.has(hit.name)) continue;
+    seen.add(hit.name);
+    out.push({
+      en,
+      he: String(place?.he ?? '').trim(),
+      lat: hit.lat,
+      lng: hit.lng,
+      verses: Array.isArray(place?.verses)
+        ? place.verses.filter((verse) => Number.isInteger(verse) && verse >= 1)
+        : [],
+    });
+  }
+  return out;
+}

--- a/packages/tanach/src/worker/index.ts
+++ b/packages/tanach/src/worker/index.ts
@@ -19,6 +19,7 @@ import type { StoredArtifact } from '@corpus/core/store/envelope';
 import type { Context } from 'hono';
 import { Hono } from 'hono';
 import { isBook } from '../lib/books.ts';
+import { locatePlaces, type NamedPlace } from '../lib/geography.ts';
 import {
   buildParshaMap,
   formatParshaRange,
@@ -282,27 +283,17 @@ app.get('/api/geography/:book/:chapter', async (c) => {
   } catch (e) {
     return runErrorResponse(c, e);
   }
-  const parsed = artifact.parsed as {
-    places?: { en?: string; he?: string; verses?: number[] }[];
-  } | null;
-  const seen = new Set<string>();
-  const places = (parsed?.places ?? [])
-    .map((p) => {
-      const en = String(p?.en ?? '').trim();
-      const g = en ? lookupPlace(en) : null;
-      if (!g) return null;
-      const verses = Array.isArray(p?.verses)
-        ? p.verses.filter((v) => Number.isInteger(v) && v >= 1)
-        : [];
-      return { en, he: String(p?.he ?? '').trim(), lat: g.lat, lng: g.lng, verses };
-    })
-    .filter((p): p is { en: string; he: string; lat: number; lng: number; verses: number[] } => {
-      if (!p) return false;
-      const key = `${p.lat},${p.lng}`; // dedupe places that resolve to one point
-      if (seen.has(key)) return false;
-      seen.add(key);
-      return true;
-    });
+  // A model output that didn't parse is a FAILURE, not a chapter without
+  // places. Reporting it as an empty map is what made the itinerary chapters
+  // (Numbers 33, Numbers 21, Joshua 15 — the ones a map is most wanted for)
+  // read "No mapped places in this chapter": the place list overran the token
+  // budget, the JSON came back cut in half, and the reader was told the
+  // wilderness itinerary passes through nowhere.
+  if (artifact.parse_error) {
+    return c.json({ error: `Geography generation failed: ${artifact.parse_error}` }, 502);
+  }
+  const parsed = artifact.parsed as { places?: NamedPlace[] } | null;
+  const places = locatePlaces(parsed?.places, lookupPlace);
   // Deterministic per (book, chapter), lang-independent, already KV-cached
   // server-side — let the browser cache it so re-opening Geography is instant.
   c.header('Cache-Control', 'public, max-age=600, stale-while-revalidate=86400');

--- a/packages/tanach/src/worker/producers/defs.ts
+++ b/packages/tanach/src/worker/producers/defs.ts
@@ -153,9 +153,19 @@ const geographyExtractor: TanachLLMExtractor = {
   // 900 was enough for ~21 places, which quietly broke exactly the chapters a
   // map is for: Numbers 33's forty-two encampments overran it, the JSON came
   // back truncated, the parse failed, and the reader was told the chapter has
-  // no places. A place costs ~50 tokens (nikud is expensive), so the schema's
-  // 40-place ceiling needs ~2000 — 3000 leaves room.
-  max_tokens: 3000,
+  // no places.
+  //
+  // A place costs ~50 tokens (nikud is expensive), so the 40-place cap needs
+  // ~2000. The ceiling is set far above that because the cap is NOT enforced
+  // by the provider on the deployed path — first-party DeepSeek can't honour
+  // json_schema, so the schema rides in the prompt as text (core llm.ts
+  // `inlineSchemaForFirstParty`) and a chapter like Joshua 15, which names
+  // over a hundred towns, can still be answered in full. Truncation is the one
+  // failure that loses EVERYTHING (the JSON is unparseable), so the budget
+  // buys room for the model to finish; `locatePlaces` then caps what is drawn.
+  // max_tokens is a ceiling, not a charge — ordinary chapters still cost what
+  // they generate.
+  max_tokens: 8000,
   temperature: 0.2,
   tag: 'tanach:geography',
 };

--- a/packages/tanach/src/worker/producers/defs.ts
+++ b/packages/tanach/src/worker/producers/defs.ts
@@ -150,7 +150,12 @@ const geographyExtractor: TanachLLMExtractor = {
   system_prompt: GEOGRAPHY_SYSTEM,
   user_prompt_template: GEOGRAPHY_USER_TEMPLATE,
   output_schema: GEOGRAPHY_SCHEMA,
-  max_tokens: 900,
+  // 900 was enough for ~21 places, which quietly broke exactly the chapters a
+  // map is for: Numbers 33's forty-two encampments overran it, the JSON came
+  // back truncated, the parse failed, and the reader was told the chapter has
+  // no places. A place costs ~50 tokens (nikud is expensive), so the schema's
+  // 40-place ceiling needs ~2000 — 3000 leaves room.
+  max_tokens: 3000,
   temperature: 0.2,
   tag: 'tanach:geography',
 };

--- a/packages/tanach/src/worker/producers/geography.ts
+++ b/packages/tanach/src/worker/producers/geography.ts
@@ -43,6 +43,9 @@ export const GEOGRAPHY_SYSTEM = [
   '- Do NOT include people, tribes, or peoples — only physical places.',
   '- Do NOT invent coordinates or places not in the text.',
   '- Return them in the order they first appear.',
+  '- At most 40. A chapter that names more (a border survey, a town list, a',
+  '  march itinerary) gets the 40 a reader is most likely to look for, still in',
+  '  the order they appear — a map is not the place for a hundred pins.',
 ].join('\n');
 
 /** Rendered with vars from the 'chapter-verses' source resolver (same as the
@@ -59,6 +62,10 @@ export const GEOGRAPHY_SCHEMA = {
     properties: {
       places: {
         type: 'array',
+        // Bounded so a town-list chapter can't run the response past the token
+        // budget: an overrun truncates the JSON mid-array, and a truncated
+        // response is not a short map, it is NO map (the parse fails).
+        maxItems: 40,
         items: {
           type: 'object',
           additionalProperties: false,

--- a/packages/tanach/tests/geography.test.ts
+++ b/packages/tanach/tests/geography.test.ts
@@ -15,14 +15,24 @@ const fake = (name: string): GazetteerHit | null => ENTRIES[name.toLowerCase()] 
 describe('locating a chapter’s named places', () => {
   it('keeps two different places that the gazetteer puts at one point', () => {
     // The regression: keying dedupe on `lat,lng` dropped Havilah from Genesis
-    // 10, because the data gives it Babylon's coordinate.
+    // 10, because the data files it at Babylon's coordinate.
     const places = locatePlaces([{ en: 'Babylon' }, { en: 'Havilah' }], fake);
     expect(places.map((p) => p.en)).toEqual(['Babylon', 'Havilah']);
   });
 
-  it('collapses two names for the same place to one pin', () => {
+  it('collapses two names for the same gazetteer entry to one pin', () => {
     const places = locatePlaces([{ en: 'Ai', verses: [1] }, { en: 'Aiath' }], fake);
     expect(places).toEqual([{ en: 'Ai', he: '', lat: 31.9169, lng: 35.2611, verses: [1] }]);
+  });
+
+  it('caps the map so a town-list chapter stays readable', () => {
+    // The producer is asked for at most 40, but on the deployed path that is
+    // prompt guidance rather than an enforced grammar — so the cap has to hold
+    // here too. Joshua 15 names well over a hundred towns.
+    const many = Array.from({ length: 60 }, (_, i) => ({ en: `Town ${i}` }));
+    const lookupAll = (name: string): GazetteerHit => ({ name, lat: 31 + Math.random(), lng: 35 });
+    expect(locatePlaces(many, lookupAll)).toHaveLength(40);
+    expect(locatePlaces(many, lookupAll, 5)).toHaveLength(5);
   });
 
   it('omits a place it cannot locate rather than guessing', () => {
@@ -49,6 +59,11 @@ describe('locating a chapter’s named places', () => {
     expect(locatePlaces([{ en: 'Babylon' }, { en: 'Havilah' }], lookupPlace)).toHaveLength(2);
     // Two names for one entry still collapse.
     expect(locatePlaces([{ en: 'Salt Sea' }, { en: 'Dead Sea' }], lookupPlace)).toHaveLength(1);
+    expect(locatePlaces([{ en: 'Kiriath-arba' }, { en: 'Hebron' }], lookupPlace)).toHaveLength(1);
+    // The accepted cost of entry-granularity: OpenBible files a few alias pairs
+    // as separate entries at one site, so these draw two (spiralled) pins
+    // rather than one. Cosmetic, and both names are genuinely in the text.
+    expect(locatePlaces([{ en: 'Ai' }, { en: 'Aiath' }], lookupPlace)).toHaveLength(2);
     expect(lookupPlace('a place that does not exist')).toBeNull();
   });
 });

--- a/packages/tanach/tests/geography.test.ts
+++ b/packages/tanach/tests/geography.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { type GazetteerHit, locatePlaces } from '../src/lib/geography';
+import { lookupPlace } from '../src/worker/gazetteer';
+
+/** A stand-in gazetteer with the two shapes that matter: several names for one
+ *  entry, and two DIFFERENT entries the data happens to put at one point. */
+const ENTRIES: Record<string, GazetteerHit> = {
+  ai: { name: 'Ai 1', lat: 31.9169, lng: 35.2611 },
+  aiath: { name: 'Ai 1', lat: 31.9169, lng: 35.2611 },
+  babylon: { name: 'Babylon 1', lat: 32.5433, lng: 44.4222 },
+  havilah: { name: 'Havilah 1', lat: 32.5433, lng: 44.4222 },
+};
+const fake = (name: string): GazetteerHit | null => ENTRIES[name.toLowerCase()] ?? null;
+
+describe('locating a chapter’s named places', () => {
+  it('keeps two different places that the gazetteer puts at one point', () => {
+    // The regression: keying dedupe on `lat,lng` dropped Havilah from Genesis
+    // 10, because the data gives it Babylon's coordinate.
+    const places = locatePlaces([{ en: 'Babylon' }, { en: 'Havilah' }], fake);
+    expect(places.map((p) => p.en)).toEqual(['Babylon', 'Havilah']);
+  });
+
+  it('collapses two names for the same place to one pin', () => {
+    const places = locatePlaces([{ en: 'Ai', verses: [1] }, { en: 'Aiath' }], fake);
+    expect(places).toEqual([{ en: 'Ai', he: '', lat: 31.9169, lng: 35.2611, verses: [1] }]);
+  });
+
+  it('omits a place it cannot locate rather than guessing', () => {
+    expect(locatePlaces([{ en: 'Nowhere-in-particular' }, { en: 'Ai' }], fake)).toHaveLength(1);
+  });
+
+  it('drops junk: no name, no verses, nothing to map', () => {
+    expect(locatePlaces([{ en: '  ' }, { he: 'עַי' }], fake)).toEqual([]);
+    expect(locatePlaces(undefined, fake)).toEqual([]);
+    // Verse numbers are filtered to real ones.
+    expect(locatePlaces([{ en: 'Ai', verses: [0, 2, -1, 3.5 as number] }], fake)[0].verses).toEqual(
+      [2],
+    );
+  });
+
+  it('reads the real gazetteer for the places these rules were written from', () => {
+    // Genesis 10 lost Havilah because the data files it at Babylon's point —
+    // and it is not a rare accident: 774 of the gazetteer's 1330 entries sit
+    // on a coordinate shared with another (the Jerusalem point alone carries
+    // 57, every gate and quarter of the city). Deduping on the coordinate
+    // therefore threw away real places by the dozen.
+    expect(lookupPlace('Havilah')).toEqual({ name: 'Havilah 1', lat: 32.5433, lng: 44.4222 });
+    expect(lookupPlace('Babylon')).toEqual({ name: 'Babylon 1', lat: 32.5433, lng: 44.4222 });
+    expect(locatePlaces([{ en: 'Babylon' }, { en: 'Havilah' }], lookupPlace)).toHaveLength(2);
+    // Two names for one entry still collapse.
+    expect(locatePlaces([{ en: 'Salt Sea' }, { en: 'Dead Sea' }], lookupPlace)).toHaveLength(1);
+    expect(lookupPlace('a place that does not exist')).toBeNull();
+  });
+});

--- a/packages/tanach/tests/producer-defs.test.ts
+++ b/packages/tanach/tests/producer-defs.test.ts
@@ -124,7 +124,9 @@ describe('the eleven producers as core Producer objects', () => {
       },
       'parsha-section': { max_tokens: 2800, temperature: 0.3, tag: 'tanach:parsha-section' },
       'parsha-thread': { max_tokens: 4200, temperature: 0.35, tag: 'tanach:parsha-thread' },
-      geography: { max_tokens: 900, temperature: 0.2, tag: 'tanach:geography' },
+      // 3000, not 900: the old budget truncated the JSON on a place-dense
+      // chapter, which reads as "no places" rather than "fewer places".
+      geography: { max_tokens: 3000, temperature: 0.2, tag: 'tanach:geography' },
       tidbit: { max_tokens: 1800, temperature: 0.45, tag: 'tanach:tidbit' },
       synthesis: { max_tokens: 800, temperature: 0.3, tag: 'tanach:synthesis' },
       'midrash-synthesis': { max_tokens: 800, temperature: 0.35, tag: 'tanach:midrash-synthesis' },

--- a/packages/tanach/tests/producer-defs.test.ts
+++ b/packages/tanach/tests/producer-defs.test.ts
@@ -124,9 +124,10 @@ describe('the eleven producers as core Producer objects', () => {
       },
       'parsha-section': { max_tokens: 2800, temperature: 0.3, tag: 'tanach:parsha-section' },
       'parsha-thread': { max_tokens: 4200, temperature: 0.35, tag: 'tanach:parsha-thread' },
-      // 3000, not 900: the old budget truncated the JSON on a place-dense
-      // chapter, which reads as "no places" rather than "fewer places".
-      geography: { max_tokens: 3000, temperature: 0.2, tag: 'tanach:geography' },
+      // Roomy, not 900: the old budget truncated the JSON on a place-dense
+      // chapter, and a truncated response is no map at all rather than a
+      // shorter one. The reader-facing cap lives in locatePlaces.
+      geography: { max_tokens: 8000, temperature: 0.2, tag: 'tanach:geography' },
       tidbit: { max_tokens: 1800, temperature: 0.45, tag: 'tanach:tidbit' },
       synthesis: { max_tokens: 800, temperature: 0.3, tag: 'tanach:synthesis' },
       'midrash-synthesis': { max_tokens: 800, temperature: 0.35, tag: 'tanach:midrash-synthesis' },


### PR DESCRIPTION
The Geography pill said **"No mapped places in this chapter"** for Numbers 33, Numbers 21 and Joshua 15 — the wilderness itinerary, the march to Moab, and the towns of Judah. The chapters a map is most wanted for were exactly the ones that had none.

Two independent faults, both silent.

## 1. The place list overran its token budget

`geography` ran at `max_tokens: 900`, which fits about 21 places. Numbers 33 names forty-two encampments, so the JSON came back cut in half and the parse failed. `runProducer` then correctly refused to cache it — but the route read `parsed?.places ?? []` and served a perfectly ordinary **200 with an empty list**. The reader was told the chapter passes through nowhere, and because nothing was cached, every open re-ran the model and re-paid to fail again.

Fixed three ways, because the obvious one isn't enough:
- **A parse failure is now reported as a failure** (502), not dressed up as an empty chapter.
- **The ceiling rises to 8000.** Review caught that the schema's `maxItems: 40` is *advisory on the deployed path*: first-party DeepSeek can't honour `json_schema`, so the schema is inlined into the prompt as text (`inlineSchemaForFirstParty`). Joshua 15 can still answer with a hundred towns. Truncation is the one failure that loses everything, so the budget buys room to finish. `max_tokens` is a ceiling, not a charge.
- **The reader-facing cap moved to `locatePlaces`**, where it actually holds regardless of what the model returns.

## 2. Dedupe was keyed on the coordinate

Two names landing on one point were treated as one place. But the gazetteer parks many unlocated biblical names on a regional fallback point: **774 of its 1330 entries share a coordinate with another**, and the Jerusalem point alone carries 57 names (every gate and quarter). So real places were dropped wholesale — **Genesis 10 lost Havilah**, because the data files it at Babylon's coordinate.

Dedupe now keys on the gazetteer **entry**. The accepted trade: OpenBible records some alias pairs (Ai / Aiath, Ephrath / Bethlehem) as separate entries at one site, so those draw two pins that the map's existing de-overlap spiral fans apart. Cosmetic, and both names genuinely are in the text — against a systematic loss of places the reader was never shown at all.

## Shape

The join moves out of the route into `src/lib/geography.ts` as a pure function with the gazetteer injected, so both rules are testable. New tests cover the coincident-coordinate case, the alias collapse, the cap, place-or-omit, and junk input — plus assertions against the *real* gazetteer for the two entries the Genesis 10 regression turned on.

## Cache

No key change. The broken chapters were never cached (that was the bug), so they simply generate correctly on next open; chapters already cached keep serving and pick up the dedupe fix immediately, since the join happens at read time.

## Checks

`pnpm typecheck`, `pnpm test` (92 tanach), `pnpm lint`, `pnpm --filter tanach build` all pass.