### PR TITLE
Record where each OpenRouter key lives, and that the pool is shared

### DIFF
--- a/packages/talmud/wrangler.generator.toml
+++ b/packages/talmud/wrangler.generator.toml
@@ -18,7 +18,10 @@
 # worker needs (OPENROUTER_API_KEY, CLOUDFLARE_ACCOUNT_ID — the AI-Gateway URL
 # is built from the account id) are set with `wrangler secret put -c
 # wrangler.generator.toml`; the inference key is in vault at
-# legacy/prod/talmud/openrouter-api-key.
+# legacy/prod/talmud/openrouter-api-key — the SAME key the reader holds, and
+# not the one local dev uses (that is the spend-capped
+# legacy/prod/talmud/openrouter-api-key-dev, read from packages/talmud/.dev.vars).
+# Rotating prod means `wrangler secret put` on BOTH workers, then a vault put.
 name = "talmud-gen"
 main = "src/worker/index.ts"
 compatibility_date = "2025-04-01"

--- a/packages/tanach/wrangler.toml
+++ b/packages/tanach/wrangler.toml
@@ -55,8 +55,23 @@ OPENROUTER_GATEWAY_PROVIDER = "openrouter"
 DAILY_BUDGET_USD = "20"
 HOURLY_CUSTOM_BUDGET_USD = "5"
 
-# Secret (set with `wrangler secret put OPENROUTER_API_KEY`; locally via
-# packages/tanach/.dev.vars): OPENROUTER_API_KEY.
+# Secret: OPENROUTER_API_KEY (`wrangler secret put OPENROUTER_API_KEY` from
+# this directory). The deployed value lives in vault at
+# legacy/prod/tanach/openrouter-api-key; local dev reads a SEPARATE, spend-
+# capped dev key from packages/tanach/.dev.vars (gitignored, one copy per
+# worktree) recorded at legacy/prod/tanach/openrouter-api-key-dev.
+#
+# SHARED CREDIT POOL: the tanach and talmud keys sit in one OpenRouter
+# workspace, so they draw on the SAME prepaid balance — a tanach backfill can
+# starve talmud generation and vice versa. The per-key weekly caps (tanach
+# prod $20, tanach dev $15) bound each side; the budget caps above bound this
+# worker's own spend. Both apps classify a dry pool REACTIVELY via
+# classifyAiUnavailable (@corpus/core/llm/ai-status) and surface the shared
+# "AI paused" banner; only talmud additionally checks the live account balance
+# BEFORE starting generation (packages/talmud/src/worker/ai-credits.ts, which
+# needs OPENROUTER_PROVISIONING_KEY). That probe reads whichever workspace the
+# provisioning key belongs to, so it must be a key from the SAME workspace as
+# the inference keys above or it reports the wrong pool.
 
 # Warm-cron: keep this week's parsha's chapter enrichments hot (warm-cron.ts).
 # Every 30 min — a fresh parsha warms over a few ticks, then the cursor latches


### PR DESCRIPTION
The tanach worker's inference key had no vault entry — the only record was the deployed secret, which cannot be read back. Both wrangler configs now name the vault path for the key they consume, and distinguish the deployed key from the spend-capped dev key that `.dev.vars` supplies.

Also documents the consequence of talmud and tanach sharing one OpenRouter workspace: one prepaid balance behind both, so either side can starve the other, and `ai-credits.ts`'s balance gate only reports the real pool if `OPENROUTER_PROVISIONING_KEY` comes from that same workspace.

Comments only — no code paths touched. `pnpm lint`, `pnpm typecheck`, `pnpm test` (2865 tests) all pass.