### PR TITLE
Cite a real example for the coordinate-dedupe fix

### DIFF
--- a/packages/tanach/src/lib/geography.ts
+++ b/packages/tanach/src/lib/geography.ts
@@ -48,11 +48,13 @@ export interface GazetteerHit {
  * Resolve the producer's named places to mappable ones.
  *
  * Dedupe keys on the gazetteer ENTRY, not on `lat,lng`. The coordinate is not
- * an identity: the gazetteer parks many unlocated biblical names on a regional
- * fallback point — 774 of its 1330 entries share a coordinate with another,
- * and the Jerusalem point alone carries 57 names — so keying on the coordinate
- * deleted real places wholesale (Genesis 10 lost Havilah, which the data files
- * at Babylon's point).
+ * an identity: 774 of the gazetteer's 1330 entries share a coordinate with
+ * another (the Jerusalem point alone carries 57 names), because neighbouring
+ * sites round together and unlocated names get a regional fallback. Keying on
+ * the coordinate therefore deleted real places — in the live data, Joshua 19
+ * files Beer-sheba, Hazar-shual and Eltolad at one point and Numbers 33 files
+ * Tahath, Terah and Mithkah at another, so two of each three were silently
+ * dropped from those maps.
  *
  * The trade this makes: OpenBible also records some alias pairs as separate
  * entries at one site (Ai / Aiath, Ephrath / Bethlehem), and those now draw

--- a/packages/tanach/tests/geography.test.ts
+++ b/packages/tanach/tests/geography.test.ts
@@ -14,8 +14,10 @@ const fake = (name: string): GazetteerHit | null => ENTRIES[name.toLowerCase()] 
 
 describe('locating a chapter’s named places', () => {
   it('keeps two different places that the gazetteer puts at one point', () => {
-    // The regression: keying dedupe on `lat,lng` dropped Havilah from Genesis
-    // 10, because the data files it at Babylon's coordinate.
+    // The regression: keying dedupe on `lat,lng` dropped the second and third
+    // of any places the gazetteer files at one point — e.g. Joshua 19's
+    // Beer-sheba / Hazar-shual / Eltolad, three distinct towns of the tribal
+    // allotment that all sit at 31.2447, 34.8408.
     const places = locatePlaces([{ en: 'Babylon' }, { en: 'Havilah' }], fake);
     expect(places.map((p) => p.en)).toEqual(['Babylon', 'Havilah']);
   });
@@ -49,14 +51,20 @@ describe('locating a chapter’s named places', () => {
   });
 
   it('reads the real gazetteer for the places these rules were written from', () => {
-    // Genesis 10 lost Havilah because the data files it at Babylon's point —
-    // and it is not a rare accident: 774 of the gazetteer's 1330 entries sit
-    // on a coordinate shared with another (the Jerusalem point alone carries
-    // 57, every gate and quarter of the city). Deduping on the coordinate
-    // therefore threw away real places by the dozen.
-    expect(lookupPlace('Havilah')).toEqual({ name: 'Havilah 1', lat: 32.5433, lng: 44.4222 });
-    expect(lookupPlace('Babylon')).toEqual({ name: 'Babylon 1', lat: 32.5433, lng: 44.4222 });
-    expect(locatePlaces([{ en: 'Babylon' }, { en: 'Havilah' }], lookupPlace)).toHaveLength(2);
+    // Not a rare accident: 774 of the gazetteer's 1330 entries sit on a
+    // coordinate shared with another (the Jerusalem point alone carries 57,
+    // every gate and quarter of the city). Deduping on the coordinate threw
+    // away real places by the dozen — these three towns of Simeon's allotment
+    // are a live example, and only Beer-sheba used to survive Joshua 19.
+    const simeon = ['Beer-sheba', 'Hazar-shual', 'Eltolad'];
+    const points = new Set(simeon.map((n) => `${lookupPlace(n)?.lat},${lookupPlace(n)?.lng}`));
+    expect(points.size).toBe(1);
+    expect(
+      locatePlaces(
+        simeon.map((en) => ({ en })),
+        lookupPlace,
+      ),
+    ).toHaveLength(3);
     // Two names for one entry still collapse.
     expect(locatePlaces([{ en: 'Salt Sea' }, { en: 'Dead Sea' }], lookupPlace)).toHaveLength(1);
     expect(locatePlaces([{ en: 'Kiriath-arba' }, { en: 'Hebron' }], lookupPlace)).toHaveLength(1);


### PR DESCRIPTION
Follow-up to #583, correcting its stated justification.

The comment and test explaining why place dedupe keys on the gazetteer *entry* rather than the coordinate used "Genesis 10 lost Havilah" as its example. **That example is wrong.** In Genesis 10 Havilah is a person — a son of Cush (v7) and of Joktan (v29) — not a place, so the producer correctly never names it there and the map never carried it. I inferred the case from a gazetteer coordinate collision without checking the actual payload.

The bug is real, and the live data demonstrates it directly:

| Chapter | Places at one coordinate | Dropped before |
| --- | --- | --- |
| Joshua 19 | Beer-sheba, Hazar-shual, Eltolad (31.2447, 34.8408) | 2 of 3 |
| Numbers 33 | Tahath, Terah, Mithkah (30.6406, 34.4111) | 2 of 3 |
| Joshua 19 | Ezem, Ain | 1 of 2 |

These are distinct towns of the tribal allotment and distinct wilderness encampments — exactly the places a map of those chapters exists to show. The test now asserts the Simeon three against the real gazetteer instead of describing a case in prose.

No behaviour change; the fix in #583 was correct, only its stated reason was not. A wrong reason in a comment is worse than no reason — it invites the next reader to check it, find it doesn't hold, and undo the fix.

`pnpm typecheck`, `pnpm test` (92 tanach), `pnpm lint` pass.