### PR TITLE
Keep expanded-map pins in view, and fail a broken parsha parse

### DIFF
--- a/packages/talmud/tests/client/geomap-labels.test.ts
+++ b/packages/talmud/tests/client/geomap-labels.test.ts
@@ -1,3 +1,4 @@
+import { inBBox } from '@corpus/ui/geo/bbox';
 import { type LabelCandidate, placeLabels } from '@corpus/ui/geo/labels';
 import { describe, expect, it } from 'vitest';
 
@@ -71,5 +72,30 @@ describe('geomap label placement', () => {
   it('is stable: the same input places the same way twice', () => {
     const input = [at(0, 100, 100), at(1, 103, 104), at(2, 106, 108), at(3, 99, 112)];
     expect(placeLabels(input, OPTS)).toEqual(placeLabels(input, OPTS));
+  });
+});
+
+describe('inBBox — filter markers against the live view, not the original frame', () => {
+  const start = { lonMin: 34, lonMax: 36.3, latMin: 29.4, latMax: 33.6 };
+  // After a pan east + zoom in, Hebron (35.0, 31.5) is still in frame but
+  // a point that was on the original western edge is not.
+  const panned = { lonMin: 34.6, lonMax: 36.0, latMin: 30.6, latMax: 32.6 };
+
+  it('keeps a point inside the starting frame', () => {
+    expect(inBBox(35.0, 31.5, start)).toBe(true);
+    expect(inBBox(34.0, 29.4, start)).toBe(true); // inclusive edges
+  });
+
+  it('drops a point that left the live (panned) view', () => {
+    expect(inBBox(34.1, 31.5, start)).toBe(true);
+    expect(inBBox(34.1, 31.5, panned)).toBe(false);
+  });
+
+  it('admits a point that entered the live view from outside the start frame', () => {
+    expect(inBBox(35.9, 32.4, start)).toBe(true);
+    expect(inBBox(36.2, 32.4, start)).toBe(true);
+    expect(inBBox(36.2, 32.4, panned)).toBe(false);
+    // A point just inside the panned east edge that was also in the start.
+    expect(inBBox(35.9, 32.4, panned)).toBe(true);
   });
 });

--- a/packages/tanach/src/client/ParshaDrawer.tsx
+++ b/packages/tanach/src/client/ParshaDrawer.tsx
@@ -285,7 +285,11 @@ export function ParshaDrawer(props: ParshaDrawerProps): JSX.Element {
                 : 'Connecting the passage, sources, and dvar Torah…'}
             </p>
           </Show>
-          <Show when={!thread.loading && thread() === null}>
+          {/* thread.error first: reading thread() while the resource is
+              errored (a rejected fetch, not a non-ok status) would rethrow
+              and break the drawer subtree. Same guard as the close-reading
+              `deep` resource above. */}
+          <Show when={!thread.loading && (thread.error || thread() === null)}>
             <p class="comm-muted">
               {aiStatus()
                 ? props.lang === 'he'
@@ -296,7 +300,7 @@ export function ParshaDrawer(props: ParshaDrawerProps): JSX.Element {
                   : "Couldn't build this study thread. Try again."}
             </p>
           </Show>
-          <Show when={thread()}>
+          <Show when={!thread.loading && !thread.error && thread()}>
             {(value) => (
               <>
                 <h4>{textFor(props.lang, value().titleEn, value().titleHe)}</h4>

--- a/packages/tanach/src/worker/index.ts
+++ b/packages/tanach/src/worker/index.ts
@@ -303,7 +303,7 @@ app.get('/api/geography/:book/:chapter', async (c) => {
 // Perek tidbit (whole-chapter enrichment): ONE curated "did you notice…" — the
 // against-the-grain reading the Overview deliberately leaves out — opened from
 // available for future composed study surfaces. Chapter-scoped
-// (tidbit:v1:{book}:{chapter}).
+// (tidbit:v2:{book}:{chapter}).
 app.get('/api/tidbit/:book/:chapter', async (c) => {
   const book = c.req.param('book');
   const chapter = c.req.param('chapter');
@@ -385,6 +385,12 @@ app.get('/api/parsha-study', async (c) => {
     });
   } catch (e) {
     return runErrorResponse(c, e);
+  }
+  // Same contract as geography: a truncated / unparseable model output is a
+  // FAILURE, not "this week's portion has no structure." An empty `flow`
+  // after a parse error made the drawer show titles with 0 moves.
+  if (artifact.parse_error) {
+    return c.json({ error: `Parsha study generation failed: ${artifact.parse_error}` }, 502);
   }
   const parsed = (artifact.parsed ?? {}) as {
     titleEn?: string;
@@ -487,6 +493,9 @@ async function resolveParshaSection(
   } catch (e) {
     return runErrorResponse(c, e);
   }
+  if (overview.parse_error) {
+    return c.json({ error: `Parsha overview generation failed: ${overview.parse_error}` }, 502);
+  }
   const sections =
     (overview.parsed as { flow?: Omit<ParshaFlowSection, 'ref'>[] } | null)?.flow ?? [];
   const section = sections[sectionIndex];
@@ -511,6 +520,9 @@ app.get('/api/parsha-section/:section', async (c) => {
     });
   } catch (e) {
     return runErrorResponse(c, e);
+  }
+  if (study.parse_error) {
+    return c.json({ error: `Parsha section generation failed: ${study.parse_error}` }, 502);
   }
   c.header('Cache-Control', 'public, max-age=600, stale-while-revalidate=86400');
   return c.json({
@@ -539,6 +551,9 @@ app.get('/api/parsha-thread/:section', async (c) => {
     });
   } catch (e) {
     return runErrorResponse(c, e);
+  }
+  if (thread.parse_error) {
+    return c.json({ error: `Parsha thread generation failed: ${thread.parse_error}` }, 502);
   }
   c.header('Cache-Control', 'public, max-age=600, stale-while-revalidate=86400');
   return c.json({

--- a/packages/tanach/src/worker/inspect.ts
+++ b/packages/tanach/src/worker/inspect.ts
@@ -85,7 +85,7 @@ interface InstanceShape {
 const KEY_SHAPES: Record<string, ChapterShape | InstanceShape> = {
   events: { kind: 'chapter', key: (b, c) => `events:v2:${b}:${c}` },
   overview: { kind: 'chapter', key: (b, c) => `overview:v1:${b}:${c}` },
-  geography: { kind: 'chapter', key: (b, c) => `geography:v2:${b}:${c}` },
+  geography: { kind: 'chapter', key: (b, c) => `geography:v3:${b}:${c}` },
   tidbit: { kind: 'chapter', key: (b, c) => `tidbit:v2:${b}:${c}` },
   note: {
     kind: 'instance',

--- a/packages/tanach/src/worker/producers/geography.ts
+++ b/packages/tanach/src/worker/producers/geography.ts
@@ -11,7 +11,7 @@
  *
  * This module carries the producer's RECIPE (prompts + schema); the run goes
  * through the corpus-agnostic runProducer (producers/defs.ts + run-ports.ts).
- * Chapter-scoped — key geography:v1:{book}:{chapter}.
+ * Chapter-scoped — key geography:v3:{book}:{chapter}.
  */
 
 export interface PerekPlace {

--- a/packages/tanach/src/worker/producers/tidbit.ts
+++ b/packages/tanach/src/worker/producers/tidbit.ts
@@ -11,7 +11,7 @@
  *
  * Recipe only (prompts + schema); the run goes through the corpus-agnostic
  * runProducer (defs.ts assembles the Producer, run-ports.ts wires the ports).
- * Chapter-scoped — key tidbit:v1:{book}:{chapter}, instance ignored.
+ * Chapter-scoped — key tidbit:v2:{book}:{chapter}, instance ignored.
  */
 
 export type TidbitFlavor =

--- a/packages/tanach/tests/inspect.test.ts
+++ b/packages/tanach/tests/inspect.test.ts
@@ -119,6 +119,21 @@ describe('chapterRuns', () => {
     expect(res.totals.cost).toBeCloseTo(0.01 + 0.0004 * 3, 6);
   });
 
+  it('reads geography at the writer v3 key (a v2 leftover is a miss)', async () => {
+    const store = {
+      'geography:v2:Genesis:22': envelope(),
+      'geography:v3:Genesis:22': envelope({
+        elapsed_ms: 800,
+        cost: { estimatedUsd: 0.002, billedUsd: null, tokensIn: 50, tokensOut: 20 },
+      }),
+    };
+    const res = await chapterRuns(fakeCache(store), 'Genesis', '22');
+    const geo = res.runs.find((r) => r.id === 'geography');
+    expect(geo?.cached).toBe(true);
+    expect(geo?.coldMs).toBe(800);
+    expect(geo?.cost).toBe(0.002);
+  });
+
   it('every row carries a registry-DERIVED `expandable` (false: tanach pieces depend only on sources)', async () => {
     const res = await chapterRuns(fakeCache({}), 'Genesis', '22');
     expect(res.runs.length).toBeGreaterThan(0);

--- a/packages/tanach/tests/producer-keys.test.ts
+++ b/packages/tanach/tests/producer-keys.test.ts
@@ -67,9 +67,9 @@ describe('key byte-parity with the legacy literals', () => {
 
   it('geography — geography:v3:{book}:{chapter} (template owns the bytes, not cacheVersion)', () => {
     const def = info(enrichRunDefOf('geography'), 'enrich');
-    expect(TANACH_KEY_SCHEME.key(def, enrichmentAddress('geography', 'perek', 'Numbers', '33'))).toBe(
-      'geography:v3:Numbers:33',
-    );
+    expect(
+      TANACH_KEY_SCHEME.key(def, enrichmentAddress('geography', 'perek', 'Numbers', '33')),
+    ).toBe('geography:v3:Numbers:33');
     expect(
       TANACH_KEY_SCHEME.key(def, enrichmentAddress('geography', 'perek', 'Song of Songs', '1')),
     ).toBe('geography:v3:Song of Songs:1');

--- a/packages/tanach/tests/producer-keys.test.ts
+++ b/packages/tanach/tests/producer-keys.test.ts
@@ -8,6 +8,8 @@
  *   `note:v1:${book}:${chapter}:${start}-${end}`
  *   `synthesis:v1:${book}:${chapter}:${verse}`
  *   `midrash-synth:v1:${book}:${chapter}:${verse}`   (producer: midrash-synthesis)
+ *   `geography:v3:${book}:${chapter}`
+ *   `tidbit:v2:${book}:${chapter}`
  *
  * translate:v1:* is deliberately absent (kept on bespoke raw-string+TTL
  * plumbing); midrash:v1:* is a source cache, not a producer output.
@@ -60,6 +62,23 @@ describe('key byte-parity with the legacy literals', () => {
     const def = info(enrichRunDefOf('synthesis'), 'enrich');
     expect(TANACH_KEY_SCHEME.key(def, enrichmentAddress('synthesis', '1', 'Genesis', '1'))).toBe(
       'synthesis:v1:Genesis:1:1',
+    );
+  });
+
+  it('geography — geography:v3:{book}:{chapter} (template owns the bytes, not cacheVersion)', () => {
+    const def = info(enrichRunDefOf('geography'), 'enrich');
+    expect(TANACH_KEY_SCHEME.key(def, enrichmentAddress('geography', 'perek', 'Numbers', '33'))).toBe(
+      'geography:v3:Numbers:33',
+    );
+    expect(
+      TANACH_KEY_SCHEME.key(def, enrichmentAddress('geography', 'perek', 'Song of Songs', '1')),
+    ).toBe('geography:v3:Song of Songs:1');
+  });
+
+  it('tidbit — tidbit:v2:{book}:{chapter}', () => {
+    const def = info(enrichRunDefOf('tidbit'), 'enrich');
+    expect(TANACH_KEY_SCHEME.key(def, enrichmentAddress('tidbit', 'perek', 'Genesis', '1'))).toBe(
+      'tidbit:v2:Genesis:1',
     );
   });
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -29,6 +29,7 @@
     "./Prose": "./src/Prose.tsx",
     "./LangToggle": "./src/LangToggle.tsx",
     "./GeoMap": "./src/GeoMap.tsx",
+    "./geo/bbox": "./src/geo/bbox.ts",
     "./geo/labels": "./src/geo/labels.ts",
     "./WorldBubbleMap": "./src/WorldBubbleMap.tsx",
     "./LoadProgress": "./src/LoadProgress.tsx",

--- a/packages/ui/src/GeoMap.tsx
+++ b/packages/ui/src/GeoMap.tsx
@@ -25,14 +25,11 @@ import {
 } from 'solid-js';
 import { Portal } from 'solid-js/web';
 import { BASEMAP } from './geo/basemap.ts';
+import { type GeoBBox, inBBox } from './geo/bbox.ts';
 import { type LabelCandidate, placeLabels } from './geo/labels.ts';
 
-export interface GeoBBox {
-  lonMin: number;
-  lonMax: number;
-  latMin: number;
-  latMax: number;
-}
+export { type GeoBBox, inBBox } from './geo/bbox.ts';
+
 export interface GeoPoint {
   /** Stable id (for selection + keys). */
   id?: string;
@@ -304,11 +301,11 @@ export function GeoMap(props: GeoMapProps): JSX.Element {
   const toggle = (l: GeoLayer) => setOverrides((o) => ({ ...o, [l]: !layers()[l] }));
 
   // points/regions kept in-frame (the SVG clips, but skipping off-view labels
-  // avoids stray text in the margins).
-  const inView = (lng: number, lat: number) => {
-    const b = props.bbox;
-    return lng >= b.lonMin && lng <= b.lonMax && lat >= b.latMin && lat <= b.latMax;
-  };
+  // avoids stray text in the margins). Filter against the live view, not the
+  // original props.bbox — after pan/zoom those two diverge, and using the
+  // static frame hid markers that had entered the viewport (and kept ones
+  // that had left).
+  const inView = (lng: number, lat: number) => inBBox(lng, lat, activeBbox());
   // Project points, then DE-OVERLAP co-located ones (many points at the same
   // place — e.g. several sages in one city): spiral the group around its centre
   // with a sunflower/golden-angle pattern so each marker is distinct. Index 0

--- a/packages/ui/src/geo/bbox.ts
+++ b/packages/ui/src/geo/bbox.ts
@@ -1,0 +1,19 @@
+/**
+ * Point-in-bbox for GeoMap. Pure so the pan/zoom filter can be tested
+ * without mounting the Solid map.
+ *
+ * The live view (`activeBbox`) and the original `props.bbox` diverge after
+ * pan/zoom — filtering against the original hid markers that had entered
+ * the viewport and kept ones that had left.
+ */
+
+export interface GeoBBox {
+  lonMin: number;
+  lonMax: number;
+  latMin: number;
+  latMax: number;
+}
+
+export function inBBox(lng: number, lat: number, b: GeoBBox): boolean {
+  return lng >= b.lonMin && lng <= b.lonMax && lat >= b.latMin && lat <= b.latMax;
+}

--- a/packages/ui/src/geomap.css
+++ b/packages/ui/src/geomap.css
@@ -43,6 +43,7 @@
   border: 1px solid var(--geo-land-edge);
   border-radius: var(--radius);
   box-shadow: 0 6px 24px rgba(60, 40, 12, 0.1);
+  overflow: hidden;
 }
 .geomap-drybg {
   fill: var(--geo-dry);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
A general pass over the recent geography and parsha work turned up a few leftover bugs. This PR fixes the user-visible ones and pins the inspect/key drift that would have hidden the next one.

## What changed

**Expanded maps kept filtering pins against the original frame.** After pan or zoom, `GeoMap` projected against the live bbox but still asked `inView` about `props.bbox`. Pins that entered the viewport stayed hidden; pins that left it stayed drawn (and could bleed past the frame). Filtering now uses the live view, and the SVG clips overflow.

**A rejected dvar-Torah fetch could crash the parsha drawer.** The close-reading path already guards `deep.error` before reading the resource. The study-thread path did not. Same guard now.

**A broken parsha parse looked like “no structure.”** Geography already treats `parse_error` as a 502 (so a truncated itinerary is not “no places”). The parsha-study / section / thread routes now do the same, instead of returning titles with an empty flow.

**Tanach inspect was reading yesterday’s geography key.** The writer stores `geography:v3:…`; inspect still asked for `v2`, so a warm chapter always looked cold. Inspect now matches the writer, with a byte-parity test so this class of miss does not come back.

## Left for later

These are real, but they are separate PRs:

- Delete the unused `RabbiGeographyCard` UI (types still live; the card itself has no importer).
- Convert the remaining `place` sidebar to the recipe model.
- Distinguish “chapter names no places” from “names we cannot locate” on the Tanach geography empty state.

## Validation

- `pnpm typecheck` — pass
- `pnpm test` — pass (core 147, tanach 95, talmud 2776)
- `pnpm lint` — no new errors; remaining Biome warnings are pre-existing on master
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-56d0a16a-23b1-4a97-9a7f-f72fc5d50f92?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-56d0a16a-23b1-4a97-9a7f-f72fc5d50f92&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

